### PR TITLE
refactor: rename DataType to ColType and add a ColumnType method to semantic.Type

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -1101,8 +1101,8 @@ func copyLine(line []string) []string {
 	return cpy
 }
 
-// decodeType returns the execute.DataType and any additional format description.
-func decodeType(datatype string) (t flux.DataType, desc string, err error) {
+// decodeType returns the flux.ColType and any additional format description.
+func decodeType(datatype string) (t flux.ColType, desc string, err error) {
 	split := strings.SplitN(datatype, ":", 2)
 	if len(split) > 1 {
 		desc = split[1]

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -204,7 +204,7 @@ type Aggregate interface {
 }
 
 type ValueFunc interface {
-	Type() flux.DataType
+	Type() flux.ColType
 }
 type DoBoolAgg interface {
 	ValueFunc

--- a/execute/format.go
+++ b/execute/format.go
@@ -65,7 +65,7 @@ func (w *writeToHelper) write(data []byte) {
 	w.err = err
 }
 
-var minWidthsByType = map[flux.DataType]int{
+var minWidthsByType = map[flux.ColType]int{
 	flux.TBool:    12,
 	flux.TInt:     26,
 	flux.TUInt:    27,
@@ -213,7 +213,7 @@ func (f *Formatter) writeHeaderSeparator(w *writeToHelper) {
 	w.write(eol)
 }
 
-func (f *Formatter) valueBuf(i, j int, typ flux.DataType, cr flux.ColReader) (buf []byte) {
+func (f *Formatter) valueBuf(i, j int, typ flux.ColType, cr flux.ColReader) (buf []byte) {
 	switch typ {
 	case flux.TBool:
 		buf = strconv.AppendBool(f.fmtBuf[0:0], cr.Bools(j)[i])

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -68,7 +68,7 @@ func (f *rowFn) prepare(cols []flux.ColMeta) error {
 	return nil
 }
 
-func ConvertToKind(t flux.DataType) semantic.Kind {
+func ConvertToKind(t flux.ColType) semantic.Kind {
 	// TODO make this an array lookup.
 	switch t {
 	case flux.TInvalid:
@@ -90,7 +90,7 @@ func ConvertToKind(t flux.DataType) semantic.Kind {
 	}
 }
 
-func ConvertFromKind(k semantic.Kind) flux.DataType {
+func ConvertFromKind(k semantic.Kind) flux.ColType {
 	// TODO make this an array lookup.
 	switch k {
 	case semantic.Invalid:

--- a/execute/table.go
+++ b/execute/table.go
@@ -632,17 +632,17 @@ func (b ColListTableBuilder) AppendValue(j int, v values.Value) {
 	}
 }
 
-func (b ColListTableBuilder) checkColType(j int, typ flux.DataType) {
+func (b ColListTableBuilder) checkColType(j int, typ flux.ColType) {
 	CheckColType(b.table.colMeta[j], typ)
 }
 
-func CheckColType(col flux.ColMeta, typ flux.DataType) {
+func CheckColType(col flux.ColMeta, typ flux.ColType) {
 	if col.Type != typ {
 		panic(fmt.Errorf("column %s is not of type %v", col.Label, typ))
 	}
 }
 
-func PanicUnknownType(typ flux.DataType) {
+func PanicUnknownType(typ flux.ColType) {
 	panic(fmt.Errorf("unknown type %v", typ))
 }
 

--- a/functions/inputs/from_sql.go
+++ b/functions/inputs/from_sql.go
@@ -172,7 +172,7 @@ func (c *SQLIterator) Decode() (flux.Table, error) {
 
 		if firstRow {
 			for i, col := range columns {
-				var dataType flux.DataType
+				var dataType flux.ColType
 				switch col.(type) {
 				case bool:
 					dataType = flux.TBool

--- a/functions/transformations/count.go
+++ b/functions/transformations/count.go
@@ -119,7 +119,7 @@ func (a *CountAgg) DoString(vs []string) {
 	a.count += int64(len(vs))
 }
 
-func (a *CountAgg) Type() flux.DataType {
+func (a *CountAgg) Type() flux.ColType {
 	return flux.TInt
 }
 func (a *CountAgg) ValueInt() int64 {

--- a/functions/transformations/difference.go
+++ b/functions/transformations/difference.go
@@ -150,7 +150,7 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 		}
 
 		if found {
-			var typ flux.DataType
+			var typ flux.ColType
 			switch c.Type {
 			case flux.TInt, flux.TUInt:
 				typ = flux.TInt

--- a/functions/transformations/mean.go
+++ b/functions/transformations/mean.go
@@ -120,7 +120,7 @@ func (a *MeanAgg) DoFloat(vs []float64) {
 		a.sum += v
 	}
 }
-func (a *MeanAgg) Type() flux.DataType {
+func (a *MeanAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 func (a *MeanAgg) ValueFloat() float64 {

--- a/functions/transformations/percentile.go
+++ b/functions/transformations/percentile.go
@@ -234,7 +234,7 @@ func (a *PercentileAgg) DoFloat(vs []float64) {
 	}
 }
 
-func (a *PercentileAgg) Type() flux.DataType {
+func (a *PercentileAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 func (a *PercentileAgg) ValueFloat() float64 {
@@ -288,7 +288,7 @@ func (a *ExactPercentileAgg) DoFloat(vs []float64) {
 	a.data = append(a.data, vs...)
 }
 
-func (a *ExactPercentileAgg) Type() flux.DataType {
+func (a *ExactPercentileAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 

--- a/functions/transformations/pivot.go
+++ b/functions/transformations/pivot.go
@@ -187,7 +187,7 @@ func (t *pivotTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 	// determine the initial column schema
 	colKeyIndex := make(map[string]int)
 	valueColIndex := -1
-	var valueColType flux.DataType
+	var valueColType flux.ColType
 	for _, v := range t.spec.ColKey {
 		colKeyIndex[v] = -1
 	}
@@ -310,7 +310,7 @@ func (t *pivotTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 	return err
 }
 
-func growColumn(builder execute.TableBuilder, colType flux.DataType, colIdx, nRows int) {
+func growColumn(builder execute.TableBuilder, colType flux.ColType, colIdx, nRows int) {
 	switch colType {
 	case flux.TBool:
 		builder.GrowBools(colIdx, nRows)
@@ -329,7 +329,7 @@ func growColumn(builder execute.TableBuilder, colType flux.DataType, colIdx, nRo
 	}
 }
 
-func setBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColType flux.DataType, readerRowIndex, readerColIndex, builderRow, builderCol int) {
+func setBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColType flux.ColType, readerRowIndex, readerColIndex, builderRow, builderCol int) {
 	switch readerColType {
 	case flux.TBool:
 		builder.SetBool(builderRow, builderCol, cr.Bools(readerColIndex)[readerRowIndex])
@@ -348,7 +348,7 @@ func setBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColT
 	}
 }
 
-func appendBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColType flux.DataType, readerRowIndex, readerColIndex, builderColIndex int) {
+func appendBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColType flux.ColType, readerRowIndex, readerColIndex, builderColIndex int) {
 	switch readerColType {
 	case flux.TBool:
 		builder.AppendBool(builderColIndex, cr.Bools(readerColIndex)[readerRowIndex])

--- a/functions/transformations/skew.go
+++ b/functions/transformations/skew.go
@@ -147,7 +147,7 @@ func (a *SkewAgg) DoFloat(vs []float64) {
 		a.m1 += deltaN
 	}
 }
-func (a *SkewAgg) Type() flux.DataType {
+func (a *SkewAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 func (a *SkewAgg) ValueFloat() float64 {

--- a/functions/transformations/spread.go
+++ b/functions/transformations/spread.go
@@ -138,7 +138,7 @@ func (a *SpreadIntAgg) DoInt(vs []int64) {
 	}
 }
 
-func (a *SpreadIntAgg) Type() flux.DataType {
+func (a *SpreadIntAgg) Type() flux.ColType {
 	return flux.TInt
 }
 
@@ -161,7 +161,7 @@ func (a *SpreadUIntAgg) DoUInt(vs []uint64) {
 	}
 }
 
-func (a *SpreadUIntAgg) Type() flux.DataType {
+func (a *SpreadUIntAgg) Type() flux.ColType {
 	return flux.TUInt
 }
 
@@ -184,7 +184,7 @@ func (a *SpreadFloatAgg) DoFloat(vs []float64) {
 	}
 }
 
-func (a *SpreadFloatAgg) Type() flux.DataType {
+func (a *SpreadFloatAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 

--- a/functions/transformations/stddev.go
+++ b/functions/transformations/stddev.go
@@ -129,7 +129,7 @@ func (a *StddevAgg) DoFloat(vs []float64) {
 		a.m2 += delta * delta2
 	}
 }
-func (a *StddevAgg) Type() flux.DataType {
+func (a *StddevAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 func (a *StddevAgg) ValueFloat() float64 {

--- a/functions/transformations/sum.go
+++ b/functions/transformations/sum.go
@@ -110,7 +110,7 @@ func (a *SumIntAgg) DoInt(vs []int64) {
 		a.sum += v
 	}
 }
-func (a *SumIntAgg) Type() flux.DataType {
+func (a *SumIntAgg) Type() flux.ColType {
 	return flux.TInt
 }
 func (a *SumIntAgg) ValueInt() int64 {
@@ -126,7 +126,7 @@ func (a *SumUIntAgg) DoUInt(vs []uint64) {
 		a.sum += v
 	}
 }
-func (a *SumUIntAgg) Type() flux.DataType {
+func (a *SumUIntAgg) Type() flux.ColType {
 	return flux.TUInt
 }
 func (a *SumUIntAgg) ValueUInt() uint64 {
@@ -142,7 +142,7 @@ func (a *SumFloatAgg) DoFloat(vs []float64) {
 		a.sum += v
 	}
 }
-func (a *SumFloatAgg) Type() flux.DataType {
+func (a *SumFloatAgg) Type() flux.ColType {
 	return flux.TFloat
 }
 func (a *SumFloatAgg) ValueFloat() float64 {

--- a/result.go
+++ b/result.go
@@ -35,15 +35,19 @@ type Table interface {
 	Empty() bool
 }
 
+// ColMeta contains the information about the column metadata.
 type ColMeta struct {
+	// Label is the name of the column. The label is unique per table.
 	Label string
-	Type  DataType
+	// Type is the type of the column. Only basic types are allowed.
+	Type ColType
 }
 
-type DataType int
+// ColType is the type for a column. This covers only basic data types.
+type ColType int
 
 const (
-	TInvalid DataType = iota
+	TInvalid ColType = iota
 	TBool
 	TInt
 	TUInt
@@ -52,7 +56,7 @@ const (
 	TTime
 )
 
-func (t DataType) String() string {
+func (t ColType) String() string {
 	switch t {
 	case TInvalid:
 		return "invalid"

--- a/semantic/types.go
+++ b/semantic/types.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+
+	"github.com/influxdata/flux"
 )
 
 // Type is the representation of a Flux type.
@@ -31,6 +33,10 @@ type Type interface {
 	// ElementType return the type of elements in the array.
 	// It panics if the type's Kind is not Array.
 	ElementType() Type
+
+	// ColumnType returns the column type for a basic data type.
+	// It returns flux.TInvalid if the Kind is not a valid column type.
+	ColumnType() flux.ColType
 
 	// Params reports the parameters of a function type.
 	// It panics if the type's Kind is not Function.
@@ -102,6 +108,24 @@ func (k Kind) Properties() map[string]Type {
 func (k Kind) ElementType() Type {
 	panic(fmt.Errorf("cannot get element type from kind %s", k))
 }
+func (k Kind) ColumnType() flux.ColType {
+	switch k {
+	case Bool:
+		return flux.TBool
+	case Int:
+		return flux.TInt
+	case UInt:
+		return flux.TUInt
+	case Float:
+		return flux.TFloat
+	case String:
+		return flux.TString
+	case Time:
+		return flux.TTime
+	default:
+		return flux.TInvalid
+	}
+}
 func (k Kind) Params() map[string]Type {
 	panic(fmt.Errorf("cannot get parameters from kind %s", k))
 }
@@ -132,6 +156,9 @@ func (t *arrayType) Properties() map[string]Type {
 }
 func (t *arrayType) ElementType() Type {
 	return t.elementType
+}
+func (t *arrayType) ColumnType() flux.ColType {
+	return flux.TInvalid
 }
 func (t *arrayType) Params() map[string]Type {
 	panic(fmt.Errorf("cannot get parameters from kind %s", t.Kind()))
@@ -222,6 +249,9 @@ func (t *objectType) Properties() map[string]Type {
 }
 func (t *objectType) ElementType() Type {
 	panic(fmt.Errorf("cannot get element type of kind %s", t.Kind()))
+}
+func (t *objectType) ColumnType() flux.ColType {
+	return flux.TInvalid
 }
 func (t *objectType) Params() map[string]Type {
 	panic(fmt.Errorf("cannot get parameters from kind %s", t.Kind()))
@@ -366,6 +396,9 @@ func (t *functionType) Properties() map[string]Type {
 }
 func (t *functionType) ElementType() Type {
 	panic(fmt.Errorf("cannot get element type of kind %s", t.Kind()))
+}
+func (t *functionType) ColumnType() flux.ColType {
+	return flux.TInvalid
 }
 func (t *functionType) Params() map[string]Type {
 	return t.params


### PR DESCRIPTION
This renames and adds a GoDoc for ColType to make it clear that the
DataType is only for column data types. It also adds a ColumnType method
to the semantic types so that it is possible to take a value and
determine the type that should be used for a column.