### PR TITLE
compare flux tables for equality

### DIFF
--- a/execute/executetest/result.go
+++ b/execute/executetest/result.go
@@ -1,6 +1,9 @@
 package executetest
 
 import (
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 )
 
@@ -49,4 +52,48 @@ func (ti *TableIterator) Do(f func(flux.Table) error) error {
 		}
 	}
 	return nil
+}
+
+// EqualResults compares two lists of Flux Results for equlity
+func EqualResults(want, got []flux.Result) (bool, error) {
+	if len(want) != len(got) {
+		return false, fmt.Errorf("unexpected number of results - want %d results, got %d results", len(want), len(got))
+	}
+	for i, result := range want {
+		w := result
+		g := got[i]
+		if w.Name() != g.Name() {
+			return false, fmt.Errorf("unexpected result name - want %s, got %s", w.Name(), g.Name())
+		}
+		var wt, gt []*Table
+		if err := w.Tables().Do(func(tbl flux.Table) error {
+			t, err := ConvertTable(tbl)
+			if err != nil {
+				return err
+			}
+			wt = append(wt, t)
+			return nil
+		}); err != nil {
+			return false, err
+		}
+		if err := g.Tables().Do(func(tbl flux.Table) error {
+			t, err := ConvertTable(tbl)
+			if err != nil {
+				return err
+			}
+			gt = append(gt, t)
+			return nil
+		}); err != nil {
+			return false, err
+		}
+		NormalizeTables(wt)
+		NormalizeTables(gt)
+		if len(wt) != len(gt) {
+			return false, fmt.Errorf("unexpected size for result %s - want %d tables, got %d tables", w.Name(), len(wt), len(gt))
+		}
+		if !cmp.Equal(wt, gt, floatOptions) {
+			return false, fmt.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(wt, gt))
+		}
+	}
+	return true, nil
 }

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -3,10 +3,9 @@ package executetest
 import (
 	"fmt"
 
-	"github.com/influxdata/flux/semantic"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 

--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -1,14 +1,48 @@
 package executetest
 
 import (
+	"math"
 	"sort"
 	"testing"
 
+	"github.com/gonum/floats"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 )
+
+// Two floating point values are considered
+// equal if they are within tol of each other.
+const tol float64 = 1e-25
+
+// The maximum number of floating point values that are allowed
+// to lie between two float64s and still be considered equal.
+const ulp uint = 2
+
+// Comparison options for floating point values.
+// NaNs are considered equal, and float64s must
+// be sufficiently close to be considered equal.
+var floatOptions = cmp.Options{
+	cmpopts.EquateNaNs(),
+	cmp.FilterValues(func(x, y float64) bool {
+		return !math.IsNaN(x) && !math.IsNaN(y)
+	}, cmp.Comparer(func(x, y float64) bool {
+		// If sufficiently close, then move on.
+		// This avoids situations close to zero.
+		if floats.EqualWithinAbs(x, y, tol) {
+			return true
+		}
+		// If not sufficiently close, both floats
+		// must be within ulp steps of each other.
+		if !floats.EqualWithinULP(x, y, ulp) {
+			return false
+		}
+		return true
+	})),
+}
 
 func ProcessTestHelper(
 	t *testing.T,
@@ -50,7 +84,7 @@ func ProcessTestHelper(
 	sort.Sort(SortedTables(got))
 	sort.Sort(SortedTables(want))
 
-	if !cmp.Equal(want, got, cmpopts.EquateNaNs()) {
+	if !cmp.Equal(want, got, floatOptions) {
 		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/gonum/blas v0.0.0-20180125090452-e7c5890b24cf // indirect
 	github.com/gonum/diff v0.0.0-20180125090814-f0137a19aa16 // indirect
-	github.com/gonum/floats v0.0.0-20180125090339-7de1f4ea7ab5 // indirect
+	github.com/gonum/floats v0.0.0-20180125090339-7de1f4ea7ab5
 	github.com/gonum/integrate v0.0.0-20180125090255-09c2f478329f // indirect
 	github.com/gonum/internal v0.0.0-20180125090855-fda53f8d2571 // indirect
 	github.com/gonum/lapack v0.0.0-20180125091020-f0b8b25edece // indirect


### PR DESCRIPTION
Related to #236 .

This PR exposes some utility functions for comparing Flux tables for equality. All values are compared for exact equality except floating point values - they are compared using a combination of absolute tolerance and ULPs (units in the last place).

When two values fail an equality comparison, a table formatter along with an appropriate error message is returned. This allows the caller of the function to print out both formatted tables along with the row and column number where the equality comparison failed.