### PR TITLE
 Moved logical parts of buckets() function to flux

### DIFF
--- a/functions/inputs/buckets.go
+++ b/functions/inputs/buckets.go
@@ -3,7 +3,6 @@ package inputs
 import (
 	"fmt"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -22,7 +21,6 @@ func init() {
 	flux.RegisterFunction(BucketsKind, createBucketsOpSpec, bucketsSignature)
 	flux.RegisterOpSpec(BucketsKind, newBucketsOp)
 	plan.RegisterProcedureSpec(BucketsKind, newBucketsProcedure, BucketsKind)
-	execute.RegisterSource(BucketsKind, createBucketsSource)
 }
 
 func createBucketsOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {

--- a/functions/inputs/buckets.go
+++ b/functions/inputs/buckets.go
@@ -1,0 +1,60 @@
+package inputs
+
+import (
+	"fmt"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
+)
+
+const BucketsKind = "buckets"
+
+type BucketsOpSpec struct {
+}
+
+var bucketsSignature = semantic.FunctionSignature{
+	Params:     map[string]semantic.Type{},
+	ReturnType: flux.TableObjectType,
+}
+
+func init() {
+	flux.RegisterFunction(BucketsKind, createBucketsOpSpec, bucketsSignature)
+	flux.RegisterOpSpec(BucketsKind, newBucketsOp)
+	plan.RegisterProcedureSpec(BucketsKind, newBucketsProcedure, BucketsKind)
+	execute.RegisterSource(BucketsKind, createBucketsSource)
+}
+
+func createBucketsOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	spec := new(BucketsOpSpec)
+	return spec, nil
+}
+
+func newBucketsOp() flux.OperationSpec {
+	return new(BucketsOpSpec)
+}
+
+func (s *BucketsOpSpec) Kind() flux.OperationKind {
+	return BucketsKind
+}
+
+type BucketsProcedureSpec struct {
+}
+
+func newBucketsProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	_, ok := qs.(*BucketsOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+
+	return &BucketsProcedureSpec{}, nil
+}
+
+func (s *BucketsProcedureSpec) Kind() plan.ProcedureKind {
+	return BucketsKind
+}
+
+func (s *BucketsProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(BucketsProcedureSpec)
+	return ns
+}


### PR DESCRIPTION
In line with having a logical/physical split of influxdb-dependent sources, the logical parts of the proposed buckets() function will be placed here, while there will be separate implementations for each of platform/idpe  and influxdb. 