### PR TITLE
fix: decode the error annotation in the csv format

### DIFF
--- a/functions/testdata/drop_after_rename.out.csv
+++ b/functions/testdata/drop_after_rename.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"drop error: column ""old"" doesn't exist",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"drop error: column ""old"" doesn't exist",

--- a/functions/testdata/drop_before_rename.out.csv
+++ b/functions/testdata/drop_before_rename.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"rename error: column ""old"" doesn't exist",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"rename error: column ""old"" doesn't exist",

--- a/functions/testdata/drop_newname_before.out.csv
+++ b/functions/testdata/drop_newname_before.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"drop error: column ""new"" doesn't exist",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"drop error: column ""new"" doesn't exist",

--- a/functions/testdata/drop_referenced.out.csv
+++ b/functions/testdata/drop_referenced.out.csv
@@ -1,2 +1,5 @@
-error,reference
-"function references unknown column ""_field""",
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,"function references unknown column ""_field""",


### PR DESCRIPTION
This fixes the csv decoder so it recognizes and decodes the error
annotation.

Also fixes an error in the multi result decoder because it didn't share
the `csv.Reader` instance across results which caused buffered data to
be discarded.