### PR TITLE
fix: handle errors everywhere in functions and things that use the table builder

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -579,7 +579,9 @@ func (d *tableDecoder) appendRecord(record []string) error {
 	for j, c := range d.meta.Cols {
 		if record[j] == "" && d.meta.Defaults[j] != nil {
 			v := d.meta.Defaults[j]
-			d.builder.AppendValue(j, v)
+			if err := d.builder.AppendValue(j, v); err != nil {
+				return err
+			}
 			continue
 		}
 		if err := decodeValueInto(j, c, record[j], d.builder); err != nil {
@@ -992,37 +994,36 @@ func decodeValueInto(j int, c colMeta, value string, builder execute.TableBuilde
 		if err != nil {
 			return err
 		}
-		builder.AppendBool(j, v)
+		return builder.AppendBool(j, v)
 	case flux.TInt:
 		v, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return err
 		}
-		builder.AppendInt(j, v)
+		return builder.AppendInt(j, v)
 	case flux.TUInt:
 		v, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return err
 		}
-		builder.AppendUInt(j, v)
+		return builder.AppendUInt(j, v)
 	case flux.TFloat:
 		v, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return err
 		}
-		builder.AppendFloat(j, v)
+		return builder.AppendFloat(j, v)
 	case flux.TString:
-		builder.AppendString(j, value)
+		return builder.AppendString(j, value)
 	case flux.TTime:
 		t, err := decodeTime(value, c.fmt)
 		if err != nil {
 			return err
 		}
-		builder.AppendTime(j, t)
+		return builder.AppendTime(j, t)
 	default:
 		return fmt.Errorf("unsupported type %v", c.Type)
 	}
