### PR TITLE
Add Flux function `union` to SPEC

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2146,6 +2146,69 @@ Examples:
     | 0002  | "temp" | 75 | "temp" | 56 |
     | 0003  | "temp" | 72 | "temp: | 55 |
 
+#### Union
+
+Union concatenates two input streams into a single output stream.  In tables that have identical
+schema and group keys, contents of the tables will be concatenated in the output stream.
+
+Example:
+
+* SF_Weather
+* Group Key for both tables {"_field"}
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "temp" | 70 |
+    | 0002  | "temp" | 75 |
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "humidity" | 81 |
+    | 0002  | "humidity" | 82 |
+
+* NY_Temperature
+* Group Key for both tables {"_field"}
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "temp" | 55 |
+    | 0002  | "temp" | 56 |
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "pressure" | 29.82 |
+    | 0002  | "pressure" | 30.01 |
+
+`union(tables: {sf: SF_Temperature, ny: NY_Temperature})` produces:
+
+* Group Key for all tables {"_field"}
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "temp" | 70 |
+    | 0002  | "temp" | 75 |
+    | 0001  | "temp" | 55 |
+    | 0002  | "temp" | 56 |
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "humidity" | 81 |
+    | 0002  | "humidity" | 82 |
+
+    | _time | _field | _value |
+    | ----- | ------ | ------ |
+    | 0001  | "pressure" | 29.82 |
+    | 0002  | "pressure" | 30.01 |
+
+##### Options
+
+| Name   | Type | Required | Default Value | Possible Values |
+| ------ | ---- | -------- | ------------- | --------------- |
+| tables | map  | yes      |  none         |  N/A            |
+
+##### Output Schema
+
+The output schema of union shall be identical to the input schema.
 
 #### Cumulative sum
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2158,46 +2158,46 @@ Union has the following properties:
 
 For example, given this stream, `SF_Weather` with group key `"_field"` on both tables:
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "temp" | 70 |
-    | 0002  | "temp" | 75 |
+   |  _time |  _field |  _value |
+   | ----- | ------ | ------ |
+   | 0001  | "temp" | 70 |
+   | 0002  | "temp" | 75 |
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "humidity" | 81 |
-    | 0002  | "humidity" | 82 |
+   | _time | _field | _value |
+   | ----- | ------ | ------ |
+   | 0001  | "humidity" | 81 |
+   | 0002  | "humidity" | 82 |
 
 And this stream, `NY_Weather`, also with group key `"_field"` on both tables:
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "temp" | 55 |
-    | 0002  | "temp" | 56 |
+   | _time | _field | _value |
+   | ----- | ------ | ------ |
+   | 0001  | "temp" | 55 |
+   | 0002  | "temp" | 56 |
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "pressure" | 29.82 |
-    | 0002  | "pressure" | 30.01 |
+   | _time | _field | _value |
+   | ----- | ------ | ------ |
+   | 0001  | "pressure" | 29.82 |
+   | 0002  | "pressure" | 30.01 |
 
-`union(tables: [SF_Weather, NY_Weather])` produces this stream (whose tables are grouped by `"_field"`)
+`union(tables: [SF_Weather, NY_Weather])` produces this stream (whose tables are grouped by `"_field"`):
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "temp" | 70 |
-    | 0002  | "temp" | 75 |
-    | 0001  | "temp" | 55 |
-    | 0002  | "temp" | 56 |
+   | _time | _field | _value |
+   | ----- | ------ | ------ |
+   | 0001  | "temp" | 70 |
+   | 0002  | "temp" | 75 |
+   | 0001  | "temp" | 55 |
+   | 0002  | "temp" | 56 |
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "humidity" | 81 |
-    | 0002  | "humidity" | 82 |
+   | _time | _field | _value |
+   | ----- | ------ | ------ |
+   | 0001  | "humidity" | 81 |
+   | 0002  | "humidity" | 82 |
 
-    | _time | _field | _value |
-    | ----- | ------ | ------ |
-    | 0001  | "pressure" | 29.82 |
-    | 0002  | "pressure" | 30.01 |
+   | _time | _field | _value |
+   | ----- | ------ | ------ |
+   | 0001  | "pressure" | 29.82 |
+   | 0002  | "pressure" | 30.01 |
 
 #### Cumulative sum
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2148,13 +2148,15 @@ Examples:
 
 #### Union
 
-Union concatenates two input streams into a single output stream.  In tables that have identical
-schema and group keys, contents of the tables will be concatenated in the output stream.
+Union concatenates two or more input streams into a single output stream.  In tables that have identical
+schema and group keys, contents of the tables will be concatenated in the output stream.  The output schemas of 
+the Union operation shall be the union of all input schemas.
 
-Example:
+Union has the following properties:
+* `streams` a list of steams
+    streams specifies the streams to union together.  There must be at least two streams.
 
-* SF_Weather
-* Group Key for both tables {"_field"}
+For example, given this stream, `SF_Weather` with group key `"_field"` on both tables:
 
     | _time | _field | _value |
     | ----- | ------ | ------ |
@@ -2166,8 +2168,7 @@ Example:
     | 0001  | "humidity" | 81 |
     | 0002  | "humidity" | 82 |
 
-* NY_Temperature
-* Group Key for both tables {"_field"}
+And this stream, `NY_Weather`, also with group key `"_field"` on both tables:
 
     | _time | _field | _value |
     | ----- | ------ | ------ |
@@ -2179,9 +2180,7 @@ Example:
     | 0001  | "pressure" | 29.82 |
     | 0002  | "pressure" | 30.01 |
 
-`union(tables: {sf: SF_Temperature, ny: NY_Temperature})` produces:
-
-* Group Key for all tables {"_field"}
+`union(tables: [SF_Weather, NY_Weather])` produces this stream (whose tables are grouped by `"_field"`)
 
     | _time | _field | _value |
     | ----- | ------ | ------ |
@@ -2199,16 +2198,6 @@ Example:
     | ----- | ------ | ------ |
     | 0001  | "pressure" | 29.82 |
     | 0002  | "pressure" | 30.01 |
-
-##### Options
-
-| Name   | Type | Required | Default Value | Possible Values |
-| ------ | ---- | -------- | ------------- | --------------- |
-| tables | map  | yes      |  none         |  N/A            |
-
-##### Output Schema
-
-The output schema of union shall be identical to the input schema.
 
 #### Cumulative sum
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2153,8 +2153,8 @@ schema and group keys, contents of the tables will be concatenated in the output
 the Union operation shall be the union of all input schemas.
 
 Union has the following properties:
-* `streams` a list of steams
-    streams specifies the streams to union together.  There must be at least two streams.
+* `tables` a list of streams
+    tables specifies the streams to union together.  There must be at least two streams.
 
 For example, given this stream, `SF_Weather` with group key `"_field"` on both tables:
 


### PR DESCRIPTION
I treated `join()` as a template where applicable, and included an example so semantics are clear.

Question: should the parameter name be called `streams` instead of `tables`?  This question applies to `join()` too.