### PR TITLE
fix(control): fix when a query is requeued multiple times

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -615,6 +615,9 @@ func (q *Query) tryRequeue() bool {
 
 		q.state = Requeueing
 		return true
+	} else if q.state == Requeueing {
+		// Already in the correct state.
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
When a query is requeued multiple times, it will return an error on the
second attempt. This is because it tries to transition into the
requeueing state, but it's already in that state so there is nowhere to
go and it thinks a fatal error has happened.

This fix patches things so if it is already in the requeueing state it
does nothing.

Fixes #239.