### PR TITLE
feat(ast): add a function for checking for errors within the AST

### DIFF
--- a/ast/asttest/cmpopts.go
+++ b/ast/asttest/cmpopts.go
@@ -10,6 +10,7 @@ import (
 
 var IgnoreBaseNodeOptions = []cmp.Option{
 	cmpopts.IgnoreFields(ast.ArrayExpression{}, "BaseNode"),
+	cmpopts.IgnoreFields(ast.BadStatement{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.BinaryExpression{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.Block{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.BooleanLiteral{}, "BaseNode"),

--- a/ast/edit/option_editor_test.go
+++ b/ast/edit/option_editor_test.go
@@ -202,8 +202,9 @@ option task = {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			p, err := parser.NewAST(tc.in)
-			if err != nil {
+			p := parser.NewAST(tc.in)
+			if ast.Check(p) > 0 {
+				err := ast.GetError(p)
 				t.Fatal(errors.Wrapf(err, "input program has bad syntax:\n%s", tc.in))
 			}
 

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -1,0 +1,92 @@
+package ast
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// Check will inspect each node and annotate it with any AST errors.
+// It will return the number of errors that were found.
+func Check(root Node) int {
+	v := errorVisitor{}
+	Walk(&v, root)
+	return v.count
+}
+
+// check will inspect a single node and annotate it with any AST errors.
+// For convenience, it returns the number of errors that were identified.
+func check(n Node) int {
+	// TODO(jsternberg): Fill in the details for how we retrieve errors.
+	switch n := n.(type) {
+	case *BadStatement:
+		n.Errors = append(n.Errors, Error{
+			Msg: fmt.Sprintf("invalid statement: %s", n.Text),
+		})
+		return len(n.Errors)
+	}
+
+	return 0
+}
+
+// GetError will return the first error within an AST.
+func GetError(n Node) error {
+	errs := GetErrors(n)
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs[0]
+}
+
+// GetErrors will return each of the errors within an AST.
+func GetErrors(n Node) (errs []error) {
+	Walk(CreateVisitor(func(node Node) {
+		if nerrs := node.Errs(); len(nerrs) > 0 {
+			for _, err := range nerrs {
+				errs = append(errs, err)
+			}
+		}
+	}), n)
+	return errs
+}
+
+// PrintErrors will format the errors within the AST and output them
+// to the writer.
+func PrintErrors(w io.Writer, root Node) {
+	var buf bytes.Buffer
+	Walk(CreateVisitor(func(node Node) {
+		if errs := node.Errs(); len(errs) > 0 {
+			loc := node.Location()
+			for _, err := range errs {
+				buf.WriteString("error")
+				if loc.Start.Line > 0 {
+					buf.WriteByte(':')
+					buf.WriteString(strconv.FormatInt(int64(loc.Start.Line), 10))
+				}
+				if loc.Start.Column > 0 {
+					if buf.Len() > 0 {
+						buf.WriteByte(':')
+					}
+					buf.WriteString(strconv.FormatInt(int64(loc.Start.Column), 10))
+				}
+				buf.WriteString(": ")
+				buf.WriteString(err.Msg)
+				buf.WriteByte('\n')
+				_, _ = w.Write(buf.Bytes())
+				buf.Reset()
+			}
+		}
+	}), root)
+}
+
+type errorVisitor struct {
+	count int
+}
+
+func (ev *errorVisitor) Visit(n Node) Visitor {
+	ev.count += check(n)
+	return ev
+}
+
+func (ev *errorVisitor) Done(n Node) {}

--- a/ast/errors_test.go
+++ b/ast/errors_test.go
@@ -1,0 +1,50 @@
+package ast_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/influxdata/flux/ast"
+)
+
+func TestPrintErrors(t *testing.T) {
+	program := &ast.Program{
+		Body: []ast.Statement{
+			&ast.BadStatement{
+				BaseNode: ast.BaseNode{
+					Loc: &ast.SourceLocation{
+						Start: ast.Position{
+							Line:   1,
+							Column: 1,
+						},
+					},
+					Errors: []ast.Error{
+						{Msg: "invalid statement: @"},
+					},
+				},
+			},
+			&ast.BadStatement{
+				BaseNode: ast.BaseNode{
+					Loc: &ast.SourceLocation{
+						Start: ast.Position{
+							Line:   2,
+							Column: 7,
+						},
+					},
+					Errors: []ast.Error{
+						{Msg: "invalid statement: &"},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	ast.PrintErrors(&buf, program)
+
+	if got, want := buf.String(), `error:1:1: invalid statement: @
+error:2:7: invalid statement: &
+`; want != got {
+		t.Errorf("unexpected output -want/+got\n\t- %q\n\t+ %q", want, got)
+	}
+}

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -276,8 +276,9 @@ highestAverage = (n, columns=["_value"], by, tables=<-) =>
 				t.Skip(reason)
 			}
 
-			originalProgram, err := parser.NewAST(tc.script)
-			if err != nil {
+			originalProgram := parser.NewAST(tc.script)
+			if ast.Check(originalProgram) > 0 {
+				err := ast.GetError(originalProgram)
 				t.Fatal(errors.Wrapf(err, "original program has bad syntax:\n%s", tc.script))
 			}
 

--- a/ast/json.go
+++ b/ast/json.go
@@ -63,6 +63,17 @@ func (d *ImportDeclaration) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(raw)
 }
+func (s *BadStatement) MarshalJSON() ([]byte, error) {
+	type Alias BadStatement
+	raw := struct {
+		Type string `json:"type"`
+		*Alias
+	}{
+		Type:  s.Type(),
+		Alias: (*Alias)(s),
+	}
+	return json.Marshal(raw)
+}
 func (s *Block) MarshalJSON() ([]byte, error) {
 	type Alias Block
 	raw := struct {
@@ -877,6 +888,8 @@ func unmarshalNode(msg json.RawMessage) (Node, error) {
 		node = new(PackageClause)
 	case "ImportDeclaration":
 		node = new(ImportDeclaration)
+	case "BadStatement":
+		node = new(BadStatement)
 	case "Block":
 		node = new(Block)
 	case "OptionStatement":

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -158,7 +158,7 @@ func (p *parser) parseStatementList(eof token.Token) []ast.Statement {
 }
 
 func (p *parser) parseStatement() ast.Statement {
-	switch _, tok, lit := p.peek(); tok {
+	switch pos, tok, lit := p.peek(); tok {
 	case token.IDENT:
 		if lit == "option" {
 			return p.parseOptionStatement()
@@ -172,9 +172,11 @@ func (p *parser) parseStatement() ast.Statement {
 		token.ADD, token.SUB, token.NOT:
 		return p.parseExpressionStatement()
 	default:
-		// todo(jsternberg): error handling.
 		p.consume()
-		return nil
+		return &ast.BadStatement{
+			Text:     lit,
+			BaseNode: p.posRange(pos, len(lit)),
+		}
 	}
 }
 

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -395,9 +395,9 @@ func TestEval(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			program, err := parser.NewAST(tc.query)
-			if err != nil {
-				t.Fatal(err)
+			program := parser.NewAST(tc.query)
+			if ast.Check(program) > 0 {
+				t.Fatal(ast.GetError(program))
 			}
 			graph, err := semantic.New(program)
 			if err != nil {
@@ -488,11 +488,11 @@ func TestInterpreter_TypeErrors(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ast, err := parser.NewAST(tc.program)
-			if err != nil {
-				t.Fatal(err)
+			program := parser.NewAST(tc.program)
+			if ast.Check(program) > 0 {
+				t.Fatal(ast.GetError(program))
 			}
-			graph, err := semantic.New(ast)
+			graph, err := semantic.New(program)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -641,12 +641,12 @@ func TestResolver(t *testing.T) {
 	scope := make(map[string]values.Value)
 	scope[f.name] = f
 
-	program, err := parser.NewAST(`
+	program := parser.NewAST(`
 	x = 42
 	resolver(f: (r) => r + x)
 `)
-	if err != nil {
-		t.Fatal(err)
+	if ast.Check(program) > 0 {
+		t.Fatal(ast.GetError(program))
 	}
 
 	graph, err := semantic.New(program)

--- a/interpreter/package_test.go
+++ b/interpreter/package_test.go
@@ -3,6 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
+	"github.com/influxdata/flux/ast"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
@@ -301,11 +303,11 @@ func TestInterpreter_EvalPackage(t *testing.T) {
 }
 
 func eval(itrp *interpreter.Interpreter, importer interpreter.Importer, program string) error {
-	ast, err := parser.NewAST(program)
-	if err != nil {
-		return err
+	programAST := parser.NewAST(program)
+	if ast.Check(programAST) > 0 {
+		return ast.GetError(programAST)
 	}
-	node, err := semantic.New(ast)
+	node, err := semantic.New(programAST)
 	if err != nil {
 		return err
 	}

--- a/parser/gofuzz.go
+++ b/parser/gofuzz.go
@@ -2,9 +2,12 @@
 
 package parser
 
+import "github.com/influxdata/flux/ast"
+
 // Fuzz will run the parser on the input data and return 1 on success and 0 on failure.
 func Fuzz(data []byte) int {
-	if _, err := NewAST(string(data)); err != nil {
+	program := NewAST(string(data))
+	if ast.Check(program) > 0 {
 		return 0
 	}
 	return 1

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,7 +5,7 @@ import (
 	fastparser "github.com/influxdata/flux/internal/parser"
 )
 
-// NewAST parses Flux query and produces an ast.Program
-func NewAST(flux string) (*ast.Program, error) {
-	return fastparser.NewAST([]byte(flux)), nil
+// NewAST parses Flux query and produces an ast.Program.
+func NewAST(flux string) *ast.Program {
+	return fastparser.NewAST([]byte(flux))
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/influxdata/flux/ast"
+
 	prompt "github.com/c-bata/go-prompt"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
@@ -137,9 +139,9 @@ func (r *REPL) executeLine(t string) (values.Value, error) {
 		t = q
 	}
 
-	astProg, err := parser.NewAST(t)
-	if err != nil {
-		return nil, err
+	astProg := parser.NewAST(t)
+	if ast.Check(astProg) > 0 {
+		return nil, ast.GetError(astProg)
 	}
 
 	semProg, err := semantic.New(astProg)

--- a/semantic/inference_test.go
+++ b/semantic/inference_test.go
@@ -1573,9 +1573,9 @@ foo.b
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.script != "" {
-				program, err := parser.NewAST(tc.script)
-				if err != nil {
-					t.Fatal(err)
+				program := parser.NewAST(tc.script)
+				if ast.Check(program) > 0 {
+					t.Fatal(ast.GetError(program))
 				}
 				node, err := semantic.New(program)
 				if err != nil {

--- a/semantic/package_test.go
+++ b/semantic/package_test.go
@@ -3,6 +3,8 @@ package semantic_test
 import (
 	"testing"
 
+	"github.com/influxdata/flux/ast"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
@@ -154,9 +156,9 @@ bar.x = 10
 			if tc.skip {
 				t.Skip()
 			}
-			program, err := parser.NewAST(tc.script)
-			if err != nil {
-				t.Fatal(err)
+			program := parser.NewAST(tc.script)
+			if ast.Check(program) > 0 {
+				t.Fatal(ast.GetError(program))
 			}
 			node, err := semantic.New(program)
 			if err != nil {

--- a/spec_test.go
+++ b/spec_test.go
@@ -316,7 +316,7 @@ func Example_overrideDefaultOptionExternally() {
 
 	itrp := flux.NewInterpreter()
 
-	ast, _ := parser.NewAST(queryString)
+	ast := parser.NewAST(queryString)
 	semanticProgram, _ := semantic.New(ast)
 
 	// Evaluate program
@@ -340,7 +340,7 @@ func Example_overrideDefaultOptionInternally() {
 
 	itrp := flux.NewInterpreter()
 
-	ast, _ := parser.NewAST(queryString)
+	ast := parser.NewAST(queryString)
 	semanticProgram, _ := semantic.New(ast)
 
 	// Define a new now function which returns a static time value of 2018-07-13T00:00:00.000000000Z


### PR DESCRIPTION
The `Check` function will annotate the AST with errors in the AST
construction. The parser will be modified to make a best effort to
produce an AST, but it will produce an invalid AST when it gets an
invalid input.

The `GetErrors` method will traverse the AST and report any errors it
finds within the AST construction that were added a result of `Check`.

Related to #305.