### PR TITLE
feat: add error node to the flux ast

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -55,6 +55,7 @@ type Node interface {
 }
 
 func (*Program) node() {}
+func (*Error) node()   {}
 
 func (*BlockStatement) node()      {}
 func (*ExpressionStatement) node() {}
@@ -100,6 +101,25 @@ func (b BaseNode) Location() SourceLocation {
 	return *b.Loc
 }
 
+// Error represents an error within the AST. It is created
+// by the parser when the parser gets an invalid sequence.
+type Error struct {
+	BaseNode
+	Message string `json:"message"`
+}
+
+// Type is the abstract type.
+func (*Error) Type() string { return "Error" }
+
+func (e *Error) Copy() Node {
+	ne := *e
+	return &ne
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}
+
 // Program represents a complete program source tree
 type Program struct {
 	BaseNode
@@ -127,6 +147,7 @@ type Statement interface {
 	stmt()
 }
 
+func (*Error) stmt()               {}
 func (*BlockStatement) stmt()      {}
 func (*ExpressionStatement) stmt() {}
 func (*ReturnStatement) stmt()     {}
@@ -272,6 +293,7 @@ type Expression interface {
 	expression()
 }
 
+func (*Error) expression()                   {}
 func (*ArrayExpression) expression()         {}
 func (*ArrowFunctionExpression) expression() {}
 func (*BinaryExpression) expression()        {}
@@ -685,6 +707,7 @@ type Literal interface {
 	literal() //lint:ignore U1000 Yes, this function is unused, but it's here to limit the implementers of the Literal interface.
 }
 
+func (*Error) literal()                  {}
 func (*BooleanLiteral) literal()         {}
 func (*DateTimeLiteral) literal()        {}
 func (*DurationLiteral) literal()        {}

--- a/ast/json.go
+++ b/ast/json.go
@@ -7,6 +7,17 @@ import (
 	"strconv"
 )
 
+func (e *Error) MarshalJSON() ([]byte, error) {
+	type Alias Error
+	raw := struct {
+		Type string `json:"type"`
+		*Alias
+	}{
+		Type:  e.Type(),
+		Alias: (*Alias)(e),
+	}
+	return json.Marshal(raw)
+}
 func (p *Program) MarshalJSON() ([]byte, error) {
 	type Alias Program
 	raw := struct {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"errors"
+	"fmt"
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/internal/token"
@@ -21,6 +21,25 @@ type Scanner interface {
 }
 
 // NewAST parses Flux query and produces an ast.Program.
-func NewAST(src Scanner) (*ast.Program, error) {
-	return nil, errors.New("implement me")
+func NewAST(src Scanner) *ast.Program {
+	// todo(jsternberg): like everything.
+	program := &ast.Program{}
+	for {
+		switch _, tok, lit := src.ScanWithRegex(); tok {
+		case token.IDENT:
+			program.Body = append(program.Body, &ast.ExpressionStatement{
+				Expression: &ast.Identifier{Name: lit},
+			})
+		case token.ILLEGAL:
+			program.Body = append(program.Body, &ast.Error{
+				Message: fmt.Sprintf("illegal token: %s", lit),
+			})
+		case token.EOF:
+			return program
+		default:
+			program.Body = append(program.Body, &ast.Error{
+				Message: "implement me",
+			})
+		}
+	}
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1844,6 +1844,20 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
 			},
 			skip: true,
 		},
+		{
+			name: "invalid token",
+			raw:  `@ ident`,
+			want: &ast.Program{
+				Body: []ast.Statement{
+					&ast.Error{
+						Message: "illegal token: @",
+					},
+					&ast.ExpressionStatement{
+						Expression: &ast.Identifier{Name: "ident"},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			fatalf := t.Fatalf
@@ -1852,11 +1866,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
 			}
 
 			s := scanner.New([]byte(tt.raw))
-			result, err := parser.NewAST(s)
-			if err != nil {
-				fatalf("unexpected error: %s", err)
-			}
-
+			result := parser.NewAST(s)
 			if got, want := result, tt.want; !cmp.Equal(want, got, CompareOptions...) {
 				fatalf("unexpected statement -want/+got\n%s", cmp.Diff(want, got, CompareOptions...))
 			}


### PR DESCRIPTION
The error node can go anywhere in the AST and signals there was an
error.