### PR TITLE
feat: add Fuzz method for go-fuzz into the parser

### DIFF
--- a/parser/gofuzz.go
+++ b/parser/gofuzz.go
@@ -1,0 +1,11 @@
+//+build gofuzz
+
+package parser
+
+// Fuzz will run the parser on the input data and return 1 on success and 0 on failure.
+func Fuzz(data []byte) int {
+	if _, err := NewAST(string(data)); err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
The Fuzz method is added to a separate file with the `gofuzz` tag so it
is not included in non-gofuzz builds. The Fuzz method is not considered
part of the public API.