### PR TITLE
feat: add support for string comparison operators

### DIFF
--- a/values/binary.go
+++ b/values/binary.go
@@ -159,6 +159,11 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 		r := rv.Float()
 		return NewBool(l <= r)
 	},
+	{Operator: ast.LessThanEqualOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
+		return NewBool(l <= r)
+	},
 
 	// LessThanOperator
 
@@ -211,6 +216,11 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.LessThanOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
+		return NewBool(l < r)
+	},
+	{Operator: ast.LessThanOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
 		return NewBool(l < r)
 	},
 
@@ -267,6 +277,11 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 		r := rv.Float()
 		return NewBool(l >= r)
 	},
+	{Operator: ast.GreaterThanEqualOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
+		return NewBool(l >= r)
+	},
 
 	// GreaterThanOperator
 
@@ -319,6 +334,11 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.GreaterThanOperator, Left: semantic.Float, Right: semantic.Float}: func(lv, rv Value) Value {
 		l := lv.Float()
 		r := rv.Float()
+		return NewBool(l > r)
+	},
+	{Operator: ast.GreaterThanOperator, Left: semantic.String, Right: semantic.String}: func(lv, rv Value) Value {
+		l := lv.Str()
+		r := rv.Str()
 		return NewBool(l > r)
 	},
 

--- a/values/binary_test.go
+++ b/values/binary_test.go
@@ -75,6 +75,12 @@ func TestBinaryOperator(t *testing.T) {
 		{lhs: 8.2, op: "<=", rhs: 4.5, want: false},
 		{lhs: 4.5, op: "<=", rhs: 4.5, want: true},
 		{lhs: 4.5, op: "<=", rhs: 8.2, want: true},
+		// string <= string
+		{lhs: "", op: "<=", rhs: "x", want: true},
+		{lhs: "x", op: "<=", rhs: "", want: false},
+		{lhs: "x", op: "<=", rhs: "x", want: true},
+		{lhs: "x", op: "<=", rhs: "a", want: false},
+		{lhs: "x", op: "<=", rhs: "abc", want: false},
 		// int < int
 		{lhs: int64(6), op: "<", rhs: int64(4), want: false},
 		{lhs: int64(4), op: "<", rhs: int64(4), want: false},
@@ -111,6 +117,12 @@ func TestBinaryOperator(t *testing.T) {
 		{lhs: 8.2, op: "<", rhs: 4.5, want: false},
 		{lhs: 4.5, op: "<", rhs: 4.5, want: false},
 		{lhs: 4.5, op: "<", rhs: 8.2, want: true},
+		// string < string
+		{lhs: "", op: "<", rhs: "x", want: true},
+		{lhs: "x", op: "<", rhs: "", want: false},
+		{lhs: "x", op: "<", rhs: "x", want: false},
+		{lhs: "x", op: "<", rhs: "a", want: false},
+		{lhs: "x", op: "<", rhs: "abc", want: false},
 		// int >= int
 		{lhs: int64(6), op: ">=", rhs: int64(4), want: true},
 		{lhs: int64(4), op: ">=", rhs: int64(4), want: true},
@@ -147,7 +159,13 @@ func TestBinaryOperator(t *testing.T) {
 		{lhs: 8.2, op: ">=", rhs: 4.5, want: true},
 		{lhs: 4.5, op: ">=", rhs: 4.5, want: true},
 		{lhs: 4.5, op: ">=", rhs: 8.2, want: false},
-		// int < int
+		// string >= string
+		{lhs: "", op: ">=", rhs: "x", want: false},
+		{lhs: "x", op: ">=", rhs: "", want: true},
+		{lhs: "x", op: ">=", rhs: "x", want: true},
+		{lhs: "x", op: ">=", rhs: "a", want: true},
+		{lhs: "x", op: ">=", rhs: "abc", want: true},
+		// int > int
 		{lhs: int64(6), op: ">", rhs: int64(4), want: true},
 		{lhs: int64(4), op: ">", rhs: int64(4), want: false},
 		{lhs: int64(4), op: ">", rhs: int64(6), want: false},
@@ -183,6 +201,12 @@ func TestBinaryOperator(t *testing.T) {
 		{lhs: 8.2, op: ">", rhs: 4.5, want: true},
 		{lhs: 4.5, op: ">", rhs: 8.2, want: false},
 		{lhs: 4.5, op: ">", rhs: 4.5, want: false},
+		// string > string
+		{lhs: "", op: ">", rhs: "x", want: false},
+		{lhs: "x", op: ">", rhs: "", want: true},
+		{lhs: "x", op: ">", rhs: "x", want: false},
+		{lhs: "x", op: ">", rhs: "a", want: true},
+		{lhs: "x", op: ">", rhs: "abc", want: true},
 		// int == int
 		{lhs: int64(4), op: "==", rhs: int64(4), want: true},
 		{lhs: int64(6), op: "==", rhs: int64(4), want: false},


### PR DESCRIPTION
Previously, `x < y`, `x <= y`, `x > y`, and `x >= y` were rejected when
x and y were both strings. Now they are accepted, and they operate on
lexicographic comparison like any other language.