### PR TITLE
bug(csv): csv multi-result decoder was not handling the case where an…

### DIFF
--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -605,6 +605,37 @@ func TestMultiResultEncoder(t *testing.T) {
 `),
 		},
 		{
+			name:   "empty result",
+			config: csv.DefaultEncoderConfig(),
+			results: flux.NewSliceResultIterator([]flux.Result{&executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					KeyValues: []interface{}{
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+						"cpu",
+						"A",
+					},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{},
+				}},
+			}}),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+,result,table,_start,_stop,_time,_measurement,host,_value
+
+`),
+		},
+		{
 			name:   "two results",
 			config: csv.DefaultEncoderConfig(),
 			results: flux.NewSliceResultIterator([]flux.Result{
@@ -827,6 +858,36 @@ func TestMultiResultDecoder(t *testing.T) {
 			}},
 		},
 		{
+			name: "empty result",
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+,result,table,_start,_stop,_time,_measurement,host,_value
+
+`),
+			results: []*executetest.Result{{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					KeyValues: []interface{}{
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+						"cpu",
+						"A",
+					},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}(nil),
+				}},
+			}},
+		},
+		{
 			name: "two results",
 			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #group,false,false,true,true,false,true,true,false
@@ -909,6 +970,64 @@ func TestMultiResultDecoder(t *testing.T) {
 					}},
 				},
 			},
+		},
+		{
+			name: "two empty results",
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result1,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+,result,table,_start,_stop,_time,_measurement,host,_value
+
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result2,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu-0,B,
+,result,table,_start,_stop,_time,_measurement,host,_value
+
+
+`),
+			results: []*executetest.Result{{
+				Nm: "_result1",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					KeyValues: []interface{}{
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+						"cpu",
+						"A",
+					},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}(nil),
+				}},
+			},
+				{
+					Nm: "_result2",
+					Tbls: []*executetest.Table{{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						KeyValues: []interface{}{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							"cpu-0",
+							"B",
+						},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}(nil),
+					}},
+				}},
 		},
 		{
 			name: "decodes errors",


### PR DESCRIPTION
… empty annotation group is followed by another group.  fix checks for empty tables before erroring.