### PR TITLE
fix: controller statistics should not panic

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -525,7 +525,6 @@ func (q *Query) Statistics() flux.Statistics {
 	defer q.mu.Unlock()
 
 	stats := q.stats
-	stats.TotalDuration = q.parentSpan.Duration
 	stats.Concurrency = q.concurrency
 	if q.alloc != nil {
 		stats.MaxAllocated = q.alloc.MaxAllocated()
@@ -580,6 +579,7 @@ TRANSITION:
 	case Errored, Canceled, Finished:
 		if q.parentSpan != nil {
 			q.parentSpan.Finish()
+			q.stats.TotalDuration = q.parentSpan.Duration
 			q.parentSpan = nil
 
 			// Close the ready channel on the first time we move to one of these states.


### PR DESCRIPTION
The parent span is closed when entering a final state and removed to
signal that it has been finished and to prevent it from being finished
multiple times. But, it did not copy the duration to the statistics and
instead tried to read the statistics from a nil span.

It now copies the total duration when the span is closed.