### PR TITLE
refactor(execute): update column reader to use the array interfaces

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -1086,17 +1086,17 @@ func encodeValue(value values.Value, c colMeta) (string, error) {
 func encodeValueFrom(i, j int, c colMeta, cr flux.ColReader) (string, error) {
 	switch c.Type {
 	case flux.TBool:
-		return strconv.FormatBool(cr.Bools(j)[i]), nil
+		return strconv.FormatBool(cr.Bools(j).Value(i)), nil
 	case flux.TInt:
-		return strconv.FormatInt(cr.Ints(j)[i], 10), nil
+		return strconv.FormatInt(cr.Ints(j).Value(i), 10), nil
 	case flux.TUInt:
-		return strconv.FormatUint(cr.UInts(j)[i], 10), nil
+		return strconv.FormatUint(cr.UInts(j).Value(i), 10), nil
 	case flux.TFloat:
-		return strconv.FormatFloat(cr.Floats(j)[i], 'f', -1, 64), nil
+		return strconv.FormatFloat(cr.Floats(j).Value(i), 'f', -1, 64), nil
 	case flux.TString:
-		return cr.Strings(j)[i], nil
+		return cr.Strings(j).Value(i), nil
 	case flux.TTime:
-		return encodeTime(cr.Times(j)[i], c.fmt), nil
+		return encodeTime(cr.Times(j).Value(i), c.fmt), nil
 	default:
 		return "", fmt.Errorf("unknown type %v", c.Type)
 	}

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
@@ -219,23 +220,23 @@ type ValueFunc interface {
 }
 type DoBoolAgg interface {
 	ValueFunc
-	DoBool([]bool)
+	DoBool(array.BooleanRef)
 }
 type DoFloatAgg interface {
 	ValueFunc
-	DoFloat([]float64)
+	DoFloat(array.FloatRef)
 }
 type DoIntAgg interface {
 	ValueFunc
-	DoInt([]int64)
+	DoInt(array.IntRef)
 }
 type DoUIntAgg interface {
 	ValueFunc
-	DoUInt([]uint64)
+	DoUInt(array.UIntRef)
 }
 type DoStringAgg interface {
 	ValueFunc
-	DoString([]string)
+	DoString(array.StringRef)
 }
 
 type BoolValueFunc interface {

--- a/execute/executetest/aggregate.go
+++ b/execute/executetest/aggregate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/staticarray"
 )
 
 // AggFuncTestHelper splits the data in half, runs Do over each split and compares
@@ -17,9 +18,9 @@ func AggFuncTestHelper(t *testing.T, agg execute.Aggregate, data []float64, want
 	// Call Do twice, since this is possible according to the interface.
 	h := len(data) / 2
 	vf := agg.NewFloatAgg()
-	vf.DoFloat(data[:h])
+	vf.DoFloat(staticarray.Float(data[:h]))
 	if h < len(data) {
-		vf.DoFloat(data[h:])
+		vf.DoFloat(staticarray.Float(data[h:]))
 	}
 
 	var got interface{}
@@ -47,7 +48,7 @@ func AggFuncBenchmarkHelper(b *testing.B, agg execute.Aggregate, data []float64,
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		vf := agg.NewFloatAgg()
-		vf.DoFloat(data)
+		vf.DoFloat(staticarray.Float(data))
 		var got interface{}
 		switch vf.Type() {
 		case flux.TBool:

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/staticarray"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -103,28 +105,28 @@ func (cr ColReader) Len() int {
 	return 1
 }
 
-func (cr ColReader) Bools(j int) []bool {
-	return []bool{cr.row[j].(bool)}
+func (cr ColReader) Bools(j int) array.BooleanRef {
+	return staticarray.Boolean([]bool{cr.row[j].(bool)})
 }
 
-func (cr ColReader) Ints(j int) []int64 {
-	return []int64{cr.row[j].(int64)}
+func (cr ColReader) Ints(j int) array.IntRef {
+	return staticarray.Int([]int64{cr.row[j].(int64)})
 }
 
-func (cr ColReader) UInts(j int) []uint64 {
-	return []uint64{cr.row[j].(uint64)}
+func (cr ColReader) UInts(j int) array.UIntRef {
+	return staticarray.UInt([]uint64{cr.row[j].(uint64)})
 }
 
-func (cr ColReader) Floats(j int) []float64 {
-	return []float64{cr.row[j].(float64)}
+func (cr ColReader) Floats(j int) array.FloatRef {
+	return staticarray.Float([]float64{cr.row[j].(float64)})
 }
 
-func (cr ColReader) Strings(j int) []string {
-	return []string{cr.row[j].(string)}
+func (cr ColReader) Strings(j int) array.StringRef {
+	return staticarray.String([]string{cr.row[j].(string)})
 }
 
-func (cr ColReader) Times(j int) []execute.Time {
-	return []execute.Time{cr.row[j].(execute.Time)}
+func (cr ColReader) Times(j int) array.TimeRef {
+	return staticarray.Time([]values.Time{cr.row[j].(execute.Time)})
 }
 
 func TablesFromCache(c execute.DataCache) (tables []*Table, err error) {
@@ -190,17 +192,17 @@ func ConvertTable(tbl flux.Table) (*Table, error) {
 				var v interface{}
 				switch c.Type {
 				case flux.TBool:
-					v = cr.Bools(j)[i]
+					v = cr.Bools(j).Value(i)
 				case flux.TInt:
-					v = cr.Ints(j)[i]
+					v = cr.Ints(j).Value(i)
 				case flux.TUInt:
-					v = cr.UInts(j)[i]
+					v = cr.UInts(j).Value(i)
 				case flux.TFloat:
-					v = cr.Floats(j)[i]
+					v = cr.Floats(j).Value(i)
 				case flux.TString:
-					v = cr.Strings(j)[i]
+					v = cr.Strings(j).Value(i)
 				case flux.TTime:
-					v = cr.Times(j)[i]
+					v = cr.Times(j).Value(i)
 				default:
 					panic(fmt.Errorf("unknown column type %s", c.Type))
 				}

--- a/execute/format.go
+++ b/execute/format.go
@@ -216,18 +216,18 @@ func (f *Formatter) writeHeaderSeparator(w *writeToHelper) {
 func (f *Formatter) valueBuf(i, j int, typ flux.ColType, cr flux.ColReader) (buf []byte) {
 	switch typ {
 	case flux.TBool:
-		buf = strconv.AppendBool(f.fmtBuf[0:0], cr.Bools(j)[i])
+		buf = strconv.AppendBool(f.fmtBuf[0:0], cr.Bools(j).Value(i))
 	case flux.TInt:
-		buf = strconv.AppendInt(f.fmtBuf[0:0], cr.Ints(j)[i], 10)
+		buf = strconv.AppendInt(f.fmtBuf[0:0], cr.Ints(j).Value(i), 10)
 	case flux.TUInt:
-		buf = strconv.AppendUint(f.fmtBuf[0:0], cr.UInts(j)[i], 10)
+		buf = strconv.AppendUint(f.fmtBuf[0:0], cr.UInts(j).Value(i), 10)
 	case flux.TFloat:
 		// TODO allow specifying format and precision
-		buf = strconv.AppendFloat(f.fmtBuf[0:0], cr.Floats(j)[i], 'f', -1, 64)
+		buf = strconv.AppendFloat(f.fmtBuf[0:0], cr.Floats(j).Value(i), 'f', -1, 64)
 	case flux.TString:
-		buf = []byte(cr.Strings(j)[i])
+		buf = []byte(cr.Strings(j).Value(i))
 	case flux.TTime:
-		buf = []byte(cr.Times(j)[i].String())
+		buf = []byte(cr.Times(j).Value(i).String())
 	}
 	return
 }

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -205,6 +205,28 @@ func (f *RowMapFn) Eval(row int, cr flux.ColReader) (values.Object, error) {
 	return v.Object(), nil
 }
 
+// ValueForRow retrieves a value from a column reader at the given index.
+func ValueForRow(cr flux.ColReader, i, j int) values.Value {
+	t := cr.Cols()[j].Type
+	switch t {
+	case flux.TString:
+		return values.NewString(cr.Strings(j).Value(i))
+	case flux.TInt:
+		return values.NewInt(cr.Ints(j).Value(i))
+	case flux.TUInt:
+		return values.NewUInt(cr.UInts(j).Value(i))
+	case flux.TFloat:
+		return values.NewFloat(cr.Floats(j).Value(i))
+	case flux.TBool:
+		return values.NewBool(cr.Bools(j).Value(i))
+	case flux.TTime:
+		return values.NewTime(cr.Times(j).Value(i))
+	default:
+		PanicUnknownType(t)
+		return values.InvalidValue
+	}
+}
+
 func findColReferences(fn *semantic.FunctionExpression) []string {
 	v := &colReferenceVisitor{
 		recordName: fn.Block.Parameters.List[0].Key.Name,

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -252,19 +253,19 @@ type IndexSelector interface {
 	NewStringSelector() DoStringIndexSelector
 }
 type DoBoolIndexSelector interface {
-	DoBool([]bool) []int
+	DoBool(array.BooleanRef) []int
 }
 type DoIntIndexSelector interface {
-	DoInt([]int64) []int
+	DoInt(array.IntRef) []int
 }
 type DoUIntIndexSelector interface {
-	DoUInt([]uint64) []int
+	DoUInt(array.UIntRef) []int
 }
 type DoFloatIndexSelector interface {
-	DoFloat([]float64) []int
+	DoFloat(array.FloatRef) []int
 }
 type DoStringIndexSelector interface {
-	DoString([]string) []int
+	DoString(array.StringRef) []int
 }
 
 type RowSelector interface {
@@ -281,23 +282,23 @@ type Rower interface {
 
 type DoBoolRowSelector interface {
 	Rower
-	DoBool(vs []bool, cr flux.ColReader)
+	DoBool(vs array.BooleanRef, cr flux.ColReader)
 }
 type DoIntRowSelector interface {
 	Rower
-	DoInt(vs []int64, cr flux.ColReader)
+	DoInt(vs array.IntRef, cr flux.ColReader)
 }
 type DoUIntRowSelector interface {
 	Rower
-	DoUInt(vs []uint64, cr flux.ColReader)
+	DoUInt(vs array.UIntRef, cr flux.ColReader)
 }
 type DoFloatRowSelector interface {
 	Rower
-	DoFloat(vs []float64, cr flux.ColReader)
+	DoFloat(vs array.FloatRef, cr flux.ColReader)
 }
 type DoStringRowSelector interface {
 	Rower
-	DoString(vs []string, cr flux.ColReader)
+	DoString(vs array.StringRef, cr flux.ColReader)
 }
 
 type Row struct {
@@ -310,17 +311,17 @@ func ReadRow(i int, cr flux.ColReader) (row Row) {
 	for j, c := range cols {
 		switch c.Type {
 		case flux.TBool:
-			row.Values[j] = cr.Bools(j)[i]
+			row.Values[j] = cr.Bools(j).Value(i)
 		case flux.TInt:
-			row.Values[j] = cr.Ints(j)[i]
+			row.Values[j] = cr.Ints(j).Value(i)
 		case flux.TUInt:
-			row.Values[j] = cr.UInts(j)[i]
+			row.Values[j] = cr.UInts(j).Value(i)
 		case flux.TFloat:
-			row.Values[j] = cr.Floats(j)[i]
+			row.Values[j] = cr.Floats(j).Value(i)
 		case flux.TString:
-			row.Values[j] = cr.Strings(j)[i]
+			row.Values[j] = cr.Strings(j).Value(i)
 		case flux.TTime:
-			row.Values[j] = cr.Times(j)[i]
+			row.Values[j] = cr.Times(j).Value(i)
 		}
 	}
 	return

--- a/functions/outputs/to_http.go
+++ b/functions/outputs/to_http.go
@@ -371,32 +371,32 @@ func (t *ToHTTPTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 				for j, col := range er.Cols() {
 					switch {
 					case col.Label == timeColLabel:
-						m.t = er.Times(j)[i].Time()
+						m.t = er.Times(j).Value(i).Time()
 					case measurementNameCol != "" && measurementNameCol == col.Label:
 						if col.Type != flux.TString {
 							return errors.New("invalid type for measurement column")
 						}
-						m.name = er.Strings(j)[i]
+						m.name = er.Strings(j).Value(i)
 					case isTag[j]:
 						if col.Type != flux.TString {
 							return errors.New("invalid type for measurement column")
 						}
-						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j)[i]})
+						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j).Value(i)})
 
 					case isValue[j]:
 						switch col.Type {
 						case flux.TFloat:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Floats(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Floats(j).Value(i)})
 						case flux.TInt:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Ints(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Ints(j).Value(i)})
 						case flux.TUInt:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.UInts(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.UInts(j).Value(i)})
 						case flux.TString:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j).Value(i)})
 						case flux.TTime:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Times(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Times(j).Value(i)})
 						case flux.TBool:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Bools(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Bools(j).Value(i)})
 						default:
 							return fmt.Errorf("invalid type for column %s", col.Label)
 						}

--- a/functions/outputs/to_kafka.go
+++ b/functions/outputs/to_kafka.go
@@ -338,31 +338,31 @@ func (t *ToKafkaTransformation) Process(id execute.DatasetID, tbl flux.Table) (e
 				for j, col := range er.Cols() {
 					switch {
 					case col.Label == timeColLabel:
-						m.t = er.Times(j)[i].Time()
+						m.t = er.Times(j).Value(i).Time()
 					case measurementNameCol != "" && measurementNameCol == col.Label:
 						if col.Type != flux.TString {
 							return errors.New("invalid type for measurement column")
 						}
-						m.name = er.Strings(j)[i]
+						m.name = er.Strings(j).Value(i)
 					case isTag[j]:
 						if col.Type != flux.TString {
 							return errors.New("invalid type for measurement column")
 						}
-						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j)[i]})
+						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j).Value(i)})
 					case isValue[j]:
 						switch col.Type {
 						case flux.TFloat:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Floats(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Floats(j).Value(i)})
 						case flux.TInt:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Ints(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Ints(j).Value(i)})
 						case flux.TUInt:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.UInts(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.UInts(j).Value(i)})
 						case flux.TString:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j).Value(i)})
 						case flux.TTime:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Times(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Times(j).Value(i)})
 						case flux.TBool:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Bools(j)[i]})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Bools(j).Value(i)})
 						default:
 							return fmt.Errorf("invalid type for column %s", col.Label)
 						}

