### PR TITLE
fix how specs are constructed from table objects

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -420,14 +420,14 @@ func (t *TableObject) Equal(rhs values.Value) bool {
 	if t.Len() != r.Len() {
 		return false
 	}
-	for _, k := range t.keys() {
-		val1, ok1 := t.Get(k)
-		val2, ok2 := r.Get(k)
-		if !ok1 || !ok2 || !val1.Equal(val2) {
-			return false
-		}
-	}
-	return true
+	var isEqual = true
+	// Range over both TableObjects and
+	// compare their properties for equality
+	t.Range(func(k string, v values.Value) {
+		w, ok := r.Get(k)
+		isEqual = isEqual && ok && v.Equal(w)
+	})
+	return isEqual
 }
 func (t *TableObject) Function() values.Function {
 	panic(values.UnexpectedKind(semantic.Object, semantic.Function))
@@ -444,17 +444,12 @@ func (t *TableObject) Get(name string) (values.Value, bool) {
 	}
 }
 
-func (t *TableObject) keys() []string {
-	tableKeys := make([]string, 0, len(t.args.GetAll())+2)
-	return append(tableKeys, tableParentsKey, tableParentsKey)
-}
-
 func (t *TableObject) Set(name string, v values.Value) {
 	// immutable
 }
 
 func (t *TableObject) Len() int {
-	return len(t.keys())
+	return len(t.args.GetAll()) + 2
 }
 
 func (t *TableObject) Range(f func(name string, v values.Value)) {

--- a/functions/transformations/yield_test.go
+++ b/functions/transformations/yield_test.go
@@ -1,0 +1,227 @@
+package transformations_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/functions/inputs"
+	"github.com/influxdata/flux/functions/transformations"
+	"github.com/influxdata/flux/querytest"
+)
+
+func TestYield_NewQuery(t *testing.T) {
+	testcases := []querytest.NewQueryTestCase{
+		{
+			Name: "mutliple yields",
+			Raw: `
+				from(bucket: "foo") |> range(start:-1h) |> yield(name: "1")
+				from(bucket: "foo") |> range(start:-2h) |> yield(name: "2")
+			`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &inputs.FromOpSpec{
+							Bucket: "foo",
+						},
+					},
+					{
+						ID: "range1",
+						Spec: &transformations.RangeOpSpec{
+							Start: flux.Time{
+								Relative:   -1 * time.Hour,
+								IsRelative: true,
+							},
+							Stop: flux.Time{
+								IsRelative: true,
+							},
+							TimeCol:  "_time",
+							StartCol: "_start",
+							StopCol:  "_stop",
+						},
+					},
+					{
+						ID: "yield2",
+						Spec: &transformations.YieldOpSpec{
+							Name: "1",
+						},
+					},
+					{
+						ID: "from3",
+						Spec: &inputs.FromOpSpec{
+							Bucket: "foo",
+						},
+					},
+					{
+						ID: "range4",
+						Spec: &transformations.RangeOpSpec{
+							Start: flux.Time{
+								Relative:   -2 * time.Hour,
+								IsRelative: true,
+							},
+							Stop: flux.Time{
+								IsRelative: true,
+							},
+							TimeCol:  "_time",
+							StartCol: "_start",
+							StopCol:  "_stop",
+						},
+					},
+					{
+						ID: "yield5",
+						Spec: &transformations.YieldOpSpec{
+							Name: "2",
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{
+						Parent: flux.OperationID("from0"),
+						Child:  flux.OperationID("range1"),
+					},
+					{
+						Parent: flux.OperationID("range1"),
+						Child:  flux.OperationID("yield2"),
+					},
+					{
+						Parent: flux.OperationID("from3"),
+						Child:  flux.OperationID("range4"),
+					},
+					{
+						Parent: flux.OperationID("range4"),
+						Child:  flux.OperationID("yield5"),
+					},
+				},
+			},
+		},
+		{
+			Name: "yield in sub-block",
+			Raw: `
+				f = () => {
+					g = () => from(bucket: "foo") |> range(start:-1h) |> yield()
+					return g
+				}
+				f()()
+			`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &inputs.FromOpSpec{
+							Bucket: "foo",
+						},
+					},
+					{
+						ID: "range1",
+						Spec: &transformations.RangeOpSpec{
+							Start: flux.Time{
+								Relative:   -1 * time.Hour,
+								IsRelative: true,
+							},
+							Stop: flux.Time{
+								IsRelative: true,
+							},
+							TimeCol:  "_time",
+							StartCol: "_start",
+							StopCol:  "_stop",
+						},
+					},
+					{
+						ID: "yield2",
+						Spec: &transformations.YieldOpSpec{
+							Name: "_result",
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{
+						Parent: flux.OperationID("from0"),
+						Child:  flux.OperationID("range1"),
+					},
+					{
+						Parent: flux.OperationID("range1"),
+						Child:  flux.OperationID("yield2"),
+					},
+				},
+			},
+		},
+		{
+			Name: "sub-yield",
+			Raw: `
+				from(bucket: "foo") |> range(start:-1h) |> yield(name: "1") |> sum() |> yield(name: "2")
+			`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &inputs.FromOpSpec{
+							Bucket: "foo",
+						},
+					},
+					{
+						ID: "range1",
+						Spec: &transformations.RangeOpSpec{
+							Start: flux.Time{
+								Relative:   -1 * time.Hour,
+								IsRelative: true,
+							},
+							Stop: flux.Time{
+								IsRelative: true,
+							},
+							TimeCol:  "_time",
+							StartCol: "_start",
+							StopCol:  "_stop",
+						},
+					},
+					{
+						ID: "yield2",
+						Spec: &transformations.YieldOpSpec{
+							Name: "1",
+						},
+					},
+					{
+						ID: "sum3",
+						Spec: &transformations.SumOpSpec{
+							AggregateConfig: execute.AggregateConfig{
+								Columns: []string{"_value"},
+							},
+						},
+					},
+					{
+						ID: "yield4",
+						Spec: &transformations.YieldOpSpec{
+							Name: "2",
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{
+						Parent: flux.OperationID("from0"),
+						Child:  flux.OperationID("range1"),
+					},
+					{
+						Parent: flux.OperationID("range1"),
+						Child:  flux.OperationID("yield2"),
+					},
+					{
+						Parent: flux.OperationID("yield2"),
+						Child:  flux.OperationID("sum3"),
+					},
+					{
+						Parent: flux.OperationID("sum3"),
+						Child:  flux.OperationID("yield4"),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			querytest.NewQueryTestHelper(t, tc)
+		})
+	}
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -383,9 +383,11 @@ func (itrp *Interpreter) doCall(call *semantic.CallExpression, scope *Scope) (va
 	if err != nil {
 		return nil, err
 	}
+
 	if f.HasSideEffect() {
 		itrp.values = append(itrp.values, value)
 	}
+
 	return value, nil
 }
 
