### PR TITLE
fix: return error in covariance when a column doesn't exist

### DIFF
--- a/functions/transformations/covariance.go
+++ b/functions/transformations/covariance.go
@@ -171,7 +171,13 @@ func (t *CovarianceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 		return err
 	}
 	xIdx := execute.ColIdx(t.spec.Columns[0], cols)
+	if xIdx < 0 {
+		return fmt.Errorf("specified column does not exist in table: %v", t.spec.Columns[0])
+	}
 	yIdx := execute.ColIdx(t.spec.Columns[1], cols)
+	if yIdx < 0 {
+		return fmt.Errorf("specified column does not exist in table: %v", t.spec.Columns[1])
+	}
 
 	if cols[xIdx].Type != cols[yIdx].Type {
 		return errors.New("cannot compute the covariance between different types")

--- a/functions/transformations/testdata/covariance_missing_column_1.flux
+++ b/functions/transformations/testdata/covariance_missing_column_1.flux
@@ -1,0 +1,6 @@
+from(bucket: "test")
+	|> range(start: 2018-05-22T19:53:26Z)
+  |> covariance(columns: ["x", "y"])
+	|> yield(name: "0")
+
+

--- a/functions/transformations/testdata/covariance_missing_column_1.in.csv
+++ b/functions/transformations/testdata/covariance_missing_column_1.in.csv
@@ -1,0 +1,8 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string
+#group,false,false,false,false,false,false,true
+#default,_result,,,,,,
+,result,table,_start,_stop,_time,x,_measurement
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,0,cpu
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,0,cpu
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,2,cpu
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,7,cpu

--- a/functions/transformations/testdata/covariance_missing_column_1.out.csv
+++ b/functions/transformations/testdata/covariance_missing_column_1.out.csv
@@ -1,0 +1,5 @@
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,specified column does not exist in table: y,

--- a/functions/transformations/testdata/covariance_missing_column_2.flux
+++ b/functions/transformations/testdata/covariance_missing_column_2.flux
@@ -1,0 +1,6 @@
+from(bucket: "test")
+	|> range(start: 2018-05-22T19:53:26Z)
+  |> covariance(columns: ["x", "y"])
+	|> yield(name: "0")
+
+

--- a/functions/transformations/testdata/covariance_missing_column_2.in.csv
+++ b/functions/transformations/testdata/covariance_missing_column_2.in.csv
@@ -1,0 +1,8 @@
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string
+#group,false,false,false,false,false,false,true
+#default,_result,,,,,,
+,result,table,_start,_stop,_time,y,_measurement
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,0,cpu
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,0,cpu
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:46Z,2,cpu
+,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:56Z,7,cpu

--- a/functions/transformations/testdata/covariance_missing_column_2.out.csv
+++ b/functions/transformations/testdata/covariance_missing_column_2.out.csv
@@ -1,0 +1,5 @@
+#datatype,string,string
+#group,true,true
+#default,,
+,error,reference
+,specified column does not exist in table: x,


### PR DESCRIPTION
The covariance function would panic if one of the columns that were
referenced did not exist. This checks for that and returns an error
instead of panicking.

Fixes #240.