### PR TITLE
feat: staticarray supports using the allocator for tracking memory usage

### DIFF
--- a/array/base.go
+++ b/array/base.go
@@ -1,18 +1,47 @@
 package array
 
+import "github.com/influxdata/flux/semantic"
+
+// BaseRef defines the base interface for working with an array interface.
+type BaseRef interface {
+	// Type returns the type of values that this array contains.
+	Type() semantic.Type
+
+	// IsNull will return true if the given index is null.
+	IsNull(i int) bool
+
+	// IsValid will return true if the given index is a valid value (not null).
+	IsValid(i int) bool
+
+	// Len will return the length of this array.
+	Len() int
+
+	// NullN will return the number of null values in this array.
+	NullN() int
+
+	// Slice will return a slice of the array.
+	Slice(start, stop int) BaseRef
+
+	// Copy will retain a reference to the array.
+	Copy() Base
+}
+
 // Base defines the base interface for working with any array type.
 // All array types share this common interface.
 type Base interface {
-	IsNull(i int) bool
-	IsValid(i int) bool
-	Len() int
-	NullN() int
-	Slice(start, stop int) Base
+	BaseRef
+
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // BaseBuilder defines the base interface for building an array of a given array type.
 // All builder types share this common interface.
 type BaseBuilder interface {
+	// Type returns the type of values that this builder accepts.
+	Type() semantic.Type
+
 	// Len returns the currently allocated length for the array builder.
 	Len() int
 
@@ -28,4 +57,7 @@ type BaseBuilder interface {
 
 	// BuildArray will construct the array.
 	BuildArray() Base
+
+	// Free will release the memory used for this builder.
+	Free()
 }

--- a/array/bool.go
+++ b/array/bool.go
@@ -1,10 +1,19 @@
 package array
 
+// BooleanRef is a reference to a Boolean.
+type BooleanRef interface {
+	BaseRef
+	Value(i int) bool
+	BooleanSlice(start, stop int) BooleanRef
+}
+
 // Boolean represents an abstraction over a bool array.
 type Boolean interface {
-	Base
-	Value(i int) bool
-	BooleanSlice(start, stop int) Boolean
+	BooleanRef
+
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // BooleanBuilder represents an abstraction over building a bool array.

--- a/array/float.go
+++ b/array/float.go
@@ -1,14 +1,23 @@
 package array
 
-// Float represents an abstraction over a float array.
-type Float interface {
-	Base
+// FloatRef is a reference to a Float.
+type FloatRef interface {
+	BaseRef
 	Value(i int) float64
-	FloatSlice(start, stop int) Float
+	FloatSlice(start, stop int) FloatRef
 
 	// Float64Values will return the underlying slice for the Float array. It is the size
 	// of the array and null values will be present, but the data at null indexes will be invalid.
 	Float64Values() []float64
+}
+
+// Float represents an abstraction over a float array.
+type Float interface {
+	FloatRef
+
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // FloatBuilder represents an abstraction over building a float array.

--- a/array/int.go
+++ b/array/int.go
@@ -1,14 +1,23 @@
 package array
 
-// Int represents an abstraction over an integer array.
-type Int interface {
-	Base
+// IntRef is a reference to an Int.
+type IntRef interface {
+	BaseRef
 	Value(i int) int64
-	IntSlice(start, stop int) Int
+	IntSlice(start, stop int) IntRef
 
 	// Int64Values will return the underlying slice for the Int array. It is the size
 	// of the array and null values will be present, but the data at null indexes will be invalid.
 	Int64Values() []int64
+}
+
+// Int represents an abstraction over an integer array.
+type Int interface {
+	IntRef
+
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // IntBuilder represents an abstraction over building a int array.

--- a/array/string.go
+++ b/array/string.go
@@ -1,10 +1,19 @@
 package array
 
+// StringRef is a reference to a String.
+type StringRef interface {
+	BaseRef
+	Value(i int) string
+	StringSlice(start, stop int) StringRef
+}
+
 // String represents an abstraction over a string array.
 type String interface {
-	Base
-	Value(i int) string
-	StringSlice(start, stop int) String
+	StringRef
+
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // StringBuilder represents an abstraction over building a string array.

--- a/array/time.go
+++ b/array/time.go
@@ -2,15 +2,20 @@ package array
 
 import "github.com/influxdata/flux/values"
 
+// TimeRef is a reference to a Time.
+type TimeRef interface {
+	BaseRef
+	Value(i int) values.Time
+	TimeSlice(start, stop int) TimeRef
+}
+
 // Time represents an abstraction over a time array.
 type Time interface {
-	Base
-	Value(i int) values.Time
-	TimeSlice(start, stop int) Time
+	TimeRef
 
-	// TimeValues will return the underlying slice for the Time array. It is the size
-	// of the array and null values will be present, but the data at null indexes will be invalid.
-	TimeValues() []values.Time
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // TimeBuilder represents an abstraction over building a time array.

--- a/array/uint.go
+++ b/array/uint.go
@@ -1,14 +1,23 @@
 package array
 
-// UInt represents an abstraction over an unsigned array.
-type UInt interface {
-	Base
+// UIntRef is a reference to a UInt.
+type UIntRef interface {
+	BaseRef
 	Value(i int) uint64
-	UIntSlice(start, stop int) UInt
+	UIntSlice(start, stop int) UIntRef
 
 	// Uint64Values will return the underlying slice for the UInt array. It is the size
 	// of the array and null values will be present, but the data at null indexes will be invalid.
 	Uint64Values() []uint64
+}
+
+// UInt represents an abstraction over an unsigned array.
+type UInt interface {
+	UIntRef
+
+	// Free will release the memory for this array. After Free is called,
+	// the array should no longer be used.
+	Free()
 }
 
 // UIntBuilder represents an abstraction over building a uint array.

--- a/array/value.go
+++ b/array/value.go
@@ -1,0 +1,63 @@
+package array
+
+import (
+	"fmt"
+
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// ValueBuilder is a wrapper around the various builders
+// that allows appending to a builder using values.Value types.
+type ValueBuilder struct {
+	// Builder holds the BaseBuilder that will be used.
+	Builder BaseBuilder
+}
+
+func (b *ValueBuilder) Type() semantic.Type {
+	return b.Builder.Type()
+}
+
+func (b *ValueBuilder) Len() int {
+	return b.Builder.Len()
+}
+
+func (b *ValueBuilder) Cap() int {
+	return b.Builder.Cap()
+}
+
+func (b *ValueBuilder) Reserve(n int) {
+	b.Builder.Reserve(n)
+}
+
+func (b *ValueBuilder) AppendNull() {
+	b.Builder.AppendNull()
+}
+
+func (b *ValueBuilder) BuildArray() Base {
+	return b.Builder.BuildArray()
+}
+
+func (b *ValueBuilder) Append(v values.Value) error {
+	if vtype := v.Type(); b.Type() != vtype {
+		return fmt.Errorf("invalid value type: %s != %s", b.Type(), vtype)
+	}
+
+	switch b := b.Builder.(type) {
+	case FloatBuilder:
+		b.Append(v.Float())
+	case IntBuilder:
+		b.Append(v.Int())
+	case UIntBuilder:
+		b.Append(v.UInt())
+	case StringBuilder:
+		b.Append(v.Str())
+	case BooleanBuilder:
+		b.Append(v.Bool())
+	case TimeBuilder:
+		b.Append(v.Time())
+	default:
+		return fmt.Errorf("unsupported value type: %s", b.Type())
+	}
+	return nil
+}

--- a/internal/staticarray/constants.go
+++ b/internal/staticarray/constants.go
@@ -1,0 +1,10 @@
+package staticarray
+
+const (
+	boolSize    = 1
+	int64Size   = 8
+	uint64Size  = 8
+	float64Size = 8
+	stringSize  = 16
+	timeSize    = 8
+)

--- a/internal/staticarray/time.go
+++ b/internal/staticarray/time.go
@@ -2,104 +2,138 @@ package staticarray
 
 import (
 	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
-var _ array.Time = Time(nil)
+type times struct {
+	data  []values.Time
+	alloc *memory.Allocator
+}
 
-type Time []values.Time
+func Time(data []values.Time) array.Time {
+	return &times{data: data}
+}
 
-func (a Time) IsNull(i int) bool {
+func (a *times) Type() semantic.Type {
+	return semantic.Time
+}
+
+func (a *times) IsNull(i int) bool {
 	return false
 }
 
-func (a Time) IsValid(i int) bool {
-	return i >= 0 && i < len(a)
+func (a *times) IsValid(i int) bool {
+	return i >= 0 && i < len(a.data)
 }
 
-func (a Time) Len() int {
-	return len(a)
+func (a *times) Len() int {
+	return len(a.data)
 }
 
-func (a Time) NullN() int {
+func (a *times) NullN() int {
 	return 0
 }
 
-func (a Time) Value(i int) values.Time {
-	return a[i]
+func (a *times) Value(i int) values.Time {
+	return a.data[i]
 }
 
-func (a Time) Slice(start, stop int) array.Base {
+func (a *times) Copy() array.Base {
+	panic("implement me")
+}
+
+func (a *times) Free() {
+	if a.alloc != nil {
+		a.alloc.Free(cap(a.data) * timeSize)
+	}
+	a.data = nil
+}
+
+func (a *times) Slice(start, stop int) array.BaseRef {
 	return a.TimeSlice(start, stop)
 }
 
-func (a Time) TimeSlice(start, stop int) array.Time {
-	return Time(a[start:stop])
+func (a *times) TimeSlice(start, stop int) array.TimeRef {
+	return &times{data: a.data[start:stop]}
 }
 
-func (a Time) TimeValues() []values.Time {
-	return []values.Time(a)
+func (a *times) TimeValues() []values.Time {
+	return a.data
 }
 
-var _ array.TimeBuilder = (*TimeBuilder)(nil)
-
-type TimeBuilder []values.Time
-
-func (b *TimeBuilder) Len() int {
-	if b == nil {
-		return 0
-	}
-	return len(*b)
+func TimeBuilder(a *memory.Allocator) array.TimeBuilder {
+	return &timeBuilder{alloc: a}
 }
 
-func (b *TimeBuilder) Cap() int {
-	if b == nil {
-		return 0
-	}
-	return cap(*b)
+type timeBuilder struct {
+	data  []values.Time
+	alloc *memory.Allocator
 }
 
-func (b *TimeBuilder) Reserve(n int) {
-	if b == nil {
-		*b = make([]values.Time, 0, n)
+func (b *timeBuilder) Type() semantic.Type {
+	return semantic.Time
+}
+
+func (b *timeBuilder) Len() int {
+	return len(b.data)
+}
+
+func (b *timeBuilder) Cap() int {
+	return cap(b.data)
+}
+
+func (b *timeBuilder) Reserve(n int) {
+	newCap := len(b.data) + n
+	if newCap := len(b.data) + n; newCap <= cap(b.data) {
 		return
-	} else if cap(*b) < n {
-		newB := make([]values.Time, len(*b), n)
-		copy(newB, *b)
-		*b = newB
 	}
+	if err := b.alloc.Allocate(newCap * timeSize); err != nil {
+		panic(err)
+	}
+	data := make([]values.Time, len(b.data), newCap)
+	copy(data, b.data)
+	b.alloc.Free(cap(b.data) * timeSize)
+	b.data = data
 }
 
-func (b *TimeBuilder) BuildArray() array.Base {
+func (b *timeBuilder) BuildArray() array.Base {
 	return b.BuildTimeArray()
 }
 
-func (b *TimeBuilder) Append(v values.Time) {
-	if b == nil {
-		*b = append([]values.Time{}, v)
-		return
-	}
-	*b = append(*b, v)
+func (b *timeBuilder) Free() {
+	panic("implement me")
 }
 
-func (b *TimeBuilder) AppendNull() {
+func (b *timeBuilder) Append(v values.Time) {
+	if len(b.data) == cap(b.data) {
+		// Grow the slice in the same way as built-in append.
+		n := len(b.data)
+		if n == 0 {
+			n = 2
+		}
+		b.Reserve(n)
+	}
+	b.data = append(b.data, v)
+}
+
+func (b *timeBuilder) AppendNull() {
 	// The staticarray does not support nulls so it will do the current behavior of just appending
 	// the zero value.
 	b.Append(0)
 }
 
-func (b *TimeBuilder) AppendValues(v []values.Time, valid ...[]bool) {
-	// We ignore the valid array since it does not apply to this implementation type.
-	if b == nil {
-		*b = append([]values.Time{}, v...)
-		return
+func (b *timeBuilder) AppendValues(v []values.Time, valid ...[]bool) {
+	if newCap := len(b.data) + len(v); newCap > cap(b.data) {
+		b.Reserve(newCap - cap(b.data))
 	}
-	*b = append(*b, v...)
+	b.data = append(b.data, v...)
 }
 
-func (b *TimeBuilder) BuildTimeArray() array.Time {
-	if b == nil {
-		return Time(nil)
+func (b *timeBuilder) BuildTimeArray() array.Time {
+	return &times{
+		data:  b.data,
+		alloc: b.alloc,
 	}
-	return Time(*b)
 }


### PR DESCRIPTION
The staticarray package did not use the allocator so it would not track
memory usage. The table builder will track usage so this adds that
functionality to these utilities so the two are equivalent.