### PR TITLE
feat: add interfaces for reading array data

### DIFF
--- a/array/base.go
+++ b/array/base.go
@@ -1,0 +1,11 @@
+package array
+
+// Base defines the base interface for working with any array type.
+// All array types share this common interface.
+type Base interface {
+	IsNull(i int) bool
+	IsValid(i int) bool
+	Len() int
+	NullN() int
+	Slice(start, stop int) Base
+}

--- a/array/bool.go
+++ b/array/bool.go
@@ -1,0 +1,8 @@
+package array
+
+// Boolean represents an abstraction over a bool array.
+type Boolean interface {
+	Base
+	Value(i int) bool
+	BooleanSlice(start, stop int) Boolean
+}

--- a/array/float.go
+++ b/array/float.go
@@ -1,0 +1,12 @@
+package array
+
+// Float represents an abstraction over a float array.
+type Float interface {
+	Base
+	Value(i int) float64
+	FloatSlice(start, stop int) Float
+
+	// Float64Values will return the underlying slice for the Float array. It is the size
+	// of the array and null values will be present, but the data at null indexes will be invalid.
+	Float64Values() []float64
+}

--- a/array/int.go
+++ b/array/int.go
@@ -1,0 +1,12 @@
+package array
+
+// Int represents an abstraction over an integer array.
+type Int interface {
+	Base
+	Value(i int) int64
+	IntSlice(start, stop int) Int
+
+	// Int64Values will return the underlying slice for the Int array. It is the size
+	// of the array and null values will be present, but the data at null indexes will be invalid.
+	Int64Values() []int64
+}

--- a/array/string.go
+++ b/array/string.go
@@ -1,0 +1,8 @@
+package array
+
+// String represents an abstraction over a string array.
+type String interface {
+	Base
+	Value(i int) string
+	StringSlice(start, stop int) String
+}

--- a/array/time.go
+++ b/array/time.go
@@ -1,0 +1,14 @@
+package array
+
+import "github.com/influxdata/flux/values"
+
+// Time represents an abstraction over a time array.
+type Time interface {
+	Base
+	Value(i int) values.Time
+	TimeSlice(start, stop int) Time
+
+	// TimeValues will return the underlying slice for the Time array. It is the size
+	// of the array and null values will be present, but the data at null indexes will be invalid.
+	TimeValues() []values.Time
+}

--- a/array/uint.go
+++ b/array/uint.go
@@ -1,0 +1,12 @@
+package array
+
+// UInt represents an abstraction over an unsigned array.
+type UInt interface {
+	Base
+	Value(i int) uint64
+	UIntSlice(start, stop int) UInt
+
+	// Uint64Values will return the underlying slice for the UInt array. It is the size
+	// of the array and null values will be present, but the data at null indexes will be invalid.
+	Uint64Values() []uint64
+}

--- a/internal/staticarray/bool.go
+++ b/internal/staticarray/bool.go
@@ -1,0 +1,35 @@
+package staticarray
+
+import "github.com/influxdata/flux/array"
+
+var _ array.Boolean = Boolean(nil)
+
+type Boolean []bool
+
+func (a Boolean) IsNull(i int) bool {
+	return false
+}
+
+func (a Boolean) IsValid(i int) bool {
+	return i >= 0 && i < len(a)
+}
+
+func (a Boolean) Len() int {
+	return len(a)
+}
+
+func (a Boolean) NullN() int {
+	return 0
+}
+
+func (a Boolean) Value(i int) bool {
+	return a[i]
+}
+
+func (a Boolean) Slice(start, stop int) array.Base {
+	return a.BooleanSlice(start, stop)
+}
+
+func (a Boolean) BooleanSlice(start, stop int) array.Boolean {
+	return Boolean(a[start:stop])
+}

--- a/internal/staticarray/doc.go
+++ b/internal/staticarray/doc.go
@@ -1,0 +1,3 @@
+// Package staticarray defines implementations of flux arrays with static data.
+// It does not support null values.
+package staticarray

--- a/internal/staticarray/float.go
+++ b/internal/staticarray/float.go
@@ -1,0 +1,39 @@
+package staticarray
+
+import "github.com/influxdata/flux/array"
+
+var _ array.Float = Float(nil)
+
+type Float []float64
+
+func (a Float) IsNull(i int) bool {
+	return false
+}
+
+func (a Float) IsValid(i int) bool {
+	return i >= 0 && i < len(a)
+}
+
+func (a Float) Len() int {
+	return len(a)
+}
+
+func (a Float) NullN() int {
+	return 0
+}
+
+func (a Float) Value(i int) float64 {
+	return a[i]
+}
+
+func (a Float) Slice(start, stop int) array.Base {
+	return a.FloatSlice(start, stop)
+}
+
+func (a Float) FloatSlice(start, stop int) array.Float {
+	return Float(a[start:stop])
+}
+
+func (a Float) Float64Values() []float64 {
+	return []float64(a)
+}