--- a/functions/transformations/count.go
+++ b/functions/transformations/count.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -102,20 +103,20 @@ func (a *CountAgg) NewStringAgg() execute.DoStringAgg {
 	return new(CountAgg)
 }
 
-func (a *CountAgg) DoBool(vs []bool) {
-	a.count += int64(len(vs))
+func (a *CountAgg) DoBool(vs array.BooleanRef) {
+	a.count += int64(vs.Len() - vs.NullN())
 }
-func (a *CountAgg) DoUInt(vs []uint64) {
-	a.count += int64(len(vs))
+func (a *CountAgg) DoUInt(vs array.UIntRef) {
+	a.count += int64(vs.Len() - vs.NullN())
 }
-func (a *CountAgg) DoInt(vs []int64) {
-	a.count += int64(len(vs))
+func (a *CountAgg) DoInt(vs array.IntRef) {
+	a.count += int64(vs.Len() - vs.NullN())
 }
-func (a *CountAgg) DoFloat(vs []float64) {
-	a.count += int64(len(vs))
+func (a *CountAgg) DoFloat(vs array.FloatRef) {
+	a.count += int64(vs.Len() - vs.NullN())
 }
-func (a *CountAgg) DoString(vs []string) {
-	a.count += int64(len(vs))
+func (a *CountAgg) DoString(vs array.StringRef) {
+	a.count += int64(vs.Len())
 }
 
 func (a *CountAgg) Type() flux.ColType {

--- a/functions/transformations/covariance.go
+++ b/functions/transformations/covariance.go
@@ -187,7 +187,7 @@ func (t *CovarianceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 	err = tbl.Do(func(cr flux.ColReader) error {
 		switch typ := cols[xIdx].Type; typ {
 		case flux.TFloat:
-			t.DoFloat(cr.Floats(xIdx), cr.Floats(yIdx))
+			t.DoFloat(cr.Floats(xIdx).Float64Values(), cr.Floats(yIdx).Float64Values())
 		default:
 			return fmt.Errorf("covariance does not support %v", typ)
 		}

--- a/functions/transformations/cumulative_sum.go
+++ b/functions/transformations/cumulative_sum.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
 )
 
 const CumulativeSumKind = "cumulativeSum"
@@ -140,51 +141,57 @@ func (t *cumulativeSumTransformation) Process(id execute.DatasetID, tbl flux.Tab
 		for j, c := range cols {
 			switch c.Type {
 			case flux.TBool:
-				if err := builder.AppendBools(j, cr.Bools(j)); err != nil {
+				if err := builder.AppendBools(j, cr.Bools(j).(interface {
+					BoolValues() []bool
+				}).BoolValues()); err != nil {
 					return err
 				}
 			case flux.TInt:
 				if sumers[j] != nil {
 					for i := 0; i < l; i++ {
-						if err := builder.AppendInt(j, sumers[j].sumInt(cr.Ints(j)[i])); err != nil {
+						if err := builder.AppendInt(j, sumers[j].sumInt(cr.Ints(j).Value(i))); err != nil {
 							return err
 						}
 					}
 				} else {
-					if err := builder.AppendInts(j, cr.Ints(j)); err != nil {
+					if err := builder.AppendInts(j, cr.Ints(j).Int64Values()); err != nil {
 						return err
 					}
 				}
 			case flux.TUInt:
 				if sumers[j] != nil {
 					for i := 0; i < l; i++ {
-						if err := builder.AppendUInt(j, sumers[j].sumUInt(cr.UInts(j)[i])); err != nil {
+						if err := builder.AppendUInt(j, sumers[j].sumUInt(cr.UInts(j).Value(i))); err != nil {
 							return err
 						}
 					}
 				} else {
-					if err := builder.AppendUInts(j, cr.UInts(j)); err != nil {
+					if err := builder.AppendUInts(j, cr.UInts(j).Uint64Values()); err != nil {
 						return err
 					}
 				}
 			case flux.TFloat:
 				if sumers[j] != nil {
 					for i := 0; i < l; i++ {
-						if err := builder.AppendFloat(j, sumers[j].sumFloat(cr.Floats(j)[i])); err != nil {
+						if err := builder.AppendFloat(j, sumers[j].sumFloat(cr.Floats(j).Value(i))); err != nil {
 							return err
 						}
 					}
 				} else {
-					if err := builder.AppendFloats(j, cr.Floats(j)); err != nil {
+					if err := builder.AppendFloats(j, cr.Floats(j).Float64Values()); err != nil {
 						return err
 					}
 				}
 			case flux.TString:
-				if err := builder.AppendStrings(j, cr.Strings(j)); err != nil {
+				if err := builder.AppendStrings(j, cr.Strings(j).(interface {
+					StringValues() []string
+				}).StringValues()); err != nil {
 					return err
 				}
 			case flux.TTime:
-				if err := builder.AppendTimes(j, cr.Times(j)); err != nil {
+				if err := builder.AppendTimes(j, cr.Times(j).(interface {
+					TimeValues() []values.Time
+				}).TimeValues()); err != nil {
 					return err
 				}
 			}

--- a/functions/transformations/derivative.go
+++ b/functions/transformations/derivative.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"time"
 
+	"github.com/influxdata/flux/values"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
@@ -208,14 +210,16 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 			d := derivatives[j]
 			switch c.Type {
 			case flux.TBool:
-				if err := builder.AppendBools(j, cr.Bools(j)[firstIdx:]); err != nil {
+				if err := builder.AppendBools(j, cr.Bools(j).(interface {
+					BoolValues() []bool
+				}).BoolValues()[firstIdx:]); err != nil {
 					return err
 				}
 			case flux.TInt:
 				if d != nil {
 					for i := 0; i < l; i++ {
-						time := cr.Times(timeIdx)[i]
-						v := d.updateInt(time, cr.Ints(j)[i])
+						time := cr.Times(timeIdx).Value(i)
+						v := d.updateInt(time, cr.Ints(j).Value(i))
 						if i != 0 || firstIdx == 0 {
 							if err := builder.AppendFloat(j, v); err != nil {
 								return err
@@ -223,15 +227,15 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 						}
 					}
 				} else {
-					if err := builder.AppendInts(j, cr.Ints(j)[firstIdx:]); err != nil {
+					if err := builder.AppendInts(j, cr.Ints(j).Int64Values()[firstIdx:]); err != nil {
 						return err
 					}
 				}
 			case flux.TUInt:
 				if d != nil {
 					for i := 0; i < l; i++ {
-						time := cr.Times(timeIdx)[i]
-						v := d.updateUInt(time, cr.UInts(j)[i])
+						time := cr.Times(timeIdx).Value(i)
+						v := d.updateUInt(time, cr.UInts(j).Value(i))
 						if i != 0 || firstIdx == 0 {
 							if err := builder.AppendFloat(j, v); err != nil {
 								return err
@@ -239,15 +243,15 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 						}
 					}
 				} else {
-					if err := builder.AppendUInts(j, cr.UInts(j)[firstIdx:]); err != nil {
+					if err := builder.AppendUInts(j, cr.UInts(j).Uint64Values()[firstIdx:]); err != nil {
 						return err
 					}
 				}
 			case flux.TFloat:
 				if d != nil {
 					for i := 0; i < l; i++ {
-						time := cr.Times(timeIdx)[i]
-						v := d.updateFloat(time, cr.Floats(j)[i])
+						time := cr.Times(timeIdx).Value(i)
+						v := d.updateFloat(time, cr.Floats(j).Value(i))
 						if i != 0 || firstIdx == 0 {
 							if err := builder.AppendFloat(j, v); err != nil {
 								return err
@@ -255,16 +259,20 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 						}
 					}
 				} else {
-					if err := builder.AppendFloats(j, cr.Floats(j)[firstIdx:]); err != nil {
+					if err := builder.AppendFloats(j, cr.Floats(j).Float64Values()[firstIdx:]); err != nil {
 						return err
 					}
 				}
 			case flux.TString:
-				if err := builder.AppendStrings(j, cr.Strings(j)[firstIdx:]); err != nil {
+				if err := builder.AppendStrings(j, cr.Strings(j).(interface {
+					StringValues() []string
+				}).StringValues()[firstIdx:]); err != nil {
 					return err
 				}
 			case flux.TTime:
-				if err := builder.AppendTimes(j, cr.Times(j)[firstIdx:]); err != nil {
+				if err := builder.AppendTimes(j, cr.Times(j).(interface {
+					TimeValues() []values.Time
+				}).TimeValues()[firstIdx:]); err != nil {
 					return err
 				}
 			}

--- a/functions/transformations/difference.go
+++ b/functions/transformations/difference.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/influxdata/flux/values"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
@@ -186,13 +188,15 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 				d := differences[j]
 				switch c.Type {
 				case flux.TBool:
-					if err := builder.AppendBools(j, cr.Bools(j)[firstIdx:]); err != nil {
+					if err := builder.AppendBools(j, cr.Bools(j).(interface {
+						BoolValues() []bool
+					}).BoolValues()[firstIdx:]); err != nil {
 						return err
 					}
 				case flux.TInt:
 					if d != nil {
 						for i := 0; i < l; i++ {
-							v := d.updateInt(cr.Ints(j)[i])
+							v := d.updateInt(cr.Ints(j).Value(i))
 							if i != 0 || firstIdx == 0 {
 								if err := builder.AppendInt(j, v); err != nil {
 									return err
@@ -200,14 +204,14 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 							}
 						}
 					} else {
-						if err := builder.AppendInts(j, cr.Ints(j)[firstIdx:]); err != nil {
+						if err := builder.AppendInts(j, cr.Ints(j).Int64Values()[firstIdx:]); err != nil {
 							return err
 						}
 					}
 				case flux.TUInt:
 					if d != nil {
 						for i := 0; i < l; i++ {
-							v := d.updateUInt(cr.UInts(j)[i])
+							v := d.updateUInt(cr.UInts(j).Value(i))
 							if i != 0 || firstIdx == 0 {
 								if err := builder.AppendInt(j, v); err != nil {
 									return err
@@ -215,14 +219,14 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 							}
 						}
 					} else {
-						if err := builder.AppendUInts(j, cr.UInts(j)[firstIdx:]); err != nil {
+						if err := builder.AppendUInts(j, cr.UInts(j).Uint64Values()[firstIdx:]); err != nil {
 							return err
 						}
 					}
 				case flux.TFloat:
 					if d != nil {
 						for i := 0; i < l; i++ {
-							v := d.updateFloat(cr.Floats(j)[i])
+							v := d.updateFloat(cr.Floats(j).Value(i))
 							if i != 0 || firstIdx == 0 {
 								if err := builder.AppendFloat(j, v); err != nil {
 									return err
@@ -230,16 +234,20 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 							}
 						}
 					} else {
-						if err := builder.AppendFloats(j, cr.Floats(j)[firstIdx:]); err != nil {
+						if err := builder.AppendFloats(j, cr.Floats(j).Float64Values()[firstIdx:]); err != nil {
 							return err
 						}
 					}
 				case flux.TString:
-					if err := builder.AppendStrings(j, cr.Strings(j)[firstIdx:]); err != nil {
+					if err := builder.AppendStrings(j, cr.Strings(j).(interface {
+						StringValues() []string
+					}).StringValues()[firstIdx:]); err != nil {
 						return err
 					}
 				case flux.TTime:
-					if err := builder.AppendTimes(j, cr.Times(j)[firstIdx:]); err != nil {
+					if err := builder.AppendTimes(j, cr.Times(j).(interface {
+						TimeValues() []values.Time
+					}).TimeValues()[firstIdx:]); err != nil {
 						return err
 					}
 				}

--- a/functions/transformations/distinct.go
+++ b/functions/transformations/distinct.go
@@ -226,7 +226,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 			// Check distinct
 			switch col.Type {
 			case flux.TBool:
-				v := cr.Bools(j)[i]
+				v := cr.Bools(j).Value(i)
 				if boolDistinct[v] {
 					continue
 				}
@@ -235,7 +235,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					return err
 				}
 			case flux.TInt:
-				v := cr.Ints(j)[i]
+				v := cr.Ints(j).Value(i)
 				if intDistinct[v] {
 					continue
 				}
@@ -244,7 +244,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					return err
 				}
 			case flux.TUInt:
-				v := cr.UInts(j)[i]
+				v := cr.UInts(j).Value(i)
 				if uintDistinct[v] {
 					continue
 				}
@@ -253,7 +253,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					return err
 				}
 			case flux.TFloat:
-				v := cr.Floats(j)[i]
+				v := cr.Floats(j).Value(i)
 				if floatDistinct[v] {
 					continue
 				}
@@ -262,7 +262,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					return err
 				}
 			case flux.TString:
-				v := cr.Strings(j)[i]
+				v := cr.Strings(j).Value(i)
 				if stringDistinct[v] {
 					continue
 				}
@@ -271,7 +271,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					return err
 				}
 			case flux.TTime:
-				v := cr.Times(j)[i]
+				v := cr.Times(j).Value(i)
 				if timeDistinct[v] {
 					continue
 				}

--- a/functions/transformations/first.go
+++ b/functions/transformations/first.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -114,18 +115,18 @@ func (s *FirstSelector) selectFirst(l int) []int {
 	}
 	return nil
 }
-func (s *FirstSelector) DoBool(vs []bool) []int {
-	return s.selectFirst(len(vs))
+func (s *FirstSelector) DoBool(vs array.BooleanRef) []int {
+	return s.selectFirst(vs.Len())
 }
-func (s *FirstSelector) DoInt(vs []int64) []int {
-	return s.selectFirst(len(vs))
+func (s *FirstSelector) DoInt(vs array.IntRef) []int {
+	return s.selectFirst(vs.Len())
 }
-func (s *FirstSelector) DoUInt(vs []uint64) []int {
-	return s.selectFirst(len(vs))
+func (s *FirstSelector) DoUInt(vs array.UIntRef) []int {
+	return s.selectFirst(vs.Len())
 }
-func (s *FirstSelector) DoFloat(vs []float64) []int {
-	return s.selectFirst(len(vs))
+func (s *FirstSelector) DoFloat(vs array.FloatRef) []int {
+	return s.selectFirst(vs.Len())
 }
-func (s *FirstSelector) DoString(vs []string) []int {
-	return s.selectFirst(len(vs))
+func (s *FirstSelector) DoString(vs array.StringRef) []int {
+	return s.selectFirst(vs.Len())
 }

--- a/functions/transformations/histogram.go
+++ b/functions/transformations/histogram.go
@@ -192,7 +192,7 @@ func (t *histogramTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 	counts := make([]float64, len(t.spec.Bins))
 	err = tbl.Do(func(cr flux.ColReader) error {
 		totalRows += float64(cr.Len())
-		for _, v := range cr.Floats(valueIdx) {
+		for _, v := range cr.Floats(valueIdx).Float64Values() {
 			idx := sort.Search(len(t.spec.Bins), func(i int) bool {
 				return v <= t.spec.Bins[i]
 			})

--- a/functions/transformations/histogram_quantile.go
+++ b/functions/transformations/histogram_quantile.go
@@ -214,8 +214,8 @@ func (t histogramQuantileTransformation) Process(id execute.DatasetID, tbl flux.
 			curr := i + offset
 			prev := curr - 1
 			cdf[curr] = bucket{
-				count:      cr.Floats(countIdx)[i],
-				upperBound: cr.Floats(upperBoundIdx)[i],
+				count:      cr.Floats(countIdx).Value(i),
+				upperBound: cr.Floats(upperBoundIdx).Value(i),
 			}
 			if prev >= 0 {
 				sorted = sorted && cdf[prev].upperBound <= cdf[curr].upperBound

--- a/functions/transformations/integral.go
+++ b/functions/transformations/integral.go
@@ -172,8 +172,8 @@ func (t *integralTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 			}
 			l := cr.Len()
 			for i := 0; i < l; i++ {
-				tm := cr.Times(timeIdx)[i]
-				in.updateFloat(tm, cr.Floats(j)[i])
+				tm := cr.Times(timeIdx).Value(i)
+				in.updateFloat(tm, cr.Floats(j).Value(i))
 			}
 		}
 		return nil

--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -958,27 +958,27 @@ func equalRowKeys(x, y int, table flux.ColReader, on map[string]bool) bool {
 		}
 		switch c.Type {
 		case flux.TBool:
-			if xv, yv := table.Bools(j)[x], table.Bools(j)[y]; xv != yv {
+			if xv, yv := table.Bools(j).Value(x), table.Bools(j).Value(y); xv != yv {
 				return false
 			}
 		case flux.TInt:
-			if xv, yv := table.Ints(j)[x], table.Ints(j)[y]; xv != yv {
+			if xv, yv := table.Ints(j).Value(x), table.Ints(j).Value(y); xv != yv {
 				return false
 			}
 		case flux.TUInt:
-			if xv, yv := table.UInts(j)[x], table.UInts(j)[y]; xv != yv {
+			if xv, yv := table.UInts(j).Value(x), table.UInts(j).Value(y); xv != yv {
 				return false
 			}
 		case flux.TFloat:
-			if xv, yv := table.Floats(j)[x], table.Floats(j)[y]; xv != yv {
+			if xv, yv := table.Floats(j).Value(x), table.Floats(j).Value(y); xv != yv {
 				return false
 			}
 		case flux.TString:
-			if xv, yv := table.Strings(j)[x], table.Strings(j)[y]; xv != yv {
+			if xv, yv := table.Strings(j).Value(x), table.Strings(j).Value(y); xv != yv {
 				return false
 			}
 		case flux.TTime:
-			if xv, yv := table.Times(j)[x], table.Times(j)[y]; xv != yv {
+			if xv, yv := table.Times(j).Value(x), table.Times(j).Value(y); xv != yv {
 				return false
 			}
 		default:

--- a/functions/transformations/key_values.go
+++ b/functions/transformations/key_values.go
@@ -232,7 +232,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 				}
 				switch keyColType {
 				case flux.TBool:
-					v := cr.Bools(rowIdx)[i]
+					v := cr.Bools(rowIdx).Value(i)
 					if t.distinct {
 						if boolDistinct[v] {
 							continue
@@ -246,7 +246,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						return err
 					}
 				case flux.TInt:
-					v := cr.Ints(rowIdx)[i]
+					v := cr.Ints(rowIdx).Value(i)
 					if t.distinct {
 						if intDistinct[v] {
 							continue
@@ -260,7 +260,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						return err
 					}
 				case flux.TUInt:
-					v := cr.UInts(rowIdx)[i]
+					v := cr.UInts(rowIdx).Value(i)
 					if t.distinct {
 						if uintDistinct[v] {
 							continue
@@ -274,7 +274,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						return err
 					}
 				case flux.TFloat:
-					v := cr.Floats(rowIdx)[i]
+					v := cr.Floats(rowIdx).Value(i)
 					if t.distinct {
 						if floatDistinct[v] {
 							continue
@@ -288,7 +288,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						return err
 					}
 				case flux.TString:
-					v := cr.Strings(rowIdx)[i]
+					v := cr.Strings(rowIdx).Value(i)
 					if t.distinct {
 						if stringDistinct[v] {
 							continue
@@ -302,7 +302,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						return err
 					}
 				case flux.TTime:
-					v := cr.Times(rowIdx)[i]
+					v := cr.Times(rowIdx).Value(i)
 					if t.distinct {
 						if timeDistinct[v] {
 							continue

--- a/functions/transformations/last.go
+++ b/functions/transformations/last.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -118,18 +119,18 @@ func (s *LastSelector) selectLast(l int, cr flux.ColReader) {
 	}
 }
 
-func (s *LastSelector) DoBool(vs []bool, cr flux.ColReader) {
-	s.selectLast(len(vs), cr)
+func (s *LastSelector) DoBool(vs array.BooleanRef, cr flux.ColReader) {
+	s.selectLast(vs.Len(), cr)
 }
-func (s *LastSelector) DoInt(vs []int64, cr flux.ColReader) {
-	s.selectLast(len(vs), cr)
+func (s *LastSelector) DoInt(vs array.IntRef, cr flux.ColReader) {
+	s.selectLast(vs.Len(), cr)
 }
-func (s *LastSelector) DoUInt(vs []uint64, cr flux.ColReader) {
-	s.selectLast(len(vs), cr)
+func (s *LastSelector) DoUInt(vs array.UIntRef, cr flux.ColReader) {
+	s.selectLast(vs.Len(), cr)
 }
-func (s *LastSelector) DoFloat(vs []float64, cr flux.ColReader) {
-	s.selectLast(len(vs), cr)
+func (s *LastSelector) DoFloat(vs array.FloatRef, cr flux.ColReader) {
+	s.selectLast(vs.Len(), cr)
 }
-func (s *LastSelector) DoString(vs []string, cr flux.ColReader) {
-	s.selectLast(len(vs), cr)
+func (s *LastSelector) DoString(vs array.StringRef, cr flux.ColReader) {
+	s.selectLast(vs.Len(), cr)
 }

--- a/functions/transformations/limit.go
+++ b/functions/transformations/limit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -178,31 +179,31 @@ type sliceColReader struct {
 }
 
 func (cr sliceColReader) Len() int {
-	return cr.stop
+	return cr.stop - cr.start
 }
 
-func (cr sliceColReader) Bools(j int) []bool {
-	return cr.ColReader.Bools(j)[cr.start:cr.stop]
+func (cr sliceColReader) Bools(j int) array.BooleanRef {
+	return cr.ColReader.Bools(j).BooleanSlice(cr.start, cr.stop)
 }
 
-func (cr sliceColReader) Ints(j int) []int64 {
-	return cr.ColReader.Ints(j)[cr.start:cr.stop]
+func (cr sliceColReader) Ints(j int) array.IntRef {
+	return cr.ColReader.Ints(j).IntSlice(cr.start, cr.stop)
 }
 
-func (cr sliceColReader) UInts(j int) []uint64 {
-	return cr.ColReader.UInts(j)[cr.start:cr.stop]
+func (cr sliceColReader) UInts(j int) array.UIntRef {
+	return cr.ColReader.UInts(j).UIntSlice(cr.start, cr.stop)
 }
 
-func (cr sliceColReader) Floats(j int) []float64 {
-	return cr.ColReader.Floats(j)[cr.start:cr.stop]
+func (cr sliceColReader) Floats(j int) array.FloatRef {
+	return cr.ColReader.Floats(j).FloatSlice(cr.start, cr.stop)
 }
 
-func (cr sliceColReader) Strings(j int) []string {
-	return cr.ColReader.Strings(j)[cr.start:cr.stop]
+func (cr sliceColReader) Strings(j int) array.StringRef {
+	return cr.ColReader.Strings(j).StringSlice(cr.start, cr.stop)
 }
 
-func (cr sliceColReader) Times(j int) []execute.Time {
-	return cr.ColReader.Times(j)[cr.start:cr.stop]
+func (cr sliceColReader) Times(j int) array.TimeRef {
+	return cr.ColReader.Times(j).TimeSlice(cr.start, cr.stop)
 }
 
 func (t *limitTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {

--- a/functions/transformations/map.go
+++ b/functions/transformations/map.go
@@ -229,17 +229,17 @@ func groupKeyForObject(i int, cr flux.ColReader, obj values.Object, on map[strin
 		} else {
 			switch c.Type {
 			case flux.TBool:
-				vs = append(vs, values.NewBool(cr.Bools(j)[i]))
+				vs = append(vs, values.NewBool(cr.Bools(j).Value(i)))
 			case flux.TInt:
-				vs = append(vs, values.NewInt(cr.Ints(j)[i]))
+				vs = append(vs, values.NewInt(cr.Ints(j).Value(i)))
 			case flux.TUInt:
-				vs = append(vs, values.NewUInt(cr.UInts(j)[i]))
+				vs = append(vs, values.NewUInt(cr.UInts(j).Value(i)))
 			case flux.TFloat:
-				vs = append(vs, values.NewFloat(cr.Floats(j)[i]))
+				vs = append(vs, values.NewFloat(cr.Floats(j).Value(i)))
 			case flux.TString:
-				vs = append(vs, values.NewString(cr.Strings(j)[i]))
+				vs = append(vs, values.NewString(cr.Strings(j).Value(i)))
 			case flux.TTime:
-				vs = append(vs, values.NewTime(cr.Times(j)[i]))
+				vs = append(vs, values.NewTime(cr.Times(j).Value(i)))
 			}
 		}
 	}

--- a/functions/transformations/max.go
+++ b/functions/transformations/max.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -128,9 +129,9 @@ func (s *MaxSelector) selectRow(idx int, cr flux.ColReader) {
 	}
 }
 
-func (s *MaxIntSelector) DoInt(vs []int64, cr flux.ColReader) {
+func (s *MaxIntSelector) DoInt(vs array.IntRef, cr flux.ColReader) {
 	maxIdx := -1
-	for i, v := range vs {
+	for i, v := range vs.Int64Values() {
 		if !s.set || v > s.max {
 			s.set = true
 			s.max = v
@@ -139,9 +140,9 @@ func (s *MaxIntSelector) DoInt(vs []int64, cr flux.ColReader) {
 	}
 	s.selectRow(maxIdx, cr)
 }
-func (s *MaxUIntSelector) DoUInt(vs []uint64, cr flux.ColReader) {
+func (s *MaxUIntSelector) DoUInt(vs array.UIntRef, cr flux.ColReader) {
 	maxIdx := -1
-	for i, v := range vs {
+	for i, v := range vs.Uint64Values() {
 		if !s.set || v > s.max {
 			s.set = true
 			s.max = v
@@ -150,9 +151,9 @@ func (s *MaxUIntSelector) DoUInt(vs []uint64, cr flux.ColReader) {
 	}
 	s.selectRow(maxIdx, cr)
 }
-func (s *MaxFloatSelector) DoFloat(vs []float64, cr flux.ColReader) {
+func (s *MaxFloatSelector) DoFloat(vs array.FloatRef, cr flux.ColReader) {
 	maxIdx := -1
-	for i, v := range vs {
+	for i, v := range vs.Float64Values() {
 		if !s.set || v > s.max {
 			s.set = true
 			s.max = v

--- a/functions/transformations/mean.go
+++ b/functions/transformations/mean.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -100,23 +101,23 @@ func (a *MeanAgg) NewStringAgg() execute.DoStringAgg {
 	return nil
 }
 
-func (a *MeanAgg) DoInt(vs []int64) {
-	a.count += float64(len(vs))
-	for _, v := range vs {
+func (a *MeanAgg) DoInt(vs array.IntRef) {
+	a.count += float64(vs.Len())
+	for _, v := range vs.Int64Values() {
 		//TODO handle overflow
 		a.sum += float64(v)
 	}
 }
-func (a *MeanAgg) DoUInt(vs []uint64) {
-	a.count += float64(len(vs))
-	for _, v := range vs {
+func (a *MeanAgg) DoUInt(vs array.UIntRef) {
+	a.count += float64(vs.Len())
+	for _, v := range vs.Uint64Values() {
 		//TODO handle overflow
 		a.sum += float64(v)
 	}
 }
-func (a *MeanAgg) DoFloat(vs []float64) {
-	a.count += float64(len(vs))
-	for _, v := range vs {
+func (a *MeanAgg) DoFloat(vs array.FloatRef) {
+	a.count += float64(vs.Len())
+	for _, v := range vs.Float64Values() {
 		a.sum += v
 	}
 }

--- a/functions/transformations/min.go
+++ b/functions/transformations/min.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -128,9 +129,9 @@ func (s *MinSelector) selectRow(idx int, cr flux.ColReader) {
 	}
 }
 
-func (s *MinIntSelector) DoInt(vs []int64, cr flux.ColReader) {
+func (s *MinIntSelector) DoInt(vs array.IntRef, cr flux.ColReader) {
 	minIdx := -1
-	for i, v := range vs {
+	for i, v := range vs.Int64Values() {
 		if !s.set || v < s.min {
 			s.set = true
 			s.min = v
@@ -139,9 +140,9 @@ func (s *MinIntSelector) DoInt(vs []int64, cr flux.ColReader) {
 	}
 	s.selectRow(minIdx, cr)
 }
-func (s *MinUIntSelector) DoUInt(vs []uint64, cr flux.ColReader) {
+func (s *MinUIntSelector) DoUInt(vs array.UIntRef, cr flux.ColReader) {
 	minIdx := -1
-	for i, v := range vs {
+	for i, v := range vs.Uint64Values() {
 		if !s.set || v < s.min {
 			s.set = true
 			s.min = v
@@ -150,9 +151,9 @@ func (s *MinUIntSelector) DoUInt(vs []uint64, cr flux.ColReader) {
 	}
 	s.selectRow(minIdx, cr)
 }
-func (s *MinFloatSelector) DoFloat(vs []float64, cr flux.ColReader) {
+func (s *MinFloatSelector) DoFloat(vs array.FloatRef, cr flux.ColReader) {
 	minIdx := -1
-	for i, v := range vs {
+	for i, v := range vs.Float64Values() {
 		if !s.set || v < s.min {
 			s.set = true
 			s.min = v

--- a/functions/transformations/percentile.go
+++ b/functions/transformations/percentile.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
@@ -234,8 +235,8 @@ func (a *PercentileAgg) NewStringAgg() execute.DoStringAgg {
 	return nil
 }
 
-func (a *PercentileAgg) DoFloat(vs []float64) {
-	for _, v := range vs {
+func (a *PercentileAgg) DoFloat(vs array.FloatRef) {
+	for _, v := range vs.Float64Values() {
 		a.digest.Add(v, 1)
 	}
 }
@@ -290,8 +291,8 @@ func (a *ExactPercentileAgg) NewStringAgg() execute.DoStringAgg {
 	return nil
 }
 
-func (a *ExactPercentileAgg) DoFloat(vs []float64) {
-	a.data = append(a.data, vs...)
+func (a *ExactPercentileAgg) DoFloat(vs array.FloatRef) {
+	a.data = append(a.data, vs.Float64Values()...)
 }
 
 func (a *ExactPercentileAgg) Type() flux.ColType {

--- a/functions/transformations/pivot.go
+++ b/functions/transformations/pivot.go
@@ -342,17 +342,17 @@ func growColumn(builder execute.TableBuilder, colType flux.ColType, colIdx, nRow
 func setBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColType flux.ColType, readerRowIndex, readerColIndex, builderRow, builderCol int) error {
 	switch readerColType {
 	case flux.TBool:
-		return builder.SetBool(builderRow, builderCol, cr.Bools(readerColIndex)[readerRowIndex])
+		return builder.SetBool(builderRow, builderCol, cr.Bools(readerColIndex).Value(readerRowIndex))
 	case flux.TInt:
-		return builder.SetInt(builderRow, builderCol, cr.Ints(readerColIndex)[readerRowIndex])
+		return builder.SetInt(builderRow, builderCol, cr.Ints(readerColIndex).Value(readerRowIndex))
 	case flux.TUInt:
-		return builder.SetUInt(builderRow, builderCol, cr.UInts(readerColIndex)[readerRowIndex])
+		return builder.SetUInt(builderRow, builderCol, cr.UInts(readerColIndex).Value(readerRowIndex))
 	case flux.TFloat:
-		return builder.SetFloat(builderRow, builderCol, cr.Floats(readerColIndex)[readerRowIndex])
+		return builder.SetFloat(builderRow, builderCol, cr.Floats(readerColIndex).Value(readerRowIndex))
 	case flux.TString:
-		return builder.SetString(builderRow, builderCol, cr.Strings(readerColIndex)[readerRowIndex])
+		return builder.SetString(builderRow, builderCol, cr.Strings(readerColIndex).Value(readerRowIndex))
 	case flux.TTime:
-		return builder.SetTime(builderRow, builderCol, cr.Times(readerColIndex)[readerRowIndex])
+		return builder.SetTime(builderRow, builderCol, cr.Times(readerColIndex).Value(readerRowIndex))
 	default:
 		execute.PanicUnknownType(readerColType)
 		return fmt.Errorf("invalid column type: %s", readerColType)
@@ -362,17 +362,17 @@ func setBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColT
 func appendBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerColType flux.ColType, readerRowIndex, readerColIndex, builderColIndex int) error {
 	switch readerColType {
 	case flux.TBool:
-		return builder.AppendBool(builderColIndex, cr.Bools(readerColIndex)[readerRowIndex])
+		return builder.AppendBool(builderColIndex, cr.Bools(readerColIndex).Value(readerRowIndex))
 	case flux.TInt:
-		return builder.AppendInt(builderColIndex, cr.Ints(readerColIndex)[readerRowIndex])
+		return builder.AppendInt(builderColIndex, cr.Ints(readerColIndex).Value(readerRowIndex))
 	case flux.TUInt:
-		return builder.AppendUInt(builderColIndex, cr.UInts(readerColIndex)[readerRowIndex])
+		return builder.AppendUInt(builderColIndex, cr.UInts(readerColIndex).Value(readerRowIndex))
 	case flux.TFloat:
-		return builder.AppendFloat(builderColIndex, cr.Floats(readerColIndex)[readerRowIndex])
+		return builder.AppendFloat(builderColIndex, cr.Floats(readerColIndex).Value(readerRowIndex))
 	case flux.TString:
-		return builder.AppendString(builderColIndex, cr.Strings(readerColIndex)[readerRowIndex])
+		return builder.AppendString(builderColIndex, cr.Strings(readerColIndex).Value(readerRowIndex))
 	case flux.TTime:
-		return builder.AppendTime(builderColIndex, cr.Times(readerColIndex)[readerRowIndex])
+		return builder.AppendTime(builderColIndex, cr.Times(readerColIndex).Value(readerRowIndex))
 	default:
 		execute.PanicUnknownType(readerColType)
 		return fmt.Errorf("invalid column type: %s", readerColType)
@@ -382,17 +382,17 @@ func appendBuilderValue(cr flux.ColReader, builder execute.TableBuilder, readerC
 func valueToStr(cr flux.ColReader, c flux.ColMeta, row, col int) string {
 	switch c.Type {
 	case flux.TBool:
-		return strconv.FormatBool(cr.Bools(col)[row])
+		return strconv.FormatBool(cr.Bools(col).Value(row))
 	case flux.TInt:
-		return strconv.FormatInt(cr.Ints(col)[row], 10)
+		return strconv.FormatInt(cr.Ints(col).Value(row), 10)
 	case flux.TUInt:
-		return strconv.FormatUint(cr.UInts(col)[row], 10)
+		return strconv.FormatUint(cr.UInts(col).Value(row), 10)
 	case flux.TFloat:
-		return strconv.FormatFloat(cr.Floats(col)[row], 'E', -1, 64)
+		return strconv.FormatFloat(cr.Floats(col).Value(row), 'E', -1, 64)
 	case flux.TString:
-		return cr.Strings(col)[row]
+		return cr.Strings(col).Value(row)
 	case flux.TTime:
-		return cr.Times(col)[row].String()
+		return cr.Times(col).Value(row).String()
 	default:
 		execute.PanicUnknownType(c.Type)
 	}

--- a/functions/transformations/range.go
+++ b/functions/transformations/range.go
@@ -283,7 +283,7 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			tVal := cr.Times(timeIdx)[i]
+			tVal := cr.Times(timeIdx).Value(i)
 			if !t.bounds.Contains(tVal) {
 				continue
 			}
@@ -295,7 +295,7 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 					if startAdded {
 						start = t.bounds.Start
 					} else {
-						start = cr.Times(j)[i]
+						start = cr.Times(j).Value(i)
 					}
 
 					if start < t.bounds.Start {
@@ -310,7 +310,7 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 					if stopAdded {
 						stop = t.bounds.Stop
 					} else {
-						stop = cr.Times(j)[i]
+						stop = cr.Times(j).Value(i)
 					}
 
 					if stop > t.bounds.Stop {

--- a/functions/transformations/sample.go
+++ b/functions/transformations/sample.go
@@ -2,10 +2,10 @@ package transformations
 
 import (
 	"fmt"
-
 	"math/rand"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -164,18 +164,18 @@ func (s *SampleSelector) selectSample(l int) []int {
 	return s.selected
 }
 
-func (s *SampleSelector) DoBool(vs []bool) []int {
-	return s.selectSample(len(vs))
+func (s *SampleSelector) DoBool(vs array.BooleanRef) []int {
+	return s.selectSample(vs.Len())
 }
-func (s *SampleSelector) DoInt(vs []int64) []int {
-	return s.selectSample(len(vs))
+func (s *SampleSelector) DoInt(vs array.IntRef) []int {
+	return s.selectSample(vs.Len())
 }
-func (s *SampleSelector) DoUInt(vs []uint64) []int {
-	return s.selectSample(len(vs))
+func (s *SampleSelector) DoUInt(vs array.UIntRef) []int {
+	return s.selectSample(vs.Len())
 }
-func (s *SampleSelector) DoFloat(vs []float64) []int {
-	return s.selectSample(len(vs))
+func (s *SampleSelector) DoFloat(vs array.FloatRef) []int {
+	return s.selectSample(vs.Len())
 }
-func (s *SampleSelector) DoString(vs []string) []int {
-	return s.selectSample(len(vs))
+func (s *SampleSelector) DoString(vs array.StringRef) []int {
+	return s.selectSample(vs.Len())
 }

--- a/functions/transformations/shift.go
+++ b/functions/transformations/shift.go
@@ -179,7 +179,7 @@ func (t *shiftTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 			if execute.ContainsStr(t.columns, c.Label) {
 				l := cr.Len()
 				for i := 0; i < l; i++ {
-					if err := builder.AppendTime(j, cr.Times(j)[i].Add(t.shift)); err != nil {
+					if err := builder.AppendTime(j, cr.Times(j).Value(i).Add(t.shift)); err != nil {
 						return err
 					}
 				}

--- a/functions/transformations/skew.go
+++ b/functions/transformations/skew.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -109,8 +110,8 @@ func (a *SkewAgg) NewStringAgg() execute.DoStringAgg {
 	return nil
 }
 
-func (a *SkewAgg) DoInt(vs []int64) {
-	for _, v := range vs {
+func (a *SkewAgg) DoInt(vs array.IntRef) {
+	for _, v := range vs.Int64Values() {
 		n0 := a.n
 		a.n++
 		// TODO handle overflow
@@ -122,8 +123,8 @@ func (a *SkewAgg) DoInt(vs []int64) {
 		a.m1 += deltaN
 	}
 }
-func (a *SkewAgg) DoUInt(vs []uint64) {
-	for _, v := range vs {
+func (a *SkewAgg) DoUInt(vs array.UIntRef) {
+	for _, v := range vs.Uint64Values() {
 		n0 := a.n
 		a.n++
 		// TODO handle overflow
@@ -135,8 +136,8 @@ func (a *SkewAgg) DoUInt(vs []uint64) {
 		a.m1 += deltaN
 	}
 }
-func (a *SkewAgg) DoFloat(vs []float64) {
-	for _, v := range vs {
+func (a *SkewAgg) DoFloat(vs array.FloatRef) {
+	for _, v := range vs.Float64Values() {
 		n0 := a.n
 		a.n++
 		delta := v - a.m1

--- a/functions/transformations/spread.go
+++ b/functions/transformations/spread.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -125,8 +126,8 @@ func (a *SpreadAgg) NewStringAgg() execute.DoStringAgg {
 }
 
 // DoInt searches for the min and max value of the array and caches them in the aggregate
-func (a *SpreadIntAgg) DoInt(vs []int64) {
-	for _, v := range vs {
+func (a *SpreadIntAgg) DoInt(vs array.IntRef) {
+	for _, v := range vs.Int64Values() {
 		if !a.minSet || v < a.min {
 			a.minSet = true
 			a.min = v
@@ -148,8 +149,8 @@ func (a *SpreadIntAgg) ValueInt() int64 {
 }
 
 // Do searches for the min and max value of the array and caches them in the aggregate
-func (a *SpreadUIntAgg) DoUInt(vs []uint64) {
-	for _, v := range vs {
+func (a *SpreadUIntAgg) DoUInt(vs array.UIntRef) {
+	for _, v := range vs.Uint64Values() {
 		if !a.minSet || v < a.min {
 			a.minSet = true
 			a.min = v
@@ -171,8 +172,8 @@ func (a *SpreadUIntAgg) ValueUInt() uint64 {
 }
 
 // Do searches for the min and max value of the array and caches them in the aggregate
-func (a *SpreadFloatAgg) DoFloat(vs []float64) {
-	for _, v := range vs {
+func (a *SpreadFloatAgg) DoFloat(vs array.FloatRef) {
+	for _, v := range vs.Float64Values() {
 		if !a.minSet || v < a.min {
 			a.minSet = true
 			a.min = v

--- a/functions/transformations/state_tracking.go
+++ b/functions/transformations/state_tracking.go
@@ -277,7 +277,7 @@ func (t *stateTrackingTransformation) Process(id execute.DatasetID, tbl flux.Tab
 	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			tm := cr.Times(timeIdx)[i]
+			tm := cr.Times(timeIdx).Value(i)
 			match, err := t.fn.Eval(i, cr)
 			if err != nil {
 				log.Printf("failed to evaluate state count expression: %v", err)

--- a/functions/transformations/stddev.go
+++ b/functions/transformations/stddev.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -97,9 +98,9 @@ func (a *StddevAgg) NewFloatAgg() execute.DoFloatAgg {
 func (a *StddevAgg) NewStringAgg() execute.DoStringAgg {
 	return nil
 }
-func (a *StddevAgg) DoInt(vs []int64) {
+func (a *StddevAgg) DoInt(vs array.IntRef) {
 	var delta, delta2 float64
-	for _, v := range vs {
+	for _, v := range vs.Int64Values() {
 		a.n++
 		// TODO handle overflow
 		delta = float64(v) - a.mean
@@ -108,9 +109,9 @@ func (a *StddevAgg) DoInt(vs []int64) {
 		a.m2 += delta * delta2
 	}
 }
-func (a *StddevAgg) DoUInt(vs []uint64) {
+func (a *StddevAgg) DoUInt(vs array.UIntRef) {
 	var delta, delta2 float64
-	for _, v := range vs {
+	for _, v := range vs.Uint64Values() {
 		a.n++
 		// TODO handle overflow
 		delta = float64(v) - a.mean
@@ -119,9 +120,9 @@ func (a *StddevAgg) DoUInt(vs []uint64) {
 		a.m2 += delta * delta2
 	}
 }
-func (a *StddevAgg) DoFloat(vs []float64) {
+func (a *StddevAgg) DoFloat(vs array.FloatRef) {
 	var delta, delta2 float64
-	for _, v := range vs {
+	for _, v := range vs.Float64Values() {
 		a.n++
 		delta = v - a.mean
 		a.mean += delta / a.n

--- a/functions/transformations/sum.go
+++ b/functions/transformations/sum.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 )
@@ -105,8 +106,8 @@ type SumIntAgg struct {
 	sum int64
 }
 
-func (a *SumIntAgg) DoInt(vs []int64) {
-	for _, v := range vs {
+func (a *SumIntAgg) DoInt(vs array.IntRef) {
+	for _, v := range vs.Int64Values() {
 		a.sum += v
 	}
 }
@@ -121,8 +122,8 @@ type SumUIntAgg struct {
 	sum uint64
 }
 
-func (a *SumUIntAgg) DoUInt(vs []uint64) {
-	for _, v := range vs {
+func (a *SumUIntAgg) DoUInt(vs array.UIntRef) {
+	for _, v := range vs.Uint64Values() {
 		a.sum += v
 	}
 }
@@ -137,8 +138,8 @@ type SumFloatAgg struct {
 	sum float64
 }
 
-func (a *SumFloatAgg) DoFloat(vs []float64) {
-	for _, v := range vs {
+func (a *SumFloatAgg) DoFloat(vs array.FloatRef) {
+	for _, v := range vs.Float64Values() {
 		a.sum += v
 	}
 }

--- a/functions/transformations/unique.go
+++ b/functions/transformations/unique.go
@@ -156,37 +156,37 @@ func (t *uniqueTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 			// Check unique
 			switch col.Type {
 			case flux.TBool:
-				v := cr.Bools(colIdx)[i]
+				v := cr.Bools(colIdx).Value(i)
 				if boolUnique[v] {
 					continue
 				}
 				boolUnique[v] = true
 			case flux.TInt:
-				v := cr.Ints(colIdx)[i]
+				v := cr.Ints(colIdx).Value(i)
 				if intUnique[v] {
 					continue
 				}
 				intUnique[v] = true
 			case flux.TUInt:
-				v := cr.UInts(colIdx)[i]
+				v := cr.UInts(colIdx).Value(i)
 				if uintUnique[v] {
 					continue
 				}
 				uintUnique[v] = true
 			case flux.TFloat:
-				v := cr.Floats(colIdx)[i]
+				v := cr.Floats(colIdx).Value(i)
 				if floatUnique[v] {
 					continue
 				}
 				floatUnique[v] = true
 			case flux.TString:
-				v := cr.Strings(colIdx)[i]
+				v := cr.Strings(colIdx).Value(i)
 				if stringUnique[v] {
 					continue
 				}
 				stringUnique[v] = true
 			case flux.TTime:
-				v := cr.Times(colIdx)[i]
+				v := cr.Times(colIdx).Value(i)
 				if timeUnique[v] {
 					continue
 				}

--- a/functions/transformations/window.go
+++ b/functions/transformations/window.go
@@ -336,7 +336,7 @@ func (t *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table
 	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			tm := cr.Times(timeIdx)[i]
+			tm := cr.Times(timeIdx).Value(i)
 			bounds := t.getWindowBounds(tm)
 
 			for _, bnds := range bounds {

--- a/result.go
+++ b/result.go
@@ -3,6 +3,7 @@ package flux
 import (
 	"io"
 
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -116,12 +117,12 @@ type ColReader interface {
 	// Len returns the length of the slices.
 	// All slices will have the same length.
 	Len() int
-	Bools(j int) []bool
-	Ints(j int) []int64
-	UInts(j int) []uint64
-	Floats(j int) []float64
-	Strings(j int) []string
-	Times(j int) []values.Time
+	Bools(j int) array.BooleanRef
+	Ints(j int) array.IntRef
+	UInts(j int) array.UIntRef
+	Floats(j int) array.FloatRef
+	Strings(j int) array.StringRef
+	Times(j int) array.TimeRef
 }
 
 type GroupKey interface {


### PR DESCRIPTION
This modifies `execute.ColReader` to use the interfaces in the `array` package. This will make it easier to integrate arrow with the query engine when we make an array implementation of it.

Some of the array interfaces in arrow do not expose the underlying array to the data, but they are used in some of the functions. For those, they will do a typecast directly on the staticarray implementation to access the data. These will need to be removed before we change to arrow implementations.