### PR TITLE
refactor: use AppendValue in more places where it is useful

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -19,26 +19,14 @@ func init() {
 }
 
 func ValueEqual(x, y values.Value) bool {
-	if x.Type() != y.Type() {
-		return false
-	}
 	switch k := x.Type().Kind(); k {
-	case semantic.Bool:
-		return x.Bool() == y.Bool()
-	case semantic.UInt:
-		return x.UInt() == y.UInt()
-	case semantic.Int:
-		return x.Int() == y.Int()
-	case semantic.Float:
-		return x.Float() == y.Float()
-	case semantic.String:
-		return x.Str() == y.Str()
-	case semantic.Time:
-		return x.Time() == y.Time()
 	case semantic.Object:
+		if x.Type() != y.Type() {
+			return false
+		}
 		return cmp.Equal(x.Object(), y.Object(), CmpOptions...)
 	default:
-		return false
+		return x.Equal(y)
 	}
 }
 

--- a/csv/result.go
+++ b/csv/result.go
@@ -578,28 +578,8 @@ func (d *tableDecoder) appendRecord(record []string) error {
 	d.empty = false
 	for j, c := range d.meta.Cols {
 		if record[j] == "" && d.meta.Defaults[j] != nil {
-			switch c.Type {
-			case flux.TBool:
-				v := d.meta.Defaults[j].Bool()
-				d.builder.AppendBool(j, v)
-			case flux.TInt:
-				v := d.meta.Defaults[j].Int()
-				d.builder.AppendInt(j, v)
-			case flux.TUInt:
-				v := d.meta.Defaults[j].UInt()
-				d.builder.AppendUInt(j, v)
-			case flux.TFloat:
-				v := d.meta.Defaults[j].Float()
-				d.builder.AppendFloat(j, v)
-			case flux.TString:
-				v := d.meta.Defaults[j].Str()
-				d.builder.AppendString(j, v)
-			case flux.TTime:
-				v := d.meta.Defaults[j].Time()
-				d.builder.AppendTime(j, v)
-			default:
-				return fmt.Errorf("unsupported column type %v", c.Type)
-			}
+			v := d.meta.Defaults[j]
+			d.builder.AppendValue(j, v)
 			continue
 		}
 		if err := decodeValueInto(j, c, record[j], d.builder); err != nil {

--- a/execute/group_key_builder.go
+++ b/execute/group_key_builder.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -32,21 +31,11 @@ func (gkb *GroupKeyBuilder) AddKeyValue(key string, value values.Value) *GroupKe
 		return gkb
 	}
 
-	cm := flux.ColMeta{Label: key}
-	switch k := value.Type().Kind(); k {
-	case semantic.Bool:
-		cm.Type = flux.TBool
-	case semantic.UInt:
-		cm.Type = flux.TUInt
-	case semantic.Int:
-		cm.Type = flux.TInt
-	case semantic.Float:
-		cm.Type = flux.TFloat
-	case semantic.String:
-		cm.Type = flux.TString
-	case semantic.Time:
-		cm.Type = flux.TTime
-	default:
+	cm := flux.ColMeta{
+		Label: key,
+		Type:  flux.ColumnType(value.Type()),
+	}
+	if cm.Type == flux.TInvalid {
 		gkb.err = fmt.Errorf("invalid group key type: %s", value.Type())
 		return gkb
 	}

--- a/execute/table.go
+++ b/execute/table.go
@@ -25,20 +25,7 @@ func GroupKeyForRowOn(i int, cr flux.ColReader, on map[string]bool) flux.GroupKe
 			continue
 		}
 		cols = append(cols, c)
-		switch c.Type {
-		case flux.TBool:
-			vs = append(vs, values.NewBool(cr.Bools(j)[i]))
-		case flux.TInt:
-			vs = append(vs, values.NewInt(cr.Ints(j)[i]))
-		case flux.TUInt:
-			vs = append(vs, values.NewUInt(cr.UInts(j)[i]))
-		case flux.TFloat:
-			vs = append(vs, values.NewFloat(cr.Floats(j)[i]))
-		case flux.TString:
-			vs = append(vs, values.NewString(cr.Strings(j)[i]))
-		case flux.TTime:
-			vs = append(vs, values.NewTime(cr.Times(j)[i]))
-		}
+		vs = append(vs, ValueForRow(cr, i, j))
 	}
 	return NewGroupKey(cols, vs)
 }
