### PR TITLE
remove cyclic dependency bug

### DIFF
--- a/functions/transformations/filter.go
+++ b/functions/transformations/filter.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/flux/functions/inputs"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"


### PR DESCRIPTION
A cyclic dependency was introduced between the `transformations` and `inputs` packages. This is the fix.