### PR TITLE
type scope for interpreter

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -90,7 +90,7 @@ func NewInterpreter() *interpreter.Interpreter {
 		options[k] = v
 	}
 
-	return interpreter.NewInterpreter(options, builtinValues)
+	return interpreter.NewInterpreter(options, builtinValues, builtinTypeScope)
 }
 
 func nowFunc(now time.Time) values.Function {
@@ -147,6 +147,7 @@ type CreateOperationSpec func(args Arguments, a *Administration) (OperationSpec,
 
 var builtinValues = make(map[string]values.Value)
 var builtinOptions = make(map[string]values.Value)
+var builtinTypeScope = interpreter.NewTypeScope()
 
 // list of builtin scripts
 var builtinScripts = make(map[string]string)
@@ -226,7 +227,7 @@ func FinalizeBuiltIns() {
 }
 
 func evalBuiltInScripts() error {
-	itrp := interpreter.NewMutableInterpreter(builtinOptions, builtinValues)
+	itrp := interpreter.NewMutableInterpreter(builtinOptions, builtinValues, builtinTypeScope)
 	for name, script := range builtinScripts {
 		astProg, err := parser.NewAST(script)
 		if err != nil {

--- a/semantic/walk.go
+++ b/semantic/walk.go
@@ -11,6 +11,21 @@ type Visitor interface {
 	Done(node Node)
 }
 
+func CreateVisitor(f func(Node)) Visitor {
+	return &visitor{f: f}
+}
+
+type visitor struct {
+	f func(Node)
+}
+
+func (v *visitor) Visit(node Node) Visitor {
+	v.f(node)
+	return v
+}
+
+func (v *visitor) Done(node Node) {}
+
 func walk(v Visitor, n Node) {
 	switch n := n.(type) {
 	case *Program:


### PR DESCRIPTION
This PR addresses a bug that was discovered through #216 .

Previously when evaluating a Flux program, type inference would infer the types of all expressions in the program and store them in a `TypeSolution`. However a `TypeSolution` was tied to a single instance of the Flux interpreter, and Flux programs use at least two distinct instances of the interpreter - one for builtin evaluation and one for program evaluation. Whenever a new interpreter was instantiated the previous `TypeSolution` was effectively discarded.

This PR adds a `TypeScope` object that is passed to a new Flux interpreter as a way to keep the `TypeSolution` information from previous builtin evaluations.