### PR TITLE
feat: add a new table builder that builds on the array package

### DIFF
--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -19,11 +19,24 @@ func ProcessTestHelper(
 ) {
 	t.Helper()
 
-	d := NewDataset(RandomDatasetID())
-	c := execute.NewTableBuilderCache(UnlimitedAllocator)
-	c.SetTriggerSpec(execute.DefaultTriggerSpec)
+	ProcessTest(t, data, want, wantErr, func() (execute.DataCache, execute.Transformation) {
+		d := NewDataset(RandomDatasetID())
+		c := execute.NewTableBuilderCache(UnlimitedAllocator)
+		c.SetTriggerSpec(execute.DefaultTriggerSpec)
+		return c, create(d, c)
+	})
+}
 
-	tx := create(d, c)
+func ProcessTest(
+	t *testing.T,
+	data []flux.Table,
+	want []*Table,
+	wantErr error,
+	create func() (execute.DataCache, execute.Transformation),
+) {
+	t.Helper()
+
+	c, tx := create()
 
 	parentID := RandomDatasetID()
 	for _, b := range data {

--- a/functions/transformations/distinct.go
+++ b/functions/transformations/distinct.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/execute/tablebuilder"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -87,7 +89,7 @@ func createDistinctTransformation(id execute.DatasetID, mode execute.Accumulatio
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
 	}
-	cache := execute.NewTableBuilderCache(a.Allocator())
+	cache := tablebuilder.NewCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
 	t := NewDistinctTransformation(d, cache, s)
 	return t, d, nil
@@ -95,12 +97,12 @@ func createDistinctTransformation(id execute.DatasetID, mode execute.Accumulatio
 
 type distinctTransformation struct {
 	d     execute.Dataset
-	cache execute.TableBuilderCache
+	cache *tablebuilder.Cache
 
 	column string
 }
 
-func NewDistinctTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DistinctProcedureSpec) *distinctTransformation {
+func NewDistinctTransformation(d execute.Dataset, cache *tablebuilder.Cache, spec *DistinctProcedureSpec) *distinctTransformation {
 	return &distinctTransformation{
 		d:      d,
 		cache:  cache,
@@ -113,29 +115,11 @@ func (t *distinctTransformation) RetractTable(id execute.DatasetID, key flux.Gro
 }
 
 func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
-	builder, created := t.cache.TableBuilder(tbl.Key())
-	if !created {
-		return fmt.Errorf("distinct found duplicate table with key: %v", tbl.Key())
-	}
+	builder := t.cache.Get(tbl.Key())
 
 	colIdx := execute.ColIdx(t.column, tbl.Cols())
 	if colIdx < 0 {
-		// doesn't exist in this table, so add an empty value
-		if err := execute.AddTableKeyCols(tbl.Key(), builder); err != nil {
-			return err
-		}
-		colIdx, err := builder.AddCol(flux.ColMeta{
-			Label: execute.DefaultValueColLabel,
-			Type:  flux.TString,
-		})
-		if err != nil {
-			return err
-		}
-
-		if err := builder.AppendString(colIdx, ""); err != nil {
-			return err
-		}
-		if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+		if err := builder.AppendString(execute.DefaultValueColLabel, ""); err != nil {
 			return err
 		}
 		// TODO: hack required to ensure data flows downstream
@@ -146,147 +130,106 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 
 	col := tbl.Cols()[colIdx]
 
-	if err := execute.AddTableKeyCols(tbl.Key(), builder); err != nil {
-		return err
-	}
-	colIdx, err := builder.AddCol(flux.ColMeta{
-		Label: execute.DefaultValueColLabel,
-		Type:  col.Type,
-	})
-	if err != nil {
-		return err
-	}
-
 	if tbl.Key().HasCol(t.column) {
 		j := execute.ColIdx(t.column, tbl.Key().Cols())
-		switch col.Type {
-		case flux.TBool:
-			if err := builder.AppendBool(colIdx, tbl.Key().ValueBool(j)); err != nil {
-				return err
-			}
-		case flux.TInt:
-			if err := builder.AppendInt(colIdx, tbl.Key().ValueInt(j)); err != nil {
-				return err
-			}
-		case flux.TUInt:
-			if err := builder.AppendUInt(colIdx, tbl.Key().ValueUInt(j)); err != nil {
-				return err
-			}
-		case flux.TFloat:
-			if err := builder.AppendFloat(colIdx, tbl.Key().ValueFloat(j)); err != nil {
-				return err
-			}
-		case flux.TString:
-			if err := builder.AppendString(colIdx, tbl.Key().ValueString(j)); err != nil {
-				return err
-			}
-		case flux.TTime:
-			if err := builder.AppendTime(colIdx, tbl.Key().ValueTime(j)); err != nil {
-				return err
-			}
-		}
-
-		if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+		if err := builder.AppendValue(execute.DefaultValueColLabel, tbl.Key().Value(j)); err != nil {
 			return err
 		}
+
 		// TODO: hack required to ensure data flows downstream
 		return tbl.Do(func(flux.ColReader) error {
 			return nil
 		})
 	}
 
-	var (
-		boolDistinct   map[bool]bool
-		intDistinct    map[int64]bool
-		uintDistinct   map[uint64]bool
-		floatDistinct  map[float64]bool
-		stringDistinct map[string]bool
-		timeDistinct   map[execute.Time]bool
-	)
 	switch col.Type {
 	case flux.TBool:
-		boolDistinct = make(map[bool]bool)
+		distinct := make(map[bool]bool)
+		return builder.Bools(execute.DefaultValueColLabel).Do(func(b array.BooleanBuilder) error {
+			return tbl.Do(func(cr flux.ColReader) error {
+				for _, v := range cr.Bools(colIdx) {
+					if distinct[v] {
+						continue
+					}
+					distinct[v] = true
+					b.Append(v)
+				}
+				return nil
+			})
+		})
 	case flux.TInt:
-		intDistinct = make(map[int64]bool)
+		distinct := make(map[int64]bool)
+		return builder.Ints(execute.DefaultValueColLabel).Do(func(b array.IntBuilder) error {
+			return tbl.Do(func(cr flux.ColReader) error {
+				for _, v := range cr.Ints(colIdx) {
+					if distinct[v] {
+						continue
+					}
+					distinct[v] = true
+					b.Append(v)
+				}
+				return nil
+			})
+		})
 	case flux.TUInt:
-		uintDistinct = make(map[uint64]bool)
+		distinct := make(map[uint64]bool)
+		return builder.UInts(execute.DefaultValueColLabel).Do(func(b array.UIntBuilder) error {
+			return tbl.Do(func(cr flux.ColReader) error {
+				for _, v := range cr.UInts(colIdx) {
+					if distinct[v] {
+						continue
+					}
+					distinct[v] = true
+					b.Append(v)
+				}
+				return nil
+			})
+		})
 	case flux.TFloat:
-		floatDistinct = make(map[float64]bool)
+		distinct := make(map[float64]bool)
+		return builder.Floats(execute.DefaultValueColLabel).Do(func(b array.FloatBuilder) error {
+			return tbl.Do(func(cr flux.ColReader) error {
+				for _, v := range cr.Floats(colIdx) {
+					if distinct[v] {
+						continue
+					}
+					distinct[v] = true
+					b.Append(v)
+				}
+				return nil
+			})
+		})
 	case flux.TString:
-		stringDistinct = make(map[string]bool)
+		distinct := make(map[string]bool)
+		return builder.Strings(execute.DefaultValueColLabel).Do(func(b array.StringBuilder) error {
+			return tbl.Do(func(cr flux.ColReader) error {
+				for _, v := range cr.Strings(colIdx) {
+					if distinct[v] {
+						continue
+					}
+					distinct[v] = true
+					b.Append(v)
+				}
+				return nil
+			})
+		})
 	case flux.TTime:
-		timeDistinct = make(map[execute.Time]bool)
-	}
-
-	j := execute.ColIdx(t.column, tbl.Cols())
-	return tbl.Do(func(cr flux.ColReader) error {
-		l := cr.Len()
-
-		for i := 0; i < l; i++ {
-			// Check distinct
-			switch col.Type {
-			case flux.TBool:
-				v := cr.Bools(j)[i]
-				if boolDistinct[v] {
-					continue
+		distinct := make(map[execute.Time]bool)
+		return builder.Times(execute.DefaultValueColLabel).Do(func(b array.TimeBuilder) error {
+			return tbl.Do(func(cr flux.ColReader) error {
+				for _, v := range cr.Times(colIdx) {
+					if distinct[v] {
+						continue
+					}
+					distinct[v] = true
+					b.Append(v)
 				}
-				boolDistinct[v] = true
-				if err := builder.AppendBool(colIdx, v); err != nil {
-					return err
-				}
-			case flux.TInt:
-				v := cr.Ints(j)[i]
-				if intDistinct[v] {
-					continue
-				}
-				intDistinct[v] = true
-				if err := builder.AppendInt(colIdx, v); err != nil {
-					return err
-				}
-			case flux.TUInt:
-				v := cr.UInts(j)[i]
-				if uintDistinct[v] {
-					continue
-				}
-				uintDistinct[v] = true
-				if err := builder.AppendUInt(colIdx, v); err != nil {
-					return err
-				}
-			case flux.TFloat:
-				v := cr.Floats(j)[i]
-				if floatDistinct[v] {
-					continue
-				}
-				floatDistinct[v] = true
-				if err := builder.AppendFloat(colIdx, v); err != nil {
-					return err
-				}
-			case flux.TString:
-				v := cr.Strings(j)[i]
-				if stringDistinct[v] {
-					continue
-				}
-				stringDistinct[v] = true
-				if err := builder.AppendString(colIdx, v); err != nil {
-					return err
-				}
-			case flux.TTime:
-				v := cr.Times(j)[i]
-				if timeDistinct[v] {
-					continue
-				}
-				timeDistinct[v] = true
-				if err := builder.AppendTime(colIdx, v); err != nil {
-					return err
-				}
-			}
-
-			if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
-				return err
-			}
-		}
+				return nil
+			})
+		})
+	default:
 		return nil
-	})
+	}
 }
 
 func (t *distinctTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {

--- a/functions/transformations/distinct_test.go
+++ b/functions/transformations/distinct_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/functions/transformations"
+	"github.com/influxdata/flux/internal/execute/tablebuilder"
 )
 
 func TestDistinct_Process(t *testing.T) {
@@ -174,13 +175,16 @@ func TestDistinct_Process(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			executetest.ProcessTestHelper(
+			executetest.ProcessTest(
 				t,
 				tc.data,
 				tc.want,
 				nil,
-				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					return transformations.NewDistinctTransformation(d, c, tc.spec)
+				func() (execute.DataCache, execute.Transformation) {
+					d := executetest.NewDataset(executetest.RandomDatasetID())
+					c := tablebuilder.NewCache(executetest.UnlimitedAllocator)
+					c.SetTriggerSpec(execute.DefaultTriggerSpec)
+					return c, transformations.NewDistinctTransformation(d, c, tc.spec)
 				},
 			)
 		})

--- a/internal/execute/tablebuilder/cache.go
+++ b/internal/execute/tablebuilder/cache.go
@@ -1,0 +1,84 @@
+package tablebuilder
+
+import (
+	"fmt"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
+)
+
+// Cache will contain a group of TableBuilder instances.
+type Cache struct {
+	// tables holds the instantiated tables.
+	tables *execute.GroupLookup
+	alloc  *memory.Allocator
+
+	triggerSpec flux.TriggerSpec
+}
+
+// NewCache creates a new Cache for retrieving table builders.
+func NewCache(alloc *memory.Allocator) *Cache {
+	return &Cache{
+		tables: execute.NewGroupLookup(),
+		alloc:  alloc,
+	}
+}
+
+type tableState struct {
+	builder *Instance
+	trigger execute.Trigger
+}
+
+// Get will retrieve a TableBuilder instance or, if it hasn't been
+// created yet, it will create a new one. If a Table has already
+// been instantiated for a specific key, it cannot be retrieved again.
+func (c *Cache) Get(key flux.GroupKey) *Instance {
+	b, ok := c.tables.Lookup(key)
+	if !ok {
+		builder, _ := New(c.alloc).WithGroupKey(key)
+		t := execute.NewTriggerFromSpec(c.triggerSpec)
+		b = tableState{
+			builder: builder,
+			trigger: t,
+		}
+		c.tables.Set(key, b)
+	}
+	return b.(tableState).builder
+}
+
+func (c *Cache) Table(key flux.GroupKey) (flux.Table, error) {
+	b, ok := c.tables.Lookup(key)
+	if !ok {
+		return nil, fmt.Errorf("table not found with key %v", key)
+	}
+	return b.(tableState).builder.Table()
+}
+
+func (c *Cache) ForEach(fn func(key flux.GroupKey)) {
+	c.tables.Range(func(key flux.GroupKey, _ interface{}) {
+		fn(key)
+	})
+}
+
+func (c *Cache) ForEachWithContext(fn func(key flux.GroupKey, trigger execute.Trigger, bc execute.TableContext)) {
+	c.tables.Range(func(key flux.GroupKey, value interface{}) {
+		b := value.(tableState)
+		fn(key, b.trigger, execute.TableContext{
+			Key:   key,
+			Count: b.builder.NRows(),
+		})
+	})
+}
+
+func (*Cache) DiscardTable(flux.GroupKey) {
+	//panic("implement me")
+}
+
+func (*Cache) ExpireTable(flux.GroupKey) {
+	//panic("implement me")
+}
+
+func (c *Cache) SetTriggerSpec(t flux.TriggerSpec) {
+	c.triggerSpec = t
+}

--- a/internal/execute/tablebuilder/table.go
+++ b/internal/execute/tablebuilder/table.go
@@ -1,0 +1,80 @@
+package tablebuilder
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/values"
+)
+
+// table is an implementation of flux.Table that is constructed
+// by the Instance.
+// TODO(jsternberg): The ColReader interface needs to be updated to
+// use the array interface types. At the moment, we use staticarray
+// values as a compatibility layer so we will have to cast away from
+// that.
+type table struct {
+	key     flux.GroupKey
+	colMeta []flux.ColMeta
+	columns []array.Base
+	sz      int
+}
+
+func (tbl *table) Key() flux.GroupKey {
+	return tbl.key
+}
+
+func (tbl *table) Cols() []flux.ColMeta {
+	return tbl.colMeta
+}
+
+func (tbl *table) Do(f func(flux.ColReader) error) error {
+	return f(tbl)
+}
+
+func (tbl *table) RefCount(n int) {
+	// TODO(jsternberg): Does this need to be implemented?
+}
+
+func (tbl *table) Empty() bool {
+	return tbl.sz == 0
+}
+
+func (tbl *table) Len() int {
+	return tbl.sz
+}
+
+func (tbl *table) Bools(j int) []bool {
+	column := tbl.columns[j]
+	return column.(interface {
+		BoolValues() []bool
+	}).BoolValues()
+}
+
+func (tbl *table) Ints(j int) []int64 {
+	column := tbl.columns[j]
+	return column.(array.Int).Int64Values()
+}
+
+func (tbl *table) UInts(j int) []uint64 {
+	column := tbl.columns[j]
+	return column.(array.UInt).Uint64Values()
+}
+
+func (tbl *table) Floats(j int) []float64 {
+	column := tbl.columns[j]
+	return column.(array.Float).Float64Values()
+}
+
+func (tbl *table) Strings(j int) []string {
+	column := tbl.columns[j]
+	return column.(interface {
+		StringValues() []string
+	}).StringValues()
+}
+
+func (tbl *table) Times(j int) []values.Time {
+	column := tbl.columns[j]
+	return column.(interface {
+		TimeValues() []values.Time
+	}).TimeValues()
+}

--- a/internal/execute/tablebuilder/tablebuilder.go
+++ b/internal/execute/tablebuilder/tablebuilder.go
@@ -1,0 +1,740 @@
+package tablebuilder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/staticarray"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// Instance builds tables using an underlying column constructor.
+type Instance struct {
+	// alloc is the allocator used for the array builders.
+	alloc *memory.Allocator
+
+	// key contains the group key for this table. This group key is specified
+	// by WithGroupKey and will only be set if AddKeyValue is not called.
+	// If AddKeyValue is called, the keyBuilder will be used instead.
+	key flux.GroupKey
+
+	// keyBuilder contains an in-progress key that is being built.
+	keyBuilder execute.GroupKeyBuilder
+
+	// keyBuilderKeys keeps track of the actual keys in the key builder since
+	// the key builder does not do that.
+	keyBuilderKeys map[string]struct{}
+
+	// columns contains the various builders for different columns.
+	columns []array.BaseBuilder
+
+	// indexes contains an index of existing column names to the actual column.
+	indexes map[string]int
+
+	// size is the size of the table in rows. This is used as a hint
+	// for automatically reserving the necessary space in new and existing
+	// columns with a call to Resize. If there are no value columns,
+	// then this is the size of the table. If this number mismatches
+	// the actual length of the table columns, the table columns will
+	// determine the length of the table.
+	size int
+}
+
+// New will construct a new table builder with the given allocator.
+func New(a *memory.Allocator) *Instance {
+	return &Instance{alloc: a}
+}
+
+// WithGroupKey will use the given group key for this table. If group key entries have
+// already been added, this will append or replace the values within the constructed group key.
+// See AddKeyValue for details of how the group key is constructed.
+func (b *Instance) WithGroupKey(key flux.GroupKey) (*Instance, error) {
+	if b.key == nil && b.keyBuilder.Len() == 0 {
+		// If we have indexes already, we have to validate that we aren't causing a conflict.
+		if len(b.indexes) > 0 {
+			for _, c := range key.Cols() {
+				if _, ok := b.indexes[c.Label]; ok {
+					// This error message should be correct since we don't have a group key yet.
+					// So the column in the index can't be part of the group key.
+					return nil, fmt.Errorf("key %q is already present as a column", c.Label)
+				}
+			}
+		}
+
+		// Set the key and exit. Nothing else to do since we aren't making a copy.
+		b.key = key
+
+		// Add indexes for each of the keys with a nil builder.
+		if b.indexes == nil {
+			b.indexes = make(map[string]int)
+		}
+		for _, c := range key.Cols() {
+			b.indexes[c.Label] = len(b.columns)
+			b.columns = append(b.columns, nil)
+		}
+		return b, nil
+	}
+
+	// We need to make a copy so this method is the equivalent of calling AddKeyValue on each
+	// entry in the group key.
+	for i, c := range key.Cols() {
+		if err := b.AddKeyValue(c.Label, key.Value(i)); err != nil {
+			return nil, err
+		}
+	}
+	return b, nil
+}
+
+// NRows lists the number of rows that would be created if the table
+// was constructed at that moment assuming that there are no errors.
+// If there would be an error in table construction, this function is
+// not guaranteed to return the correct length.
+func (b *Instance) NRows() int {
+	// Look for the first valid builder column and return that size.
+	// If the columns are unequal, then building a table would return
+	// an error and we don't care.
+	for _, c := range b.columns {
+		if c != nil {
+			return c.Len()
+		}
+	}
+	// The table is composed of only group keys so the size is whatever
+	// Resize set it to.
+	return b.size
+}
+
+// AddKeyValue will add an additional column to the table and mark it as part of the group key.
+// The column will not be modifiable as group keys remain consistent within the table.
+// The column type is automatically inferred from the value.
+func (b *Instance) AddKeyValue(key string, value values.Value) error {
+	// Verify that the key is not already present in a column and it is not already in
+	// the key.
+	if b.isInGroupKey(key) {
+		return fmt.Errorf("key %q is already in the group key", key)
+	} else if _, ok := b.indexes[key]; ok {
+		return fmt.Errorf("key %q is already present as a column", key)
+	}
+
+	// Initialize the mapping of current keys in the key builder if not previously done.
+	if b.keyBuilderKeys == nil {
+		b.keyBuilderKeys = make(map[string]struct{})
+	}
+
+	if b.indexes == nil {
+		b.indexes = make(map[string]int)
+	}
+
+	// We can add the key.
+	if b.key != nil {
+		// We now need to use the group key builder so let's add the existing keys to that.
+		for i, c := range b.key.Cols() {
+			b.keyBuilder.AddKeyValue(c.Label, b.key.Value(i))
+			b.keyBuilderKeys[c.Label] = struct{}{}
+			b.indexes[c.Label] = len(b.columns)
+			b.columns = append(b.columns, nil)
+		}
+		b.key = nil
+	}
+
+	b.keyBuilder.AddKeyValue(key, value)
+	b.keyBuilderKeys[key] = struct{}{}
+	b.indexes[key] = len(b.columns)
+	b.columns = append(b.columns, nil)
+	return nil
+}
+
+// isInGroupKey checks if the given name is within the group key.
+func (b *Instance) isInGroupKey(name string) bool {
+	if b.key != nil {
+		return b.key.HasCol(name)
+	}
+	_, ok := b.keyBuilderKeys[name]
+	return ok
+}
+
+// Resize will call resize on each column and ensure that the table has n columns.
+// This is important to call before constructing the table to ensure that it has
+// the appropriate number of columns. If a table is only comprised of group keys,
+// the size specified here determines how many rows there are.
+func (b *Instance) Resize(n int) {
+	for _, c := range b.columns {
+		if c == nil {
+			continue
+		}
+		c.Reserve(n)
+	}
+	b.size = n
+}
+
+// TODO(jsternberg): Consider a good way to deal with a building method that handles access
+// to schema changes that are compatible. This is, for example, when we are constructing a table from
+// multiple inputs and one of the inputs does not have a certain column in its output schema. The
+// number of columns in the output will be wrong in this circumstance.
+
+// column retrieves a column of the given name. If the column doesn't exist, it uses the builderFn
+// to construct the builder.
+func (b *Instance) column(name string, builderFn func() array.BaseBuilder) (int, bool, array.BaseBuilder) {
+	idx, ok := b.indexes[name]
+	if !ok {
+		idx = len(b.columns)
+		b.columns = append(b.columns, builderFn())
+		if b.indexes == nil {
+			b.indexes = make(map[string]int)
+		}
+		b.indexes[name] = idx
+
+		if b.size > 0 {
+			b.columns[idx].Reserve(b.size)
+		}
+	}
+	return idx, !ok, b.columns[idx]
+}
+
+// FloatColumn is a wrapper around an array.FloatColumn that contains additional information
+// for the builder about the current state of the column. The additional attributes are read
+// only and modifying them will not affect anything.
+type FloatColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// BaseBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil.
+	array.BaseBuilder
+}
+
+// Floats will find a column with the given name and invoke the function on the builder for that
+// column. If a column with that name does not exist, it is created and appended to the Instance.
+// If a column of that name exists with a different type or it is already added as part of the group key,
+// the Do function will return an error.
+func (b *Instance) Floats(name string) FloatColumn {
+	idx, created, builder := b.column(name, b.newFloatBuilder)
+	return FloatColumn{
+		Name:        name,
+		Index:       idx,
+		Created:     created,
+		BaseBuilder: builder,
+	}
+}
+
+func (b *Instance) newFloatBuilder() array.BaseBuilder {
+	return staticarray.FloatBuilder(b.alloc)
+}
+
+func (b FloatColumn) Append(v float64) error {
+	return b.Do(func(b array.FloatBuilder) error {
+		b.Append(v)
+		return nil
+	})
+}
+
+func (b FloatColumn) AppendValues(v []float64, valid ...[]bool) error {
+	return b.Do(func(b array.FloatBuilder) error {
+		b.AppendValues(v, valid...)
+		return nil
+	})
+}
+
+func (b FloatColumn) Do(fn func(b array.FloatBuilder) error) error {
+	if b.BaseBuilder == nil {
+		return fmt.Errorf("%s is part of the group key and cannot be modified", b.Name)
+	}
+
+	// Try typecasting to the correct type.
+	builder, ok := b.BaseBuilder.(array.FloatBuilder)
+	if !ok {
+		return fmt.Errorf("incompatible column type: %s", b.BaseBuilder.Type())
+	}
+	return fn(builder)
+}
+
+type IntColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// BaseBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil.
+	array.BaseBuilder
+}
+
+func (b *Instance) Ints(name string) IntColumn {
+	idx, created, builder := b.column(name, b.newIntBuilder)
+	return IntColumn{
+		Name:        name,
+		Index:       idx,
+		Created:     created,
+		BaseBuilder: builder,
+	}
+}
+
+func (b *Instance) newIntBuilder() array.BaseBuilder {
+	return staticarray.IntBuilder(b.alloc)
+}
+
+func (b IntColumn) Append(v int64) error {
+	return b.Do(func(b array.IntBuilder) error {
+		b.Append(v)
+		return nil
+	})
+}
+
+func (b IntColumn) AppendValues(v []int64, valid ...[]bool) error {
+	return b.Do(func(b array.IntBuilder) error {
+		b.AppendValues(v, valid...)
+		return nil
+	})
+}
+
+func (b IntColumn) Do(fn func(b array.IntBuilder) error) error {
+	if b.BaseBuilder == nil {
+		return fmt.Errorf("%s is part of the group key and cannot be modified", b.Name)
+	}
+
+	// Try typecasting to the correct type.
+	builder, ok := b.BaseBuilder.(array.IntBuilder)
+	if !ok {
+		return fmt.Errorf("incompatible column type: %s", b.BaseBuilder.Type())
+	}
+	return fn(builder)
+}
+
+type UIntColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// BaseBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil.
+	array.BaseBuilder
+}
+
+func (b *Instance) UInts(name string) UIntColumn {
+	idx, created, builder := b.column(name, b.newUIntBuilder)
+	return UIntColumn{
+		Name:        name,
+		Index:       idx,
+		Created:     created,
+		BaseBuilder: builder,
+	}
+}
+
+func (b *Instance) newUIntBuilder() array.BaseBuilder {
+	return staticarray.UIntBuilder(b.alloc)
+}
+
+func (b UIntColumn) Append(v uint64) error {
+	return b.Do(func(b array.UIntBuilder) error {
+		b.Append(v)
+		return nil
+	})
+}
+
+func (b UIntColumn) AppendValues(v []uint64, valid ...[]bool) error {
+	return b.Do(func(b array.UIntBuilder) error {
+		b.AppendValues(v, valid...)
+		return nil
+	})
+}
+
+func (b UIntColumn) Do(fn func(b array.UIntBuilder) error) error {
+	if b.BaseBuilder == nil {
+		return fmt.Errorf("%s is part of the group key and cannot be modified", b.Name)
+	}
+
+	// Try typecasting to the correct type.
+	builder, ok := b.BaseBuilder.(array.UIntBuilder)
+	if !ok {
+		return fmt.Errorf("incompatible column type: %s", b.BaseBuilder.Type())
+	}
+	return fn(builder)
+}
+
+type StringColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// BaseBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil.
+	array.BaseBuilder
+}
+
+func (b *Instance) Strings(name string) StringColumn {
+	idx, created, builder := b.column(name, b.newStringBuilder)
+	return StringColumn{
+		Name:        name,
+		Index:       idx,
+		Created:     created,
+		BaseBuilder: builder,
+	}
+}
+
+func (b *Instance) newStringBuilder() array.BaseBuilder {
+	return staticarray.StringBuilder(b.alloc)
+}
+
+func (b StringColumn) Append(v string) error {
+	return b.Do(func(b array.StringBuilder) error {
+		b.Append(v)
+		return nil
+	})
+}
+
+func (b StringColumn) AppendValues(v []string, valid ...[]bool) error {
+	return b.Do(func(b array.StringBuilder) error {
+		b.AppendValues(v, valid...)
+		return nil
+	})
+}
+
+func (b StringColumn) Do(fn func(b array.StringBuilder) error) error {
+	if b.BaseBuilder == nil {
+		return fmt.Errorf("%s is part of the group key and cannot be modified", b.Name)
+	}
+
+	// Try typecasting to the correct type.
+	builder, ok := b.BaseBuilder.(array.StringBuilder)
+	if !ok {
+		return fmt.Errorf("incompatible column type: %s", b.BaseBuilder.Type())
+	}
+	return fn(builder)
+}
+
+type BoolColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// BaseBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil.
+	array.BaseBuilder
+}
+
+func (b *Instance) Bools(name string) BoolColumn {
+	idx, created, builder := b.column(name, b.newBoolBuilder)
+	return BoolColumn{
+		Name:        name,
+		Index:       idx,
+		Created:     created,
+		BaseBuilder: builder,
+	}
+}
+
+func (b *Instance) newBoolBuilder() array.BaseBuilder {
+	return staticarray.BooleanBuilder(b.alloc)
+}
+
+func (b BoolColumn) Append(v bool) error {
+	return b.Do(func(b array.BooleanBuilder) error {
+		b.Append(v)
+		return nil
+	})
+}
+
+func (b BoolColumn) AppendValues(v []bool, valid ...[]bool) error {
+	return b.Do(func(b array.BooleanBuilder) error {
+		b.AppendValues(v, valid...)
+		return nil
+	})
+}
+
+func (b BoolColumn) Do(fn func(b array.BooleanBuilder) error) error {
+	if b.BaseBuilder == nil {
+		return fmt.Errorf("%s is part of the group key and cannot be modified", b.Name)
+	}
+
+	// Try typecasting to the correct type.
+	builder, ok := b.BaseBuilder.(array.BooleanBuilder)
+	if !ok {
+		return fmt.Errorf("incompatible column type: %s", b.BaseBuilder.Type())
+	}
+	return fn(builder)
+}
+
+type TimeColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// BaseBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil.
+	array.BaseBuilder
+}
+
+func (b *Instance) Times(name string) TimeColumn {
+	idx, created, builder := b.column(name, b.newTimeBuilder)
+	return TimeColumn{
+		Name:        name,
+		Index:       idx,
+		Created:     created,
+		BaseBuilder: builder,
+	}
+}
+
+func (b *Instance) newTimeBuilder() array.BaseBuilder {
+	return staticarray.TimeBuilder(b.alloc)
+}
+
+func (b TimeColumn) Append(v values.Time) error {
+	return b.Do(func(b array.TimeBuilder) error {
+		b.Append(v)
+		return nil
+	})
+}
+
+func (b TimeColumn) AppendValues(v []values.Time, valid ...[]bool) error {
+	return b.Do(func(b array.TimeBuilder) error {
+		b.AppendValues(v, valid...)
+		return nil
+	})
+}
+
+func (b TimeColumn) Do(fn func(b array.TimeBuilder) error) error {
+	if b.BaseBuilder == nil {
+		return fmt.Errorf("%s is part of the group key and cannot be modified", b.Name)
+	}
+
+	// Try typecasting to the correct type.
+	builder, ok := b.BaseBuilder.(array.TimeBuilder)
+	if !ok {
+		return fmt.Errorf("incompatible column type: %s", b.BaseBuilder.Type())
+	}
+	return fn(builder)
+}
+
+type ValueColumn struct {
+	// Name contains the name of the column.
+	Name string
+
+	// Index contains the current index of the column.
+	Index int
+
+	// Created is set to true when the column has been newly created.
+	// This is useful if an algorithm needs to access columns multiple times and expects
+	// the schema to change during the algorithm.
+	Created bool
+
+	// Err holds any errors that happened on column creation.
+	Err error
+
+	// ValueBuilder holds the underlying builder. If this column is part of the group key,
+	// then the builder will be nil. If there was an error in column
+	// creation, this may not contain a value value.
+	*array.ValueBuilder
+}
+
+// Values will return a ValueBuilder interface. If the column does not
+// exist, the passed in column type will be used.
+func (b *Instance) Values(name string, typ flux.ColType) ValueColumn {
+	idx, created, builder := b.column(name, b.newValueBuilder(typ))
+	column := ValueColumn{
+		Name:         name,
+		Index:        idx,
+		Created:      created,
+		ValueBuilder: &array.ValueBuilder{Builder: builder},
+	}
+	if !created {
+		if btype := flux.ColumnType(builder.Type()); typ != btype {
+			column.Err = fmt.Errorf("conflicting column types: %s != %s", btype, typ)
+		}
+	}
+	return column
+}
+
+func (b ValueColumn) Do(fn func(b *array.ValueBuilder) error) error {
+	if b.Err != nil {
+		return b.Err
+	}
+	return fn(b.ValueBuilder)
+}
+
+func (b *Instance) newValueBuilder(typ flux.ColType) func() array.BaseBuilder {
+	switch typ {
+	case flux.TFloat:
+		return b.newFloatBuilder
+	case flux.TInt:
+		return b.newIntBuilder
+	case flux.TUInt:
+		return b.newUIntBuilder
+	case flux.TString:
+		return b.newStringBuilder
+	case flux.TBool:
+		return b.newBoolBuilder
+	case flux.TTime:
+		return b.newTimeBuilder
+	default:
+		// TODO(jsternberg): Probably find some way to have this not panic.
+		panic(fmt.Sprintf("unsupported column type: %s", typ))
+	}
+}
+
+func (b *Instance) AppendFloat(name string, v float64) error {
+	return b.Floats(name).Append(v)
+}
+
+func (b *Instance) AppendInt(name string, v int64) error {
+	return b.Ints(name).Append(v)
+}
+
+func (b *Instance) AppendUInt(name string, v uint64) error {
+	return b.UInts(name).Append(v)
+}
+
+func (b *Instance) AppendString(name string, v string) error {
+	return b.Strings(name).Append(v)
+}
+
+func (b *Instance) AppendBool(name string, v bool) error {
+	return b.Bools(name).Append(v)
+}
+
+func (b *Instance) AppendTime(name string, v values.Time) error {
+	return b.Times(name).Append(v)
+}
+
+func (b *Instance) AppendValue(name string, v values.Value) error {
+	return b.Values(name, flux.ColumnType(v.Type())).Append(v)
+}
+
+// Table will construct the table and return it. If there was an error constructing the table,
+// this will return an error.
+func (b *Instance) Table() (flux.Table, error) {
+	// A table with no columns cannot be built.
+	if len(b.columns) == 0 {
+		return nil, errors.New("table is empty")
+	}
+
+	// Ensure that all columns are the same length. If the builder for a column is nil,
+	// it's part of the group key so skip it.
+	sz := -1
+	for _, c := range b.columns {
+		if c == nil {
+			// This is a group key so skip it.
+		} else if sz == -1 {
+			sz = c.Len()
+		} else if c.Len() != sz {
+			return nil, fmt.Errorf("incompatible column lengths")
+		}
+	}
+
+	if sz == -1 {
+		// Only use the specified size if we don't have a better value from the columns.
+		sz = b.size
+	}
+
+	// Generate the key.
+	key := b.key
+	if key == nil {
+		k, err := b.keyBuilder.Build()
+		if err != nil {
+			return nil, err
+		}
+		key = k
+	}
+
+	// Instantiate the tag columns and copy them to a new slice.
+	columns := make([]array.Base, len(b.columns))
+	colMeta := make([]flux.ColMeta, len(b.columns))
+	for name, idx := range b.indexes {
+		if c := b.columns[idx]; c != nil {
+			columns[idx] = c.BuildArray()
+		} else {
+			switch v := key.LabelValue(name); v.Type() {
+			case semantic.Float:
+				arr := make([]float64, sz)
+				for i := 0; i < sz; i++ {
+					arr[i] = v.Float()
+				}
+				columns[idx] = staticarray.Float(arr)
+			case semantic.Int:
+				arr := make([]int64, sz)
+				for i := 0; i < sz; i++ {
+					arr[i] = v.Int()
+				}
+				columns[idx] = staticarray.Int(arr)
+			case semantic.UInt:
+				arr := make([]uint64, sz)
+				for i := 0; i < sz; i++ {
+					arr[i] = v.UInt()
+				}
+				columns[idx] = staticarray.UInt(arr)
+			case semantic.String:
+				arr := make([]string, sz)
+				for i := 0; i < sz; i++ {
+					arr[i] = v.Str()
+				}
+				columns[idx] = staticarray.String(arr)
+			case semantic.Bool:
+				arr := make([]bool, sz)
+				for i := 0; i < sz; i++ {
+					arr[i] = v.Bool()
+				}
+				columns[idx] = staticarray.Boolean(arr)
+			default:
+				panic(fmt.Sprintf("invalid type: %s", v.Type()))
+			}
+		}
+
+		// Set the column metadata.
+		colMeta[idx] = flux.ColMeta{
+			Label: name,
+			Type:  flux.ColumnType(columns[idx].Type()),
+		}
+	}
+
+	// Return the table.
+	return &table{
+		key:     key,
+		colMeta: colMeta,
+		columns: columns,
+		sz:      sz,
+	}, nil
+}

