### PR TITLE
Implement Formatted for plans

### DIFF
--- a/functions/inputs/from_test.go
+++ b/functions/inputs/from_test.go
@@ -161,7 +161,7 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 			},
 			after: &plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plan.CreatePhysicalNode("merged_merged_from_range0_range1", fromWithIntersectedBounds),
+					plan.CreatePhysicalNode("merged_from_range0_range1", fromWithIntersectedBounds),
 				},
 			},
 		},
@@ -282,7 +282,7 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 			},
 			after: &plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plan.CreatePhysicalNode("merged_merged_from_filter1_filter2",
+					plan.CreatePhysicalNode("merged_from_filter1_filter2",
 						&inputs.FromProcedureSpec{
 							FilterSet: true,
 							Filter:    makeFilterFn(pushableExpr1, pushableExpr2),
@@ -334,7 +334,7 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 			},
 			after: &plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plan.CreatePhysicalNode("merged_merged_from_range_filter", &inputs.FromProcedureSpec{
+					plan.CreatePhysicalNode("merged_from_range_filter", &inputs.FromProcedureSpec{
 						FilterSet: true,
 						Filter:    makeFilterFn(pushableExpr1),
 						BoundsSet: true,
@@ -541,7 +541,7 @@ func TestFrom_PlannerTransformationRules(t *testing.T) {
 			},
 			after: &plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plan.CreatePhysicalNode("merged_merged_from_range_group1", &inputs.FromProcedureSpec{
+					plan.CreatePhysicalNode("merged_from_range_group1", &inputs.FromProcedureSpec{
 						BoundsSet:   true,
 						Bounds:      flux.Bounds{Start: fluxTime(5), Stop: fluxTime(10)},
 						GroupingSet: true,

--- a/plan/format.go
+++ b/plan/format.go
@@ -4,7 +4,7 @@ import "fmt"
 
 type FormatOption func(*formatter)
 
-// TODO: make this actually do something useful
+// TODO(cwolff): enhance the this output to make it more useful
 func Formatted(p *PlanSpec, opts ...FormatOption) fmt.Formatter {
 	f := formatter{
 		p: p,
@@ -20,5 +20,13 @@ type formatter struct {
 }
 
 func (f formatter) Format(fs fmt.State, c rune) {
-	fmt.Fprintf(fs, "%#v", f.p)
+	fmt.Fprintf(fs, "\ndigraph {\n")
+	f.p.BottomUpWalk(func(pn PlanNode) error {
+		fmt.Fprintf(fs, "  %v\n", pn.ID())
+		for _, pred := range pn.Predecessors() {
+			fmt.Fprintf(fs, "  %v -> %v\n", pred.ID(), pn.ID())
+		}
+		return nil
+	})
+	fmt.Fprintf(fs, "}\n")
 }

--- a/plan/format.go
+++ b/plan/format.go
@@ -21,12 +21,18 @@ type formatter struct {
 
 func (f formatter) Format(fs fmt.State, c rune) {
 	fmt.Fprintf(fs, "\ndigraph {\n")
+	var edges []string
 	f.p.BottomUpWalk(func(pn PlanNode) error {
 		fmt.Fprintf(fs, "  %v\n", pn.ID())
 		for _, pred := range pn.Predecessors() {
-			fmt.Fprintf(fs, "  %v -> %v\n", pred.ID(), pn.ID())
+			edges = append(edges, fmt.Sprintf("  %v -> %v", pred.ID(), pn.ID()))
 		}
 		return nil
 	})
+
+	fmt.Fprintf(fs, "\n")
+	for _, e := range edges {
+		fmt.Fprintf(fs, "%v\n", e)
+	}
 	fmt.Fprintf(fs, "}\n")
 }

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -446,7 +446,7 @@ func TestLogicalPlanner(t *testing.T) {
 		wantPlan: plantest.PlanSpec{
 			Nodes: []plan.PlanNode{
 				plan.CreateLogicalNode("from0", &inputs.FromProcedureSpec{Bucket: "telegraf"}),
-				plan.CreateLogicalNode("merged_filter1_merged_filter2_filter3", &transformations.FilterProcedureSpec{Fn: &semantic.FunctionExpression{
+				plan.CreateLogicalNode("merged_filter1_filter2_filter3", &transformations.FilterProcedureSpec{Fn: &semantic.FunctionExpression{
 					Block: &semantic.FunctionBlock{
 						Parameters: &semantic.FunctionParameters{
 							List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},

--- a/plan/types.go
+++ b/plan/types.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/influxdata/flux"
@@ -139,7 +140,7 @@ func (e *edges) shallowCopy() edges {
 // the plan to attach the merged node to its successors.
 func MergeLogicalPlanNodes(top, bottom PlanNode, procSpec ProcedureSpec) (PlanNode, error) {
 	merged := &LogicalPlanNode{
-		id:   "merged_" + bottom.ID() + "_" + top.ID(),
+		id:   mergeIDs(top.ID(), bottom.ID()),
 		Spec: procSpec,
 	}
 
@@ -148,11 +149,23 @@ func MergeLogicalPlanNodes(top, bottom PlanNode, procSpec ProcedureSpec) (PlanNo
 
 func MergePhysicalPlanNodes(top, bottom PlanNode, procSpec PhysicalProcedureSpec) (PlanNode, error) {
 	merged := &PhysicalPlanNode{
-		id:   "merged_" + bottom.ID() + "_" + top.ID(),
+		id:   mergeIDs(top.ID(), bottom.ID()),
 		Spec: procSpec,
 	}
 
 	return mergePlanNodes(top, bottom, merged)
+}
+
+func mergeIDs(top, bottom NodeID) NodeID {
+	if strings.HasPrefix(string(top), "merged_", ) {
+		top = top[7:]
+	}
+	if strings.HasPrefix(string(bottom), "merged_", ) {
+		bottom = bottom[7:]
+	}
+
+	return "merged_" + bottom + "_" + top
+
 }
 
 func mergePlanNodes(top, bottom, merged PlanNode) (PlanNode, error) {

--- a/plan/types.go
+++ b/plan/types.go
@@ -157,10 +157,10 @@ func MergePhysicalPlanNodes(top, bottom PlanNode, procSpec PhysicalProcedureSpec
 }
 
 func mergeIDs(top, bottom NodeID) NodeID {
-	if strings.HasPrefix(string(top), "merged_", ) {
+	if strings.HasPrefix(string(top), "merged_") {
 		top = top[7:]
 	}
-	if strings.HasPrefix(string(bottom), "merged_", ) {
+	if strings.HasPrefix(string(bottom), "merged_") {
 		bottom = bottom[7:]
 	}
 


### PR DESCRIPTION
This adds log output for plans when the `Verbose` flag is set in the Controller.  Output looks like this:
```dot
digraph {
  from0
  range1
  filter2
  filter3
  group4
  sum5
  generated_yield

  from0 -> range1
  range1 -> filter2
  filter2 -> filter3
  filter3 -> group4
  group4 -> sum5
  sum5 -> generated_yield
}
```