### PR TITLE
docs: Add rough draft of virtual machine design

### DIFF
--- a/docs/VirtualMachine.md
+++ b/docs/VirtualMachine.md
@@ -1,0 +1,160 @@
+# Virtual Machine Design
+
+This document details the workings and design of the virtual machine that executes a Flux script.
+
+## Execution Stack
+
+A Flux script goes through several transformations from text to execution.
+
+1. Flux source code is created via any means.
+2. The parser produces an abstract syntax tree (AST) from the source code.
+3. The semantic analyzer produces a semantic graph from the AST.
+4. The compiler accepts the semantic graph and produces an intermediate representation (IR) to be executed.
+5. The flux virtual machine executes the IR.
+
+NOTE: Should we call it bytecode or IR?
+Should we call it a VM or an interpreter?
+
+## Execution model
+
+Flux has a specific execution model.
+The model depends on the definitions of various data types and operations on those types.
+The Flux spec defines some of those types.
+This document reviews those types as well as defines a few new types that are specific to the implementation.
+
+### Data types and operations
+
+#### Table
+
+A Flux table consists of rows and columns.
+Columns have a label and a type.
+The table has zero or more rows, where each row defines a value for each column or a null is used to indicate a missing value.
+
+A table additionaly has a group key, which is a list of columns and their values.
+All rows within a table have the same value for all columns that are part of the group key.
+
+#### Stream
+
+A stream is an unbounded set of tables.
+Each table must have a different group key.
+
+#### Input
+
+An input is a source of a stream.
+
+Inputs are reprented as functions that produce a stream.
+
+#### Output
+
+An output consumes a stream and send the data to an external system.
+
+Output are reprented as functions that consume a stream and produce a stream.
+Outputs are transparent proxies, passing their input data downstream unmodified.
+As a result outputs themselves have no effect on the Flux program, in other words they only have side effects.
+
+#### Transformation
+
+A transformation is not a data type but rather an operation defined on a stream.
+A transformation consumes a stream of tables and produces a new stream of tables.
+
+Transformations may make use of a data cache to allow for multiple edits to a table before materializing the table into the new stream.
+
+Transformations are reprented as functions that consume a stream and produce a stream.
+
+#### Data cache
+
+A data cache is a set of tables that have yet to be materialized.
+Tables in a data cache may receive edits.
+The cache identifies each table by its group key.
+
+#### Triggers
+
+A trigger indicates that a table in the data cache should be materialized and delivered downstream.
+
+A trigger can fire multiple times until it is finished.
+Once a trigger is finished it will never fire again.
+
+A data cache uses triggers to know when it can evit and materialize tables.
+
+Triggers fire based on events.
+For example a trigger may fire after receiving an update watermark event.
+See the Flux spec for complete details on events available to triggers.
+
+#### Message bus
+
+The message bus is a queue where trigger events and data messages can be placed.
+Each transformation has its own message bus.
+A transformation consumes messages off its bus and processes them.
+
+### Data flow
+
+With the various data types and operations defined lets be explicit about how data flows through a Flux program.
+
+A Flux program describes a graph through which data flows.
+This graph may have complex data dependencies between transformations.
+Sources produce an inital stream of tables, each table is placed on the message bus for the downstream transformations of the source.
+Each transformation is linked to its downstream transformations via the message bus.
+Sources produces trigger events about the stream which are also placed on the message bus.
+The trigger events cause tables to be materialized from the data cache, if it exists. 
+The materialized tables are placed on the message bus of the downstream transformations.
+If a transformation does not need to make edits to a table it does not need to use the data cache but can simply place its generated tables directly on the downstream message bus.
+
+## Compiler
+
+The compiler is responsible for transforming a semantic graph into an IR.
+Internally the compiler performs several passes in order to produce optimized IR.
+
+1. Initial Pass - Convert the semantic graph into non-optimized IR.
+2. Planner - The planner rewrites the IR to optimize for the structure of the Flux script.
+3. Final Pass - The final pass rewrites the IR for any final optimizations that can be performed.
+
+
+The planner tends to perform more macro optimizations, like merging entire data transformations together.
+The final pass tends to perform more micro optimizations, like rewriting a few instructions to allow for better cache locality.
+
+## Intermediate Representation
+
+The Flux IR consists of a set of instructions and arguments to those instructions.
+The IR is a high level IR, specifically instructions are not required to directly map to hardware operations.
+
+The data types the IR can describe are also high level.
+For example an instruction may take an entire table as its input argument.
+
+The IR describes the both the control flow and the data dependencies between function calls.
+The IR is represented as imperative code.
+As such data dependencies are encoded in the order of the instructions and control flow is encoded through condition jumps to different sections of code.
+
+Here are a few examples of the IR instructions:
+
+* AddInt - Add two integers
+* Stddev - Compute the stddev of a table of data
+* Join - Joins N streams of tables
+
+The IR is not a language to describe how to process the data with tables.
+In other words the IR is not used to describe the implementation of the transformations themselves rather it is used to describe the data flow between transformations.
+The implementations of the transformations is left to the virtual machine runtime.
+
+## Virtual Machine
+
+The virtual machine will consume a list of IR instructions and execute them.
+Many instructions will call out to the Flux runtime.
+
+### Runtime
+
+The Flux runtime provides the heavy data processing for the virtual machine.
+
+The following operations will be implemented in the runtime.
+
+* Transformations
+* Data cache
+* Message bus
+
+
+## Debugger
+
+Flux will provide a debugger to allow a user to step through their Flux source code.
+The compiler can be instructed to generate debug IR.
+This IR will allow a debugger to step through the function calls of a Flux program and inspect the data being passed.
+Since the IR describes data flow and conditional logic it is the correct abstract to debug a Flux program since the details of how a transformation is implemented should not be the concern of a user.
+Large amounts of data can be passed between functions, the debugger will expose ways to page through the data in a streaming manner.
+


