### PR TITLE
fix: revert the change to query result iterator

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -112,7 +112,7 @@ func runHttp() {
 			}
 			encoder := pr.Dialect.Encoder()
 			n, err := func() (int64, error) {
-				results := flux.NewResultIteratorFromQuery(ctx, q)
+				results := flux.NewResultIteratorFromQuery(q)
 				defer results.Release()
 				return encoder.Encode(w, results)
 			}()
@@ -140,7 +140,7 @@ func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flu
 	if err != nil {
 		return 0, err
 	}
-	results := flux.NewResultIteratorFromQuery(ctx, qry)
+	results := flux.NewResultIteratorFromQuery(qry)
 	defer results.Release()
 
 	encoder := d.Encoder()

--- a/querytest/execute.go
+++ b/querytest/execute.go
@@ -19,7 +19,7 @@ func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flu
 	if err != nil {
 		return 0, err
 	}
-	results := flux.NewResultIteratorFromQuery(ctx, query)
+	results := flux.NewResultIteratorFromQuery(query)
 	defer results.Release()
 
 	encoder := d.Encoder()


### PR DESCRIPTION
The query result iterator should not take a context. The context passed
to Query should be the one that controls whether or not a query gets
canceled.

This reverts the API back, but keeps the cancel stuff removed since
cancel was never used for actually canceling a query. The context was
always used for that.