### PR TITLE
Rename QueryPlan to PlanSpec

### DIFF
--- a/planner/logical.go
+++ b/planner/logical.go
@@ -27,7 +27,7 @@ func (lpn *LogicalPlanNode) ProcedureSpec() ProcedureSpec {
 }
 
 // CreateLogicalPlan creates a logical query plan from a flux spec
-func CreateLogicalPlan(spec *flux.Spec, a Administration) (*QueryPlan, error) {
+func CreateLogicalPlan(spec *flux.Spec, a Administration) (*PlanSpec, error) {
 	nodes := make(map[flux.OperationID]PlanNode, len(spec.Operations))
 
 	v := &fluxSpecVisitor{

--- a/planner/plan_traversal_test.go
+++ b/planner/plan_traversal_test.go
@@ -25,7 +25,7 @@ func (sr *SimpleRule) Rewrite(node planner.PlanNode) (planner.PlanNode, bool) {
 	return node, false
 }
 
-func fluxToQueryPlan(fluxQuery string, a planner.Administration) (*planner.QueryPlan, error) {
+func fluxToQueryPlan(fluxQuery string, a planner.Administration) (*planner.PlanSpec, error) {
 	now := time.Now().UTC()
 	spec, err := flux.Compile(context.Background(), fluxQuery, now)
 	if err != nil {

--- a/planner/planner.go
+++ b/planner/planner.go
@@ -11,7 +11,7 @@ type Planner interface {
 	ConvertID()
 
 	// Plan takes an initial query plan and returns an optimized plan
-	Plan(*QueryPlan) (*QueryPlan, error)
+	Plan(*PlanSpec) (*PlanSpec, error)
 }
 
 type LogicalToPhysicalPlanner struct {
@@ -64,9 +64,9 @@ func (p LogicalToPhysicalPlanner) AddRules(rules []Rule) {
 // It traverses the DAG depth-first, attempting to apply rewrite rules at each node.
 // Traversal is repeated until a pass over the DAG results in no changes with the given rule set.
 //
-// Plan may change its argument and/or return a new instance of QueryPlan, so the correct way to call Plan is:
+// Plan may change its argument and/or return a new instance of PlanSpec, so the correct way to call Plan is:
 //     plan, err = planner.Plan(plan)
-func (p *LogicalToPhysicalPlanner) Plan(inputPlan *QueryPlan) (*QueryPlan, error) {
+func (p *LogicalToPhysicalPlanner) Plan(inputPlan *PlanSpec) (*PlanSpec, error) {
 
 	for anyChanged := true; anyChanged == true; {
 
@@ -112,7 +112,7 @@ func (p *LogicalToPhysicalPlanner) Plan(inputPlan *QueryPlan) (*QueryPlan, error
 //   node  becomes   newNode
 //   / \               / \
 //  D   E             D'  E'    <-- predecessors
-func updateSuccessors(plan *QueryPlan, oldNode, newNode PlanNode) {
+func updateSuccessors(plan *PlanSpec, oldNode, newNode PlanNode) {
 	newNode.ClearSuccessors()
 
 	if len(oldNode.Successors()) == 0 {

--- a/planner/plantest/cmp.go
+++ b/planner/plantest/cmp.go
@@ -18,7 +18,7 @@ func (v *defaultVisitor) Visit(node planner.PlanNode) Visitor {
 }
 
 // ComparePlans compares two query plans using an arbitrary comparator function f
-func ComparePlans(p, q *planner.QueryPlan, f func(p, q planner.PlanNode) error) error {
+func ComparePlans(p, q *planner.PlanSpec, f func(p, q planner.PlanNode) error) error {
 	v := &defaultVisitor{}
 	w := &defaultVisitor{}
 

--- a/planner/plantest/plan.go
+++ b/planner/plantest/plan.go
@@ -15,7 +15,7 @@ type DAG struct {
 }
 
 // CreatePlanFromDAG constructs a query plan DAG from a set of nodes and edges
-func CreatePlanFromDAG(graph DAG) *planner.QueryPlan {
+func CreatePlanFromDAG(graph DAG) *planner.PlanSpec {
 	predecessors := make(map[planner.PlanNode][]planner.PlanNode)
 	successors := make(map[planner.PlanNode][]planner.PlanNode)
 

--- a/planner/plantest/walk.go
+++ b/planner/plantest/walk.go
@@ -13,7 +13,7 @@ type Visitor interface {
 
 // Walk traverses a query plan in a depth-first fashion.
 // visitor.Visit() is called on each node exactly once.
-func Walk(plan *planner.QueryPlan, visitor Visitor) {
+func Walk(plan *planner.PlanSpec, visitor Visitor) {
 	roots := plan.Roots()
 
 	sort.Slice(roots, func(i, j int) bool {

--- a/planner/types.go
+++ b/planner/types.go
@@ -34,23 +34,23 @@ type PlanNode interface {
 
 type NodeID string
 
-// QueryPlan holds the roots of the query plan DAG.
+// PlanSpec holds the roots of the query plan DAG.
 // Roots correspond to nodes that produce final results.
-type QueryPlan struct {
+type PlanSpec struct {
 	roots map[PlanNode]struct{}
 }
 
 // NewQueryPlan instantiates a new query plan
-func NewQueryPlan(roots []PlanNode) *QueryPlan {
+func NewQueryPlan(roots []PlanNode) *PlanSpec {
 	r := make(map[PlanNode]struct{}, len(roots))
 	for _, root := range roots {
 		r[root] = struct{}{}
 	}
-	return &QueryPlan{roots: r}
+	return &PlanSpec{roots: r}
 }
 
 // Roots returns the roots of the query plan
-func (plan *QueryPlan) Roots() []PlanNode {
+func (plan *PlanSpec) Roots() []PlanNode {
 	roots := []PlanNode{}
 	for k := range plan.roots {
 		roots = append(roots, k)
@@ -59,7 +59,7 @@ func (plan *QueryPlan) Roots() []PlanNode {
 }
 
 // Replace replaces one of the roots of the query plan
-func (plan *QueryPlan) Replace(root, with PlanNode) {
+func (plan *PlanSpec) Replace(root, with PlanNode) {
 	delete(plan.roots, root)
 	plan.roots[with] = struct{}{}
 }


### PR DESCRIPTION
This is a straightforward renaming of `QueryPlan` to `PlanSpec`, so that when we alias imports in `control` and `execute` to use `planner` in place of `plan`, it tries to compile against our new plan structure.