### PR TITLE
feat: add an influxql json decoder as a library

### DIFF
--- a/influxql/decoder.go
+++ b/influxql/decoder.go
@@ -1,0 +1,195 @@
+package influxql
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/values"
+)
+
+// NewResultDecoder will construct a new result decoder for an influxql response.
+func NewResultDecoder(a *execute.Allocator) flux.MultiResultDecoder {
+	return &resultDecoder{a: a}
+}
+
+type resultDecoder struct {
+	a *execute.Allocator
+}
+
+func (dec *resultDecoder) Decode(r io.ReadCloser) (flux.ResultIterator, error) {
+	var resp Response
+	if err := json.NewDecoder(r).Decode(&resp); err != nil {
+		return nil, err
+	}
+	return &resultIterator{resp: &resp, a: dec.a}, nil
+}
+
+type resultIterator struct {
+	resp *Response
+	a    *execute.Allocator
+}
+
+func (ri *resultIterator) More() bool {
+	return len(ri.resp.Results) > 0 && ri.resp.Results[0].Err == ""
+}
+
+func (ri *resultIterator) Next() flux.Result {
+	res := ri.resp.Results[0]
+	ri.resp.Results = ri.resp.Results[1:]
+	return &result{res: &res, a: ri.a}
+}
+
+func (ri *resultIterator) Cancel() {
+	ri.resp.Results = nil
+}
+
+func (ri *resultIterator) Err() error {
+	if ri.resp.Err != "" {
+		return errors.New(ri.resp.Err)
+	} else if len(ri.resp.Results) > 0 && ri.resp.Results[0].Err != "" {
+		return errors.New(ri.resp.Results[0].Err)
+	}
+	return nil
+}
+
+type result struct {
+	res *Result
+	a   *execute.Allocator
+}
+
+func (r *result) Name() string {
+	return strconv.Itoa(r.res.StatementID)
+}
+
+func (r *result) Tables() flux.TableIterator {
+	return r
+}
+
+func (r *result) Do(f func(tbl flux.Table) error) error {
+	// Iterate through each series within the table.
+	for _, series := range r.res.Series {
+		// Find the time column.
+		// TODO(jsternberg): Allow the time column to be customized.
+		timeCol := -1
+		for i, col := range series.Columns {
+			if col == "time" {
+				timeCol = i
+				break
+			}
+		}
+
+		// Within each series, we have a common group key base. Construct that here.
+		seriesKeyBuilder := execute.NewGroupKeyBuilder(nil)
+		if series.Name != "" {
+			seriesKeyBuilder.AddKeyValue("_measurement", values.NewString(series.Name))
+		}
+
+		tagKeys := make([]string, 0, len(series.Tags))
+		for k := range series.Tags {
+			tagKeys = append(tagKeys, k)
+		}
+		sort.Strings(tagKeys)
+		for _, k := range tagKeys {
+			seriesKeyBuilder.AddKeyValue(k, values.NewString(series.Tags[k]))
+		}
+
+		seriesKey, err := seriesKeyBuilder.Build()
+		if err != nil {
+			return err
+		}
+
+		// Iterate through the columns and create a new table for each field.
+		for i, col := range series.Columns {
+			if i == timeCol {
+				// Skip the time column if one was found.
+				continue
+			}
+
+			// Construct the key using the field name.
+			gkb := execute.NewGroupKeyBuilder(seriesKey)
+			gkb.AddKeyValue("_field", values.NewString(col))
+			key, err := gkb.Build()
+			if err != nil {
+				return err
+			}
+
+			// Construct a new table.
+			b := execute.NewColListTableBuilder(key, r.a)
+
+			// If we have a time column, do it here.
+			if timeCol >= 0 {
+				if _, err := b.AddCol(flux.ColMeta{
+					Label: execute.DefaultTimeColLabel,
+					Type:  flux.TTime,
+				}); err != nil {
+					return err
+				}
+			}
+			if err := execute.AddTableKeyCols(key, b); err != nil {
+				return err
+			}
+
+			// Search for the first non-null value in the column.
+			valueIdx := -1
+			for _, row := range series.Values {
+				if row[i] == nil {
+					continue
+				}
+
+				valueIdx, err = b.AddCol(flux.ColMeta{
+					Label: execute.DefaultValueColLabel,
+					Type:  flux.ColumnType(values.New(row[i]).Type()),
+				})
+				if err != nil {
+					return err
+				}
+				break
+			}
+
+			if valueIdx == -1 {
+				// Move to the next column as there are no non-null values.
+				continue
+			}
+
+			for _, row := range series.Values {
+				// Skip null values.
+				if row[i] == nil {
+					continue
+				}
+
+				if timeCol >= 0 {
+					s := row[timeCol].(string)
+					t, err := time.Parse(time.RFC3339, s)
+					if err != nil {
+						return err
+					}
+					if err := b.AppendTime(0, values.Time(t.UnixNano())); err != nil {
+						return err
+					}
+				}
+
+				if err := execute.AppendKeyValues(key, b); err != nil {
+					return err
+				}
+
+				v := values.New(row[i])
+				if err := b.AppendValue(b.NCols()-1, v); err != nil {
+					return err
+				}
+			}
+
+			if table, err := b.Table(); err != nil {
+				return err
+			} else if err := f(table); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/influxql/decoder_test.go
+++ b/influxql/decoder_test.go
@@ -1,0 +1,88 @@
+package influxql_test
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/influxql"
+)
+
+func TestDecoder(t *testing.T) {
+	exp := []executetest.Result{
+		{
+			Nm: "0",
+			Tbls: []*executetest.Table{{
+				KeyCols: []string{"_measurement", "host", "_field"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "host", Type: flux.TString},
+					{Label: "_field", Type: flux.TString},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), "cpu", "server01", "usage_user", 0.0},
+				},
+			}},
+		},
+	}
+	for i := range exp {
+		exp[i].Normalize()
+	}
+
+	dec := influxql.NewResultDecoder(executetest.UnlimitedAllocator)
+	ri, err := dec.Decode(ioutil.NopCloser(strings.NewReader(`
+{
+	"results": [
+		{
+			"statement_id": 0,
+			"series": [
+				{
+					"name": "cpu",
+					"tags": {
+						"host": "server01"
+					},
+					"columns": ["time", "usage_user"],
+					"values": [
+						["1970-01-01T00:00:00Z", 0.0]
+					]
+				}
+			]
+		}
+	]
+}
+`)))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var got []executetest.Result
+	for ri.More() {
+		next := ri.Next()
+
+		res := executetest.Result{
+			Nm: next.Name(),
+		}
+
+		if err := next.Tables().Do(func(table flux.Table) error {
+			tbl, err := executetest.ConvertTable(table)
+			if err != nil {
+				return err
+			}
+			res.Tbls = append(res.Tbls, tbl)
+			return nil
+		}); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got = append(got, res)
+	}
+
+	if !cmp.Equal(exp, got) {
+		t.Fatalf("unexpected result -want/+got:\n%s", cmp.Diff(exp, got))
+	}
+}

