### PR TITLE
fix: range should have the default logic for stop when creating the procedure

### DIFF
--- a/functions/transformations/range.go
+++ b/functions/transformations/range.go
@@ -57,9 +57,6 @@ func createRangeOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operat
 		return nil, err
 	} else if ok {
 		spec.Stop = stop
-	} else {
-		// Make stop time implicit "now"
-		spec.Stop = flux.Now
 	}
 
 	if col, ok, err := args.GetString("timeColumn"); err != nil {
@@ -132,6 +129,10 @@ func newRangeProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.Proc
 		Start: spec.Start,
 		Stop:  spec.Stop,
 		Now:   pa.Now(),
+	}
+	if bounds.Stop.IsZero() {
+		// Make stop time implicit "now"
+		spec.Stop = flux.Now
 	}
 
 	if bounds.HasZero() {


### PR DESCRIPTION
The `range()` function would fill in the default value for `stop`, which
was `now()` as the current time within the `createRangeOpSpec` function.
This function is only called by those go who through the compiler so the
defaults never get filled in when directly submitting the spec.

This moves that logic to when we create the procedure node so that the
spec gets the same default value.

Fixes #238.