@@ -562,34 +564,34 @@ func (f *function) Type() semantic.Type {
 }
 
 func (f *function) Str() string {
-	panic(values.UnexpectedKind(semantic.Object, semantic.String))
+	panic(values.UnexpectedKind(semantic.Function, semantic.String))
 }
 func (f *function) Int() int64 {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Int))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
 }
 func (f *function) UInt() uint64 {
-	panic(values.UnexpectedKind(semantic.Object, semantic.UInt))
+	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
 }
 func (f *function) Float() float64 {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Float))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
 }
 func (f *function) Bool() bool {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Bool))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
 }
 func (f *function) Time() values.Time {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Time))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Time))
 }
 func (f *function) Duration() values.Duration {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Duration))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Duration))
 }
 func (f *function) Regexp() *regexp.Regexp {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Regexp))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Regexp))
 }
 func (f *function) Array() values.Array {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Function))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Array))
 }
 func (f *function) Object() values.Object {
-	panic(values.UnexpectedKind(semantic.Object, semantic.Object))
+	panic(values.UnexpectedKind(semantic.Function, semantic.Object))
 }
 func (f *function) Function() values.Function {
 	return f


### PR DESCRIPTION
Fixes #103 

This commit fixes how the compiler compares TableObjects
and, as a result, how it constructs a Flux Spec. This
fixes an error where queries with multiple yields were
having all but one of those yields stripped during compilation.