### PR TITLE
give plan nodes bounds

### DIFF
--- a/bounds.go
+++ b/bounds.go
@@ -5,12 +5,13 @@ import "time"
 type Bounds struct {
 	Start Time
 	Stop  Time
+	Now   time.Time
 }
 
 // IsEmpty reports whether the given bounds
 // are empty, i.e., if start >= stop.
-func (b Bounds) IsEmpty(now time.Time) bool {
-	return b.Start.Time(now).Equal(b.Stop.Time(now)) || b.Start.Time(now).After(b.Stop.Time(now))
+func (b Bounds) IsEmpty() bool {
+	return b.Start.Time(b.Now).Equal(b.Stop.Time(b.Now)) || b.Start.Time(b.Now).After(b.Stop.Time(b.Now))
 }
 
 // HasZero returns true if the given bounds contain a Go zero time value as either Start or Stop.

--- a/bounds_test.go
+++ b/bounds_test.go
@@ -73,45 +73,45 @@ func TestBounds_IsEmpty(t *testing.T) {
 	}{
 		{
 			name: "empty bounds / start == stop",
-			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			bounds: flux.Bounds{
 				Start: flux.Now,
 				Stop:  flux.Now,
+				Now:   time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			},
 			want: true,
 		},
 		{
 			name: "empty bounds / absolute now == relative now",
-			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			bounds: flux.Bounds{
 				Start: flux.Now,
 				Stop: flux.Time{
 					Absolute: time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 				},
+				Now: time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			},
 			want: true,
 		},
 		{
 			name: "start > stop",
-			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			bounds: flux.Bounds{
 				Start: flux.Time{
 					IsRelative: true,
 					Relative:   time.Hour,
 				},
 				Stop: flux.Now,
+				Now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			},
 			want: true,
 		},
 		{
 			name: "start < stop",
-			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			bounds: flux.Bounds{
 				Start: flux.Time{
 					IsRelative: true,
 					Relative:   -1 * time.Hour,
 				},
 				Stop: flux.Now,
+				Now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
 			},
 			want: false,
 		},
@@ -119,7 +119,7 @@ func TestBounds_IsEmpty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.bounds.IsEmpty(tt.now)
+			got := tt.bounds.IsEmpty()
 			if got != tt.want {
 				t.Errorf("unexpected result for bounds.IsEmpty(): got %t, want %t", got, tt.want)
 			}

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -138,11 +138,21 @@ func (v *createExecutionNodeVisitor) Visit(node plan.PlanNode) error {
 	kind := spec.Kind()
 	id := plan.ProcedureIDFromNodeID(node.ID())
 
+	// Add explicit stream context if bounds are set on this node
+	var streamContext streamContext
+	if node.Bounds() != nil {
+		streamContext.bounds = &Bounds{
+			Start: node.Bounds().Start,
+			Stop:  node.Bounds().Stop,
+		}
+	}
+
 	// Build execution context
 	ec := executionContext{
-		ctx:     v.ctx,
-		es:      v.es,
-		parents: make([]DatasetID, len(node.Predecessors())),
+		ctx:           v.ctx,
+		es:            v.es,
+		parents:       make([]DatasetID, len(node.Predecessors())),
+		streamContext: streamContext,
 	}
 
 	for i, pred := range node.Predecessors() {

--- a/planner/bounds.go
+++ b/planner/bounds.go
@@ -1,0 +1,110 @@
+package planner
+
+import "github.com/influxdata/flux/values"
+
+// EmptyBounds is a time range containing only a single point
+var EmptyBounds = &Bounds{
+	Start: values.Time(0),
+	Stop:  values.Time(0),
+}
+
+// Bounds is a range of time
+type Bounds struct {
+	Start values.Time
+	Stop  values.Time
+}
+
+// BoundsAwareProcedureSpec is any procedure
+// that modifies the time bounds of its data.
+type BoundsAwareProcedureSpec interface {
+	TimeBounds(predecessorBounds *Bounds) *Bounds
+}
+
+// ComputeBounds computes the time bounds for a
+// plan node from the bounds of its predecessors.
+func ComputeBounds(node PlanNode) error {
+	var bounds *Bounds
+
+	for _, pred := range node.Predecessors() {
+
+		if pred.Bounds() != nil && bounds == nil {
+			bounds = pred.Bounds()
+		}
+		if pred.Bounds() != nil && bounds != nil {
+			bounds = bounds.Union(pred.Bounds())
+		}
+	}
+
+	if s, ok := node.ProcedureSpec().(BoundsAwareProcedureSpec); ok {
+		bounds = s.TimeBounds(bounds)
+	}
+	node.SetBounds(bounds)
+	return nil
+}
+
+// IsEmpty reports whether the given bounds contain at most a single point
+func (b *Bounds) IsEmpty() bool {
+	return b.Start >= b.Stop
+}
+
+// Contains reports whether a given time is contained within the time range
+func (b *Bounds) Contains(t values.Time) bool {
+	return t >= b.Start && t < b.Stop
+}
+
+// Overlaps reports whether two given bounds have overlapping time ranges
+func (b *Bounds) Overlaps(o *Bounds) bool {
+	return b.Contains(o.Start) ||
+		(b.Contains(o.Stop) && o.Stop > b.Start) ||
+		o.Contains(b.Start)
+}
+
+// Union returns the smallest bounds which contain both input bounds.
+// It returns empty bounds if one of the input bounds are empty.
+func (b *Bounds) Union(o *Bounds) *Bounds {
+	if b.IsEmpty() || o.IsEmpty() {
+		return EmptyBounds
+	}
+	u := new(Bounds)
+
+	u.Start = b.Start
+	if o.Start < b.Start {
+		u.Start = o.Start
+	}
+
+	u.Stop = b.Stop
+	if o.Stop > b.Stop {
+		u.Stop = o.Stop
+	}
+
+	return u
+}
+
+// Intersect returns the intersection of two bounds.
+// It returns empty bounds if one of the input bounds are empty.
+func (b *Bounds) Intersect(o *Bounds) *Bounds {
+	if b.IsEmpty() || o.IsEmpty() || !b.Overlaps(o) {
+		return EmptyBounds
+	}
+	i := new(Bounds)
+
+	i.Start = b.Start
+	if o.Start > b.Start {
+		i.Start = o.Start
+	}
+
+	i.Stop = b.Stop
+	if o.Stop < b.Stop {
+		i.Stop = o.Stop
+	}
+
+	return i
+}
+
+// Shift moves the start and stop values of a time range by a specified duration
+func (b *Bounds) Shift(d values.Duration) *Bounds {
+	return &Bounds{
+		Start: b.Start.Add(d),
+		Stop:  b.Stop.Add(d),
+	}
+}

--- a/planner/bounds_test.go
+++ b/planner/bounds_test.go
@@ -1,0 +1,509 @@
+package planner_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/influxdata/flux/planner"
+	"github.com/influxdata/flux/planner/plantest"
+	"github.com/influxdata/flux/values"
+)
+
+func TestBoundsIntersect(t *testing.T) {
+	now := time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		now  time.Time
+		a, b *planner.Bounds
+		want *planner.Bounds
+	}{
+		{
+			name: "contained",
+			a: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-1 * time.Hour)),
+				Stop:  values.ConvertTime(now),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-30 * time.Minute)),
+				Stop:  values.ConvertTime(now),
+			},
+			want: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-30 * time.Minute)),
+				Stop:  values.ConvertTime(now),
+			},
+		},
+		{
+			name: "contained sym",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-30 * time.Minute)),
+				Stop:  values.ConvertTime(now),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-1 * time.Hour)),
+				Stop:  values.ConvertTime(now),
+			},
+			want: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-30 * time.Minute)),
+				Stop:  values.ConvertTime(now),
+			},
+		},
+		{
+			name: "no overlap",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-1 * time.Hour)),
+				Stop:  values.ConvertTime(now),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-3 * time.Hour)),
+				Stop:  values.ConvertTime(now.Add(-2 * time.Hour)),
+			},
+			want: planner.EmptyBounds,
+		},
+		{
+			name: "overlap",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-1 * time.Hour)),
+				Stop:  values.ConvertTime(now),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-2 * time.Hour)),
+				Stop:  values.ConvertTime(now.Add(-30 * time.Minute)),
+			},
+			want: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-1 * time.Hour)),
+				Stop:  values.ConvertTime(now.Add(-30 * time.Minute)),
+			},
+		},
+		{
+			name: "absolute times",
+			a: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 1, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 3, 0, 0, time.UTC)),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 4, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 5, 0, 0, time.UTC)),
+			},
+			want: planner.EmptyBounds,
+		},
+		{
+			name: "intersect with empty returns empty",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 15, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(now),
+			},
+			b:    planner.EmptyBounds,
+			want: planner.EmptyBounds,
+		},
+		{
+			name: "intersect with empty returns empty sym",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a:    planner.EmptyBounds,
+			b: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 15, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(now),
+			},
+			want: planner.EmptyBounds,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.a.Intersect(tt.b)
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("unexpected bounds -want/+got:\n%s", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestBounds_Union(t *testing.T) {
+	now := time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		now  time.Time
+		a, b *planner.Bounds
+		want *planner.Bounds
+	}{
+		{
+			name: "basic case",
+			a: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 1, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 3, 0, 0, time.UTC)),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 2, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 4, 0, 0, time.UTC)),
+			},
+			want: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 1, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 4, 0, 0, time.UTC)),
+			},
+		},
+		{
+			name: "union with empty returns empty",
+			a: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 15, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(now),
+			},
+			b:    planner.EmptyBounds,
+			want: planner.EmptyBounds,
+		},
+		{
+			name: "union with empty returns empty sym",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a:    planner.EmptyBounds,
+			b: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 15, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(now),
+			},
+			want: planner.EmptyBounds,
+		},
+		{
+			name: "no overlap",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			a: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 15, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 20, 0, 0, time.UTC)),
+			},
+			b: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 45, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 50, 0, 0, time.UTC)),
+			},
+			want: &planner.Bounds{
+				Start: values.ConvertTime(time.Date(2018, time.January, 1, 0, 15, 0, 0, time.UTC)),
+				Stop:  values.ConvertTime(time.Date(2018, time.January, 1, 0, 50, 0, 0, time.UTC)),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.a.Union(tt.b)
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("unexpected bounds -want/+got:\n%s", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}
+
+func TestBounds_IsEmpty(t *testing.T) {
+	now := time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		now    time.Time
+		bounds *planner.Bounds
+		want   bool
+	}{
+		{
+			name: "empty bounds / start == stop",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			bounds: &planner.Bounds{
+				Start: values.ConvertTime(now),
+				Stop:  values.ConvertTime(now),
+			},
+			want: true,
+		},
+		{
+			name: "empty bounds / absolute now == relative now",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			bounds: &planner.Bounds{
+				Start: values.ConvertTime(now),
+				Stop:  values.ConvertTime(time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC)),
+			},
+			want: true,
+		},
+		{
+			name: "start > stop",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			bounds: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(time.Hour)),
+				Stop:  values.ConvertTime(now),
+			},
+			want: true,
+		},
+		{
+			name: "start < stop",
+			now:  time.Date(2018, time.August, 14, 11, 0, 0, 0, time.UTC),
+			bounds: &planner.Bounds{
+				Start: values.ConvertTime(now.Add(-1 * time.Hour)),
+				Stop:  values.ConvertTime(now),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.bounds.IsEmpty()
+			if got != tt.want {
+				t.Errorf("unexpected result for bounds.IsEmpty(): got %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+// A BoundsAwareProcedureSpec that intersects its bounds with its predecessors' bounds
+type mockBoundsIntersectProcedureSpec struct {
+	planner.DefaultCost
+	bounds *planner.Bounds
+}
+
+func (m *mockBoundsIntersectProcedureSpec) Kind() planner.ProcedureKind {
+	return "mock-intersect-bounds"
+}
+
+func (m *mockBoundsIntersectProcedureSpec) Copy() planner.ProcedureSpec {
+	return &mockBoundsIntersectProcedureSpec{}
+}
+
+func (m *mockBoundsIntersectProcedureSpec) TimeBounds(predecessorBounds *planner.Bounds) *planner.Bounds {
+	if predecessorBounds != nil {
+		return predecessorBounds.Intersect(m.bounds)
+	}
+	return m.bounds
+}
+
+// A BoundsAwareProcedureSpec that shifts its predecessors' bounds
+type mockBoundsShiftProcedureSpec struct {
+	planner.DefaultCost
+	by values.Duration
+}
+
+func (m *mockBoundsShiftProcedureSpec) Kind() planner.ProcedureKind {
+	return "mock-shift-bounds"
+}
+
+func (m *mockBoundsShiftProcedureSpec) Copy() planner.ProcedureSpec {
+	return &mockBoundsShiftProcedureSpec{}
+}
+
+func (m *mockBoundsShiftProcedureSpec) TimeBounds(predecessorBounds *planner.Bounds) *planner.Bounds {
+	if predecessorBounds != nil {
+		return predecessorBounds.Shift(m.by)
+	}
+	return nil
+}
+
+// Create a PlanNode with id and mockBoundsIntersectProcedureSpec
+func makeBoundsNode(id string, bounds *planner.Bounds) planner.PlanNode {
+	return planner.CreatePhysicalNode(planner.NodeID(id),
+		&mockBoundsIntersectProcedureSpec{
+			bounds: bounds,
+		})
+}
+
+// Create a PlanNode with id and mockBoundsShiftProcedureSpec
+func makeShiftNode(id string, duration values.Duration) planner.PlanNode {
+	return planner.CreateLogicalNode(planner.NodeID(id),
+		&mockBoundsShiftProcedureSpec{
+			by: duration,
+		})
+}
+
+func bounds(start, stop int) *planner.Bounds {
+	return &planner.Bounds{
+		Start: values.Time(start),
+		Stop:  values.Time(stop),
+	}
+}
+
+// Test that bounds are propagated up through the plan correctly
+func TestBounds_ComputePlanBounds(t *testing.T) {
+	tests := []struct {
+		// Name of test
+		name string
+		// Nodes and edges defining plan
+		spec *plantest.PhysicalPlanSpec
+		// Map from node ID to the expected bounds for that node
+		want map[planner.NodeID]*planner.Bounds
+	}{
+		{
+			name: "no bounds",
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeNode("0"),
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": nil,
+			},
+		},
+		{
+			name: "single time bounds",
+			// 0 -> 1 -> 2 -> 3 -> 4
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeNode("0"),
+					makeNode("1"),
+					makeBoundsNode("2", bounds(5, 10)),
+					makeNode("3"),
+					makeNode("4"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": nil,
+				"1": nil,
+				"2": bounds(5, 10),
+				"3": bounds(5, 10),
+				"4": bounds(5, 10)},
+		},
+		{
+			name: "multiple intersect time bounds",
+			// 0 -> 1 -> 2 -> 3 -> 4
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeNode("0"),
+					makeBoundsNode("1", bounds(5, 10)),
+					makeNode("2"),
+					makeBoundsNode("3", bounds(7, 11)),
+					makeNode("4"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": nil,
+				"1": bounds(5, 10),
+				"2": bounds(5, 10),
+				"3": bounds(7, 10),
+				"4": bounds(7, 10)},
+		},
+		{
+			name: "shift nil time bounds",
+			// 0 -> 1 -> 2
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeNode("0"),
+					makeShiftNode("1", values.Duration(5)),
+					makeNode("2"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": nil,
+				"1": nil,
+				"2": nil,
+			},
+		},
+		{
+			name: "shift bounds after intersecting bounds",
+			// 0 -> 1 -> 2 -> 3 -> 4
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeNode("0"),
+					makeBoundsNode("1", bounds(5, 10)),
+					makeNode("2"),
+					makeShiftNode("3", values.Duration(5)),
+					makeNode("4"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+					{3, 4},
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": nil,
+				"1": bounds(5, 10),
+				"2": bounds(5, 10),
+				"3": bounds(10, 15),
+				"4": bounds(10, 15)},
+		},
+		{
+			name: "join",
+			//   2
+			//  / \
+			// 0   1
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeBoundsNode("0", bounds(5, 10)),
+					makeBoundsNode("1", bounds(12, 20)),
+					makeNode("2"),
+				},
+				Edges: [][2]int{
+					{0, 2},
+					{1, 2},
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": bounds(5, 10),
+				"1": bounds(12, 20),
+				"2": bounds(5, 20),
+			},
+		},
+		{
+			name: "yields",
+			// 3   4
+			//  \ /
+			//   1   2
+			//    \ /
+			//     0
+			spec: &plantest.PhysicalPlanSpec{
+				Nodes: []planner.PlanNode{
+					makeNode("0"),
+					makeBoundsNode("1", bounds(5, 10)),
+					makeNode("2"),
+					makeNode("3"),
+					makeNode("4"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{0, 2},
+					{1, 3},
+					{1, 4},
+				},
+			},
+			want: map[planner.NodeID]*planner.Bounds{
+				"0": nil,
+				"1": bounds(5, 10),
+				"2": nil,
+				"3": bounds(5, 10),
+				"4": bounds(5, 10),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// Create plan from spec
+			thePlan := plantest.CreatePhysicalPlanSpec(tc.spec)
+
+			// Method used to compute the bounds at each node
+			if err := thePlan.BottomUpWalk(planner.ComputeBounds); err != nil {
+				t.Fatal(err)
+			}
+
+			// Map NodeID -> Bounds
+			got := make(map[planner.NodeID]*planner.Bounds)
+			thePlan.BottomUpWalk(func(n planner.PlanNode) error {
+				got[n.ID()] = n.Bounds()
+				return nil
+			})
+
+			if !cmp.Equal(tc.want, got) {
+				t.Errorf("Did not get expected time bounds, -want/+got:\n%v", cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}

--- a/planner/logical_test.go
+++ b/planner/logical_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/influxdata/flux/semantic"
 )
 
-func compile(fluxText string) (*flux.Spec, error) {
-	now := time.Now().UTC()
+func compile(fluxText string, now time.Time) (*flux.Spec, error) {
 	return flux.Compile(context.Background(), fluxText, now)
 }
 
 // Test the translation of Flux query to logical plan
 func TestFluxSpecToLogicalPlan(t *testing.T) {
+	now := time.Now().UTC()
 	testcases := []struct {
 		// Name of the test
 		name string
@@ -48,6 +48,7 @@ func TestFluxSpecToLogicalPlan(t *testing.T) {
 							Stop: flux.Time{
 								IsRelative: true,
 							},
+							Now: now,
 						},
 						TimeCol:  "_time",
 						StartCol: "_start",
@@ -76,6 +77,7 @@ func TestFluxSpecToLogicalPlan(t *testing.T) {
 							Stop: flux.Time{
 								IsRelative: true,
 							},
+							Now: now,
 						},
 						TimeCol:  "_time",
 						StartCol: "_start",
@@ -105,7 +107,7 @@ func TestFluxSpecToLogicalPlan(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec, err := compile(tc.query)
+			spec, err := compile(tc.query, now)
 
 			if err != nil {
 				t.Fatal(err)
@@ -308,7 +310,7 @@ func TestLogicalPlanner(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			fluxSpec, err := compile(tc.flux)
+			fluxSpec, err := compile(tc.flux, time.Now().UTC())
 			if err != nil {
 				t.Fatalf("could not compile flux query: %v", err)
 			}

--- a/planner/physical.go
+++ b/planner/physical.go
@@ -51,6 +51,11 @@ func (pp *physicalPlanner) Plan(spec *PlanSpec) (*PlanSpec, error) {
 		return nil, err
 	}
 
+	// Compute time bounds for nodes in the plan
+	if err := final.BottomUpWalk(ComputeBounds); err != nil {
+		return nil, err
+	}
+
 	// Update memory quota
 	if final.Resources.MemoryBytesQuota == 0 {
 		final.Resources.MemoryBytesQuota = pp.defaultMemoryLimit
@@ -132,6 +137,7 @@ type PhysicalProcedureSpec interface {
 // PhysicalPlanNode represents a physical operation in a plan.
 type PhysicalPlanNode struct {
 	edges
+	bounds
 	id   NodeID
 	Spec PhysicalProcedureSpec
 

--- a/planner/plantest/cmp.go
+++ b/planner/plantest/cmp.go
@@ -2,6 +2,7 @@ package plantest
 
 import (
 	"fmt"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/planner"
 	"github.com/influxdata/flux/semantic/semantictest"
@@ -89,6 +90,12 @@ func cmpPlanNode(p, q planner.PlanNode) error {
 	// Both nodes must be the same kind of procedure
 	if p.Kind() != q.Kind() {
 		return fmt.Errorf("wanted %s, but got %s", p.Kind(), q.Kind())
+	}
+
+	// Both nodes must have the same time bounds
+	if !cmp.Equal(p.Bounds(), q.Bounds()) {
+		return fmt.Errorf("plan nodes have different bounds -want(%s)/+got(%s) %s",
+			p.ID(), q.ID(), cmp.Diff(p.Bounds(), q.Bounds()))
 	}
 
 	// The specifications of both procedures must be the same

--- a/planner/registration.go
+++ b/planner/registration.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/influxdata/flux"
 	uuid "github.com/satori/go.uuid"
@@ -18,6 +19,7 @@ func (id ProcedureID) String() string {
 
 type Administration interface {
 	ConvertID(flux.OperationID) ProcedureID
+	Now() time.Time
 }
 
 func ProcedureIDFromOperationID(id flux.OperationID) ProcedureID {
@@ -28,6 +30,11 @@ func ProcedureIDFromNodeID(id NodeID) ProcedureID {
 	return ProcedureID(uuid.NewV5(RootUUID, string(id)))
 }
 
+// TODO: Is it necessary to pass in an Administration?
+// Currently Administration only converts IDs and provides
+// access to the now time. If it is determined that there
+// is no need for ProcedureIDs then we could probably just
+// pass in the now time directly.
 type CreateProcedureSpec func(flux.OperationSpec, Administration) (ProcedureSpec, error)
 
 var kindToProcedure = make(map[ProcedureKind]CreateProcedureSpec)

--- a/planner/types.go
+++ b/planner/types.go
@@ -15,6 +15,9 @@ type PlanNode interface {
 	// Returns an identifier for this plan node
 	ID() NodeID
 
+	// Returns the time bounds for this plan node
+	Bounds() *Bounds
+
 	// Plan nodes executed immediately before this node
 	Predecessors() []PlanNode
 
@@ -29,6 +32,7 @@ type PlanNode interface {
 
 	// Helper methods for manipulating a plan
 	// These methods are used during planning
+	SetBounds(bounds *Bounds)
 	AddSuccessors(...PlanNode)
 	AddPredecessors(...PlanNode)
 	RemovePredecessor(PlanNode)
@@ -156,6 +160,18 @@ type ProcedureSpec interface {
 
 // ProcedureKind denotes the kind of operation
 type ProcedureKind string
+
+type bounds struct {
+	value *Bounds
+}
+
+func (b *bounds) SetBounds(bounds *Bounds) {
+	b.value = bounds
+}
+
+func (b *bounds) Bounds() *Bounds {
+	return b.value
+}
 
 type edges struct {
 	predecessors []PlanNode


### PR DESCRIPTION
This PR gives a `PlanNode` time bounds. Originally I had tried to make bounds plan node statistics. However, because the execution engine uses the bounds associated with each plan node, the execution engine would also have to have access to input statistics for each node. To go that direction would require more design, so instead I made bounds a property of the node itself. Thoughts?