### PR TITLE
improve query plan comparison

### DIFF
--- a/planner/logical_test.go
+++ b/planner/logical_test.go
@@ -165,7 +165,10 @@ func TestFluxSpecToLogicalPlan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := plannertest.CompareLogicalPlans(want, got); err != nil {
+			// Comparator function for LogicalPlanNodes
+			f := plannertest.CompareLogicalPlanNodes
+
+			if err := plannertest.ComparePlans(want, got, f); err != nil {
 				t.Fatal(err)
 			}
 		})

--- a/planner/plannertest/cmp.go
+++ b/planner/plannertest/cmp.go
@@ -2,160 +2,105 @@ package plannertest
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/planner"
 	"github.com/influxdata/flux/semantic/semantictest"
 )
 
-// CompareLogicalPlans compares two logical query plans for equality by value
-func CompareLogicalPlans(p, q *planner.QueryPlan) error {
-	pRoots := p.Roots()
-	qRoots := q.Roots()
-
-	// Sort the roots of the two plans
-	sort.Slice(pRoots, func(i, j int) bool {
-		return pRoots[i].ID() < pRoots[j].ID()
-	})
-	sort.Slice(qRoots, func(i, j int) bool {
-		return qRoots[i].ID() < qRoots[j].ID()
-	})
-	return cmpLogicalPlans(pRoots, qRoots, map[cmpPair]bool{}, 0)
+type defaultVisitor struct {
+	nodes []planner.PlanNode
 }
 
-func cmpLogicalPlans(p, q []planner.PlanNode, visited map[cmpPair]bool, level int) error {
-	if len(p) != len(q) {
-		return fmt.Errorf("plans do not have same number of nodes at level %d", level)
+func (v *defaultVisitor) Visit(node planner.PlanNode) Visitor {
+	v.nodes = append(v.nodes, node)
+	return v
+}
+
+// ComparePlans compares two query plans using an arbitrary comparator function f
+func ComparePlans(p, q *planner.QueryPlan, f func(p, q planner.PlanNode) error) error {
+	v := &defaultVisitor{}
+	w := &defaultVisitor{}
+
+	Walk(p, v)
+	Walk(q, w)
+
+	if len(v.nodes) != len(w.nodes) {
+		return fmt.Errorf("plans have %d and %d nodes respectively",
+			len(v.nodes), len(w.nodes))
 	}
 
-	for i := 0; i < len(p); i++ {
+	for i := 0; i < len(v.nodes); i++ {
 
-		if visited[cmpPair{p[i], q[i]}] {
-			continue
-		}
-
-		// Must be logical plan nodes
-		if _, ok := p[i].(*planner.LogicalPlanNode); !ok {
-			return fmt.Errorf("encountered a non-logical plan node with spec type %T", p[i].ProcedureSpec())
-		}
-
-		if _, ok := q[i].(*planner.LogicalPlanNode); !ok {
-			return fmt.Errorf("encountered a non-logical plan node with spec type %T", q[i].ProcedureSpec())
-		}
-
-		// Must have the same IDs
-		if p[i].ID() != q[i].ID() {
-			return fmt.Errorf("expected NodeID %s, but instead got %s", p[i].ID(), q[i].ID())
-		}
-
-		// Must be the same kind of procedure
-		if p[i].Kind() != q[i].Kind() {
-			return fmt.Errorf("expected ProcedureKind %s, but instead got %s", p[i].Kind(), q[i].Kind())
-		}
-
-		// The specifications of both procedures must be the same
-		if !cmp.Equal(p[i].ProcedureSpec(), q[i].ProcedureSpec(), semantictest.CmpOptions...) {
-			return fmt.Errorf("logical plan nodes not equal -want/+got %s", cmp.Diff(
-				p[i].ProcedureSpec(), q[i].ProcedureSpec()))
-		}
-
-		// Nodes are equal
-		visited[cmpPair{p[i], q[i]}] = true
-
-		// Recurse on predecessors
-		if err := cmpLogicalPlans(p[i].Predecessors(), q[i].Predecessors(), visited, level+1); err != nil {
+		if err := f(v.nodes[i], w.nodes[i]); err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
-// ComparePhysicalPlans compares two physical query plans for equality by value
-func ComparePhysicalPlans(p, q *planner.QueryPlan) error {
-	pRoots := p.Roots()
-	qRoots := q.Roots()
+// CompareLogicalPlanNodes is a comparator fuction for LogicalPlanNodes
+func CompareLogicalPlanNodes(p, q planner.PlanNode) error {
+	if _, ok := p.(*planner.LogicalPlanNode); !ok {
+		return fmt.Errorf("expected %s to be a LogicalPlanNode", p.ID())
+	}
 
-	// Sort the roots of the two plans
-	sort.Slice(pRoots, func(i, j int) bool {
-		return pRoots[i].ID() < pRoots[j].ID()
-	})
-	sort.Slice(qRoots, func(i, j int) bool {
-		return qRoots[i].ID() < qRoots[j].ID()
-	})
-	return cmpPhysicalPlans(pRoots, qRoots, map[cmpPair]bool{}, 0)
+	if _, ok := q.(*planner.LogicalPlanNode); !ok {
+		return fmt.Errorf("expected %s to be a LogicalPlanNode", q.ID())
+	}
+
+	return cmpPlanNode(p, q)
 }
 
-func cmpPhysicalPlans(p, q []planner.PlanNode, visited map[cmpPair]bool, level int) error {
-	if len(p) != len(q) {
-		return fmt.Errorf("plans do not have same number of nodes at level %d", level)
+// ComparePhysicalPlanNodes is a comparator function for PhysicalPlanNodes
+func ComparePhysicalPlanNodes(p, q planner.PlanNode) error {
+	var pp, qq *planner.PhysicalPlanNode
+	var ok bool
+
+	if pp, ok = p.(*planner.PhysicalPlanNode); !ok {
+		return fmt.Errorf("expected %s to be a PhysicalPlanNode", p.ID())
 	}
 
-	for i := 0; i < len(p); i++ {
-
-		if visited[cmpPair{p[i], q[i]}] {
-			continue
-		}
-
-		// Must be physical plan nodes
-		if _, ok := p[i].(*planner.PhysicalPlanNode); !ok {
-			return fmt.Errorf("encountered a non-physical plan node with spec type %T", p[i].ProcedureSpec())
-		}
-
-		if _, ok := q[i].(*planner.PhysicalPlanNode); !ok {
-			return fmt.Errorf("encountered a non-physical plan node with spec type %T", q[i].ProcedureSpec())
-		}
-
-		left := p[i].(*planner.PhysicalPlanNode)
-		right := q[i].(*planner.PhysicalPlanNode)
-
-		// Must have the same IDs
-		if p[i].ID() != q[i].ID() {
-			return fmt.Errorf("expected NodeID %s, but instead got %s", p[i].ID(), q[i].ID())
-		}
-
-		// Must be the same kind of procedure
-		if p[i].Kind() != q[i].Kind() {
-			return fmt.Errorf("expected ProcedureKind %s, but instead got %s", p[i].Kind(), q[i].Kind())
-		}
-
-		// The specifications of both procedures must be the same
-		if !cmp.Equal(p[i].ProcedureSpec(), q[i].ProcedureSpec(), semantictest.CmpOptions...) {
-			return fmt.Errorf("physical plan nodes not equal -want/+got %s", cmp.Diff(
-				p[i].ProcedureSpec(), q[i].ProcedureSpec()))
-		}
-
-		// Must have the same number of required attributes
-		if len(left.RequiredAttrs) != len(right.RequiredAttrs) {
-			return fmt.Errorf("procedures %s and %s do not have the same number of required attributes",
-				left.ID(), right.ID())
-		}
-
-		// Must have the same required attributes
-		for i := 0; i < len(left.RequiredAttrs); i++ {
-			if !cmp.Equal(left.RequiredAttrs[i], right.RequiredAttrs[i]) {
-				return fmt.Errorf("required attribute not equal -want/+got %s", cmp.Diff(
-					left.RequiredAttrs[i], right.RequiredAttrs[i]))
-			}
-		}
-
-		// Must produce the same attributes
-		if !cmp.Equal(left.OutputAttrs, right.OutputAttrs) {
-			return fmt.Errorf("output attributes not equal -want/+got %s", cmp.Diff(
-				left.OutputAttrs, right.OutputAttrs))
-		}
-
-		// Nodes are equal
-		visited[cmpPair{p[i], q[i]}] = true
-
-		// Recurse on predecessors
-		if err := cmpPhysicalPlans(p[i].Predecessors(), q[i].Predecessors(), visited, level+1); err != nil {
-			return err
-		}
+	if qq, ok = q.(*planner.PhysicalPlanNode); !ok {
+		return fmt.Errorf("expected %s to be a PhysicalPlanNode", q.ID())
 	}
+
+	if err := cmpPlanNode(p, q); err != nil {
+		return err
+	}
+
+	// Both nodes must consume the same required attributes
+	if !cmp.Equal(pp.RequiredAttrs, qq.RequiredAttrs) {
+		return fmt.Errorf("required attributes not equal -want(%s)/+got(%s) %s",
+			pp.ID(), qq.ID(), cmp.Diff(pp.RequiredAttrs, qq.RequiredAttrs))
+	}
+
+	// Both nodes must produce the same physical attributes
+	if !cmp.Equal(pp.OutputAttrs, qq.OutputAttrs) {
+		return fmt.Errorf("output attributes not equal -want(%s)/+got(%s) %s",
+			pp.ID(), qq.ID(), cmp.Diff(pp.OutputAttrs, qq.OutputAttrs))
+	}
+
 	return nil
 }
 
-type cmpPair struct {
-	left, right planner.PlanNode
+func cmpPlanNode(p, q planner.PlanNode) error {
+	// Both nodes must have the same ID
+	if p.ID() != q.ID() {
+		return fmt.Errorf("wanted %s, but got %s", p.ID(), q.ID())
+	}
+
+	// Both nodes must be the same kind of procedure
+	if p.Kind() != q.Kind() {
+		return fmt.Errorf("wanted %s, but got %s", p.Kind(), q.Kind())
+	}
+
+	// The specifications of both procedures must be the same
+	if !cmp.Equal(p.ProcedureSpec(), q.ProcedureSpec(), semantictest.CmpOptions...) {
+		return fmt.Errorf("procedure specs not equal -want(%s)/+got(%s) %s",
+			p.ID(), q.ID(), cmp.Diff(p.ProcedureSpec(), q.ProcedureSpec()))
+	}
+
+	return nil
 }

--- a/planner/plannertest/walk.go
+++ b/planner/plannertest/walk.go
@@ -1,0 +1,36 @@
+package plannertest
+
+import (
+	"sort"
+
+	"github.com/influxdata/flux/planner"
+)
+
+// Visitor visits a query plan node
+type Visitor interface {
+	Visit(planner.PlanNode) Visitor
+}
+
+// Walk traverses a query plan in a depth-first fashion.
+// visitor.Visit() is called on each node exactly once.
+func Walk(plan *planner.QueryPlan, visitor Visitor) {
+	roots := plan.Roots()
+
+	sort.Slice(roots, func(i, j int) bool {
+		return roots[i].ID() < roots[j].ID()
+	})
+
+	walk(roots, visitor, map[planner.PlanNode]bool{})
+}
+
+func walk(nodes []planner.PlanNode, visitor Visitor, visited map[planner.PlanNode]bool) {
+	for _, node := range nodes {
+
+		if visited[node] {
+			continue
+		}
+
+		visitor = visitor.Visit(node)
+		walk(node.Predecessors(), visitor, visited)
+	}
+}


### PR DESCRIPTION
This PR:

* Creates a query plan walker that traverses a plan in a depth-first fashion and visits each node exactly once
* Uses this walker to simplify query plan comparisons