### PR DESCRIPTION
This PR adds a document on a proposed virtual machine implementation of Flux.
It is written as if the virtual machine already exists. I will use this PR comment to discuss how this differs from the current design and its strengths and weakness.

The current design at a high level looks like this:

```
Flux Source Code -> AST -> Semantic Graph -> Query Spec -> Plan -> Execution
```
The parser produces the AST, the analyzer produces the semantic graph, the interpreter produces the spec, the planner produces the plan and the query engine executes the plan.

Currently external systems can submit programmatically generated queries by generating  Flux source code or by generating a query spec to execute a query. For example the transpiler directly produces the query spec and submits it for execution.

The proposed change is this:

```
Flux source code -> AST -> Semantic Graph -> IR -> Execution
```

The parser produces the AST, the analyzer produces the semantic graph, the compiler produces the IR and the virtual machine executes the IR.

Obvious questions:

Q: Why the design change?
A: We want Flux to be able to describe control flow and data dependencies between transformations that a simple graph cannot describe. Using an IR allows us to describe more complex data dependencies like a `topN` query. Using an IR allows us to describe control flow, meaning execute different sub queries based on the result of a previous query. For example, anytime you use an identifier in a filter or map function, that is not just a simple constant expression, that is difficult to describe in a graph, but not in an IR. 

Q: Where did the planner go?
A: The planner is now encapsulated in the "compiler". The planner will consume IR and produce an optimized IR. The IR abstraction we have chosen maps closely to the types the planner is already manipulating. 


Q: With the query spec gone, how do external system submit programmatically generated queries?
A: External systems can use the semantic graph to submit programmatically generated queries. This means the transpiler will need to produce semantic graph instead of a query spec. We will not accept IR from external systems, the semantic graph will be the canonical source for describing Flux programs in addition to Flux source code.

Q: Is this design complete?
A: No, this is a very rough draft of the design. Please tear it apart so we can more fully specify it.

Q: Does this design make embedding Flux easier?
A: Maybe? This design is not specifically about improving the embedding story around Flux although it was discussed during design. This design will have a large runtime to handle most of the heavy lifting as such porting that runtime to other languages/systems will not be a small task.

Q: Do this mean we have to rewrite all the Go we have written as Flux/IR?
A: No, the IR abstraction is the same level as abstraction that the query spec provided. As such most of the code that has to change is the execution engine to be a virtual machine instead of just a direct Go implementation. In short the current Go code we have just becomes the virtual machine runtime. The nice thing about this is it provides a nice bridge between these designs and allows for the runtime to be updated without changing the core virtual machine. 

