### PR TITLE
fix: remove a cyclical import that got added as part of a bad merge

### DIFF
--- a/functions/transformations/filter.go
+++ b/functions/transformations/filter.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/flux/functions/inputs"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"


### PR DESCRIPTION
A combination of an error refactor (that also fixed import orderings in
some files) and the planner change resulted in an accidental cyclical
import.