### PR TITLE
interface for abstract transformation rules

### DIFF
--- a/planner/planner.go
+++ b/planner/planner.go
@@ -1,0 +1,13 @@
+package planner
+
+// Planner implements a rule-based query planner
+type Planner interface {
+	// Add rules to be enacted by the planner
+	AddRules([]Rule)
+
+	// Remove rules no longer used by the planner
+	RemoveRules([]Rule)
+
+	// Plan takes an initial query plan and returns an optimized plan
+	Plan(PlanNode) PlanNode
+}

--- a/planner/rules.go
+++ b/planner/rules.go
@@ -1,0 +1,16 @@
+package planner
+
+// Rule is transformation rule for a query operation
+type Rule interface {
+	// Pattern for this rule to match against
+	Pattern() Pattern
+
+	// Rewrite an operation into an equivalent one
+	Rewrite(PlanNode) PlanNode
+}
+
+// Pattern represents an operator tree pattern
+// It can match itself against a query plan
+type Pattern interface {
+	Match(PlanNode) bool
+}


### PR DESCRIPTION
Introduces two interfaces: `Rule` and `Planner`. `Rule` specifies a transformation rule between two equivalent query operations. `Planner` defines behavior for a rule-based planner.