### PR TITLE
cancelling query context stops execution

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -492,8 +492,11 @@ func (q *Query) Cancel() {
 }
 
 // Ready returns a channel that will deliver the query results.
-// Its possible that the channel is closed before any results arrive, in which case the query should be
-// inspected for an error using Err().
+// It's possible that the channel is closed before any results arrive.
+// In particular, if a query's context is cancelled during execution,
+// the channel will be closed immediately and an error will be exposed
+// via Err(). For this reason, a query should always be inspected for
+// an error using Err().
 func (q *Query) Ready() <-chan map[string]flux.Result {
 	return q.ready
 }


### PR DESCRIPTION
Closes #306 .
Closes #311 .

Cancelling a query's context during execution will cause that query to return and any blocking ResultIterator calls will become unblocked. The PR adds a test case to the controller to assert that this does indeed happen. The godoc for `Ready()` is also updated to reflect this.

Note: If a query's context is cancelled mid-execution, that query should expose an appropriate error via its `Err()` method. See the godoc for:
https://github.com/influxdata/flux/blob/e4b1864ea4e87065fa23c178e178c6dd97f93d37/control/controller.go#L499

This currently is not the case. The TODO for this behavior has been added to the most recent test case:
https://github.com/influxdata/flux/blob/e4b1864ea4e87065fa23c178e178c6dd97f93d37/control/controller_test.go#L298
