### PR TITLE
fix: Add TableIterator.Statistics()

### DIFF
--- a/execute/executetest/result.go
+++ b/execute/executetest/result.go
@@ -42,6 +42,8 @@ type TableIterator struct {
 	err    error
 }
 
+func (ti *TableIterator) Statistics() flux.Statistics { return flux.Statistics{} }
+
 func (ti *TableIterator) Do(f func(flux.Table) error) error {
 	if ti.err != nil {
 		return ti.err

--- a/result.go
+++ b/result.go
@@ -19,6 +19,7 @@ type Result interface {
 
 type TableIterator interface {
 	Do(f func(Table) error) error
+	Statistics() Statistics
 }
 
 type Table interface {


### PR DESCRIPTION
The stats PR (https://github.com/influxdata/platform/pull/1265) required some refactoring to avoid race conditions. One necessary change was to expose stats from the `TableIterator` so `platform` could read stats after `Close()` instead of during iteration.