-	return nil
 }
 
 func encodeValue(value values.Value, c colMeta) (string, error) {

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -81,17 +81,18 @@ func (t *aggregateTransformation) RetractTable(id DatasetID, key flux.GroupKey) 
 }
 
 func (t *aggregateTransformation) Process(id DatasetID, tbl flux.Table) error {
-	builder, new := t.cache.TableBuilder(tbl.Key())
-	if !new {
+	builder, created := t.cache.TableBuilder(tbl.Key())
+	if !created {
 		return fmt.Errorf("aggregate found duplicate table with key: %v", tbl.Key())
 	}
 
-	AddTableKeyCols(tbl.Key(), builder)
+	if err := AddTableKeyCols(tbl.Key(), builder); err != nil {
+		return err
+	}
 
 	builderColMap := make([]int, len(t.config.Columns))
 	tableColMap := make([]int, len(t.config.Columns))
 	aggregates := make([]ValueFunc, len(t.config.Columns))
-	var err error
 	cols := tbl.Cols()
 	for j, label := range t.config.Columns {
 		idx := -1
@@ -126,6 +127,7 @@ func (t *aggregateTransformation) Process(id DatasetID, tbl flux.Table) error {
 		}
 		aggregates[j] = vf
 
+		var err error
 		builderColMap[j], err = builder.AddCol(flux.ColMeta{
 			Label: c.Label,
 			Type:  vf.Type(),
@@ -136,7 +138,7 @@ func (t *aggregateTransformation) Process(id DatasetID, tbl flux.Table) error {
 		tableColMap[j] = idx
 	}
 
-	err = tbl.Do(func(cr flux.ColReader) error {
+	if err := tbl.Do(func(cr flux.ColReader) error {
 		for j := range t.config.Columns {
 			vf := aggregates[j]
 
@@ -159,8 +161,7 @@ func (t *aggregateTransformation) Process(id DatasetID, tbl flux.Table) error {
 			}
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 	for j, vf := range aggregates {
@@ -168,21 +169,29 @@ func (t *aggregateTransformation) Process(id DatasetID, tbl flux.Table) error {
 		// Append aggregated value
 		switch vf.Type() {
 		case flux.TBool:
-			builder.AppendBool(bj, vf.(BoolValueFunc).ValueBool())
+			if err := builder.AppendBool(bj, vf.(BoolValueFunc).ValueBool()); err != nil {
+				return err
+			}
 		case flux.TInt:
-			builder.AppendInt(bj, vf.(IntValueFunc).ValueInt())
+			if err := builder.AppendInt(bj, vf.(IntValueFunc).ValueInt()); err != nil {
+				return err
+			}
 		case flux.TUInt:
-			builder.AppendUInt(bj, vf.(UIntValueFunc).ValueUInt())
+			if err := builder.AppendUInt(bj, vf.(UIntValueFunc).ValueUInt()); err != nil {
+				return err
+			}
 		case flux.TFloat:
-			builder.AppendFloat(bj, vf.(FloatValueFunc).ValueFloat())
+			if err := builder.AppendFloat(bj, vf.(FloatValueFunc).ValueFloat()); err != nil {
+				return err
+			}
 		case flux.TString:
-			builder.AppendString(bj, vf.(StringValueFunc).ValueString())
+			if err := builder.AppendString(bj, vf.(StringValueFunc).ValueString()); err != nil {
+				return err
+			}
 		}
 	}
 
-	AppendKeyValues(tbl.Key(), builder)
-
-	return nil
+	return AppendKeyValues(tbl.Key(), builder)
 }
 
 func (t *aggregateTransformation) UpdateWatermark(id DatasetID, mark Time) error {

--- a/execute/executetest/selector.go
+++ b/execute/executetest/selector.go
@@ -16,10 +16,12 @@ func RowSelectorFuncTestHelper(t *testing.T, selector execute.RowSelector, data 
 	if valueIdx < 0 {
 		t.Fatal("no _value column found")
 	}
-	data.Do(func(cr flux.ColReader) error {
+	if err := data.Do(func(cr flux.ColReader) error {
 		s.DoFloat(cr.Floats(valueIdx), cr)
 		return nil
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	got := s.Rows()
 
@@ -41,10 +43,12 @@ func RowSelectorFuncBenchmarkHelper(b *testing.B, selector execute.RowSelector, 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		s := selector.NewFloatSelector()
-		data.Do(func(cr flux.ColReader) error {
+		if err := data.Do(func(cr flux.ColReader) error {
 			s.DoFloat(cr.Floats(valueIdx), cr)
 			return nil
-		})
+		}); err != nil {
+			b.Fatal(err)
+		}
 		rows = s.Rows()
 	}
 }
@@ -58,7 +62,7 @@ func IndexSelectorFuncTestHelper(t *testing.T, selector execute.IndexSelector, d
 	if valueIdx < 0 {
 		t.Fatal("no _value column found")
 	}
-	data.Do(func(cr flux.ColReader) error {
+	if err := data.Do(func(cr flux.ColReader) error {
 		var cpy []int
 		selected := s.DoFloat(cr.Floats(valueIdx))
 		if len(selected) > 0 {
@@ -67,7 +71,9 @@ func IndexSelectorFuncTestHelper(t *testing.T, selector execute.IndexSelector, d
 		}
 		got = append(got, cpy)
 		return nil
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	if !cmp.Equal(want, got) {
 		t.Errorf("unexpected value -want/+got\n%s", cmp.Diff(want, got))
@@ -86,9 +92,11 @@ func IndexSelectorFuncBenchmarkHelper(b *testing.B, selector execute.IndexSelect
 	var got [][]int
 	for n := 0; n < b.N; n++ {
 		s := selector.NewFloatSelector()
-		data.Do(func(cr flux.ColReader) error {
+		if err := data.Do(func(cr flux.ColReader) error {
 			got = append(got, s.DoFloat(cr.Floats(valueIdx)))
 			return nil
-		})
+		}); err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
 )
 
 type selectorTransformation struct {
@@ -97,11 +98,13 @@ func (t *selectorTransformation) Finish(id DatasetID, err error) {
 }
 
 func (t *selectorTransformation) setupBuilder(tbl flux.Table) (TableBuilder, int, error) {
-	builder, new := t.cache.TableBuilder(tbl.Key())
-	if !new {
+	builder, created := t.cache.TableBuilder(tbl.Key())
+	if !created {
 		return nil, 0, fmt.Errorf("found duplicate table with key: %v", tbl.Key())
 	}
-	AddTableCols(tbl, builder)
+	if err := AddTableCols(tbl, builder); err != nil {
+		return nil, 0, err
+	}
 
 	cols := builder.Cols()
 	valueIdx := ColIdx(t.config.Column, cols)
@@ -138,23 +141,22 @@ func (t *indexSelectorTransformation) Process(id DatasetID, tbl flux.Table) erro
 		switch valueCol.Type {
 		case flux.TBool:
 			selected := s.(DoBoolIndexSelector).DoBool(cr.Bools(valueIdx))
-			t.appendSelected(selected, builder, cr)
+			return t.appendSelected(selected, builder, cr)
 		case flux.TInt:
 			selected := s.(DoIntIndexSelector).DoInt(cr.Ints(valueIdx))
-			t.appendSelected(selected, builder, cr)
+			return t.appendSelected(selected, builder, cr)
 		case flux.TUInt:
 			selected := s.(DoUIntIndexSelector).DoUInt(cr.UInts(valueIdx))
-			t.appendSelected(selected, builder, cr)
+			return t.appendSelected(selected, builder, cr)
 		case flux.TFloat:
 			selected := s.(DoFloatIndexSelector).DoFloat(cr.Floats(valueIdx))
-			t.appendSelected(selected, builder, cr)
+			return t.appendSelected(selected, builder, cr)
 		case flux.TString:
 			selected := s.(DoStringIndexSelector).DoString(cr.Strings(valueIdx))
-			t.appendSelected(selected, builder, cr)
+			return t.appendSelected(selected, builder, cr)
 		default:
 			return fmt.Errorf("unsupported selector type %v", valueCol.Type)
 		}
-		return nil
 	})
 }
 
@@ -189,7 +191,7 @@ func (t *rowSelectorTransformation) Process(id DatasetID, tbl flux.Table) error 
 		return fmt.Errorf("invalid use of function: %T has no implementation for type %v", t.selector, valueCol.Type)
 	}
 
-	tbl.Do(func(cr flux.ColReader) error {
+	if err := tbl.Do(func(cr flux.ColReader) error {
 		switch valueCol.Type {
 		case flux.TBool:
 			rower.(DoBoolRowSelector).DoBool(cr.Bools(valueIdx), cr)
@@ -205,62 +207,39 @@ func (t *rowSelectorTransformation) Process(id DatasetID, tbl flux.Table) error 
 			return fmt.Errorf("unsupported selector type %v", valueCol.Type)
 		}
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
 	rows := rower.Rows()
-	t.appendRows(builder, rows)
+	return t.appendRows(builder, rows)
+}
+
+func (t *indexSelectorTransformation) appendSelected(selected []int, builder TableBuilder, cr flux.ColReader) error {
+	if len(selected) == 0 {
+		return nil
+	}
+	cols := builder.Cols()
+	for j := range cols {
+		for _, i := range selected {
+			if err := builder.AppendValue(j, ValueForRow(cr, i, j)); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
-func (t *indexSelectorTransformation) appendSelected(selected []int, builder TableBuilder, cr flux.ColReader) {
-	if len(selected) == 0 {
-		return
-	}
+func (t *rowSelectorTransformation) appendRows(builder TableBuilder, rows []Row) error {
 	cols := builder.Cols()
-	for j, c := range cols {
-		for _, i := range selected {
-			switch c.Type {
-			case flux.TBool:
-				builder.AppendBool(j, cr.Bools(j)[i])
-			case flux.TInt:
-				builder.AppendInt(j, cr.Ints(j)[i])
-			case flux.TUInt:
-				builder.AppendUInt(j, cr.UInts(j)[i])
-			case flux.TFloat:
-				builder.AppendFloat(j, cr.Floats(j)[i])
-			case flux.TString:
-				builder.AppendString(j, cr.Strings(j)[i])
-			case flux.TTime:
-				builder.AppendTime(j, cr.Times(j)[i])
-			default:
-				PanicUnknownType(c.Type)
-			}
-		}
-	}
-}
-
-func (t *rowSelectorTransformation) appendRows(builder TableBuilder, rows []Row) {
-	cols := builder.Cols()
-	for j, c := range cols {
+	for j := range cols {
 		for _, row := range rows {
-			v := row.Values[j]
-			switch c.Type {
-			case flux.TBool:
-				builder.AppendBool(j, v.(bool))
-			case flux.TInt:
-				builder.AppendInt(j, v.(int64))
-			case flux.TUInt:
-				builder.AppendUInt(j, v.(uint64))
-			case flux.TFloat:
-				builder.AppendFloat(j, v.(float64))
-			case flux.TString:
-				builder.AppendString(j, v.(string))
-			case flux.TTime:
-				builder.AppendTime(j, v.(Time))
-			default:
-				PanicUnknownType(c.Type)
+			v := values.New(row.Values[j])
+			if err := builder.AppendValue(j, v); err != nil {
+				return err
 			}
 		}
 	}
+	return nil
 }
 
 type IndexSelector interface {

--- a/functions/inputs/from_csv.go
+++ b/functions/inputs/from_csv.go
@@ -167,7 +167,9 @@ func (c *CSVSource) Run(ctx context.Context) {
 
 	if maxSet {
 		for _, t := range c.ts {
-			t.UpdateWatermark(c.id, max)
+			if err = t.UpdateWatermark(c.id, max); err != nil {
+				goto FINISH
+			}
 		}
 	}
 

--- a/functions/inputs/from_generator.go
+++ b/functions/inputs/from_generator.go
@@ -203,13 +203,17 @@ func (s *GeneratorSource) Decode() (flux.Table, error) {
 	timeIdx := execute.ColIdx("_time", cols)
 	valueIdx := execute.ColIdx("_value", cols)
 	for i := 0; i < int(s.Count); i++ {
-		b.AppendTime(timeIdx, values.ConvertTime(s.Start.Add(time.Duration(i)*deltaT)))
+		if err := b.AppendTime(timeIdx, values.ConvertTime(s.Start.Add(time.Duration(i)*deltaT))); err != nil {
+			return nil, err
+		}
 		scope := map[string]values.Value{s.Param: values.NewInt(int64(i))}
 		v, err := s.Fn.EvalInt(scope)
 		if err != nil {
 			return nil, err
 		}
-		b.AppendInt(valueIdx, v)
+		if err := b.AppendInt(valueIdx, v); err != nil {
+			return nil, err
+		}
 	}
 
 	return b.Table()

--- a/functions/inputs/from_sql.go
+++ b/functions/inputs/from_sql.go
@@ -205,20 +205,34 @@ func (c *SQLIterator) Decode() (flux.Table, error) {
 		for i, col := range columns {
 			switch col.(type) {
 			case bool:
-				builder.AppendBool(i, col.(bool))
+				if err := builder.AppendBool(i, col.(bool)); err != nil {
+					return nil, err
+				}
 			case int64:
-				builder.AppendInt(i, col.(int64))
+				if err := builder.AppendInt(i, col.(int64)); err != nil {
+					return nil, err
+				}
 			case uint64:
-				builder.AppendUInt(i, col.(uint64))
+				if err := builder.AppendUInt(i, col.(uint64)); err != nil {
+					return nil, err
+				}
 			case float64:
-				builder.AppendFloat(i, col.(float64))
+				if err := builder.AppendFloat(i, col.(float64)); err != nil {
+					return nil, err
+				}
 			case string:
-				builder.AppendString(i, col.(string))
+				if err := builder.AppendString(i, col.(string)); err != nil {
+					return nil, err
+				}
 			case []uint8:
 				// Hack for MySQL, might need to work with charset?
-				builder.AppendString(i, string(col.([]uint8)))
+				if err := builder.AppendString(i, string(col.([]uint8))); err != nil {
+					return nil, err
+				}
 			case time.Time:
-				builder.AppendTime(i, values.ConvertTime(col.(time.Time)))
+				if err := builder.AppendTime(i, values.ConvertTime(col.(time.Time))); err != nil {
+					return nil, err
+				}
 			default:
 				execute.PanicUnknownType(flux.TInvalid)
 			}

--- a/functions/inputs/source_iterator.go
+++ b/functions/inputs/source_iterator.go
@@ -52,7 +52,9 @@ func (c *sourceIterator) Do(f func(flux.Table) error) error {
 		if err != nil {
 			return err
 		}
-		f(tbl)
+		if err := f(tbl); err != nil {
+			return err
+		}
 		more, err = c.decoder.Fetch()
 		if err != nil {
 			return err

--- a/functions/transformations/cumulative_sum.go
+++ b/functions/transformations/cumulative_sum.go
@@ -117,7 +117,9 @@ func (t *cumulativeSumTransformation) Process(id execute.DatasetID, tbl flux.Tab
 	if !created {
 		return fmt.Errorf("cumulative sum found duplicate table with key: %v", tbl.Key())
 	}
-	execute.AddTableCols(tbl, builder)
+	if err := execute.AddTableCols(tbl, builder); err != nil {
+		return err
+	}
 
 	cols := tbl.Cols()
 	sumers := make([]*cumulativeSum, len(cols))
@@ -134,35 +136,53 @@ func (t *cumulativeSumTransformation) Process(id execute.DatasetID, tbl flux.Tab
 		for j, c := range cols {
 			switch c.Type {
 			case flux.TBool:
-				builder.AppendBools(j, cr.Bools(j))
+				if err := builder.AppendBools(j, cr.Bools(j)); err != nil {
+					return err
+				}
 			case flux.TInt:
 				if sumers[j] != nil {
 					for i := 0; i < l; i++ {
-						builder.AppendInt(j, sumers[j].sumInt(cr.Ints(j)[i]))
+						if err := builder.AppendInt(j, sumers[j].sumInt(cr.Ints(j)[i])); err != nil {
+							return err
+						}
 					}
 				} else {
-					builder.AppendInts(j, cr.Ints(j))
+					if err := builder.AppendInts(j, cr.Ints(j)); err != nil {
+						return err
+					}
 				}
 			case flux.TUInt:
 				if sumers[j] != nil {
 					for i := 0; i < l; i++ {
-						builder.AppendUInt(j, sumers[j].sumUInt(cr.UInts(j)[i]))
+						if err := builder.AppendUInt(j, sumers[j].sumUInt(cr.UInts(j)[i])); err != nil {
+							return err
+						}
 					}
 				} else {
-					builder.AppendUInts(j, cr.UInts(j))
+					if err := builder.AppendUInts(j, cr.UInts(j)); err != nil {
+						return err
+					}
 				}
 			case flux.TFloat:
 				if sumers[j] != nil {
 					for i := 0; i < l; i++ {
-						builder.AppendFloat(j, sumers[j].sumFloat(cr.Floats(j)[i]))
+						if err := builder.AppendFloat(j, sumers[j].sumFloat(cr.Floats(j)[i])); err != nil {
+							return err
+						}
 					}
 				} else {
-					builder.AppendFloats(j, cr.Floats(j))
+					if err := builder.AppendFloats(j, cr.Floats(j)); err != nil {
+						return err
+					}
 				}
 			case flux.TString:
-				builder.AppendStrings(j, cr.Strings(j))
+				if err := builder.AppendStrings(j, cr.Strings(j)); err != nil {
+					return err
+				}
 			case flux.TTime:
-				builder.AppendTimes(j, cr.Times(j))
+				if err := builder.AppendTimes(j, cr.Times(j)); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/functions/transformations/data_test.go
+++ b/functions/transformations/data_test.go
@@ -53,28 +53,22 @@ func init() {
 	)
 	normalTableBuilder := execute.NewColListTableBuilder(key, executetest.UnlimitedAllocator)
 
-	_, err := normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultTimeColLabel, Type: flux.TTime})
-	if err != nil {
+	if _, err := normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultTimeColLabel, Type: flux.TTime}); err != nil {
 		return
 	}
-	_, err = normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultStartColLabel, Type: flux.TTime})
-	if err != nil {
+	if _, err := normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultStartColLabel, Type: flux.TTime}); err != nil {
 		return
 	}
-	_, err = normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultStopColLabel, Type: flux.TTime})
-	if err != nil {
+	if _, err := normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultStopColLabel, Type: flux.TTime}); err != nil {
 		return
 	}
-	_, err = normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultValueColLabel, Type: flux.TFloat})
-	if err != nil {
+	if _, err := normalTableBuilder.AddCol(flux.ColMeta{Label: execute.DefaultValueColLabel, Type: flux.TFloat}); err != nil {
 		return
 	}
-	_, err = normalTableBuilder.AddCol(flux.ColMeta{Label: "t1", Type: flux.TString})
-	if err != nil {
+	if _, err := normalTableBuilder.AddCol(flux.ColMeta{Label: "t1", Type: flux.TString}); err != nil {
 		return
 	}
-	_, err = normalTableBuilder.AddCol(flux.ColMeta{Label: "t2", Type: flux.TString})
-	if err != nil {
+	if _, err := normalTableBuilder.AddCol(flux.ColMeta{Label: "t2", Type: flux.TString}); err != nil {
 		return
 	}
 
@@ -102,12 +96,12 @@ func init() {
 		}
 	}
 
-	normalTableBuilder.AppendTimes(0, times)
-	normalTableBuilder.AppendTimes(1, startTimes)
-	normalTableBuilder.AppendTimes(2, stopTimes)
-	normalTableBuilder.AppendFloats(3, normalValues)
-	normalTableBuilder.AppendStrings(4, t1)
-	normalTableBuilder.AppendStrings(5, t2)
+	_ = normalTableBuilder.AppendTimes(0, times)
+	_ = normalTableBuilder.AppendTimes(1, startTimes)
+	_ = normalTableBuilder.AppendTimes(2, stopTimes)
+	_ = normalTableBuilder.AppendFloats(3, normalValues)
+	_ = normalTableBuilder.AppendStrings(4, t1)
+	_ = normalTableBuilder.AppendStrings(5, t2)
 
 	NormalTable, _ = normalTableBuilder.Table()
 }

--- a/functions/transformations/derivative.go
+++ b/functions/transformations/derivative.go
@@ -204,18 +204,24 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 			d := derivatives[j]
 			switch c.Type {
 			case flux.TBool:
-				builder.AppendBools(j, cr.Bools(j)[firstIdx:])
+				if err := builder.AppendBools(j, cr.Bools(j)[firstIdx:]); err != nil {
+					return err
+				}
 			case flux.TInt:
 				if d != nil {
 					for i := 0; i < l; i++ {
 						time := cr.Times(timeIdx)[i]
 						v := d.updateInt(time, cr.Ints(j)[i])
 						if i != 0 || firstIdx == 0 {
-							builder.AppendFloat(j, v)
+							if err := builder.AppendFloat(j, v); err != nil {
+								return err
+							}
 						}
 					}
 				} else {
-					builder.AppendInts(j, cr.Ints(j)[firstIdx:])
+					if err := builder.AppendInts(j, cr.Ints(j)[firstIdx:]); err != nil {
+						return err
+					}
 				}
 			case flux.TUInt:
 				if d != nil {
@@ -223,11 +229,15 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 						time := cr.Times(timeIdx)[i]
 						v := d.updateUInt(time, cr.UInts(j)[i])
 						if i != 0 || firstIdx == 0 {
-							builder.AppendFloat(j, v)
+							if err := builder.AppendFloat(j, v); err != nil {
+								return err
+							}
 						}
 					}
 				} else {
-					builder.AppendUInts(j, cr.UInts(j)[firstIdx:])
+					if err := builder.AppendUInts(j, cr.UInts(j)[firstIdx:]); err != nil {
+						return err
+					}
 				}
 			case flux.TFloat:
 				if d != nil {
@@ -235,16 +245,24 @@ func (t *derivativeTransformation) Process(id execute.DatasetID, tbl flux.Table)
 						time := cr.Times(timeIdx)[i]
 						v := d.updateFloat(time, cr.Floats(j)[i])
 						if i != 0 || firstIdx == 0 {
-							builder.AppendFloat(j, v)
+							if err := builder.AppendFloat(j, v); err != nil {
+								return err
+							}
 						}
 					}
 				} else {
-					builder.AppendFloats(j, cr.Floats(j)[firstIdx:])
+					if err := builder.AppendFloats(j, cr.Floats(j)[firstIdx:]); err != nil {
+						return err
+					}
 				}
 			case flux.TString:
-				builder.AppendStrings(j, cr.Strings(j)[firstIdx:])
+				if err := builder.AppendStrings(j, cr.Strings(j)[firstIdx:]); err != nil {
+					return err
+				}
 			case flux.TTime:
-				builder.AppendTimes(j, cr.Times(j)[firstIdx:])
+				if err := builder.AppendTimes(j, cr.Times(j)[firstIdx:]); err != nil {
+					return err
+				}
 			}
 		}
 		// Now that we skipped the first row, start at 0 for the rest of the batches

--- a/functions/transformations/difference.go
+++ b/functions/transformations/difference.go
@@ -157,11 +157,10 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 			case flux.TFloat:
 				typ = flux.TFloat
 			}
-			_, err := builder.AddCol(flux.ColMeta{
+			if _, err := builder.AddCol(flux.ColMeta{
 				Label: c.Label,
 				Type:  typ,
-			})
-			if err != nil {
+			}); err != nil {
 				return err
 			}
 			differences[j] = newDifference(j, t.nonNegative)
@@ -183,44 +182,62 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 				d := differences[j]
 				switch c.Type {
 				case flux.TBool:
-					builder.AppendBools(j, cr.Bools(j)[firstIdx:])
+					if err := builder.AppendBools(j, cr.Bools(j)[firstIdx:]); err != nil {
+						return err
+					}
 				case flux.TInt:
 					if d != nil {
 						for i := 0; i < l; i++ {
 							v := d.updateInt(cr.Ints(j)[i])
 							if i != 0 || firstIdx == 0 {
-								builder.AppendInt(j, v)
+								if err := builder.AppendInt(j, v); err != nil {
+									return err
+								}
 							}
 						}
 					} else {
-						builder.AppendInts(j, cr.Ints(j)[firstIdx:])
+						if err := builder.AppendInts(j, cr.Ints(j)[firstIdx:]); err != nil {
+							return err
+						}
 					}
 				case flux.TUInt:
 					if d != nil {
 						for i := 0; i < l; i++ {
 							v := d.updateUInt(cr.UInts(j)[i])
 							if i != 0 || firstIdx == 0 {
-								builder.AppendInt(j, v)
+								if err := builder.AppendInt(j, v); err != nil {
+									return err
+								}
 							}
 						}
 					} else {
-						builder.AppendUInts(j, cr.UInts(j)[firstIdx:])
+						if err := builder.AppendUInts(j, cr.UInts(j)[firstIdx:]); err != nil {
+							return err
+						}
 					}
 				case flux.TFloat:
 					if d != nil {
 						for i := 0; i < l; i++ {
 							v := d.updateFloat(cr.Floats(j)[i])
 							if i != 0 || firstIdx == 0 {
-								builder.AppendFloat(j, v)
+								if err := builder.AppendFloat(j, v); err != nil {
+									return err
+								}
 							}
 						}
 					} else {
-						builder.AppendFloats(j, cr.Floats(j)[firstIdx:])
+						if err := builder.AppendFloats(j, cr.Floats(j)[firstIdx:]); err != nil {
+							return err
+						}
 					}
 				case flux.TString:
-					builder.AppendStrings(j, cr.Strings(j)[firstIdx:])
+					if err := builder.AppendStrings(j, cr.Strings(j)[firstIdx:]); err != nil {
+						return err
+					}
 				case flux.TTime:
-					builder.AppendTimes(j, cr.Times(j)[firstIdx:])
+					if err := builder.AppendTimes(j, cr.Times(j)[firstIdx:]); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/functions/transformations/distinct.go
+++ b/functions/transformations/distinct.go
@@ -154,11 +154,10 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 	colIdx := execute.ColIdx(t.column, tbl.Cols())
 	if colIdx < 0 {
 		// doesn't exist in this table, so add an empty value
-		err := execute.AddTableKeyCols(tbl.Key(), builder)
-		if err != nil {
+		if err := execute.AddTableKeyCols(tbl.Key(), builder); err != nil {
 			return err
 		}
-		colIdx, err = builder.AddCol(flux.ColMeta{
+		colIdx, err := builder.AddCol(flux.ColMeta{
 			Label: execute.DefaultValueColLabel,
 			Type:  flux.TString,
 		})
@@ -166,8 +165,12 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 			return err
 		}
 
-		builder.AppendString(colIdx, "")
-		execute.AppendKeyValues(tbl.Key(), builder)
+		if err := builder.AppendString(colIdx, ""); err != nil {
+			return err
+		}
+		if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+			return err
+		}
 		// TODO: hack required to ensure data flows downstream
 		return tbl.Do(func(flux.ColReader) error {
 			return nil
@@ -176,11 +179,10 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 
 	col := tbl.Cols()[colIdx]
 
-	err := execute.AddTableKeyCols(tbl.Key(), builder)
-	if err != nil {
+	if err := execute.AddTableKeyCols(tbl.Key(), builder); err != nil {
 		return err
 	}
-	colIdx, err = builder.AddCol(flux.ColMeta{
+	colIdx, err := builder.AddCol(flux.ColMeta{
 		Label: execute.DefaultValueColLabel,
 		Type:  col.Type,
 	})
@@ -192,20 +194,34 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 		j := execute.ColIdx(t.column, tbl.Key().Cols())
 		switch col.Type {
 		case flux.TBool:
-			builder.AppendBool(colIdx, tbl.Key().ValueBool(j))
+			if err := builder.AppendBool(colIdx, tbl.Key().ValueBool(j)); err != nil {
+				return err
+			}
 		case flux.TInt:
-			builder.AppendInt(colIdx, tbl.Key().ValueInt(j))
+			if err := builder.AppendInt(colIdx, tbl.Key().ValueInt(j)); err != nil {
+				return err
+			}
 		case flux.TUInt:
-			builder.AppendUInt(colIdx, tbl.Key().ValueUInt(j))
+			if err := builder.AppendUInt(colIdx, tbl.Key().ValueUInt(j)); err != nil {
+				return err
+			}
 		case flux.TFloat:
-			builder.AppendFloat(colIdx, tbl.Key().ValueFloat(j))
+			if err := builder.AppendFloat(colIdx, tbl.Key().ValueFloat(j)); err != nil {
+				return err
+			}
 		case flux.TString:
-			builder.AppendString(colIdx, tbl.Key().ValueString(j))
+			if err := builder.AppendString(colIdx, tbl.Key().ValueString(j)); err != nil {
+				return err
+			}
 		case flux.TTime:
-			builder.AppendTime(colIdx, tbl.Key().ValueTime(j))
+			if err := builder.AppendTime(colIdx, tbl.Key().ValueTime(j)); err != nil {
+				return err
+			}
 		}
 
-		execute.AppendKeyValues(tbl.Key(), builder)
+		if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+			return err
+		}
 		// TODO: hack required to ensure data flows downstream
 		return tbl.Do(func(flux.ColReader) error {
 			return nil
@@ -248,45 +264,59 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					continue
 				}
 				boolDistinct[v] = true
-				builder.AppendBool(colIdx, v)
+				if err := builder.AppendBool(colIdx, v); err != nil {
+					return err
+				}
 			case flux.TInt:
 				v := cr.Ints(j)[i]
 				if intDistinct[v] {
 					continue
 				}
 				intDistinct[v] = true
-				builder.AppendInt(colIdx, v)
+				if err := builder.AppendInt(colIdx, v); err != nil {
+					return err
+				}
 			case flux.TUInt:
 				v := cr.UInts(j)[i]
 				if uintDistinct[v] {
 					continue
 				}
 				uintDistinct[v] = true
-				builder.AppendUInt(colIdx, v)
+				if err := builder.AppendUInt(colIdx, v); err != nil {
+					return err
+				}
 			case flux.TFloat:
 				v := cr.Floats(j)[i]
 				if floatDistinct[v] {
 					continue
 				}
 				floatDistinct[v] = true
-				builder.AppendFloat(colIdx, v)
+				if err := builder.AppendFloat(colIdx, v); err != nil {
+					return err
+				}
 			case flux.TString:
 				v := cr.Strings(j)[i]
 				if stringDistinct[v] {
 					continue
 				}
 				stringDistinct[v] = true
-				builder.AppendString(colIdx, v)
+				if err := builder.AppendString(colIdx, v); err != nil {
+					return err
+				}
 			case flux.TTime:
 				v := cr.Times(j)[i]
 				if timeDistinct[v] {
 					continue
 				}
 				timeDistinct[v] = true
-				builder.AppendTime(colIdx, v)
+				if err := builder.AppendTime(colIdx, v); err != nil {
+					return err
+				}
 			}
 
-			execute.AppendKeyValues(tbl.Key(), builder)
+			if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/functions/transformations/filter.go
+++ b/functions/transformations/filter.go
@@ -2,12 +2,12 @@ package transformations
 
 import (
 	"fmt"
-	"github.com/influxdata/flux/functions/inputs"
 	"log"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/functions/inputs"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -227,7 +227,9 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 	if !created {
 		return fmt.Errorf("filter found duplicate table with key: %v", tbl.Key())
 	}
-	execute.AddTableCols(tbl, builder)
+	if err := execute.AddTableCols(tbl, builder); err != nil {
+		return err
+	}
 
 	// Prepare the function for the column types.
 	cols := tbl.Cols()
@@ -247,7 +249,9 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 				// No match, skipping
 				continue
 			}
-			execute.AppendRecord(i, cr, builder)
+			if err := execute.AppendRecord(i, cr, builder); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/functions/transformations/histogram.go
+++ b/functions/transformations/histogram.go
@@ -208,13 +208,19 @@ func (t *histogramTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 	// Add records making counts cumulative
 	total := 0.0
 	for i, v := range counts {
-		execute.AppendKeyValues(tbl.Key(), builder)
+		if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+			return err
+		}
 		count := v + total
 		if t.spec.Normalize {
 			count /= totalRows
 		}
-		builder.AppendFloat(countIdx, count)
-		builder.AppendFloat(boundIdx, t.spec.Buckets[i])
+		if err := builder.AppendFloat(countIdx, count); err != nil {
+			return err
+		}
+		if err := builder.AppendFloat(boundIdx, t.spec.Buckets[i]); err != nil {
+			return err
+		}
 		total += v
 	}
 	return nil

--- a/functions/transformations/histogram_quantile.go
+++ b/functions/transformations/histogram_quantile.go
@@ -236,8 +236,12 @@ func (t histogramQuantileTransformation) Process(id execute.DatasetID, tbl flux.
 	if err != nil {
 		return err
 	}
-	execute.AppendKeyValues(tbl.Key(), builder)
-	builder.AppendFloat(valueIdx, q)
+	if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+		return err
+	}
+	if err := builder.AppendFloat(valueIdx, q); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -872,7 +872,7 @@ func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Ta
 						}
 						newColumn := c.schemaMap[column]
 						newColumnIdx := c.colIndex[newColumn]
-						builder.AppendValue(newColumnIdx, columnVal)
+						_ = builder.AppendValue(newColumnIdx, columnVal)
 					})
 
 					rightRecord.Range(func(columnName string, columnVal values.Value) {
@@ -886,7 +886,7 @@ func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Ta
 						// No need to append value if column is part of the join key.
 						// Because value already appended when iterating over left record.
 						if !c.on[newColumn.Label] {
-							builder.AppendValue(newColumnIdx, columnVal)
+							_ = builder.AppendValue(newColumnIdx, columnVal)
 						}
 					})
 				}

--- a/functions/transformations/key_values.go
+++ b/functions/transformations/key_values.go
@@ -3,6 +3,7 @@ package transformations
 import (
 	"errors"
 	"fmt"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
@@ -231,8 +232,12 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						}
 						boolDistinct[v] = true
 					}
-					builder.AppendString(keyColIdx, t.spec.KeyCols[j])
-					builder.AppendBool(valueColIdx, v)
+					if err := builder.AppendString(keyColIdx, t.spec.KeyCols[j]); err != nil {
+						return err
+					}
+					if err := builder.AppendBool(valueColIdx, v); err != nil {
+						return err
+					}
 				case flux.TInt:
 					v := cr.Ints(rowIdx)[i]
 					if t.distinct {
@@ -241,8 +246,12 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						}
 						intDistinct[v] = true
 					}
-					builder.AppendString(keyColIdx, t.spec.KeyCols[j])
-					builder.AppendInt(valueColIdx, v)
+					if err := builder.AppendString(keyColIdx, t.spec.KeyCols[j]); err != nil {
+						return err
+					}
+					if err := builder.AppendInt(valueColIdx, v); err != nil {
+						return err
+					}
 				case flux.TUInt:
 					v := cr.UInts(rowIdx)[i]
 					if t.distinct {
@@ -251,8 +260,12 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						}
 						uintDistinct[v] = true
 					}
-					builder.AppendString(keyColIdx, t.spec.KeyCols[j])
-					builder.AppendUInt(valueColIdx, v)
+					if err := builder.AppendString(keyColIdx, t.spec.KeyCols[j]); err != nil {
+						return err
+					}
+					if err := builder.AppendUInt(valueColIdx, v); err != nil {
+						return err
+					}
 				case flux.TFloat:
 					v := cr.Floats(rowIdx)[i]
 					if t.distinct {
@@ -261,8 +274,12 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						}
 						floatDistinct[v] = true
 					}
-					builder.AppendString(keyColIdx, t.spec.KeyCols[j])
-					builder.AppendFloat(valueColIdx, v)
+					if err := builder.AppendString(keyColIdx, t.spec.KeyCols[j]); err != nil {
+						return err
+					}
+					if err := builder.AppendFloat(valueColIdx, v); err != nil {
+						return err
+					}
 				case flux.TString:
 					v := cr.Strings(rowIdx)[i]
 					if t.distinct {
@@ -271,8 +288,12 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						}
 						stringDistinct[v] = true
 					}
-					builder.AppendString(keyColIdx, t.spec.KeyCols[j])
-					builder.AppendString(valueColIdx, v)
+					if err := builder.AppendString(keyColIdx, t.spec.KeyCols[j]); err != nil {
+						return err
+					}
+					if err := builder.AppendString(valueColIdx, v); err != nil {
+						return err
+					}
 				case flux.TTime:
 					v := cr.Times(rowIdx)[i]
 					if t.distinct {
@@ -281,10 +302,16 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 						}
 						timeDistinct[v] = true
 					}
-					builder.AppendString(keyColIdx, t.spec.KeyCols[j])
-					builder.AppendTime(valueColIdx, v)
+					if err := builder.AppendString(keyColIdx, t.spec.KeyCols[j]); err != nil {
+						return err
+					}
+					if err := builder.AppendTime(valueColIdx, v); err != nil {
+						return err
+					}
 				}
-				execute.AppendKeyValues(tbl.Key(), builder)
+				if err := execute.AppendKeyValues(tbl.Key(), builder); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/functions/transformations/map.go
+++ b/functions/transformations/map.go
@@ -196,7 +196,9 @@ func (t *mapTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 						return fmt.Errorf("could not find value for column %q", c.Label)
 					}
 				}
-				builder.AppendValue(j, v)
+				if err := builder.AppendValue(j, v); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/functions/transformations/range.go
+++ b/functions/transformations/range.go
@@ -221,8 +221,7 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 		return fmt.Errorf("range found duplicate table with key: %v", tbl.Key())
 	}
 
-	err := execute.AddTableCols(tbl, builder)
-	if err != nil {
+	if err := execute.AddTableCols(tbl, builder); err != nil {
 		return err
 	}
 	timeIdx := execute.ColIdx(t.timeCol, tbl.Cols())
@@ -257,8 +256,7 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 	}
 
 	if forwardTable {
-		execute.AppendTable(tbl, builder)
-		return nil
+		return execute.AppendTable(tbl, builder)
 	}
 
 	// If the start and/or stop columns don't exist,
@@ -271,8 +269,7 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 			Label: t.startCol,
 			Type:  flux.TTime,
 		}
-		_, err := builder.AddCol(c)
-		if err != nil {
+		if _, err := builder.AddCol(c); err != nil {
 			return err
 		}
 		startAdded = true
@@ -284,14 +281,13 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 			Label: t.stopCol,
 			Type:  flux.TTime,
 		}
-		_, err := builder.AddCol(c)
-		if err != nil {
+		if _, err := builder.AddCol(c); err != nil {
 			return err
 		}
 		stopAdded = true
 	}
 
-	err = tbl.Do(func(cr flux.ColReader) error {
+	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
 			tVal := cr.Times(timeIdx)[i]
@@ -312,7 +308,9 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 					if start < t.bounds.Start {
 						start = t.bounds.Start
 					}
-					builder.AppendTime(j, start)
+					if err := builder.AppendTime(j, start); err != nil {
+						return err
+					}
 				case t.stopCol:
 					var stop values.Time
 					// If we just inserted a stop column with no values populated
@@ -325,30 +323,18 @@ func (t *rangeTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 					if stop > t.bounds.Stop {
 						stop = t.bounds.Stop
 					}
-					builder.AppendTime(j, stop)
+					if err := builder.AppendTime(j, stop); err != nil {
+						return err
+					}
 				default:
-					switch c.Type {
-					case flux.TBool:
-						builder.AppendBool(j, cr.Bools(j)[i])
-					case flux.TInt:
-						builder.AppendInt(j, cr.Ints(j)[i])
-					case flux.TUInt:
-						builder.AppendUInt(j, cr.UInts(j)[i])
-					case flux.TFloat:
-						builder.AppendFloat(j, cr.Floats(j)[i])
-					case flux.TString:
-						builder.AppendString(j, cr.Strings(j)[i])
-					case flux.TTime:
-						builder.AppendTime(j, cr.Times(j)[i])
-					default:
-						execute.PanicUnknownType(c.Type)
+					if err := builder.AppendValue(j, execute.ValueForRow(cr, i, j)); err != nil {
+						return err
 					}
 				}
 			}
 		}
 		return nil
 	})
-	return err
 }
 
 func (t *rangeTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {

--- a/functions/transformations/schema_functions.go
+++ b/functions/transformations/schema_functions.go
@@ -490,7 +490,9 @@ func (t *schemaMutationTransformation) Process(id execute.DatasetID, tbl flux.Ta
 
 	return tbl.Do(func(cr flux.ColReader) error {
 		for i := 0; i < cr.Len(); i++ {
-			execute.AppendMappedRecordWithDefaults(i, cr, builder, ctx.ColMap())
+			if err := execute.AppendMappedRecordWithDefaults(i, cr, builder, ctx.ColMap()); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/functions/transformations/set.go
+++ b/functions/transformations/set.go
@@ -143,11 +143,10 @@ func (t *setTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 			return err
 		}
 		if !execute.HasCol(t.key, builder.Cols()) {
-			_, err = builder.AddCol(flux.ColMeta{
+			if _, err = builder.AddCol(flux.ColMeta{
 				Label: t.key,
 				Type:  flux.TString,
-			})
-			if err != nil {
+			}); err != nil {
 				return err
 			}
 		}
@@ -158,12 +157,16 @@ func (t *setTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 			if j == idx {
 				continue
 			}
-			execute.AppendCol(j, j, cr, builder)
+			if err := execute.AppendCol(j, j, cr, builder); err != nil {
+				return err
+			}
 		}
 		// Set new value
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			builder.AppendString(idx, t.value)
+			if err := builder.AppendString(idx, t.value); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/functions/transformations/shift.go
+++ b/functions/transformations/shift.go
@@ -155,17 +155,23 @@ func (t *shiftTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 	if !created {
 		return fmt.Errorf("shift found duplicate table with key: %v", tbl.Key())
 	}
-	execute.AddTableCols(tbl, builder)
+	if err := execute.AddTableCols(tbl, builder); err != nil {
+		return err
+	}
 
 	return tbl.Do(func(cr flux.ColReader) error {
 		for j, c := range cr.Cols() {
 			if execute.ContainsStr(t.columns, c.Label) {
 				l := cr.Len()
 				for i := 0; i < l; i++ {
-					builder.AppendTime(j, cr.Times(j)[i].Add(t.shift))
+					if err := builder.AppendTime(j, cr.Times(j)[i].Add(t.shift)); err != nil {
+						return err
+					}
 				}
 			} else {
-				execute.AppendCol(j, j, cr, builder)
+				if err := execute.AppendCol(j, j, cr, builder); err != nil {
+					return err
+				}
 			}
 		}
 		return nil

--- a/functions/transformations/sort.go
+++ b/functions/transformations/sort.go
@@ -141,8 +141,12 @@ func (t *sortTransformation) Process(id execute.DatasetID, tbl flux.Table) error
 	if !created {
 		return fmt.Errorf("sort found duplicate table with key: %v", tbl.Key())
 	}
-	execute.AddTableCols(tbl, builder)
-	execute.AppendTable(tbl, builder)
+	if err := execute.AddTableCols(tbl, builder); err != nil {
+		return err
+	}
+	if err := execute.AppendTable(tbl, builder); err != nil {
+		return err
+	}
 
 	builder.Sort(t.cols, t.desc)
 	return nil

--- a/functions/transformations/union.go
+++ b/functions/transformations/union.go
@@ -121,10 +121,14 @@ func (t *unionTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if created {
-		execute.AddTableCols(tbl, builder)
+		if err := execute.AddTableCols(tbl, builder); err != nil {
+			return err
+		}
 	}
 
-	execute.AppendTable(tbl, builder)
+	if err := execute.AppendTable(tbl, builder); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/functions/transformations/unique.go
+++ b/functions/transformations/unique.go
@@ -113,7 +113,9 @@ func (t *uniqueTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 	if !created {
 		return fmt.Errorf("unique found duplicate table with key: %v", tbl.Key())
 	}
-	execute.AddTableCols(tbl, builder)
+	if err := execute.AddTableCols(tbl, builder); err != nil {
+		return err
+	}
 
 	colIdx := execute.ColIdx(t.column, builder.Cols())
 	if colIdx < 0 {
@@ -187,7 +189,9 @@ func (t *uniqueTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 				timeUnique[v] = true
 			}
 
-			execute.AppendRecord(i, cr, builder)
+			if err := execute.AppendRecord(i, cr, builder); err != nil {
+				return err
+			}
 		}
 		return nil
 	})

--- a/functions/transformations/window.go
+++ b/functions/transformations/window.go
@@ -347,25 +347,16 @@ func (t *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table
 				for j, c := range builder.Cols() {
 					switch c.Label {
 					case t.startColLabel:
-						builder.AppendTime(startColIdx, bnds.Start)
+						if err := builder.AppendTime(startColIdx, bnds.Start); err != nil {
+							return err
+						}
 					case t.stopColLabel:
-						builder.AppendTime(stopColIdx, bnds.Stop)
+						if err := builder.AppendTime(stopColIdx, bnds.Stop); err != nil {
+							return err
+						}
 					default:
-						switch c.Type {
-						case flux.TBool:
-							builder.AppendBool(j, cr.Bools(j)[i])
-						case flux.TInt:
-							builder.AppendInt(j, cr.Ints(j)[i])
-						case flux.TUInt:
-							builder.AppendUInt(j, cr.UInts(j)[i])
-						case flux.TFloat:
-							builder.AppendFloat(j, cr.Floats(j)[i])
-						case flux.TString:
-							builder.AppendString(j, cr.Strings(j)[i])
-						case flux.TTime:
-							builder.AppendTime(j, cr.Times(j)[i])
-						default:
-							execute.PanicUnknownType(c.Type)
+						if err := builder.AppendValue(j, execute.ValueForRow(cr, i, j)); err != nil {
+							return err
 						}
 					}
 				}


### PR DESCRIPTION
This fixes things to properly read and handle the errors that are
returned from `TableBuilder` and the `table.Do()` function.

This commit does not change things to handle errors in the entire
project so `errcheck` still reports existing unhandled errors, but it
handles all of the ones related to those mentioned above.

Fixes #135.