### PR TITLE
feat: create memory package with a memory allocator

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -324,7 +325,7 @@ func (c *Controller) processQuery(q *Query) (pop bool, err error) {
 		if !q.tryExec() {
 			return true, errors.New("failed to transition query into executing state")
 		}
-		q.alloc = new(execute.Allocator)
+		q.alloc = new(memory.Allocator)
 		// TODO: pass the plan to the executor here
 		r, err := c.executor.Execute(q.executeCtx, q.plan, q.alloc)
 		if err != nil {
@@ -404,7 +405,7 @@ type Query struct {
 	concurrency int
 	memory      int64
 
-	alloc *execute.Allocator
+	alloc *memory.Allocator
 }
 
 // ID reports an ephemeral unique ID for the query.
@@ -517,7 +518,7 @@ func (q *Query) Statistics() flux.Statistics {
 	}
 	stats.Concurrency = q.concurrency
 	if q.alloc != nil {
-		stats.MaxAllocated = q.alloc.Max()
+		stats.MaxAllocated = q.alloc.MaxAllocated()
 	}
 	return stats
 }

--- a/control/controller_test.go
+++ b/control/controller_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
-	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/mock"
 	"github.com/influxdata/flux/plan"
 	"github.com/pkg/errors"
@@ -95,7 +95,7 @@ func TestController_EnqueueQuery_Failure(t *testing.T) {
 
 func TestController_ExecuteQuery_Failure(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *execute.Allocator) (map[string]flux.Result, error) {
+	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, error) {
 		return nil, errors.New("expected")
 	}
 
@@ -138,7 +138,7 @@ func TestController_ExecuteQuery_Failure(t *testing.T) {
 
 func TestController_CancelQuery(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *execute.Allocator) (map[string]flux.Result, error) {
+	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, error) {
 		// Return an empty result.
 		return map[string]flux.Result{}, nil
 	}
@@ -181,7 +181,7 @@ func TestController_BlockedExecutor(t *testing.T) {
 	done := make(chan struct{})
 
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *execute.Allocator) (map[string]flux.Result, error) {
+	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, error) {
 		<-done
 		return nil, nil
 	}

--- a/csv/result.go
+++ b/csv/result.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/iocounter"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/values"
 	"github.com/pkg/errors"
 )
@@ -616,8 +616,8 @@ type colMeta struct {
 	fmt string
 }
 
-func newUnlimitedAllocator() *execute.Allocator {
-	return &execute.Allocator{Limit: math.MaxInt64}
+func newUnlimitedAllocator() *memory.Allocator {
+	return &memory.Allocator{}
 }
 
 type ResultEncoder struct {

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/pkg/errors"
@@ -70,7 +71,7 @@ func NewAggregateTransformation(d Dataset, c TableBuilderCache, agg Aggregate, c
 	}
 }
 
-func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, agg Aggregate, config AggregateConfig, a *Allocator) (*aggregateTransformation, Dataset) {
+func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, agg Aggregate, config AggregateConfig, a *memory.Allocator) (*aggregateTransformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewAggregateTransformation(d, cache, agg, config), d

--- a/execute/executetest/allocator.go
+++ b/execute/executetest/allocator.go
@@ -1,11 +1,7 @@
 package executetest
 
 import (
-	"math"
-
-	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 )
 
-var UnlimitedAllocator = &execute.Allocator{
-	Limit: math.MaxInt64,
-}
+var UnlimitedAllocator = &memory.Allocator{}

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -15,7 +16,7 @@ import (
 )
 
 type Executor interface {
-	Execute(ctx context.Context, p *plan.PlanSpec, a *Allocator) (map[string]flux.Result, error)
+	Execute(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, error)
 }
 
 type executor struct {
@@ -46,7 +47,7 @@ type executionState struct {
 	p    *plan.PlanSpec
 	deps Dependencies
 
-	alloc *Allocator
+	alloc *memory.Allocator
 
 	resources flux.ResourceManagement
 
@@ -59,7 +60,7 @@ type executionState struct {
 	logger     *zap.Logger
 }
 
-func (e *executor) Execute(ctx context.Context, p *plan.PlanSpec, a *Allocator) (map[string]flux.Result, error) {
+func (e *executor) Execute(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, error) {
 	es, err := e.createExecutionState(ctx, p, a)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize execute state")
@@ -76,12 +77,12 @@ func validatePlan(p *plan.PlanSpec) error {
 	return nil
 }
 
-func (e *executor) createExecutionState(ctx context.Context, p *plan.PlanSpec, a *Allocator) (*executionState, error) {
+func (e *executor) createExecutionState(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (*executionState, error) {
 	if err := validatePlan(p); err != nil {
 		return nil, errors.Wrap(err, "invalid plan")
 	}
 	// Set allocation limit
-	a.Limit = p.Resources.MemoryBytesQuota
+	a.Limit = &p.Resources.MemoryBytesQuota
 	es := &executionState{
 		p:         p,
 		deps:      e.deps,
@@ -303,7 +304,7 @@ func (ec executionContext) StreamContext() StreamContext {
 	return ec.streamContext
 }
 
-func (ec executionContext) Allocator() *Allocator {
+func (ec executionContext) Allocator() *memory.Allocator {
 	return ec.es.alloc
 }
 

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -49,7 +50,7 @@ type indexSelectorTransformation struct {
 	selector IndexSelector
 }
 
-func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a *Allocator) (*rowSelectorTransformation, Dataset) {
+func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a *memory.Allocator) (*rowSelectorTransformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewRowSelectorTransformation(d, cache, selector, config), d
@@ -61,7 +62,7 @@ func NewRowSelectorTransformation(d Dataset, c TableBuilderCache, selector RowSe
 	}
 }
 
-func NewIndexSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector IndexSelector, config SelectorConfig, a *Allocator) (*indexSelectorTransformation, Dataset) {
+func NewIndexSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector IndexSelector, config SelectorConfig, a *memory.Allocator) (*indexSelectorTransformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewIndexSelectorTransformation(d, cache, selector, config), d

--- a/execute/table.go
+++ b/execute/table.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -41,7 +42,7 @@ type OneTimeTable interface {
 // CacheOneTimeTable returns a table that can be read multiple times.
 // If the table is not a OneTimeTable it is returned directly.
 // Otherwise its contents are read into a new table.
-func CacheOneTimeTable(t flux.Table, a *Allocator) (flux.Table, error) {
+func CacheOneTimeTable(t flux.Table, a *memory.Allocator) (flux.Table, error) {
 	_, ok := t.(OneTimeTable)
 	if !ok {
 		return t, nil
@@ -50,7 +51,7 @@ func CacheOneTimeTable(t flux.Table, a *Allocator) (flux.Table, error) {
 }
 
 // CopyTable returns a copy of the table and is OneTimeTable safe.
-func CopyTable(t flux.Table, a *Allocator) (flux.Table, error) {
+func CopyTable(t flux.Table, a *memory.Allocator) (flux.Table, error) {
 	builder := NewColListTableBuilder(t.Key(), a)
 
 	cols := t.Cols()
@@ -489,10 +490,10 @@ type ColListTableBuilder struct {
 	alloc *Allocator
 }
 
-func NewColListTableBuilder(key flux.GroupKey, a *Allocator) *ColListTableBuilder {
+func NewColListTableBuilder(key flux.GroupKey, a *memory.Allocator) *ColListTableBuilder {
 	return &ColListTableBuilder{
 		table: &ColListTable{key: key},
-		alloc: a,
+		alloc: &Allocator{Allocator: a},
 	}
 }
 
@@ -1336,12 +1337,12 @@ type TableBuilderCache interface {
 
 type tableBuilderCache struct {
 	tables *GroupLookup
-	alloc  *Allocator
+	alloc  *memory.Allocator
 
 	triggerSpec flux.TriggerSpec
 }
 
-func NewTableBuilderCache(a *Allocator) *tableBuilderCache {
+func NewTableBuilderCache(a *memory.Allocator) *tableBuilderCache {
 	return &tableBuilderCache{
 		tables: NewGroupLookup(),
 		alloc:  a,

--- a/execute/transformation.go
+++ b/execute/transformation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -27,7 +28,7 @@ type Administration interface {
 
 	ResolveTime(qt flux.Time) Time
 	StreamContext() StreamContext
-	Allocator() *Allocator
+	Allocator() *memory.Allocator
 	Parents() []DatasetID
 
 	Dependencies() Dependencies

--- a/functions/inputs/from_generator.go
+++ b/functions/inputs/from_generator.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/influxdata/flux/values"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/compiler"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
 )
 
 const FromGeneratorKind = "fromGenerator"
@@ -145,11 +145,11 @@ type GeneratorSource struct {
 	Start time.Time
 	Stop  time.Time
 	Count int64
-	alloc *execute.Allocator
+	alloc *memory.Allocator
 	Fn    compiler.Func
 }
 
-func NewGeneratorSource(a *execute.Allocator) *GeneratorSource {
+func NewGeneratorSource(a *memory.Allocator) *GeneratorSource {
 	return &GeneratorSource{alloc: a}
 }
 

--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -375,7 +376,7 @@ type MergeJoinCache struct {
 	reverseLookup map[flux.GroupKey]preJoinGroupKeys
 
 	tables      map[flux.GroupKey]flux.Table
-	alloc       *execute.Allocator
+	alloc       *memory.Allocator
 	triggerSpec flux.TriggerSpec
 }
 
@@ -385,10 +386,10 @@ type streamBuffer struct {
 	ready    map[values.Value]bool
 	stale    map[flux.GroupKey]bool
 	last     values.Value
-	alloc    *execute.Allocator
+	alloc    *memory.Allocator
 }
 
-func newStreamBuffer(alloc *execute.Allocator) *streamBuffer {
+func newStreamBuffer(alloc *memory.Allocator) *streamBuffer {
 	return &streamBuffer{
 		data:     make(map[flux.GroupKey]*execute.ColListTableBuilder),
 		consumed: make(map[values.Value]int),
@@ -489,7 +490,7 @@ func (s schema) Swap(i int, j int) {
 }
 
 // NewMergeJoinCache constructs a new instance of a MergeJoinCache
-func NewMergeJoinCache(alloc *execute.Allocator, datasetIDs []execute.DatasetID, tableNames map[execute.DatasetID]string, key []string) *MergeJoinCache {
+func NewMergeJoinCache(alloc *memory.Allocator, datasetIDs []execute.DatasetID, tableNames map[execute.DatasetID]string, key []string) *MergeJoinCache {
 	// Join currently only accepts two data sources(streams) as input
 	if len(datasetIDs) != 2 {
 		panic("Join only accepts two data sources")

--- a/functions/transformations/percentile.go
+++ b/functions/transformations/percentile.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/tdigest"
@@ -333,10 +334,10 @@ type ExactPercentileSelectorTransformation struct {
 	d     execute.Dataset
 	cache execute.TableBuilderCache
 	spec  ExactPercentileSelectProcedureSpec
-	a     *execute.Allocator
+	a     *memory.Allocator
 }
 
-func NewExactPercentileSelectorTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *ExactPercentileSelectProcedureSpec, a *execute.Allocator) *ExactPercentileSelectorTransformation {
+func NewExactPercentileSelectorTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *ExactPercentileSelectProcedureSpec, a *memory.Allocator) *ExactPercentileSelectorTransformation {
 	if spec.SelectorConfig.Column == "" {
 		spec.SelectorConfig.Column = execute.DefaultValueColLabel
 	}

--- a/influxql/decoder.go
+++ b/influxql/decoder.go
@@ -10,16 +10,17 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/values"
 )
 
 // NewResultDecoder will construct a new result decoder for an influxql response.
-func NewResultDecoder(a *execute.Allocator) flux.MultiResultDecoder {
+func NewResultDecoder(a *memory.Allocator) flux.MultiResultDecoder {
 	return &resultDecoder{a: a}
 }
 
 type resultDecoder struct {
-	a *execute.Allocator
+	a *memory.Allocator
 }
 
 func (dec *resultDecoder) Decode(r io.ReadCloser) (flux.ResultIterator, error) {
@@ -32,7 +33,7 @@ func (dec *resultDecoder) Decode(r io.ReadCloser) (flux.ResultIterator, error) {
 
 type resultIterator struct {
 	resp *Response
-	a    *execute.Allocator
+	a    *memory.Allocator
 }
 
 func (ri *resultIterator) More() bool {
@@ -60,7 +61,7 @@ func (ri *resultIterator) Err() error {
 
 type result struct {
 	res *Result
-	a   *execute.Allocator
+	a   *memory.Allocator
 }
 
 func (r *result) Name() string {

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -1,0 +1,96 @@
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+)
+
+// Allocator tracks the amount of memory being consumed by a query.
+type Allocator struct {
+	// Limit is the limit on the amount of memory that this allocator
+	// can assign. If this is null, there is no limit.
+	Limit *int64
+
+	bytesAllocated int64
+	maxAllocated   int64
+}
+
+// Allocate will ensure that the requested memory is available and
+// record that it is in use.
+func (a *Allocator) Allocate(size int) error {
+	if size < 0 {
+		panic(errors.New("cannot allocate negative memory"))
+	} else if size == 0 {
+		return nil
+	}
+	return a.count(size)
+}
+
+// Allocated returns the amount of currently allocated memory.
+func (a *Allocator) Allocated() int64 {
+	return atomic.LoadInt64(&a.bytesAllocated)
+}
+
+// MaxAllocated reports the maximum amount of allocated memory at any point in the query.
+func (a *Allocator) MaxAllocated() int64 {
+	return atomic.LoadInt64(&a.maxAllocated)
+}
+
+// Free will reduce the amount of memory used by this Allocator.
+// In general, memory should be freed using the Reference returned
+// by Allocate. Not all code is capable of using this though so this
+// method provides a low-level way of releasing the memory without
+// using a Reference.
+func (a *Allocator) Free(size int) {
+	if size < 0 {
+		panic(errors.New("cannot free negative memory"))
+	}
+	atomic.AddInt64(&a.bytesAllocated, int64(-size))
+}
+
+func (a *Allocator) count(size int) error {
+	var c int64
+	if a.Limit != nil {
+		// We need to load the current bytes allocated, add to it, and
+		// compare if it is greater than the limit. If it is not, we need
+		// to modify the bytes allocated.
+		for {
+			allocated := atomic.LoadInt64(&a.bytesAllocated)
+			if want := allocated + int64(size); want > *a.Limit {
+				return LimitExceededError{
+					Limit:     *a.Limit,
+					Allocated: allocated,
+					Wanted:    want - allocated,
+				}
+			} else if atomic.CompareAndSwapInt64(&a.bytesAllocated, allocated, want) {
+				c = want
+				break
+			}
+			// We did not succeed at swapping the bytes allocated so try again.
+		}
+	} else {
+		// Otherwise, add the size directly to the bytes allocated and
+		// compare and swap to modify the max allocated.
+		c = atomic.AddInt64(&a.bytesAllocated, int64(size))
+	}
+
+	// Modify the max allocated if the amount we just allocated is greater.
+	for max := atomic.LoadInt64(&a.maxAllocated); c > max; max = atomic.LoadInt64(&a.maxAllocated) {
+		if atomic.CompareAndSwapInt64(&a.maxAllocated, max, c) {
+			break
+		}
+	}
+	return nil
+}
+
+// LimitExceededError is an error when the allocation limit is exceeded.
+type LimitExceededError struct {
+	Limit     int64
+	Allocated int64
+	Wanted    int64
+}
+
+func (a LimitExceededError) Error() string {
+	return fmt.Sprintf("allocation limit reached: limit %d, allocated: %d, wanted: %d", a.Limit, a.Allocated, a.Wanted)
+}

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -1,0 +1,129 @@
+package memory_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/memory"
+)
+
+func TestAllocator_MaxAfterFree(t *testing.T) {
+	allocator := &memory.Allocator{}
+	if err := allocator.Allocate(64); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(64), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Free should restore the memory to zero, but have max be the same.
+	allocator.Free(64)
+
+	if want, got := int64(0), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Allocate a smaller amount of memory and the max should still be 64.
+	if err := allocator.Allocate(32); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(32), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestAllocator_Limit(t *testing.T) {
+	maxLimit := int64(64)
+	allocator := &memory.Allocator{Limit: &maxLimit}
+	if err := allocator.Allocate(64); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(64), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Attempts to allocate more should result in an error.
+	if err := allocator.Allocate(1); err == nil {
+		t.Fatal("expected error")
+	}
+
+	// The counts should not change.
+	if want, got := int64(64), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Free should restore the memory so we can allocate more.
+	allocator.Free(64)
+
+	if want, got := int64(0), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// This allocation should succeed.
+	if err := allocator.Allocate(32); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(32), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// This allocation should fail.
+	if err := allocator.Allocate(64); err == nil {
+		t.Fatal("expected error")
+	}
+
+	if want, got := int64(32), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestAllocator_Free(t *testing.T) {
+	allocator := &memory.Allocator{}
+	if err := allocator.Allocate(64); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(64), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Free the memory.
+	allocator.Free(64)
+
+	if want, got := int64(0), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), allocator.MaxAllocated(); want != got {
+		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+}

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -12,18 +13,18 @@ var _ execute.Executor = (*Executor)(nil)
 
 // Executor is a mock implementation of an execute.Executor.
 type Executor struct {
-	ExecuteFn func(ctx context.Context, p *plan.PlanSpec, a *execute.Allocator) (map[string]flux.Result, error)
+	ExecuteFn func(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, error)
 }
 
 // NewExecutor returns a mock Executor where its methods will return zero values.
 func NewExecutor() *Executor {
 	return &Executor{
-		ExecuteFn: func(context.Context, *plan.PlanSpec, *execute.Allocator) (map[string]flux.Result, error) {
+		ExecuteFn: func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, error) {
 			return nil, nil
 		},
 	}
 }
 
-func (e *Executor) Execute(ctx context.Context, p *plan.PlanSpec, a *execute.Allocator) (map[string]flux.Result, error) {
+func (e *Executor) Execute(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, error) {
 	return e.ExecuteFn(ctx, p, a)
 }


### PR DESCRIPTION
This allocator is a simplification of the existing allocator in the
execute package, but moved to a new package for simplicity and without
the default panic behavior or array manipulation primitives. This
creates a lower surface area for the implementation and allows it to
focus on just tracking memory usage rather than also on array
manipulation.

The simpler interface allows us to integrate this with other allocators
like the arrow allocator which has no use for the array primitives in
the existing allocator.