### PR TITLE
fix(parser): add unary logical expression to the parser

### DIFF
--- a/internal/parser/grammar.md
+++ b/internal/parser/grammar.md
@@ -15,9 +15,12 @@ TODO(jsternberg): Move this to the spec. This information is in the spec, but it
     ReturnStatement = return Expression .
     ExpressionStatement = Expression .
     Expression = LogicalExpression .
-    LogicalExpression = ComparisonExpression
-                      | LogicalExpression LogicalOperator ComparisonExpression .
+    LogicalExpression = UnaryLogicalExpression
+                      | LogicalExpression LogicalOperator UnaryLogicalExpression .
     LogicalOperator = and | or .
+    UnaryLogicalExpression = ComparisonExpression
+                           | UnaryLogicalOperator UnaryLogicalExpression .
+    UnaryLogicalOperator = not .
     ComparisonExpression = MultiplicativeExpression
                          | ComparisonExpression ComparisonOperator MultiplicativeExpression .
     ComparisonOperator = eq | neq | regexeq | regexneq .
@@ -32,7 +35,7 @@ TODO(jsternberg): Move this to the spec. This information is in the spec, but it
     PipeOperator = pipe_forward .
     UnaryExpression = PostfixExpression
                     | PrefixOperator UnaryExpression .
-    PrefixOperator = add | sub | not .
+    PrefixOperator = add | sub .
     PostfixExpression = PrimaryExpression
                       | PostfixExpression PostfixOperator .
     PostfixOperator = DotExpression
@@ -83,9 +86,12 @@ For the parser, the above grammar undergoes a process to have the left-recursion
     ExpressionStatement = Expression .
     Expression = LogicalExpression .
     ExpressionSuffix = { PostfixOperator } { PipeExpressionSuffix } { AdditiveExpressionSuffix } { MultiplicativeExpressionSuffix } { ComparisonExpressionSuffix } { LogicalExpressionSuffix } .
-    LogicalExpression = ComparisonExpression { LogicalExpressionSuffix } .
-    LogicalExpressionSuffix = LogicalOperator ComparisonExpression .
+    LogicalExpression = UnaryLogicalExpression { LogicalExpressionSuffix } .
+    LogicalExpressionSuffix = LogicalOperator UnaryLogicalExpression .
     LogicalOperator = and | or .
+    UnaryLogicalExpression = ComparisonExpression
+                           | UnaryLogicalOperator UnaryLogicalExpression .
+    UnaryLogicalOperator = not .
     ComparisonExpression = MultiplicativeExpression { ComparisonExpressionSuffix } .
     ComparisonExpressionSuffix = ComparisonOperator MultiplicativeExpr .
     ComparisonOperator = eq | neq | lt | lte | gt | gte | regexeq | regexneq .
@@ -99,7 +105,7 @@ For the parser, the above grammar undergoes a process to have the left-recursion
     PipeOperator = pipe_forward .
     UnaryExpression = PostfixExpression
                     | PrefixOperator UnaryExpression .
-    PrefixOperator = add | sub | not .
+    PrefixOperator = add | sub .
     PostfixExpression = PrimaryExpression { PostfixOperator } .
     PostfixOperator = DotExpression
                     | CallExpression

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1495,6 +1495,38 @@ a = 5.0
 			},
 		},
 		{
+			name: "logical unary operator precedence",
+			raw:  `not -1 == a`,
+			want: &ast.Program{
+				BaseNode: base("1:1", "1:12"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:12"),
+						Expression: &ast.UnaryExpression{
+							BaseNode: base("1:1", "1:12"),
+							Operator: ast.NotOperator,
+							Argument: &ast.BinaryExpression{
+								BaseNode: base("1:5", "1:12"),
+								Operator: ast.EqualOperator,
+								Left: &ast.UnaryExpression{
+									BaseNode: base("1:5", "1:7"),
+									Operator: ast.SubtractionOperator,
+									Argument: &ast.IntegerLiteral{
+										BaseNode: base("1:6", "1:7"),
+										Value:    1,
+									},
+								},
+								Right: &ast.Identifier{
+									BaseNode: base("1:11", "1:12"),
+									Name:     "a",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "arrow function called",
 			raw: `plusOne = (r) => r + 1
 			plusOne(r:5)


### PR DESCRIPTION
The unary logical expression covers the `not` keyword so that it can be
used more easily. The following expression may be used:

    not -1 == a

In the previous parser, `not` had the same precedence as the prefix
operator so it would be parsed as:

    (not (-1)) == a

This seems obviously incorrect. The `not` keyword has now been placed
right above `and` and `or` in the operator precedence and below
everything else so the above is now parsed as:

    not ((-1) == a)

This is more intuitive.