### PR TITLE
Don't use non-exported OperationSpec field outside of parsing codepath

### DIFF
--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -50,7 +50,7 @@ type JoinOpSpec struct {
 	// interface (used by the transpiler).  It should not be assumed to be populated
 	// outside of the codepath that creates a flux.Spec from Flux text.
 	// TODO(cwolff): find a way to avoiding using a non-exported field here.
-	params     *joinParams
+	params *joinParams
 }
 
 // joinParams implements the Sort interface in order
@@ -177,7 +177,6 @@ func newMergeJoinProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.
 	if spec, ok = qs.(*JoinOpSpec); !ok {
 		return nil, fmt.Errorf("invalid spec type %T", qs)
 	}
-
 
 	tableNames := make([]string, len(spec.TableNames))
 	i := 0

--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -45,6 +45,11 @@ type JoinOpSpec struct {
 	TableNames map[flux.OperationID]string `json:"tableNames"`
 	On         []string                    `json:"on"`
 	Method     string                      `json:"method"`
+
+	// Note: this field below is non-exported and is not part of the public Flux.Spec
+	// interface (used by the transpiler).  It should not be assumed to be populated
+	// outside of the codepath that creates a flux.Spec from Flux text.
+	// TODO(cwolff): find a way to avoiding using a non-exported field here.
 	params     *joinParams
 }
 
@@ -173,8 +178,14 @@ func newMergeJoinProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.
 		return nil, fmt.Errorf("invalid spec type %T", qs)
 	}
 
-	tableNames := make([]string, spec.params.Len())
-	copy(tableNames, spec.params.names)
+
+	tableNames := make([]string, len(spec.TableNames))
+	i := 0
+	for _, name := range spec.TableNames {
+		tableNames[i] = name
+		i++
+	}
+	sort.Strings(tableNames)
 
 	on := make([]string, len(spec.On))
 	copy(on, spec.On)


### PR DESCRIPTION
This addresses a panic that's been occurring in `queryd` in the 2.0 cloud.

The offending query sent to the transpiler was this one:
```sql
select 
    SUM(inodes_free) as sum1,
    SUM(inodes_total) as sum2
FROM "disk" 
WHERE mode = 'rw' 
    AND (device = 'disk1s1' OR device = 'disk1s4' OR device = 'disk2s1') 
    AND fstype != 'hfs' 
    AND time >= '2018-11-01 12:00:00' 
    AND time < '2018-11-01 13:00:00' 
GROUP BY device
```

With this fix in place, the code no longer panics, but instead produces this error: `unsupported aggregate column type string`.

Previously we were panicking before getting the planner, and now we're getting to execution, so this is progress.