### PR TITLE
fix(interpreter): don't panic when function calls unknown function

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -19,6 +19,7 @@ func TestCompile(t *testing.T) {
 		{q: "0/0", ok: true},
 		{q: `t=""t.t`},
 		{q: `t=0t.s`},
+		{q: `"">()=>a()`},
 	} {
 		_, err := flux.Compile(ctx, tc.q, now)
 		if tc.ok && err != nil {


### PR DESCRIPTION
This is specifically to handle the case of `() => foo()` where `foo` is
an unknown function. The type of that function is evaluated as part of a
binary expression.