### PR TITLE
refactor: simplify the values package

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -94,7 +94,7 @@ func NewInterpreter() *interpreter.Interpreter {
 }
 
 func nowFunc(now time.Time) values.Function {
-	timeVal := values.NewTimeValue(values.ConvertTime(now))
+	timeVal := values.NewTime(values.ConvertTime(now))
 	ftype := semantic.NewFunctionType(semantic.FunctionSignature{
 		ReturnType: semantic.Time,
 	})
@@ -436,7 +436,7 @@ func (t *TableObject) Function() values.Function {
 func (t *TableObject) Get(name string) (values.Value, bool) {
 	switch name {
 	case tableKindKey:
-		return values.NewStringValue(string(t.Kind)), true
+		return values.NewString(string(t.Kind)), true
 	case tableParentsKey:
 		return t.Parents, true
 	default:
@@ -457,7 +457,7 @@ func (t *TableObject) Range(f func(name string, v values.Value)) {
 		val, _ := t.args.Get(arg)
 		f(arg, val)
 	}
-	f(tableKindKey, values.NewStringValue(string(t.Kind)))
+	f(tableKindKey, values.NewString(string(t.Kind)))
 	f(tableParentsKey, t.Parents)
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -67,10 +67,10 @@ func TestCompilationCache(t *testing.T) {
 				"b": semantic.Float,
 			},
 			scope: map[string]values.Value{
-				"a": values.NewFloatValue(5),
-				"b": values.NewFloatValue(4),
+				"a": values.NewFloat(5),
+				"b": values.NewFloat(4),
 			},
-			want: values.NewFloatValue(9),
+			want: values.NewFloat(9),
 		},
 		{
 			name: "ints",
@@ -79,10 +79,10 @@ func TestCompilationCache(t *testing.T) {
 				"b": semantic.Int,
 			},
 			scope: map[string]values.Value{
-				"a": values.NewIntValue(5),
-				"b": values.NewIntValue(4),
+				"a": values.NewInt(5),
+				"b": values.NewInt(4),
 			},
-			want: values.NewIntValue(9),
+			want: values.NewInt(9),
 		},
 		{
 			name: "uints",
@@ -91,10 +91,10 @@ func TestCompilationCache(t *testing.T) {
 				"b": semantic.UInt,
 			},
 			scope: map[string]values.Value{
-				"a": values.NewUIntValue(5),
-				"b": values.NewUIntValue(4),
+				"a": values.NewUInt(5),
+				"b": values.NewUInt(4),
 			},
-			want: values.NewUIntValue(9),
+			want: values.NewUInt(9),
 		},
 	}
 
@@ -156,9 +156,9 @@ func TestCompileAndEval(t *testing.T) {
 				"r": semantic.Int,
 			},
 			scope: map[string]values.Value{
-				"r": values.NewIntValue(4),
+				"r": values.NewInt(4),
 			},
-			want:    values.NewIntValue(4),
+			want:    values.NewInt(4),
 			wantErr: false,
 		},
 		{
@@ -191,9 +191,9 @@ func TestCompileAndEval(t *testing.T) {
 				"r": semantic.Int,
 			},
 			scope: map[string]values.Value{
-				"r": values.NewIntValue(4),
+				"r": values.NewInt(4),
 			},
-			want:    values.NewIntValue(5),
+			want:    values.NewInt(5),
 			wantErr: false,
 		},
 		{
@@ -235,9 +235,9 @@ func TestCompileAndEval(t *testing.T) {
 				"r": semantic.Int,
 			},
 			scope: map[string]values.Value{
-				"r": values.NewIntValue(4),
+				"r": values.NewInt(4),
 			},
-			want:    values.NewIntValue(5),
+			want:    values.NewInt(5),
 			wantErr: false,
 		},
 	}

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -65,21 +65,21 @@ func (c compiledFn) Eval(scope Scope) (values.Value, error) {
 	}
 	switch c.Type().Kind() {
 	case semantic.String:
-		return values.NewStringValue(c.root.EvalString(scope)), nil
+		return values.NewString(c.root.EvalString(scope)), nil
 	case semantic.Int:
-		return values.NewIntValue(c.root.EvalInt(scope)), nil
+		return values.NewInt(c.root.EvalInt(scope)), nil
 	case semantic.UInt:
-		return values.NewUIntValue(c.root.EvalUInt(scope)), nil
+		return values.NewUInt(c.root.EvalUInt(scope)), nil
 	case semantic.Float:
-		return values.NewFloatValue(c.root.EvalFloat(scope)), nil
+		return values.NewFloat(c.root.EvalFloat(scope)), nil
 	case semantic.Bool:
-		return values.NewBoolValue(c.root.EvalBool(scope)), nil
+		return values.NewBool(c.root.EvalBool(scope)), nil
 	case semantic.Time:
-		return values.NewTimeValue(c.root.EvalTime(scope)), nil
+		return values.NewTime(c.root.EvalTime(scope)), nil
 	case semantic.Duration:
-		return values.NewDurationValue(c.root.EvalDuration(scope)), nil
+		return values.NewDuration(c.root.EvalDuration(scope)), nil
 	case semantic.Regexp:
-		return values.NewRegexpValue(c.root.EvalRegexp(scope)), nil
+		return values.NewRegexp(c.root.EvalRegexp(scope)), nil
 	case semantic.Array:
 		return c.root.EvalArray(scope), nil
 	case semantic.Object:
@@ -212,21 +212,21 @@ func (s Scope) Copy() Scope {
 func eval(e Evaluator, scope Scope) values.Value {
 	switch e.Type().Kind() {
 	case semantic.String:
-		return values.NewStringValue(e.EvalString(scope))
+		return values.NewString(e.EvalString(scope))
 	case semantic.Int:
-		return values.NewIntValue(e.EvalInt(scope))
+		return values.NewInt(e.EvalInt(scope))
 	case semantic.UInt:
-		return values.NewUIntValue(e.EvalUInt(scope))
+		return values.NewUInt(e.EvalUInt(scope))
 	case semantic.Float:
-		return values.NewFloatValue(e.EvalFloat(scope))
+		return values.NewFloat(e.EvalFloat(scope))
 	case semantic.Bool:
-		return values.NewBoolValue(e.EvalBool(scope))
+		return values.NewBool(e.EvalBool(scope))
 	case semantic.Time:
-		return values.NewTimeValue(e.EvalTime(scope))
+		return values.NewTime(e.EvalTime(scope))
 	case semantic.Duration:
-		return values.NewDurationValue(e.EvalDuration(scope))
+		return values.NewDuration(e.EvalDuration(scope))
 	case semantic.Regexp:
-		return values.NewRegexpValue(e.EvalRegexp(scope))
+		return values.NewRegexp(e.EvalRegexp(scope))
 	case semantic.Array:
 		return e.EvalArray(scope)
 	case semantic.Object:

--- a/complete/complete_test.go
+++ b/complete/complete_test.go
@@ -32,7 +32,7 @@ func TestNames(t *testing.T) {
 func TestDeclaration(t *testing.T) {
 	name := "foo"
 	scope := interpreter.NewScope()
-	scope.Set(name, values.NewIntValue(5))
+	scope.Set(name, values.NewInt(5))
 	declarations := make(semantic.DeclarationScope)
 	declarations[name] = semantic.NewExternalVariableDeclaration(name, semantic.Int)
 

--- a/csv/result.go
+++ b/csv/result.go
@@ -972,33 +972,33 @@ func decodeValue(value string, c colMeta) (values.Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		val = values.NewBoolValue(v)
+		val = values.NewBool(v)
 	case flux.TInt:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		val = values.NewIntValue(v)
+		val = values.NewInt(v)
 	case flux.TUInt:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		val = values.NewUIntValue(v)
+		val = values.NewUInt(v)
 	case flux.TFloat:
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return nil, err
 		}
-		val = values.NewFloatValue(v)
+		val = values.NewFloat(v)
 	case flux.TString:
-		val = values.NewStringValue(value)
+		val = values.NewString(value)
 	case flux.TTime:
 		v, err := decodeTime(value, c.fmt)
 		if err != nil {
 			return nil, err
 		}
-		val = values.NewTimeValue(v)
+		val = values.NewTime(v)
 	default:
 		return nil, fmt.Errorf("unsupported type %v", c.Type)
 	}

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -3,6 +3,8 @@ package executetest
 import (
 	"fmt"
 
+	"github.com/influxdata/flux/semantic"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/values"
@@ -45,9 +47,9 @@ func (t *Table) Normalize() {
 			if len(t.Data) > 0 {
 				t.KeyValues[j] = t.Data[0][idx]
 			}
-			v, err := values.NewValue(t.KeyValues[j], execute.ConvertToKind(cols[j].Type))
-			if err != nil {
-				panic(err)
+			v := values.New(t.KeyValues[j])
+			if v.Type() == semantic.Invalid {
+				panic(fmt.Errorf("invalid value: %s", t.KeyValues[j]))
 			}
 			vs[j] = v
 		}

--- a/execute/group_key_builder_test.go
+++ b/execute/group_key_builder_test.go
@@ -1,17 +1,18 @@
 package execute_test
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/values"
-	"testing"
 
 	"github.com/influxdata/flux/execute"
 )
 
 func TestGroupKeyBuilder_Empty(t *testing.T) {
 	var gkb execute.GroupKeyBuilder
-	gkb.AddKeyValue("_measurement", values.NewStringValue("cpu"))
+	gkb.AddKeyValue("_measurement", values.NewString("cpu"))
 
 	key, err := gkb.Build()
 	if err != nil {
@@ -29,7 +30,7 @@ func TestGroupKeyBuilder_Empty(t *testing.T) {
 	}
 
 	if got, want := key.Values(), []values.Value{
-		values.NewStringValue("cpu"),
+		values.NewString("cpu"),
 	}; !cmp.Equal(want, got) {
 		t.Fatalf("unexpected columns -want/+got:\n%s", cmp.Diff(want, got))
 	}
@@ -37,7 +38,7 @@ func TestGroupKeyBuilder_Empty(t *testing.T) {
 
 func TestGroupKeyBuilder_Nil(t *testing.T) {
 	gkb := execute.NewGroupKeyBuilder(nil)
-	gkb.AddKeyValue("_measurement", values.NewStringValue("cpu"))
+	gkb.AddKeyValue("_measurement", values.NewString("cpu"))
 
 	key, err := gkb.Build()
 	if err != nil {
@@ -55,7 +56,7 @@ func TestGroupKeyBuilder_Nil(t *testing.T) {
 	}
 
 	if got, want := key.Values(), []values.Value{
-		values.NewStringValue("cpu"),
+		values.NewString("cpu"),
 	}; !cmp.Equal(want, got) {
 		t.Fatalf("unexpected columns -want/+got:\n%s", cmp.Diff(want, got))
 	}
@@ -71,11 +72,11 @@ func TestGroupKeyBuilder_Existing(t *testing.T) {
 				},
 			},
 			[]values.Value{
-				values.NewStringValue("cpu"),
+				values.NewString("cpu"),
 			},
 		),
 	)
-	gkb.AddKeyValue("_field", values.NewStringValue("usage_user"))
+	gkb.AddKeyValue("_field", values.NewString("usage_user"))
 
 	key, err := gkb.Build()
 	if err != nil {
@@ -94,8 +95,8 @@ func TestGroupKeyBuilder_Existing(t *testing.T) {
 	}
 
 	if got, want := key.Values(), []values.Value{
-		values.NewStringValue("cpu"),
-		values.NewStringValue("usage_user"),
+		values.NewString("cpu"),
+		values.NewString("usage_user"),
 	}; !cmp.Equal(want, got) {
 		t.Fatalf("unexpected columns -want/+got:\n%s", cmp.Diff(want, got))
 	}

--- a/execute/group_lookup_test.go
+++ b/execute/group_lookup_test.go
@@ -18,25 +18,25 @@ var (
 	key0 = execute.NewGroupKey(
 		cols,
 		[]values.Value{
-			values.NewStringValue("I"),
-			values.NewStringValue("J"),
-			values.NewStringValue("K"),
+			values.NewString("I"),
+			values.NewString("J"),
+			values.NewString("K"),
 		},
 	)
 	key1 = execute.NewGroupKey(
 		cols,
 		[]values.Value{
-			values.NewStringValue("L"),
-			values.NewStringValue("M"),
-			values.NewStringValue("N"),
+			values.NewString("L"),
+			values.NewString("M"),
+			values.NewString("N"),
 		},
 	)
 	key2 = execute.NewGroupKey(
 		cols,
 		[]values.Value{
-			values.NewStringValue("X"),
-			values.NewStringValue("Y"),
-			values.NewStringValue("Z"),
+			values.NewString("X"),
+			values.NewString("Y"),
+			values.NewString("Z"),
 		},
 	)
 )

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -208,17 +208,17 @@ func ValueForRow(i, j int, cr flux.ColReader) values.Value {
 	t := cr.Cols()[j].Type
 	switch t {
 	case flux.TString:
-		return values.NewStringValue(cr.Strings(j)[i])
+		return values.NewString(cr.Strings(j)[i])
 	case flux.TInt:
-		return values.NewIntValue(cr.Ints(j)[i])
+		return values.NewInt(cr.Ints(j)[i])
 	case flux.TUInt:
-		return values.NewUIntValue(cr.UInts(j)[i])
+		return values.NewUInt(cr.UInts(j)[i])
 	case flux.TFloat:
-		return values.NewFloatValue(cr.Floats(j)[i])
+		return values.NewFloat(cr.Floats(j)[i])
 	case flux.TBool:
-		return values.NewBoolValue(cr.Bools(j)[i])
+		return values.NewBool(cr.Bools(j)[i])
 	case flux.TTime:
-		return values.NewTimeValue(cr.Times(j)[i])
+		return values.NewTime(cr.Times(j)[i])
 	default:
 		PanicUnknownType(t)
 		return nil

--- a/execute/table.go
+++ b/execute/table.go
@@ -27,17 +27,17 @@ func GroupKeyForRowOn(i int, cr flux.ColReader, on map[string]bool) flux.GroupKe
 		cols = append(cols, c)
 		switch c.Type {
 		case flux.TBool:
-			vs = append(vs, values.NewBoolValue(cr.Bools(j)[i]))
+			vs = append(vs, values.NewBool(cr.Bools(j)[i]))
 		case flux.TInt:
-			vs = append(vs, values.NewIntValue(cr.Ints(j)[i]))
+			vs = append(vs, values.NewInt(cr.Ints(j)[i]))
 		case flux.TUInt:
-			vs = append(vs, values.NewUIntValue(cr.UInts(j)[i]))
+			vs = append(vs, values.NewUInt(cr.UInts(j)[i]))
 		case flux.TFloat:
-			vs = append(vs, values.NewFloatValue(cr.Floats(j)[i]))
+			vs = append(vs, values.NewFloat(cr.Floats(j)[i]))
 		case flux.TString:
-			vs = append(vs, values.NewStringValue(cr.Strings(j)[i]))
+			vs = append(vs, values.NewString(cr.Strings(j)[i]))
 		case flux.TTime:
-			vs = append(vs, values.NewTimeValue(cr.Times(j)[i]))
+			vs = append(vs, values.NewTime(cr.Times(j)[i]))
 		}
 	}
 	return NewGroupKey(cols, vs)
@@ -770,17 +770,17 @@ func (t *ColListTable) GetRow(row int) values.Object {
 	for j, col := range t.colMeta {
 		switch col.Type {
 		case flux.TBool:
-			val = values.NewBoolValue(t.cols[j].(*boolColumn).data[row])
+			val = values.NewBool(t.cols[j].(*boolColumn).data[row])
 		case flux.TInt:
-			val = values.NewIntValue(t.cols[j].(*intColumn).data[row])
+			val = values.NewInt(t.cols[j].(*intColumn).data[row])
 		case flux.TUInt:
-			val = values.NewUIntValue(t.cols[j].(*uintColumn).data[row])
+			val = values.NewUInt(t.cols[j].(*uintColumn).data[row])
 		case flux.TFloat:
-			val = values.NewFloatValue(t.cols[j].(*floatColumn).data[row])
+			val = values.NewFloat(t.cols[j].(*floatColumn).data[row])
 		case flux.TString:
-			val = values.NewStringValue(t.cols[j].(*stringColumn).data[row])
+			val = values.NewString(t.cols[j].(*stringColumn).data[row])
 		case flux.TTime:
-			val = values.NewTimeValue(t.cols[j].(*timeColumn).data[row])
+			val = values.NewTime(t.cols[j].(*timeColumn).data[row])
 		}
 		record.Set(col.Label, val)
 	}

--- a/functions/inputs/from_generator.go
+++ b/functions/inputs/from_generator.go
@@ -2,8 +2,9 @@ package inputs
 
 import (
 	"fmt"
-	"github.com/influxdata/flux/values"
 	"time"
+
+	"github.com/influxdata/flux/values"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/compiler"
@@ -172,8 +173,8 @@ func (s *GeneratorSource) Decode() (flux.Table, error) {
 		},
 	}
 	vs := []values.Value{
-		values.NewTimeValue(values.ConvertTime(s.Start)),
-		values.NewTimeValue(values.ConvertTime(s.Stop)),
+		values.NewTime(values.ConvertTime(s.Start)),
+		values.NewTime(values.ConvertTime(s.Stop)),
 	}
 	groupKey := execute.NewGroupKey(ks, vs)
 	b := execute.NewColListTableBuilder(groupKey, s.alloc)
@@ -203,7 +204,7 @@ func (s *GeneratorSource) Decode() (flux.Table, error) {
 	valueIdx := execute.ColIdx("_value", cols)
 	for i := 0; i < int(s.Count); i++ {
 		b.AppendTime(timeIdx, values.ConvertTime(s.Start.Add(time.Duration(i)*deltaT)))
-		scope := map[string]values.Value{s.Param: values.NewIntValue(int64(i))}
+		scope := map[string]values.Value{s.Param: values.NewInt(int64(i))}
 		v, err := s.Fn.EvalInt(scope)
 		if err != nil {
 			return nil, err

--- a/functions/transformations/data_test.go
+++ b/functions/transformations/data_test.go
@@ -46,9 +46,9 @@ func init() {
 			{Label: "t1", Type: flux.TString},
 		},
 		[]values.Value{
-			values.NewTimeValue(start),
-			values.NewTimeValue(stop),
-			values.NewStringValue(t1Value),
+			values.NewTime(start),
+			values.NewTime(stop),
+			values.NewString(t1Value),
 		},
 	)
 	normalTableBuilder := execute.NewColListTableBuilder(key, executetest.UnlimitedAllocator)

--- a/functions/transformations/histogram.go
+++ b/functions/transformations/histogram.go
@@ -325,7 +325,7 @@ func (b linearBuckets) Call(args values.Object) (values.Value, error) {
 	}
 	infV, ok := args.Get("infinity")
 	if !ok {
-		infV = values.NewBoolValue(true)
+		infV = values.NewBool(true)
 	}
 	if infV.Type() != semantic.Bool {
 		return nil, errors.New("infinity must be a bool")
@@ -341,11 +341,11 @@ func (b linearBuckets) Call(args values.Object) (values.Value, error) {
 	elements := make([]values.Value, l)
 	bound := start
 	for i := 0; i < l; i++ {
-		elements[i] = values.NewFloatValue(bound)
+		elements[i] = values.NewFloat(bound)
 		bound += width
 	}
 	if inf {
-		elements[l-1] = values.NewFloatValue(math.Inf(1))
+		elements[l-1] = values.NewFloat(math.Inf(1))
 	}
 	counts := values.NewArrayWithBacking(semantic.Float, elements)
 	return counts, nil
@@ -446,7 +446,7 @@ func (b logarithmicBuckets) Call(args values.Object) (values.Value, error) {
 	}
 	infV, ok := args.Get("infinity")
 	if !ok {
-		infV = values.NewBoolValue(true)
+		infV = values.NewBool(true)
 	}
 	if infV.Type() != semantic.Bool {
 		return nil, errors.New("infinity must be a bool")
@@ -462,11 +462,11 @@ func (b logarithmicBuckets) Call(args values.Object) (values.Value, error) {
 	elements := make([]values.Value, l)
 	bound := start
 	for i := 0; i < l; i++ {
-		elements[i] = values.NewFloatValue(bound)
+		elements[i] = values.NewFloat(bound)
 		bound *= factor
 	}
 	if inf {
-		elements[l-1] = values.NewFloatValue(math.Inf(1))
+		elements[l-1] = values.NewFloat(math.Inf(1))
 	}
 	counts := values.NewArrayWithBacking(semantic.Float, elements)
 	return counts, nil

--- a/functions/transformations/map.go
+++ b/functions/transformations/map.go
@@ -217,17 +217,17 @@ func groupKeyForObject(i int, cr flux.ColReader, obj values.Object, on map[strin
 		} else {
 			switch c.Type {
 			case flux.TBool:
-				vs = append(vs, values.NewBoolValue(cr.Bools(j)[i]))
+				vs = append(vs, values.NewBool(cr.Bools(j)[i]))
 			case flux.TInt:
-				vs = append(vs, values.NewIntValue(cr.Ints(j)[i]))
+				vs = append(vs, values.NewInt(cr.Ints(j)[i]))
 			case flux.TUInt:
-				vs = append(vs, values.NewUIntValue(cr.UInts(j)[i]))
+				vs = append(vs, values.NewUInt(cr.UInts(j)[i]))
 			case flux.TFloat:
-				vs = append(vs, values.NewFloatValue(cr.Floats(j)[i]))
+				vs = append(vs, values.NewFloat(cr.Floats(j)[i]))
 			case flux.TString:
-				vs = append(vs, values.NewStringValue(cr.Strings(j)[i]))
+				vs = append(vs, values.NewString(cr.Strings(j)[i]))
 			case flux.TTime:
-				vs = append(vs, values.NewTimeValue(cr.Times(j)[i]))
+				vs = append(vs, values.NewTime(cr.Times(j)[i]))
 			}
 		}
 	}

--- a/functions/transformations/range_test.go
+++ b/functions/transformations/range_test.go
@@ -1,11 +1,11 @@
 package transformations_test
 
 import (
-	"github.com/influxdata/flux/functions/inputs"
 	"testing"
 	"time"
 
-	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/functions/inputs"
+
 	"github.com/influxdata/flux/values"
 	"github.com/pkg/errors"
 
@@ -382,14 +382,8 @@ func TestRange_Process(t *testing.T) {
 				},
 			}},
 			groupKey: func() flux.GroupKey {
-				t1, err := values.NewValue(values.Time(10*time.Minute.Nanoseconds()), semantic.Time)
-				if err != nil {
-					t.Fatal(err)
-				}
-				t2, err := values.NewValue(values.Time(20*time.Minute.Nanoseconds()), semantic.Time)
-				if err != nil {
-					t.Fatal(err)
-				}
+				t1 := values.NewTime(values.Time(10 * time.Minute.Nanoseconds()))
+				t2 := values.NewTime(values.Time(20 * time.Minute.Nanoseconds()))
 
 				vs := []values.Value{t1, t2}
 				return execute.NewGroupKey(

--- a/functions/transformations/schema_functions_test.go
+++ b/functions/transformations/schema_functions_test.go
@@ -1,9 +1,10 @@
 package transformations_test
 
 import (
-	"github.com/influxdata/flux/functions/inputs"
 	"regexp"
 	"testing"
+
+	"github.com/influxdata/flux/functions/inputs"
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute/executetest"
@@ -724,7 +725,7 @@ func TestDropRenameKeep_Process(t *testing.T) {
 						Label: "1a",
 						Type:  flux.TFloat,
 					}},
-					[]values.Value{values.NewFloatValue(1.0)},
+					[]values.Value{values.NewFloat(1.0)},
 				),
 			}},
 			want: []*executetest.Table{{
@@ -745,7 +746,7 @@ func TestDropRenameKeep_Process(t *testing.T) {
 						Label: "1b",
 						Type:  flux.TFloat,
 					}},
-					[]values.Value{values.NewFloatValue(1.0)},
+					[]values.Value{values.NewFloat(1.0)},
 				),
 			}},
 		},
@@ -776,7 +777,7 @@ func TestDropRenameKeep_Process(t *testing.T) {
 						Label: "2a",
 						Type:  flux.TFloat,
 					}},
-					[]values.Value{values.NewFloatValue(2.0)},
+					[]values.Value{values.NewFloat(2.0)},
 				),
 			}},
 			want: []*executetest.Table{{
@@ -821,7 +822,7 @@ func TestDropRenameKeep_Process(t *testing.T) {
 						{Label: "1a", Type: flux.TFloat},
 						{Label: "3a", Type: flux.TFloat},
 					},
-					[]values.Value{values.NewFloatValue(1.0), values.NewFloatValue(3.0)},
+					[]values.Value{values.NewFloat(1.0), values.NewFloat(3.0)},
 				),
 			}},
 			want: []*executetest.Table{{
@@ -839,7 +840,7 @@ func TestDropRenameKeep_Process(t *testing.T) {
 					[]flux.ColMeta{
 						{Label: "1a", Type: flux.TFloat},
 					},
-					[]values.Value{values.NewFloatValue(1.0)},
+					[]values.Value{values.NewFloat(1.0)},
 				),
 			}},
 		},

--- a/functions/transformations/schema_mutators.go
+++ b/functions/transformations/schema_mutators.go
@@ -111,7 +111,7 @@ func (m *RenameMutator) renameCol(col *flux.ColMeta) error {
 			col.Label = newName
 		}
 	} else if m.Fn != nil {
-		m.Scope[m.ParamName] = values.NewStringValue(col.Label)
+		m.Scope[m.ParamName] = values.NewString(col.Label)
 		newName, err := m.Fn.EvalString(m.Scope)
 		if err != nil {
 			return err
@@ -226,7 +226,7 @@ func (m *DropKeepMutator) checkColumns(tableCols []flux.ColMeta) error {
 }
 
 func (m *DropKeepMutator) shouldDrop(col string) (bool, error) {
-	m.Scope[m.ParamName] = values.NewStringValue(col)
+	m.Scope[m.ParamName] = values.NewString(col)
 	if shouldDrop, err := m.Predicate.EvalBool(m.Scope); err != nil {
 		return false, err
 	} else if m.FlipPredicate {

--- a/functions/transformations/set.go
+++ b/functions/transformations/set.go
@@ -129,7 +129,7 @@ func (t *setTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 		for j, c := range key.Cols() {
 			cols[j] = c
 			if j == idx {
-				vs[j] = values.NewStringValue(t.value)
+				vs[j] = values.NewString(t.value)
 			} else {
 				vs[j] = key.Value(j)
 			}

--- a/functions/transformations/shift.go
+++ b/functions/transformations/shift.go
@@ -143,7 +143,7 @@ func (t *shiftTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 				return fmt.Errorf("column %q is not of type time", c.Label)
 			}
 			cols[j] = c
-			vs[j] = values.NewTimeValue(key.ValueTime(j).Add(t.shift))
+			vs[j] = values.NewTime(key.ValueTime(j).Add(t.shift))
 		} else {
 			cols[j] = c
 			vs[j] = key.Value(j)

--- a/functions/transformations/system_time.go
+++ b/functions/transformations/system_time.go
@@ -22,7 +22,7 @@ func SystemTime() values.Value {
 		ReturnType: semantic.Time,
 	})
 	call := func(args values.Object) (values.Value, error) {
-		return values.NewTimeValue(values.ConvertTime(time.Now().UTC())), nil
+		return values.NewTime(values.ConvertTime(time.Now().UTC())), nil
 	}
 	sideEffect := false
 	return values.NewFunction(name, ftype, call, sideEffect)

--- a/functions/transformations/typeconv.go
+++ b/functions/transformations/typeconv.go
@@ -113,7 +113,7 @@ func (c *stringConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to string", v.Type())
 	}
-	return values.NewStringValue(str), nil
+	return values.NewString(str), nil
 }
 
 type intConv struct{}
@@ -202,7 +202,7 @@ func (c *intConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to int", v.Type())
 	}
-	return values.NewIntValue(i), nil
+	return values.NewInt(i), nil
 }
 
 type uintConv struct{}
@@ -291,7 +291,7 @@ func (c *uintConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to uint", v.Type())
 	}
-	return values.NewUIntValue(i), nil
+	return values.NewUInt(i), nil
 }
 
 type floatConv struct{}
@@ -376,7 +376,7 @@ func (c *floatConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to float", v.Type())
 	}
-	return values.NewFloatValue(float), nil
+	return values.NewFloat(float), nil
 }
 
 type boolConv struct{}
@@ -481,7 +481,7 @@ func (c *boolConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to float", v.Type())
 	}
-	return values.NewBoolValue(b), nil
+	return values.NewBool(b), nil
 }
 
 type timeConv struct{}
@@ -558,7 +558,7 @@ func (c *timeConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to time", v.Type())
 	}
-	return values.NewTimeValue(t), nil
+	return values.NewTime(t), nil
 }
 
 type durationConv struct{}
@@ -635,5 +635,5 @@ func (c *durationConv) Call(args values.Object) (values.Value, error) {
 	default:
 		return nil, fmt.Errorf("cannot convert %v to duration", v.Type())
 	}
-	return values.NewDurationValue(d), nil
+	return values.NewDuration(d), nil
 }

--- a/functions/transformations/window.go
+++ b/functions/transformations/window.go
@@ -26,7 +26,7 @@ type WindowOpSpec struct {
 	CreateEmpty   bool             `json:"createEmpty"`
 }
 
-var infinityVar = values.NewDurationValue(math.MaxInt64)
+var infinityVar = values.NewDuration(math.MaxInt64)
 
 var windowSignature = flux.DefaultFunctionSignature()
 
@@ -382,9 +382,9 @@ func (t *fixedWindowTransformation) newWindowGroupKey(tbl flux.Table, keyCols []
 		cols[j] = c
 		switch c.Label {
 		case t.startColLabel:
-			vs[j] = values.NewTimeValue(bnds.Start)
+			vs[j] = values.NewTime(bnds.Start)
 		case t.stopColLabel:
-			vs[j] = values.NewTimeValue(bnds.Stop)
+			vs[j] = values.NewTime(bnds.Stop)
 		default:
 			vs[j] = tbl.Key().Value(keyColMap[j])
 		}

--- a/functions/transformations/window_test.go
+++ b/functions/transformations/window_test.go
@@ -1,11 +1,12 @@
 package transformations_test
 
 import (
-	"github.com/influxdata/flux/functions/inputs"
 	"sort"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/influxdata/flux/functions/inputs"
 
 	"github.com/influxdata/flux/values"
 
@@ -115,8 +116,8 @@ func newEmptyWindowTable(start execute.Time, stop execute.Time, cols []flux.ColM
 				{Label: "_stop", Type: flux.TTime},
 			},
 			[]values.Value{
-				values.NewTimeValue(start),
-				values.NewTimeValue(stop),
+				values.NewTime(start),
+				values.NewTime(stop),
 			},
 		),
 	}
@@ -284,8 +285,8 @@ func TestFixedWindow_Process(t *testing.T) {
 								{Label: "_stop", Type: flux.TTime},
 							},
 							[]values.Value{
-								values.NewTimeValue(start + execute.Time(3*time.Minute)),
-								values.NewTimeValue(start + execute.Time(4*time.Minute)),
+								values.NewTime(start + execute.Time(3*time.Minute)),
+								values.NewTime(start + execute.Time(4*time.Minute)),
 							},
 						),
 					},

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -197,15 +197,15 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope *Scope) (v
 			if v.Type() != semantic.Bool {
 				return nil, fmt.Errorf("operand to unary expression is not a boolean value, got %v", v.Type())
 			}
-			return values.NewBoolValue(!v.Bool()), nil
+			return values.NewBool(!v.Bool()), nil
 		case ast.SubtractionOperator:
 			switch t := v.Type(); t {
 			case semantic.Int:
-				return values.NewIntValue(-v.Int()), nil
+				return values.NewInt(-v.Int()), nil
 			case semantic.Float:
-				return values.NewFloatValue(-v.Float()), nil
+				return values.NewFloat(-v.Float()), nil
 			case semantic.Duration:
-				return values.NewDurationValue(-v.Duration()), nil
+				return values.NewDuration(-v.Duration()), nil
 			default:
 				return nil, fmt.Errorf("operand to unary expression is not a number value, got %v", v.Type())
 			}
@@ -245,10 +245,10 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope *Scope) (v
 
 		if e.Operator == ast.AndOperator && !left {
 			// Early return
-			return values.NewBoolValue(false), nil
+			return values.NewBool(false), nil
 		} else if e.Operator == ast.OrOperator && left {
 			// Early return
-			return values.NewBoolValue(true), nil
+			return values.NewBool(true), nil
 		}
 
 		r, err := itrp.doExpression(e.Right, scope)
@@ -262,9 +262,9 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope *Scope) (v
 
 		switch e.Operator {
 		case ast.AndOperator:
-			return values.NewBoolValue(left && right), nil
+			return values.NewBool(left && right), nil
 		case ast.OrOperator:
-			return values.NewBoolValue(left || right), nil
+			return values.NewBool(left || right), nil
 		default:
 			return nil, fmt.Errorf("invalid logical operator %v", e.Operator)
 		}
@@ -315,21 +315,21 @@ func (itrp *Interpreter) doObject(m *semantic.ObjectExpression, scope *Scope) (v
 func (itrp *Interpreter) doLiteral(lit semantic.Literal) (values.Value, error) {
 	switch l := lit.(type) {
 	case *semantic.DateTimeLiteral:
-		return values.NewTimeValue(values.Time(l.Value.UnixNano())), nil
+		return values.NewTime(values.Time(l.Value.UnixNano())), nil
 	case *semantic.DurationLiteral:
-		return values.NewDurationValue(values.Duration(l.Value)), nil
+		return values.NewDuration(values.Duration(l.Value)), nil
 	case *semantic.FloatLiteral:
-		return values.NewFloatValue(l.Value), nil
+		return values.NewFloat(l.Value), nil
 	case *semantic.IntegerLiteral:
-		return values.NewIntValue(l.Value), nil
+		return values.NewInt(l.Value), nil
 	case *semantic.UnsignedIntegerLiteral:
-		return values.NewUIntValue(l.Value), nil
+		return values.NewUInt(l.Value), nil
 	case *semantic.StringLiteral:
-		return values.NewStringValue(l.Value), nil
+		return values.NewString(l.Value), nil
 	case *semantic.RegexpLiteral:
-		return values.NewRegexpValue(l.Value), nil
+		return values.NewRegexp(l.Value), nil
 	case *semantic.BooleanLiteral:
-		return values.NewBoolValue(l.Value), nil
+		return values.NewBool(l.Value), nil
 	default:
 		return nil, fmt.Errorf("unknown literal type %T", lit)
 	}

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -35,7 +35,7 @@ func init() {
 			ReturnType: semantic.Float,
 		}),
 		call: func(args values.Object) (values.Value, error) {
-			return values.NewFloatValue(42.0), nil
+			return values.NewFloat(42.0), nil
 		},
 		hasSideEffect: false,
 	})
