### PR TITLE
refactor: rename ResultIterator.Cancel to ResultIterator.Release

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -127,7 +127,7 @@ func (r *resultIterator) More() bool {
 	}
 
 	// Release the resources for this query.
-	r.Cancel()
+	r.Release()
 	return false
 }
 
@@ -135,7 +135,7 @@ func (r *resultIterator) Next() flux.Result {
 	return r.next
 }
 
-func (r *resultIterator) Cancel() {
+func (r *resultIterator) Release() {
 	if r.canceled {
 		return
 	}

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -990,7 +990,7 @@ func (r errorResultIterator) Next() flux.Result {
 	panic("no results")
 }
 
-func (r errorResultIterator) Cancel() {
+func (r errorResultIterator) Release() {
 }
 
 func (r errorResultIterator) Err() error {

--- a/influxql/decoder.go
+++ b/influxql/decoder.go
@@ -46,7 +46,7 @@ func (ri *resultIterator) Next() flux.Result {
 	return &result{res: &res, a: ri.a}
 }
 
-func (ri *resultIterator) Cancel() {
+func (ri *resultIterator) Release() {
 	ri.resp.Results = nil
 }
 

--- a/query.go
+++ b/query.go
@@ -13,10 +13,11 @@ type Query interface {
 	// in which case the query should be inspected for an error using Err().
 	Ready() <-chan map[string]Result
 
-	// Done must always be called to free resources.
+	// Done must always be called to free resources. It is safe to call Done
+	// multiple times.
 	Done()
 
-	// Cancel will stop the query execution.
+	// Cancel will signal that query execution should stop.
 	// Done must still be called to free resources.
 	// It is safe to call Cancel multiple times.
 	Cancel()

--- a/querytest/execute.go
+++ b/querytest/execute.go
@@ -19,8 +19,8 @@ func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flu
 	if err != nil {
 		return 0, err
 	}
-	results := flux.NewResultIteratorFromQuery(query)
-	defer results.Cancel()
+	results := flux.NewResultIteratorFromQuery(ctx, query)
+	defer results.Release()
 
 	encoder := d.Encoder()
 	return encoder.Encode(w, results)

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -182,7 +182,7 @@ func (r *REPL) doQuery(spec *flux.Spec) error {
 	if err != nil {
 		return err
 	}
-	defer results.Cancel()
+	defer results.Release()
 
 	for results.More() {
 		result := results.Next()

--- a/result_iterator.go
+++ b/result_iterator.go
@@ -1,10 +1,13 @@
 package flux
 
-import "sort"
+import (
+	"context"
+	"sort"
+)
 
-// ResultIterator allows iterating through all results
-// Cancel must be called to free resources.
-// ResultIterators may implement Statisticser.
+// ResultIterator allows iterating through all results synchronously.
+// A ResultIterator is not thread-safe and all of the methods are expected to be
+// called within the same goroutine. A ResultIterator may implement Statisticser.
 type ResultIterator interface {
 	// More indicates if there are more results.
 	More() bool
@@ -13,10 +16,10 @@ type ResultIterator interface {
 	// If More is false, Next panics.
 	Next() Result
 
-	// Cancel discards the remaining results.
-	// Cancel must always be called to free resources.
-	// It is safe to call Cancel multiple times.
-	Cancel()
+	// Release discards the remaining results and frees the currently used resources.
+	// It must always be called to free resources. It can be called even if there are
+	// more results. It is safe to call Release multiple times.
+	Release()
 
 	// Err reports the first error encountered.
 	// Err will not report anything unless More has returned false,
@@ -24,123 +27,120 @@ type ResultIterator interface {
 	Err() error
 }
 
-// QueryResultIterator implements a ResultIterator while consuming a Query
-type QueryResultIterator struct {
+// queryResultIterator implements a ResultIterator while consuming a Query
+type queryResultIterator struct {
+	ctx     context.Context
 	query   Query
-	cancel  chan struct{}
-	ready   bool
-	results *MapResultIterator
+	done    bool
+	results ResultIterator
 }
 
-func NewResultIteratorFromQuery(q Query) *QueryResultIterator {
-	return &QueryResultIterator{
-		query:  q,
-		cancel: make(chan struct{}),
+func NewResultIteratorFromQuery(ctx context.Context, q Query) ResultIterator {
+	return &queryResultIterator{
+		ctx:   ctx,
+		query: q,
 	}
 }
 
-func (r *QueryResultIterator) More() bool {
-	if !r.ready {
+func (r *queryResultIterator) More() bool {
+	if r.done {
+		return false
+	}
+
+	if r.results == nil {
 		select {
-		case <-r.cancel:
-			goto DONE
+		case <-r.ctx.Done():
+			return false
 		case results, ok := <-r.query.Ready():
 			if !ok {
-				goto DONE
+				return false
 			}
-			r.ready = true
 			r.results = NewMapResultIterator(results)
 		}
 	}
-	if r.results.More() {
-		return true
-	}
-
-DONE:
-	r.query.Done()
-	return false
+	return r.results.More()
 }
 
-func (r *QueryResultIterator) Next() Result {
+func (r *queryResultIterator) Next() Result {
 	return r.results.Next()
 }
 
-func (r *QueryResultIterator) Cancel() {
-	select {
-	case <-r.cancel:
-	default:
-		close(r.cancel)
+func (r *queryResultIterator) Release() {
+	r.query.Done()
+	r.done = true
+	if r.results != nil {
+		r.results.Release()
 	}
-	r.query.Cancel()
 }
 
-func (r *QueryResultIterator) Err() error {
+func (r *queryResultIterator) Err() error {
 	return r.query.Err()
 }
 
-func (r *QueryResultIterator) Statistics() Statistics {
+func (r *queryResultIterator) Statistics() Statistics {
 	return r.query.Statistics()
 }
 
-type MapResultIterator struct {
+type mapResultIterator struct {
 	results map[string]Result
 	order   []string
 }
 
-func NewMapResultIterator(results map[string]Result) *MapResultIterator {
+func NewMapResultIterator(results map[string]Result) ResultIterator {
 	order := make([]string, 0, len(results))
 	for k := range results {
 		order = append(order, k)
 	}
 	sort.Strings(order)
-	return &MapResultIterator{
+	return &mapResultIterator{
 		results: results,
 		order:   order,
 	}
 }
 
-func (r *MapResultIterator) More() bool {
+func (r *mapResultIterator) More() bool {
 	return len(r.order) > 0
 }
 
-func (r *MapResultIterator) Next() Result {
+func (r *mapResultIterator) Next() Result {
 	next := r.order[0]
 	r.order = r.order[1:]
 	return r.results[next]
 }
 
-func (r *MapResultIterator) Cancel() {
-
+func (r *mapResultIterator) Release() {
+	r.results = nil
+	r.order = nil
 }
 
-func (r *MapResultIterator) Err() error {
+func (r *mapResultIterator) Err() error {
 	return nil
 }
 
-type SliceResultIterator struct {
+type sliceResultIterator struct {
 	results []Result
 }
 
-func NewSliceResultIterator(results []Result) *SliceResultIterator {
-	return &SliceResultIterator{
+func NewSliceResultIterator(results []Result) ResultIterator {
+	return &sliceResultIterator{
 		results: results,
 	}
 }
 
-func (r *SliceResultIterator) More() bool {
+func (r *sliceResultIterator) More() bool {
 	return len(r.results) > 0
 }
 
-func (r *SliceResultIterator) Next() Result {
+func (r *sliceResultIterator) Next() Result {
 	next := r.results[0]
 	r.results = r.results[1:]
 	return next
 }
 
-func (r *SliceResultIterator) Cancel() {
+func (r *sliceResultIterator) Release() {
 	r.results = nil
 }
 
-func (r *SliceResultIterator) Err() error {
+func (r *sliceResultIterator) Err() error {
 	return nil
 }


### PR DESCRIPTION
The ResultIterator interface had a Cancel method, but it was mostly used
to free resources and ResultIterator was used asynchronously. This
solidifies the API and removes the cancel connotation of the method name
to have a resource release connotation instead.

This also fixes things so that the Query interface is used correctly by
all ResultIterator implementations to always call `Done()` at least
once.