### PR TITLE
releasing ResultIterator resources is thread-safe

### DIFF
--- a/result_iterator.go
+++ b/result_iterator.go
@@ -6,7 +6,10 @@ import (
 
 // ResultIterator allows iterating through all results synchronously.
 // A ResultIterator is not thread-safe and all of the methods are expected to be
-// called within the same goroutine. A ResultIterator may implement Statisticser.
+// called within the same goroutine with the exception of the Release method.
+// Release is the only method that is thread-safe and may be called from a
+// goroutine different than that of the other methods. A ResultIterator may
+// implement Statisticser.
 type ResultIterator interface {
 	// More indicates if there are more results.
 	More() bool
@@ -17,7 +20,7 @@ type ResultIterator interface {
 
 	// Release discards the remaining results and frees the currently used resources.
 	// It must always be called to free resources. It can be called even if there are
-	// more results. It is safe to call Release multiple times.
+	// more results. It is safe to call Release multiple times. Release is thread-safe.
 	Release()
 
 	// Err reports the first error encountered.


### PR DESCRIPTION
Related to #306 .

The ResultIterator godoc specifies that all of its methods are expected to be called within the same goroutine. However for one of its implementations, `queryResultIterator`, the `More()` method could become blocked:
https://github.com/influxdata/flux/blob/14b3100e9ede054cb420c5ea4f0880e539c9986a/result_iterator.go#L51

The `Release()` method in this case is intended to unblock `More()`. But this is only possible if `Release()` is called from a goroutine separate from the one in which `More()` was called. This constraint should probably be relaxed as to allow blocking calls to `More()` to become unblocked.