### PR TITLE
fix(parser): fix the ident statement to use expression suffix

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -193,21 +193,7 @@ func (p *parser) parseVariableDeclaration() *ast.VariableDeclarator {
 }
 
 func (p *parser) parseIdentStatement() ast.Statement {
-	expr := p.parseExpression()
-	id, ok := expr.(*ast.Identifier)
-	if !ok {
-		return &ast.ExpressionStatement{
-			Expression: expr,
-			BaseNode: ast.BaseNode{
-				Loc: &ast.SourceLocation{
-					Start:  locStart(expr),
-					End:    locEnd(expr),
-					Source: p.s.File().Name(),
-				},
-			},
-		}
-	}
-
+	id := p.parseIdentifier()
 	switch _, tok, _ := p.peek(); tok {
 	case token.ASSIGN:
 		expr := p.parseAssignStatement()
@@ -225,6 +211,7 @@ func (p *parser) parseIdentStatement() ast.Statement {
 			},
 		}
 	default:
+		expr := p.parseExpressionSuffix(id)
 		return &ast.ExpressionStatement{
 			Expression: expr,
 			BaseNode: ast.BaseNode{


### PR DESCRIPTION
The previous implementation used `parseExpression` because it was easier
to do that than to read the identifier, read the next token, and then
try to inject the identifier into the expression parsing stack.

After this was written, `parseExpressionSuffix` was added for another
part of the grammar. It is more correct to use that function here since
it is referenced in the EBNF.

It should be functionally the same.