--- a/internal/staticarray/int.go
+++ b/internal/staticarray/int.go
@@ -1,0 +1,39 @@
+package staticarray
+
+import "github.com/influxdata/flux/array"
+
+var _ array.Int = Int(nil)
+
+type Int []int64
+
+func (a Int) IsNull(i int) bool {
+	return false
+}
+
+func (a Int) IsValid(i int) bool {
+	return i >= 0 && i < len(a)
+}
+
+func (a Int) Len() int {
+	return len(a)
+}
+
+func (a Int) NullN() int {
+	return 0
+}
+
+func (a Int) Value(i int) int64 {
+	return a[i]
+}
+
+func (a Int) Slice(start, stop int) array.Base {
+	return a.IntSlice(start, stop)
+}
+
+func (a Int) IntSlice(start, stop int) array.Int {
+	return Int(a[start:stop])
+}
+
+func (a Int) Int64Values() []int64 {
+	return []int64(a)
+}

--- a/internal/staticarray/string.go
+++ b/internal/staticarray/string.go
@@ -1,0 +1,35 @@
+package staticarray
+
+import "github.com/influxdata/flux/array"
+
+var _ array.String = String(nil)
+
+type String []string
+
+func (a String) IsNull(i int) bool {
+	return false
+}
+
+func (a String) IsValid(i int) bool {
+	return i >= 0 && i < len(a)
+}
+
+func (a String) Len() int {
+	return len(a)
+}
+
+func (a String) NullN() int {
+	return 0
+}
+
+func (a String) Value(i int) string {
+	return a[i]
+}
+
+func (a String) Slice(start, stop int) array.Base {
+	return a.StringSlice(start, stop)
+}
+
+func (a String) StringSlice(start, stop int) array.String {
+	return String(a[start:stop])
+}

--- a/internal/staticarray/time.go
+++ b/internal/staticarray/time.go
@@ -1,0 +1,42 @@
+package staticarray
+
+import (
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/values"
+)
+
+var _ array.Time = Time(nil)
+
+type Time []values.Time
+
+func (a Time) IsNull(i int) bool {
+	return false
+}
+
+func (a Time) IsValid(i int) bool {
+	return i >= 0 && i < len(a)
+}
+
+func (a Time) Len() int {
+	return len(a)
+}
+
+func (a Time) NullN() int {
+	return 0
+}
+
+func (a Time) Value(i int) values.Time {
+	return a[i]
+}
+
+func (a Time) Slice(start, stop int) array.Base {
+	return a.TimeSlice(start, stop)
+}
+
+func (a Time) TimeSlice(start, stop int) array.Time {
+	return Time(a[start:stop])
+}
+
+func (a Time) TimeValues() []values.Time {
+	return []values.Time(a)
+}

--- a/internal/staticarray/uint.go
+++ b/internal/staticarray/uint.go
@@ -1,0 +1,39 @@
+package staticarray
+
+import "github.com/influxdata/flux/array"
+
+var _ array.UInt = UInt(nil)
+
+type UInt []uint64
+
+func (a UInt) IsNull(i int) bool {
+	return false
+}
+
+func (a UInt) IsValid(i int) bool {
+	return i >= 0 && i < len(a)
+}
+
+func (a UInt) Len() int {
+	return len(a)
+}
+
+func (a UInt) NullN() int {
+	return 0
+}
+
+func (a UInt) Value(i int) uint64 {
+	return a[i]
+}
+
+func (a UInt) Slice(start, stop int) array.Base {
+	return a.UIntSlice(start, stop)
+}
+
+func (a UInt) UIntSlice(start, stop int) array.UInt {
+	return UInt(a[start:stop])
+}
+
+func (a UInt) Uint64Values() []uint64 {
+	return []uint64(a)
+}


### PR DESCRIPTION
The interfaces here match pretty closely with the equivalent arrow array
type and will act as a suitable interface between the two. Some
algorithms may have to type switch for performance reasons, but these
interfaces should work in most scenarios to abstract away the current
way that data is being stored.

This commit does not migrate to using those interfaces. It creates the
interface so we can begin integration and it provides an internal
package that implements the interface using slices (like the current
implementation uses).