@@ -254,45 +241,15 @@ func ColMap(colMap []int, builder TableBuilder, cr flux.ColReader) []int {
 
 // AppendRecordForCols appends the only the columns provided from cr onto builder.
 func AppendRecordForCols(i int, cr flux.ColReader, builder TableBuilder, cols []flux.ColMeta) {
-	for j, c := range cols {
-		switch c.Type {
-		case flux.TBool:
-			builder.AppendBool(j, cr.Bools(j)[i])
-		case flux.TInt:
-			builder.AppendInt(j, cr.Ints(j)[i])
-		case flux.TUInt:
-			builder.AppendUInt(j, cr.UInts(j)[i])
-		case flux.TFloat:
-			builder.AppendFloat(j, cr.Floats(j)[i])
-		case flux.TString:
-			builder.AppendString(j, cr.Strings(j)[i])
-		case flux.TTime:
-			builder.AppendTime(j, cr.Times(j)[i])
-		default:
-			PanicUnknownType(c.Type)
-		}
+	for j := range cols {
+		builder.AppendValue(j, ValueForRow(cr, i, j))
 	}
 }
 
 func AppendKeyValues(key flux.GroupKey, builder TableBuilder) {
 	for j, c := range key.Cols() {
 		idx := ColIdx(c.Label, builder.Cols())
-		switch c.Type {
-		case flux.TBool:
-			builder.AppendBool(idx, key.ValueBool(j))
-		case flux.TInt:
-			builder.AppendInt(idx, key.ValueInt(j))
-		case flux.TUInt:
-			builder.AppendUInt(idx, key.ValueUInt(j))
-		case flux.TFloat:
-			builder.AppendFloat(idx, key.ValueFloat(j))
-		case flux.TString:
-			builder.AppendString(idx, key.ValueString(j))
-		case flux.TTime:
-			builder.AppendTime(idx, key.ValueTime(j))
-		default:
-			PanicUnknownType(c.Type)
-		}
+		builder.AppendValue(idx, key.Value(j))
 	}
 }
 

--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -870,7 +870,7 @@ func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Ta
 						}
 						newColumn := c.schemaMap[column]
 						newColumnIdx := c.colIndex[newColumn]
-						execute.AppendValue(builder, newColumnIdx, columnVal)
+						builder.AppendValue(newColumnIdx, columnVal)
 					})
 
 					rightRecord.Range(func(columnName string, columnVal values.Value) {
@@ -884,7 +884,7 @@ func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Ta
 						// No need to append value if column is part of the join key.
 						// Because value already appended when iterating over left record.
 						if !c.on[newColumn.Label] {
-							execute.AppendValue(builder, newColumnIdx, columnVal)
+							builder.AppendValue(newColumnIdx, columnVal)
 						}
 					})
 				}

--- a/functions/transformations/map.go
+++ b/functions/transformations/map.go
@@ -196,7 +196,7 @@ func (t *mapTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 						return fmt.Errorf("could not find value for column %q", c.Label)
 					}
 				}
-				execute.AppendValue(builder, j, v)
+				builder.AppendValue(j, v)
 			}
 		}
 		return nil


### PR DESCRIPTION
Some of the current code was reusing switch statements that were already
placed into utilities to avoid requiring the switch statement to be
used. We should minimize the use of switch statements on the type to
only places that need the actual type for whatever reason to make the
code easier to follow.