--- a/internal/execute/tablebuilder/tablebuilder_test.go
+++ b/internal/execute/tablebuilder/tablebuilder_test.go
@@ -1,0 +1,75 @@
+package tablebuilder_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/internal/execute/tablebuilder"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/values"
+)
+
+func newUnlimitedAllocator() *memory.Allocator {
+	return &memory.Allocator{}
+}
+
+func TestTableBuilder_WithGroupKey(t *testing.T) {
+	tb, err := tablebuilder.New(newUnlimitedAllocator()).WithGroupKey(
+		execute.NewGroupKey(
+			[]flux.ColMeta{
+				{
+					Label: "_measurement",
+					Type:  flux.TString,
+				},
+				{
+					Label: "_field",
+					Type:  flux.TString,
+				},
+			},
+			[]values.Value{
+				values.NewString("cpu"),
+				values.NewString("usage_user"),
+			},
+		),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tb.Floats("_value").Do(func(b array.FloatBuilder) error {
+		b.Append(2.0)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	table, err := tb.Table()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp := &executetest.Table{
+		KeyCols: []string{"_measurement", "_field"},
+		ColMeta: []flux.ColMeta{
+			{Label: "_measurement", Type: flux.TString},
+			{Label: "_field", Type: flux.TString},
+			{Label: "_value", Type: flux.TFloat},
+		},
+		Data: [][]interface{}{
+			{"cpu", "usage_user", 2.0},
+		},
+	}
+	exp.Normalize()
+
+	got, err := executetest.ConvertTable(table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(exp, got) {
+		t.Fatalf("unexpected table -want/+got:\n%s", cmp.Diff(exp, got))
+	}
+}


### PR DESCRIPTION
The new table builder interface focuses on simplicity and ensuring that
column-based table construction is prioritized over other methods. We will
build other interfaces for building tables on top of this, but the underlying
data is column based so the table builder interface should be too.

It builds on the array package which, itself, builds on the arrow interface.