@@ -45,7 +45,7 @@ func init() {
 			ReturnType: semantic.Float,
 		}),
 		call: func(args values.Object) (values.Value, error) {
-			return values.NewFloatValue(6.0), nil
+			return values.NewFloat(6.0), nil
 		},
 		hasSideEffect: false,
 	})
@@ -55,7 +55,7 @@ func init() {
 			ReturnType: semantic.Float,
 		}),
 		call: func(args values.Object) (values.Value, error) {
-			return values.NewFloatValue(9.0), nil
+			return values.NewFloat(9.0), nil
 		},
 		hasSideEffect: false,
 	})
@@ -81,7 +81,7 @@ func init() {
 			if !ok {
 				return nil, errors.New("missing argument x")
 			}
-			return values.NewFloatValue(v.Float() + 1), nil
+			return values.NewFloat(v.Float() + 1), nil
 		},
 		hasSideEffect: false,
 	})
@@ -91,13 +91,13 @@ func init() {
 			ReturnType: semantic.Int,
 		}),
 		call: func(args values.Object) (values.Value, error) {
-			return values.NewIntValue(0), nil
+			return values.NewInt(0), nil
 		},
 		hasSideEffect: true,
 	})
 
-	optionsObject.Set("name", values.NewStringValue("foo"))
-	optionsObject.Set("repeat", values.NewIntValue(100))
+	optionsObject.Set("name", values.NewString("foo"))
+	optionsObject.Set("repeat", values.NewInt(100))
 
 	addOption("task", optionsObject)
 }
