### PR TITLE
docs(parser): update the godoc for the parser

### DIFF
--- a/parser/doc.go
+++ b/parser/doc.go
@@ -1,3 +1,7 @@
-// Package parser provides a PEG parser for parsing Flux.
-// Parsing an Flux script produces an AST.
+// Package parser implements a parser for Flux source files. Input is provided
+// by a string and output is an abstract-syntax tree (AST) representing the
+// Flux source.
+//
+// The parser accepts a larger language than is syntactically permitted and
+// will embed any errors from parsing the source into the AST itself.
 package parser


### PR DESCRIPTION
This removes the mention of the PEG parser and removes the mention at
all of how the parser is implemented. That is an implementation detail
anyway.