### PR TITLE
fix: switch the scanner interface for the parser

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -12,8 +12,8 @@ type Scanner interface {
 	// Scan will scan the next token.
 	Scan() (pos token.Pos, tok token.Token, lit string)
 
-	// ScanNoRegex will scan the next token, but exclude any regex literals.
-	ScanNoRegex() (pos token.Pos, tok token.Token, lit string)
+	// ScanWithRegex will scan the next token and include any regex literals.
+	ScanWithRegex() (pos token.Pos, tok token.Token, lit string)
 
 	// Unread will unread back to the previous location within the Scanner.
 	// This can only be called once so the maximum lookahead is one.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -29,16 +29,6 @@ type Scanner struct {
 }
 
 func (s *Scanner) Scan() (token.Pos, token.Token, string) {
-	if s.i >= len(s.Tokens) {
-		return 0, token.EOF, ""
-	}
-	tok := s.Tokens[s.i]
-	s.i++
-	s.buffered = false
-	return tok.Pos, tok.Token, tok.Lit
-}
-
-func (s *Scanner) ScanNoRegex() (token.Pos, token.Token, string) {
 	pos, tok, lit := s.Scan()
 	if tok == token.REGEX {
 		// The parser was asking for a non regex token and our static
@@ -48,6 +38,16 @@ func (s *Scanner) ScanNoRegex() (token.Pos, token.Token, string) {
 		return 0, token.ILLEGAL, ""
 	}
 	return pos, tok, lit
+}
+
+func (s *Scanner) ScanWithRegex() (token.Pos, token.Token, string) {
+	if s.i >= len(s.Tokens) {
+		return 0, token.EOF, ""
+	}
+	tok := s.Tokens[s.i]
+	s.i++
+	s.buffered = false
+	return tok.Pos, tok.Token, tok.Lit
 }
 
 func (s *Scanner) Unread() {


### PR DESCRIPTION
We have decided that `Scan` and `ScanWithRegex` will be used instead so
switching the interface to use that.