--- a/influxql/response.go
+++ b/influxql/response.go
@@ -1,0 +1,27 @@
+package influxql
+
+// Response contains the collection of results for a query.
+type Response struct {
+	Results []Result `json:"results,omitempty"`
+	Err     string   `json:"error,omitempty"`
+}
+
+// Result represents a resultset returned from a single statement.
+// Rows represents a list of rows that can be sorted consistently by name/tag.
+type Result struct {
+	// StatementID is just the statement's position in the query. It's used
+	// to combine statement results if they're being buffered in memory.
+	StatementID int       `json:"statement_id"`
+	Series      []*Series `json:"series,omitempty"`
+	Partial     bool      `json:"partial,omitempty"`
+	Err         string    `json:"error,omitempty"`
+}
+
+// Series represents a series of rows that share the same group key returned from the execution of a statement.
+type Series struct {
+	Name    string            `json:"name,omitempty"`
+	Tags    map[string]string `json:"tags,omitempty"`
+	Columns []string          `json:"columns,omitempty"`
+	Values  [][]interface{}   `json:"values,omitempty"`
+	Partial bool              `json:"partial,omitempty"`
+}


### PR DESCRIPTION
The json decoder will decode the influxql json format and allow it to be
used as a result decoder. This will make it easy to integrate it as an
alternative source method similar to `fromCSV`.

Fixes #138.