### PR TITLE
refactor: fix the exposed api not to use or return unexported structs

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -57,7 +57,7 @@ func Compile(ctx context.Context, q string, now time.Time, opts ...Option) (*Spe
 	spec := toSpecFromSideEffecs(itrp)
 
 	if o.verbose {
-		log.Println("Query Spec: ", Formatted(spec, FmtJSON))
+		log.Println("Query Spec: ", Formatted(spec, FmtJSON()))
 	}
 	return spec, nil
 }

--- a/control/controller.go
+++ b/control/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) createQuery(ctx context.Context, ct flux.CompilerType) *Que
 	compileLabelValues[len(compileLabelValues)-1] = string(ct)
 
 	cctx, cancel := context.WithCancel(ctx)
-	parentSpan, parentCtx := StartSpanFromContext(
+	parentSpan, parentCtx := startSpanFromContext(
 		cctx,
 		"all",
 		c.metrics.allDur.WithLabelValues(labelValues...),
@@ -186,7 +186,7 @@ func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) error {
 
 func (c *Controller) enqueueQuery(q *Query) error {
 	if c.verbose {
-		log.Println("query", flux.Formatted(&q.spec, flux.FmtJSON))
+		log.Println("query", flux.Formatted(&q.spec, flux.FmtJSON()))
 	}
 	if !q.tryQueue() {
 		return errors.New("failed to transition query to queueing state")
@@ -542,7 +542,7 @@ TRANSITION:
 		// This state is not tracked so do not create a new span or context for it.
 		return true
 	}
-	q.currentSpan, q.currentCtx = StartSpanFromContext(
+	q.currentSpan, q.currentCtx = startSpanFromContext(
 		q.parentCtx,
 		newState.String(),
 		dur.WithLabelValues(labelValues...),
@@ -675,7 +675,7 @@ type span struct {
 	gauge    prometheus.Gauge
 }
 
-func StartSpanFromContext(ctx context.Context, operationName string, hist prometheus.Observer, gauge prometheus.Gauge) (*span, context.Context) {
+func startSpanFromContext(ctx context.Context, operationName string, hist prometheus.Observer, gauge prometheus.Gauge) (*span, context.Context) {
 	start := time.Now()
 	s, sctx := opentracing.StartSpanFromContext(ctx, operationName, opentracing.StartTime(start))
 	gauge.Inc()

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -62,7 +62,7 @@ func (c *AggregateConfig) ReadArgs(args flux.Arguments) error {
 	return nil
 }
 
-func NewAggregateTransformation(d Dataset, c TableBuilderCache, agg Aggregate, config AggregateConfig) *aggregateTransformation {
+func NewAggregateTransformation(d Dataset, c TableBuilderCache, agg Aggregate, config AggregateConfig) Transformation {
 	return &aggregateTransformation{
 		d:      d,
 		cache:  c,
@@ -71,7 +71,7 @@ func NewAggregateTransformation(d Dataset, c TableBuilderCache, agg Aggregate, c
 	}
 }
 
-func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, agg Aggregate, config AggregateConfig, a *memory.Allocator) (*aggregateTransformation, Dataset) {
+func NewAggregateTransformationAndDataset(id DatasetID, mode AccumulationMode, agg Aggregate, config AggregateConfig, a *memory.Allocator) (Transformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewAggregateTransformation(d, cache, agg, config), d

--- a/execute/dataset.go
+++ b/execute/dataset.go
@@ -67,7 +67,7 @@ type dataset struct {
 	cache DataCache
 }
 
-func NewDataset(id DatasetID, accMode AccumulationMode, cache DataCache) *dataset {
+func NewDataset(id DatasetID, accMode AccumulationMode, cache DataCache) Dataset {
 	return &dataset{
 		id:      id,
 		accMode: accMode,

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -50,24 +50,24 @@ type indexSelectorTransformation struct {
 	selector IndexSelector
 }
 
-func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a *memory.Allocator) (*rowSelectorTransformation, Dataset) {
+func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a *memory.Allocator) (Transformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewRowSelectorTransformation(d, cache, selector, config), d
 }
-func NewRowSelectorTransformation(d Dataset, c TableBuilderCache, selector RowSelector, config SelectorConfig) *rowSelectorTransformation {
+func NewRowSelectorTransformation(d Dataset, c TableBuilderCache, selector RowSelector, config SelectorConfig) Transformation {
 	return &rowSelectorTransformation{
 		selectorTransformation: newSelectorTransformation(d, c, config),
 		selector:               selector,
 	}
 }
 
-func NewIndexSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector IndexSelector, config SelectorConfig, a *memory.Allocator) (*indexSelectorTransformation, Dataset) {
+func NewIndexSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector IndexSelector, config SelectorConfig, a *memory.Allocator) (Transformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewIndexSelectorTransformation(d, cache, selector, config), d
 }
-func NewIndexSelectorTransformation(d Dataset, c TableBuilderCache, selector IndexSelector, config SelectorConfig) *indexSelectorTransformation {
+func NewIndexSelectorTransformation(d Dataset, c TableBuilderCache, selector IndexSelector, config SelectorConfig) Transformation {
 	return &indexSelectorTransformation{
 		selectorTransformation: newSelectorTransformation(d, c, config),
 		selector:               selector,

--- a/execute/table.go
+++ b/execute/table.go
@@ -1342,7 +1342,12 @@ type tableBuilderCache struct {
 	triggerSpec flux.TriggerSpec
 }
 
-func NewTableBuilderCache(a *memory.Allocator) *tableBuilderCache {
+type TableBuilderDataCache interface {
+	TableBuilderCache
+	DataCache
+}
+
+func NewTableBuilderCache(a *memory.Allocator) TableBuilderDataCache {
 	return &tableBuilderCache{
 		tables: NewGroupLookup(),
 		alloc:  a,

--- a/format.go
+++ b/format.go
@@ -6,19 +6,31 @@ import (
 )
 
 // TODO(nathanielc): Add better options for formatting plans as Graphviz dot format.
-type FormatOption func(*formatter)
+type FormatOption interface {
+	apply(*formatter)
+}
+
+type formatOptionFunc func(*formatter)
+
+func (fn formatOptionFunc) apply(f *formatter) {
+	fn(f)
+}
 
 func Formatted(q *Spec, opts ...FormatOption) fmt.Formatter {
 	f := formatter{
 		q: q,
 	}
 	for _, o := range opts {
-		o(&f)
+		o.apply(&f)
 	}
 	return f
 }
 
-func FmtJSON(f *formatter) { f.json = true }
+func FmtJSON() FormatOption {
+	return formatOptionFunc(func(f *formatter) {
+		f.json = true
+	})
+}
 
 type formatter struct {
 	q    *Spec

--- a/functions/transformations/cumulative_sum.go
+++ b/functions/transformations/cumulative_sum.go
@@ -104,7 +104,7 @@ type cumulativeSumTransformation struct {
 	spec  CumulativeSumProcedureSpec
 }
 
-func NewCumulativeSumTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *CumulativeSumProcedureSpec) *cumulativeSumTransformation {
+func NewCumulativeSumTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *CumulativeSumProcedureSpec) execute.Transformation {
 	return &cumulativeSumTransformation{
 		d:     d,
 		cache: cache,

--- a/functions/transformations/derivative.go
+++ b/functions/transformations/derivative.go
@@ -145,7 +145,7 @@ type derivativeTransformation struct {
 	timeCol     string
 }
 
-func NewDerivativeTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DerivativeProcedureSpec) *derivativeTransformation {
+func NewDerivativeTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DerivativeProcedureSpec) execute.Transformation {
 	return &derivativeTransformation{
 		d:           d,
 		cache:       cache,

--- a/functions/transformations/difference.go
+++ b/functions/transformations/difference.go
@@ -124,7 +124,7 @@ type differenceTransformation struct {
 	columns     []string
 }
 
-func NewDifferenceTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DifferenceProcedureSpec) *differenceTransformation {
+func NewDifferenceTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DifferenceProcedureSpec) execute.Transformation {
 	return &differenceTransformation{
 		d:           d,
 		cache:       cache,

--- a/functions/transformations/distinct.go
+++ b/functions/transformations/distinct.go
@@ -100,7 +100,7 @@ type distinctTransformation struct {
 	column string
 }
 
-func NewDistinctTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DistinctProcedureSpec) *distinctTransformation {
+func NewDistinctTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DistinctProcedureSpec) execute.Transformation {
 	return &distinctTransformation{
 		d:      d,
 		cache:  cache,

--- a/functions/transformations/filter.go
+++ b/functions/transformations/filter.go
@@ -109,7 +109,7 @@ type filterTransformation struct {
 	fn *execute.RowPredicateFn
 }
 
-func NewFilterTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *FilterProcedureSpec) (*filterTransformation, error) {
+func NewFilterTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *FilterProcedureSpec) (execute.Transformation, error) {
 	fn, err := execute.NewRowPredicateFn(spec.Fn)
 	if err != nil {
 		return nil, err

--- a/functions/transformations/group.go
+++ b/functions/transformations/group.go
@@ -182,7 +182,7 @@ type groupTransformation struct {
 	keys []string
 }
 
-func NewGroupTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *GroupProcedureSpec) *groupTransformation {
+func NewGroupTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *GroupProcedureSpec) execute.Transformation {
 	t := &groupTransformation{
 		d:     d,
 		cache: cache,

--- a/functions/transformations/histogram.go
+++ b/functions/transformations/histogram.go
@@ -144,7 +144,7 @@ type histogramTransformation struct {
 	spec HistogramProcedureSpec
 }
 
-func NewHistogramTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *HistogramProcedureSpec) *histogramTransformation {
+func NewHistogramTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *HistogramProcedureSpec) execute.Transformation {
 	sort.Float64s(spec.Buckets)
 	return &histogramTransformation{
 		d:     d,

--- a/functions/transformations/integral.go
+++ b/functions/transformations/integral.go
@@ -120,7 +120,7 @@ type integralTransformation struct {
 	spec IntegralProcedureSpec
 }
 
-func NewIntegralTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *IntegralProcedureSpec) *integralTransformation {
+func NewIntegralTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *IntegralProcedureSpec) execute.Transformation {
 	return &integralTransformation{
 		d:     d,
 		cache: cache,

--- a/functions/transformations/join.go
+++ b/functions/transformations/join.go
@@ -246,7 +246,7 @@ type mergeJoinTransformation struct {
 	keys []string
 }
 
-func NewMergeJoinTransformation(d execute.Dataset, cache *MergeJoinCache, spec *MergeJoinProcedureSpec, parents []execute.DatasetID, tableNames map[execute.DatasetID]string) *mergeJoinTransformation {
+func NewMergeJoinTransformation(d execute.Dataset, cache *MergeJoinCache, spec *MergeJoinProcedureSpec, parents []execute.DatasetID, tableNames map[execute.DatasetID]string) execute.Transformation {
 	t := &mergeJoinTransformation{
 		d:         d,
 		cache:     cache,

--- a/functions/transformations/key_values.go
+++ b/functions/transformations/key_values.go
@@ -126,7 +126,7 @@ func createKeyValuesTransformation(id execute.DatasetID, mode execute.Accumulati
 	return t, d, nil
 }
 
-func NewKeyValuesTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *KeyValuesProcedureSpec) *keyValuesTransformation {
+func NewKeyValuesTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *KeyValuesProcedureSpec) execute.Transformation {
 	return &keyValuesTransformation{
 		d:        d,
 		cache:    cache,

--- a/functions/transformations/keys.go
+++ b/functions/transformations/keys.go
@@ -109,7 +109,7 @@ type keysTransformation struct {
 	except []string
 }
 
-func NewKeysTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *KeysProcedureSpec) *keysTransformation {
+func NewKeysTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *KeysProcedureSpec) execute.Transformation {
 	return &keysTransformation{
 		d:      d,
 		cache:  cache,

--- a/functions/transformations/limit.go
+++ b/functions/transformations/limit.go
@@ -109,7 +109,7 @@ type limitTransformation struct {
 	n, offset int
 }
 
-func NewLimitTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *LimitProcedureSpec) *limitTransformation {
+func NewLimitTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *LimitProcedureSpec) execute.Transformation {
 	return &limitTransformation{
 		d:      d,
 		cache:  cache,

--- a/functions/transformations/map.go
+++ b/functions/transformations/map.go
@@ -126,7 +126,7 @@ type mapTransformation struct {
 	mergeKey bool
 }
 
-func NewMapTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *MapProcedureSpec) (*mapTransformation, error) {
+func NewMapTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *MapProcedureSpec) (execute.Transformation, error) {
 	fn, err := execute.NewRowMapFn(spec.Fn)
 	if err != nil {
 		return nil, err

--- a/functions/transformations/pivot.go
+++ b/functions/transformations/pivot.go
@@ -162,7 +162,7 @@ type pivotTransformation struct {
 	nextRowCol map[string]rowCol
 }
 
-func NewPivotTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *PivotProcedureSpec) *pivotTransformation {
+func NewPivotTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *PivotProcedureSpec) execute.Transformation {
 	t := &pivotTransformation{
 		d:          d,
 		cache:      cache,

--- a/functions/transformations/range.go
+++ b/functions/transformations/range.go
@@ -188,7 +188,7 @@ type rangeTransformation struct {
 	stopCol  string
 }
 
-func NewRangeTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *RangeProcedureSpec, absolute execute.Bounds) (*rangeTransformation, error) {
+func NewRangeTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *RangeProcedureSpec, absolute execute.Bounds) (execute.Transformation, error) {
 	return &rangeTransformation{
 		d:        d,
 		cache:    cache,

--- a/functions/transformations/schema_functions.go
+++ b/functions/transformations/schema_functions.go
@@ -459,7 +459,7 @@ func createSchemaMutationTransformation(id execute.DatasetID, mode execute.Accum
 	return t, d, nil
 }
 
-func NewSchemaMutationTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec plan.ProcedureSpec) (*schemaMutationTransformation, error) {
+func NewSchemaMutationTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec plan.ProcedureSpec) (execute.Transformation, error) {
 	s, ok := spec.(*SchemaMutationProcedureSpec)
 	if !ok {
 		return nil, fmt.Errorf("invalid spec type %T", spec)

--- a/functions/transformations/shift.go
+++ b/functions/transformations/shift.go
@@ -134,7 +134,7 @@ type shiftTransformation struct {
 	columns []string
 }
 
-func NewShiftTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *ShiftProcedureSpec) *shiftTransformation {
+func NewShiftTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *ShiftProcedureSpec) execute.Transformation {
 	return &shiftTransformation{
 		d:       d,
 		cache:   cache,

--- a/functions/transformations/sort.go
+++ b/functions/transformations/sort.go
@@ -119,7 +119,7 @@ type sortTransformation struct {
 	desc bool
 }
 
-func NewSortTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *SortProcedureSpec) *sortTransformation {
+func NewSortTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *SortProcedureSpec) execute.Transformation {
 	return &sortTransformation{
 		d:     d,
 		cache: cache,

--- a/functions/transformations/state_tracking.go
+++ b/functions/transformations/state_tracking.go
@@ -202,7 +202,7 @@ type stateTrackingTransformation struct {
 	durationUnit int64
 }
 
-func NewStateTrackingTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *StateTrackingProcedureSpec) (*stateTrackingTransformation, error) {
+func NewStateTrackingTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *StateTrackingProcedureSpec) (execute.Transformation, error) {
 	fn, err := execute.NewRowPredicateFn(spec.Fn)
 	if err != nil {
 		return nil, err

--- a/functions/transformations/unique.go
+++ b/functions/transformations/unique.go
@@ -100,7 +100,7 @@ type uniqueTransformation struct {
 	column string
 }
 
-func NewUniqueTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *UniqueProcedureSpec) *uniqueTransformation {
+func NewUniqueTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *UniqueProcedureSpec) execute.Transformation {
 	return &uniqueTransformation{
 		d:      d,
 		cache:  cache,

--- a/values/object.go
+++ b/values/object.go
@@ -23,13 +23,13 @@ type object struct {
 	typ           atomic.Value // semantic.Type
 }
 
-func NewObject() *object {
+func NewObject() Object {
 	return &object{
 		values:        make(map[string]Value),
 		propertyTypes: make(map[string]semantic.Type),
 	}
 }
-func NewObjectWithValues(values map[string]Value) *object {
+func NewObjectWithValues(values map[string]Value) Object {
 	propertyTypes := make(map[string]semantic.Type, len(values))
 	for k, v := range values {
 		propertyTypes[k] = v.Type()


### PR DESCRIPTION
Some parts of the API would make use of unexported structs or
interfaces. While Go allows you to return an unexported struct, it isn't
very good API design and causes problems.

Additionally, FormatOption was previously defined as a function with an
unexported parameter which kept it as private. After looking at a few
other libraries that use the same pattern, I found it was better for
future compatibiity if FormatOption was changed into an interface and
the implementation of it being a function was hidden behind that.

This new method is how `zap` implements options and how `go-cmp` also
does it. When implemented in this way, the function that returns a
FormatOption is right next to the implementation so it is easy to find
what the options are without looking at individual function signatures.