### PR TITLE
Use planner rule to enable no-points optimization in storage

### DIFF
--- a/functions/inputs/from_test.go
+++ b/functions/inputs/from_test.go
@@ -418,7 +418,7 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 			},
 		},
 		{
-			name:  "from incompatible-group distinct",
+			name: "from incompatible-group distinct",
 			// If there is an incompatible grouping, don't do the no points optimization.
 			rules: []plan.Rule{inputs.FromDistinctRule{}, inputs.MergeFromGroupRule{}},
 			before: &plantest.PlanSpec{
@@ -439,8 +439,8 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 				Nodes: []plan.PlanNode{
 					plan.CreatePhysicalNode("merged_from_group", &inputs.FromProcedureSpec{
 						GroupingSet: true,
-						GroupMode: functions.GroupModeBy,
-						GroupKeys: []string{"_measurement"},
+						GroupMode:   functions.GroupModeBy,
+						GroupKeys:   []string{"_measurement"},
 					}),
 					plan.CreatePhysicalNode("distinct", &transformations.DistinctProcedureSpec{Column: "_field"}),
 				},
@@ -481,7 +481,7 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 			},
 		},
 		{
-			name:  "from group group",
+			name: "from group group",
 			// Only push down one call to group()
 			rules: []plan.Rule{inputs.MergeFromGroupRule{}},
 			before: &plantest.PlanSpec{

--- a/plan/plantest/plan.go
+++ b/plan/plantest/plan.go
@@ -1,6 +1,7 @@
 package plantest
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/influxdata/flux"
@@ -47,6 +48,10 @@ func createPlanSpec(nodes []plan.PlanNode, edges [][2]int, resources flux.Resour
 
 		if len(successors[node]) == 0 {
 			roots = append(roots, node)
+		}
+
+		if len(nodes) > 1 && len(predecessors[node]) == 0 && len(successors[node]) == 0 {
+			panic(fmt.Errorf("found disconnected node: %v", node.ID()))
 		}
 
 		node.AddPredecessors(predecessors[node]...)


### PR DESCRIPTION
Fixes #214 

This enables push down of `group` and `distinct` so queries like the following can work:
```
from(bucket:"telegraf") 
  |> range(start: -1d)
  |> group(by: ["_measurement"]) 
  |> distinct(column: "_measurement") 
  |> group(none: true)
```