@@ -114,7 +114,7 @@ func TestEval(t *testing.T) {
 			name:  "call function",
 			query: "six()",
 			want: []values.Value{
-				values.NewFloatValue(6.0),
+				values.NewFloat(6.0),
 			},
 		},
 		{
@@ -140,7 +140,7 @@ func TestEval(t *testing.T) {
 			`,
 			wantErr: true,
 			want: []values.Value{
-				values.NewFloatValue(6.0),
+				values.NewFloat(6.0),
 			},
 		},
 		{
@@ -152,9 +152,9 @@ func TestEval(t *testing.T) {
 			answer = fortyTwo() == six * nine
 			`,
 			want: []values.Value{
-				values.NewFloatValue(6),
-				values.NewFloatValue(9),
-				values.NewBoolValue(false),
+				values.NewFloat(6),
+				values.NewFloat(9),
+				values.NewBool(false),
 			},
 		},
 		{
@@ -166,9 +166,9 @@ func TestEval(t *testing.T) {
             answer = (not (fortyTwo() == six * nine)) or fail()
 			`,
 			want: []values.Value{
-				values.NewFloatValue(6.0),
-				values.NewFloatValue(9.0),
-				values.NewBoolValue(true),
+				values.NewFloat(6.0),
+				values.NewFloat(9.0),
+				values.NewBool(true),
 			},
 		},
 		{
@@ -268,7 +268,7 @@ func TestEval(t *testing.T) {
 			six() |> plusOne() == 7.0 or fail()
 			`,
 			want: []values.Value{
-				values.NewBoolValue(true),
+				values.NewBool(true),
 			},
 		},
 		{
@@ -277,7 +277,7 @@ func TestEval(t *testing.T) {
 			"abba" =~ /^a.*a$/ or fail()
 			`,
 			want: []values.Value{
-				values.NewBoolValue(true),
+				values.NewBool(true),
 			},
 		},
 		{
@@ -286,7 +286,7 @@ func TestEval(t *testing.T) {
 			"abc" =~ /^a.*a$/ and fail()
 			`,
 			want: []values.Value{
-				values.NewBoolValue(false),
+				values.NewBool(false),
 			},
 		},
 		{
@@ -295,7 +295,7 @@ func TestEval(t *testing.T) {
 			"abc" !~ /^a.*a$/ or fail()
 			`,
 			want: []values.Value{
-				values.NewBoolValue(true),
+				values.NewBool(true),
 			},
 		},
 		{
@@ -304,7 +304,7 @@ func TestEval(t *testing.T) {
 			"abba" !~ /^a.*a$/ and fail()
 			`,
 			want: []values.Value{
-				values.NewBoolValue(false),
+				values.NewBool(false),
 			},
 		},
 		{
@@ -319,16 +319,16 @@ func TestEval(t *testing.T) {
 			`,
 			want: []values.Value{
 				optionsObject,
-				values.NewBoolValue(true),
-				values.NewBoolValue(true),
+				values.NewBool(true),
+				values.NewBool(true),
 			},
 		},
 		{
 			name:  "query with side effects",
 			query: `sideEffect() == 0 or fail()`,
 			want: []values.Value{
-				values.NewIntValue(0),
-				values.NewBoolValue(true),
+				values.NewInt(0),
+				values.NewBool(true),
 			},
 		},
 	}

--- a/spec_test.go
+++ b/spec_test.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/influxdata/flux/functions/inputs"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/influxdata/flux/functions/inputs"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -300,7 +301,7 @@ func Example_setOption() {
 	itrp := flux.NewInterpreter()
 
 	// Set a new option from the interpreter
-	itrp.SetOption("dummy_option", values.NewIntValue(3))
+	itrp.SetOption("dummy_option", values.NewInt(3))
 
 	fmt.Printf("dummy_option = %d", itrp.Option("dummy_option").Int())
 	// Output: dummy_option = 3
@@ -348,7 +349,7 @@ func Example_overrideDefaultOptionInternally() {
 		ReturnType: semantic.Time,
 	})
 	functionCall := func(args values.Object) (values.Value, error) {
-		return values.NewTimeValue(values.ConvertTime(timeValue)), nil
+		return values.NewTime(values.ConvertTime(timeValue)), nil
 	}
 	sideEffect := false
 

--- a/values/binary.go
+++ b/values/binary.go
@@ -30,74 +30,74 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.AdditionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewIntValue(l + r)
+		return NewInt(l + r)
 	},
 	{Operator: ast.AdditionOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewUIntValue(l + r)
+		return NewUInt(l + r)
 	},
 	{Operator: ast.AdditionOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewFloatValue(l + r)
+		return NewFloat(l + r)
 	},
 	{Operator: ast.SubtractionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewIntValue(l - r)
+		return NewInt(l - r)
 	},
 	{Operator: ast.SubtractionOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewUIntValue(l - r)
+		return NewUInt(l - r)
 	},
 	{Operator: ast.SubtractionOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewFloatValue(l - r)
+		return NewFloat(l - r)
 	},
 	{Operator: ast.MultiplicationOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewIntValue(l * r)
+		return NewInt(l * r)
 	},
 	{Operator: ast.MultiplicationOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewUIntValue(l * r)
+		return NewUInt(l * r)
 	},
 	{Operator: ast.MultiplicationOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewFloatValue(l * r)
+		return NewFloat(l * r)
 	},
 	{Operator: ast.DivisionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
 		if r == 0 {
 			// TODO(#38): reject divisions with a constant 0 divisor.
-			return NewIntValue(0)
+			return NewInt(0)
 		}
-		return NewIntValue(l / r)
+		return NewInt(l / r)
 	},
 	{Operator: ast.DivisionOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
 		if r == 0 {
 			// TODO(#38): reject divisions with a constant 0 divisor.
-			return NewUIntValue(0)
+			return NewUInt(0)
 		}
-		return NewUIntValue(l / r)
+		return NewUInt(l / r)
 	},
 	{Operator: ast.DivisionOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
 		if r == 0 {
 			// TODO(#38): reject divisions with a constant 0 divisor.
-			return NewFloatValue(math.NaN())
+			return NewFloat(math.NaN())
 		}
-		return NewFloatValue(l / r)
+		return NewFloat(l / r)
 	},
 
 	//---------------------
@@ -109,53 +109,53 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.LessThanEqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewBoolValue(l <= r)
+		return NewBool(l <= r)
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.UInt()
 		if l < 0 {
-			return NewBoolValue(true)
+			return NewBool(true)
 		}
-		return NewBoolValue(uint64(l) <= r)
+		return NewBool(uint64(l) <= r)
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Float()
-		return NewBoolValue(float64(l) <= r)
+		return NewBool(float64(l) <= r)
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Int()
 		if r < 0 {
-			return NewBoolValue(false)
+			return NewBool(false)
 		}
-		return NewBoolValue(l <= uint64(r))
+		return NewBool(l <= uint64(r))
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewBoolValue(l <= r)
+		return NewBool(l <= r)
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Float()
-		return NewBoolValue(float64(l) <= r)
+		return NewBool(float64(l) <= r)
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Int()
-		return NewBoolValue(l <= float64(r))
+		return NewBool(l <= float64(r))
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.UInt()
-		return NewBoolValue(l <= float64(r))
+		return NewBool(l <= float64(r))
 	},
 	{Operator: ast.LessThanEqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewBoolValue(l <= r)
+		return NewBool(l <= r)
 	},
 
 	// LessThanOperator
@@ -163,53 +163,53 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.LessThanOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewBoolValue(l < r)
+		return NewBool(l < r)
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.UInt()
 		if l < 0 {
-			return NewBoolValue(true)
+			return NewBool(true)
 		}
-		return NewBoolValue(uint64(l) < r)
+		return NewBool(uint64(l) < r)
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Float()
-		return NewBoolValue(float64(l) < r)
+		return NewBool(float64(l) < r)
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Int()
 		if r < 0 {
-			return NewBoolValue(false)
+			return NewBool(false)
 		}
-		return NewBoolValue(l < uint64(r))
+		return NewBool(l < uint64(r))
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewBoolValue(l < r)
+		return NewBool(l < r)
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Float()
-		return NewBoolValue(float64(l) < r)
+		return NewBool(float64(l) < r)
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Int()
-		return NewBoolValue(l < float64(r))
+		return NewBool(l < float64(r))
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.UInt()
-		return NewBoolValue(l < float64(r))
+		return NewBool(l < float64(r))
 	},
 	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewBoolValue(l < r)
+		return NewBool(l < r)
 	},
 
 	// GreaterThanEqualOperator
@@ -217,53 +217,53 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewBoolValue(l >= r)
+		return NewBool(l >= r)
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.UInt()
 		if l < 0 {
-			return NewBoolValue(true)
+			return NewBool(true)
 		}
-		return NewBoolValue(uint64(l) >= r)
+		return NewBool(uint64(l) >= r)
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Float()
-		return NewBoolValue(float64(l) >= r)
+		return NewBool(float64(l) >= r)
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Int()
 		if r < 0 {
-			return NewBoolValue(false)
+			return NewBool(false)
 		}
-		return NewBoolValue(l >= uint64(r))
+		return NewBool(l >= uint64(r))
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewBoolValue(l >= r)
+		return NewBool(l >= r)
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Float()
-		return NewBoolValue(float64(l) >= r)
+		return NewBool(float64(l) >= r)
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Int()
-		return NewBoolValue(l >= float64(r))
+		return NewBool(l >= float64(r))
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.UInt()
-		return NewBoolValue(l >= float64(r))
+		return NewBool(l >= float64(r))
 	},
 	{Operator: ast.GreaterThanEqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewBoolValue(l >= r)
+		return NewBool(l >= r)
 	},
 
 	// GreaterThanOperator
@@ -271,53 +271,53 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.GreaterThanOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewBoolValue(l > r)
+		return NewBool(l > r)
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.UInt()
 		if l < 0 {
-			return NewBoolValue(true)
+			return NewBool(true)
 		}
-		return NewBoolValue(uint64(l) > r)
+		return NewBool(uint64(l) > r)
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Float()
-		return NewBoolValue(float64(l) > r)
+		return NewBool(float64(l) > r)
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Int()
 		if r < 0 {
-			return NewBoolValue(false)
+			return NewBool(false)
 		}
-		return NewBoolValue(l > uint64(r))
+		return NewBool(l > uint64(r))
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewBoolValue(l > r)
+		return NewBool(l > r)
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Float()
-		return NewBoolValue(float64(l) > r)
+		return NewBool(float64(l) > r)
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Int()
-		return NewBoolValue(l > float64(r))
+		return NewBool(l > float64(r))
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.UInt()
-		return NewBoolValue(l > float64(r))
+		return NewBool(l > float64(r))
 	},
 	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewBoolValue(l > r)
+		return NewBool(l > r)
 	},
 
 	// EqualOperator
@@ -325,58 +325,58 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.EqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewBoolValue(l == r)
+		return NewBool(l == r)
 	},
 	{Operator: ast.EqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.UInt()
 		if l < 0 {
-			return NewBoolValue(false)
+			return NewBool(false)
 		}
-		return NewBoolValue(uint64(l) == r)
+		return NewBool(uint64(l) == r)
 	},
 	{Operator: ast.EqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Float()
-		return NewBoolValue(float64(l) == r)
+		return NewBool(float64(l) == r)
 	},
 	{Operator: ast.EqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Int()
 		if r < 0 {
-			return NewBoolValue(false)
+			return NewBool(false)
 		}
-		return NewBoolValue(l == uint64(r))
+		return NewBool(l == uint64(r))
 	},
 	{Operator: ast.EqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewBoolValue(l == r)
+		return NewBool(l == r)
 	},
 	{Operator: ast.EqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Float()
-		return NewBoolValue(float64(l) == r)
+		return NewBool(float64(l) == r)
 	},
 	{Operator: ast.EqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Int()
-		return NewBoolValue(l == float64(r))
+		return NewBool(l == float64(r))
 	},
 	{Operator: ast.EqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.UInt()
-		return NewBoolValue(l == float64(r))
+		return NewBool(l == float64(r))
 	},
 	{Operator: ast.EqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewBoolValue(l == r)
+		return NewBool(l == r)
 	},
 	{Operator: ast.EqualOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
 		l := lv.Str()
 		r := rv.Str()
-		return NewBoolValue(l == r)
+		return NewBool(l == r)
 	},
 
 	// NotEqualOperator
@@ -384,83 +384,83 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.NotEqualOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Int()
-		return NewBoolValue(l != r)
+		return NewBool(l != r)
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.Int, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.UInt()
 		if l < 0 {
-			return NewBoolValue(true)
+			return NewBool(true)
 		}
-		return NewBoolValue(uint64(l) != r)
+		return NewBool(uint64(l) != r)
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.Int, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Int()
 		r := rv.Float()
-		return NewBoolValue(float64(l) != r)
+		return NewBool(float64(l) != r)
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.UInt, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Int()
 		if r < 0 {
-			return NewBoolValue(true)
+			return NewBool(true)
 		}
-		return NewBoolValue(l != uint64(r))
+		return NewBool(l != uint64(r))
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.UInt, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.UInt()
-		return NewBoolValue(l != r)
+		return NewBool(l != r)
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.UInt, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.UInt()
 		r := rv.Float()
-		return NewBoolValue(float64(l) != r)
+		return NewBool(float64(l) != r)
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.Float, Right: semantic.Int}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Int()
-		return NewBoolValue(l != float64(r))
+		return NewBool(l != float64(r))
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.Float, Right: semantic.UInt}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.UInt()
-		return NewBoolValue(l != float64(r))
+		return NewBool(l != float64(r))
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
-		return NewBoolValue(l != r)
+		return NewBool(l != r)
 	},
 	{Operator: ast.NotEqualOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
 		l := lv.Str()
 		r := rv.Str()
-		return NewBoolValue(l != r)
+		return NewBool(l != r)
 	},
 	{Operator: ast.RegexpMatchOperator, Left: semantic.String, Right: semantic.Regexp}: func(lv, rv Value) Value {
 		l := lv.Str()
 		r := rv.Regexp()
-		return NewBoolValue(r.MatchString(l))
+		return NewBool(r.MatchString(l))
 	},
 	{Operator: ast.RegexpMatchOperator, Left: semantic.Regexp, Right: semantic.String}: func(lv, rv Value) Value {
 		l := lv.Regexp()
 		r := rv.Str()
-		return NewBoolValue(l.MatchString(r))
+		return NewBool(l.MatchString(r))
 	},
 	{Operator: ast.NotRegexpMatchOperator, Left: semantic.String, Right: semantic.Regexp}: func(lv, rv Value) Value {
 		l := lv.Str()
 		r := rv.Regexp()
-		return NewBoolValue(!r.MatchString(l))
+		return NewBool(!r.MatchString(l))
 	},
 	{Operator: ast.NotRegexpMatchOperator, Left: semantic.Regexp, Right: semantic.String}: func(lv, rv Value) Value {
 		l := lv.Regexp()
 		r := rv.Str()
-		return NewBoolValue(!l.MatchString(r))
+		return NewBool(!l.MatchString(r))
 	},
 
 	{Operator: ast.AdditionOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
 		l := lv.Str()
 		r := rv.Str()
-		return NewStringValue(l + r)
+		return NewString(l + r)
 	},
 }

--- a/values/values.go
+++ b/values/values.go
@@ -119,100 +119,74 @@ func (v value) String() string {
 // InvalidValue is a non nil value who's type is semantic.Invalid
 var InvalidValue = value{t: semantic.Invalid}
 
-func NewValue(v interface{}, k semantic.Kind) (Value, error) {
-	switch k {
-	case semantic.String:
-		_, ok := v.(string)
-		if !ok {
-			return nil, fmt.Errorf("string value must have type string, got %T", v)
-		}
-	case semantic.Int:
-		_, ok := v.(int64)
-		if !ok {
-			return nil, fmt.Errorf("int value must have type int64, got %T", v)
-		}
-	case semantic.UInt:
-		_, ok := v.(uint64)
-		if !ok {
-			return nil, fmt.Errorf("uint value must have type uint64, got %T", v)
-		}
-	case semantic.Float:
-		_, ok := v.(float64)
-		if !ok {
-			return nil, fmt.Errorf("float value must have type float64, got %T", v)
-		}
-	case semantic.Bool:
-		_, ok := v.(bool)
-		if !ok {
-			return nil, fmt.Errorf("bool value must have type bool, got %T", v)
-		}
-	case semantic.Time:
-		_, ok := v.(Time)
-		if !ok {
-			return nil, fmt.Errorf("time value must have type Time, got %T", v)
-		}
-	case semantic.Duration:
-		_, ok := v.(Duration)
-		if !ok {
-			return nil, fmt.Errorf("duration value must have type Duration, got %T", v)
-		}
-	case semantic.Regexp:
-		_, ok := v.(*regexp.Regexp)
-		if !ok {
-			return nil, fmt.Errorf("regexp value must have type *regexp.Regexp, got %T", v)
-		}
+// New constructs a new Value by inferring the type from the interface. If the interface
+// does not translate to a valid Value type, then InvalidValue is returned.
+func New(v interface{}) Value {
+	switch v := v.(type) {
+	case string:
+		return NewString(v)
+	case int64:
+		return NewInt(v)
+	case uint64:
+		return NewUInt(v)
+	case float64:
+		return NewFloat(v)
+	case bool:
+		return NewBool(v)
+	case Time:
+		return NewTime(v)
+	case Duration:
+		return NewDuration(v)
+	case *regexp.Regexp:
+		return NewRegexp(v)
 	default:
-		return nil, fmt.Errorf("unsupported value kind %v", k)
+		return InvalidValue
 	}
-	return value{
-		t: k,
-		v: v,
-	}, nil
 }
 
-func NewStringValue(v string) Value {
+func NewString(v string) Value {
 	return value{
 		t: semantic.String,
 		v: v,
 	}
 }
-func NewIntValue(v int64) Value {
+func NewInt(v int64) Value {
 	return value{
 		t: semantic.Int,
 		v: v,
 	}
 }
-func NewUIntValue(v uint64) Value {
+func NewUInt(v uint64) Value {
 	return value{
 		t: semantic.UInt,
 		v: v,
 	}
 }
-func NewFloatValue(v float64) Value {
+func NewFloat(v float64) Value {
 	return value{
 		t: semantic.Float,
 		v: v,
 	}
 }
-func NewBoolValue(v bool) Value {
+func NewBool(v bool) Value {
 	return value{
 		t: semantic.Bool,
 		v: v,
 	}
 }
-func NewTimeValue(v Time) Value {
+func NewTime(v Time) Value {
 	return value{
 		t: semantic.Time,
 		v: v,
 	}
 }
-func NewDurationValue(v Duration) Value {
+func NewDuration(v Duration) Value {
 	return value{
 		t: semantic.Duration,
 		v: v,
 	}
 }
-func NewRegexpValue(v *regexp.Regexp) Value {
+func NewRegexp(v *regexp.Regexp) Value {
 	return value{
 		t: semantic.Regexp,
 		v: v,

--- a/values/values_test.go
+++ b/values/values_test.go
@@ -1,0 +1,38 @@
+package values_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func TestNew(t *testing.T) {
+	for _, tt := range []struct {
+		v    interface{}
+		want values.Value
+	}{
+		{v: "abc", want: values.NewString("abc")},
+		{v: int64(4), want: values.NewInt(4)},
+		{v: uint64(4), want: values.NewUInt(4)},
+		{v: float64(6.0), want: values.NewFloat(6.0)},
+		{v: true, want: values.NewBool(true)},
+		{v: values.Time(1000), want: values.NewTime(values.Time(1000))},
+		{v: values.Duration(1), want: values.NewDuration(values.Duration(1))},
+		{v: regexp.MustCompile(`.+`), want: values.NewRegexp(regexp.MustCompile(`.+`))},
+		{v: values.NewArray(semantic.String), want: values.InvalidValue},
+	} {
+		t.Run(fmt.Sprint(tt.want.Type()), func(t *testing.T) {
+			if want, got := tt.want, values.New(tt.v); !want.Equal(got) {
+				if want.Type() == semantic.Invalid && got.Type() == semantic.Invalid {
+					// If the wanted type is invalid and the gotten type is invalid, these
+					// are the same even though they do not equal each other.
+					return
+				}
+				t.Fatalf("unexpected value -want/+got\n\t- %s\n\t+ %s", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The values package will now construct values with `NewXXX` instead of
`NewXXXValue`. The `Value` at the end was redundant since this is in the
`values` package. It also modifies the `NewValue` function to just take
the interface and infer the type from that.