### PR TITLE
fix: lookup element type of array during allocation

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -342,17 +342,15 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope *Scope) (v
 
 func (itrp *Interpreter) doArray(a *semantic.ArrayExpression, scope *Scope) (values.Value, error) {
 	elements := make([]values.Value, len(a.Elements))
-	elementType := semantic.EmptyArrayType.ElementType()
+	arrayType, ok := itrp.types.LookupType(a)
+	if !ok {
+		return nil, fmt.Errorf("expecting array type")
+	}
+	elementType := arrayType.ElementType()
 	for i, el := range a.Elements {
 		v, err := itrp.doExpression(el, scope)
 		if err != nil {
 			return nil, err
-		}
-		if i == 0 {
-			elementType = v.Type()
-		}
-		if elementType != v.Type() {
-			return nil, fmt.Errorf("cannot mix types in an array, found both %v and %v", elementType, v.Type())
 		}
 		elements[i] = v
 	}


### PR DESCRIPTION
Once inside the interpreter, type inference has already taken place. Hence we can just look up the element type of an array (even an empty array) using the interpreter's typeScope. Note, any ArrayExpression passed into `doArray` must be a concrete array type. The interpreter cannot evaluate an array where the element type is unknown. It will return an error in this case.