### PR TITLE
fix(csv): include annotations on error messages.

### DIFF
--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -674,8 +674,11 @@ func TestMultiResultEncoder(t *testing.T) {
 			results: errorResultIterator{
 				Error: errors.New("test error"),
 			},
-			encoded: toCRLF(`error,reference
-test error,
+			encoded: toCRLF(`#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,test error,
 `),
 		},
 		{
@@ -686,8 +689,11 @@ test error,
 					Err: errors.New("execution error"),
 				},
 			}),
-			encoded: toCRLF(`error,reference
-execution error,
+			encoded: toCRLF(`#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,execution error,
 `),
 		},
 		{

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2632,7 +2632,7 @@ Example encoding with two tables with differing schemas in the same result with 
 Example error encoding with the datatype annotation:
 
 ```
-#datatype,string,long
+#datatype,string,string
 ,error,reference
 ,Failed to parse query,897
 ```
@@ -2646,7 +2646,7 @@ Example error encoding with after a valid table has already been encoded.
 ,mean,1,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:20Z,west,B,12.83
 ,mean,1,2018-05-08T20:50:00Z,2018-05-08T20:51:00Z,2018-05-08T20:50:40Z,west,C,51.62
 
-#datatype,string,long
+#datatype,string,string
 ,error,reference
 ,query terminated: reached maximum allowed memory limits,576
 ```

--- a/functions/testdata/drop_after_rename.out.csv
+++ b/functions/testdata/drop_after_rename.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"drop error: column ""old"" doesn't exist",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"drop error: column ""old"" doesn't exist",

--- a/functions/testdata/drop_before_rename.out.csv
+++ b/functions/testdata/drop_before_rename.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"rename error: column ""old"" doesn't exist",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"rename error: column ""old"" doesn't exist",

--- a/functions/testdata/drop_newname_before.out.csv
+++ b/functions/testdata/drop_newname_before.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"drop error: column ""new"" doesn't exist",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"drop error: column ""new"" doesn't exist",

--- a/functions/testdata/drop_referenced.out.csv
+++ b/functions/testdata/drop_referenced.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"function references unknown column ""_field""",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"function references unknown column ""_field""",


### PR DESCRIPTION
This came up from chronograf, where annotations were expected and not received in error bodies.