### PR TITLE
refactor: rename ArrowFunction* -> Function

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -62,17 +62,17 @@ func (*ReturnStatement) node()     {}
 func (*OptionStatement) node()     {}
 func (*VariableAssignment) node()  {}
 
-func (*ArrayExpression) node()         {}
-func (*ArrowFunctionExpression) node() {}
-func (*BinaryExpression) node()        {}
-func (*CallExpression) node()          {}
-func (*ConditionalExpression) node()   {}
-func (*LogicalExpression) node()       {}
-func (*MemberExpression) node()        {}
-func (*IndexExpression) node()         {}
-func (*PipeExpression) node()          {}
-func (*ObjectExpression) node()        {}
-func (*UnaryExpression) node()         {}
+func (*ArrayExpression) node()       {}
+func (*FunctionExpression) node()    {}
+func (*BinaryExpression) node()      {}
+func (*CallExpression) node()        {}
+func (*ConditionalExpression) node() {}
+func (*LogicalExpression) node()     {}
+func (*MemberExpression) node()      {}
+func (*IndexExpression) node()       {}
+func (*PipeExpression) node()        {}
+func (*ObjectExpression) node()      {}
+func (*UnaryExpression) node()       {}
 
 func (*Property) node()   {}
 func (*Identifier) node() {}
@@ -245,27 +245,27 @@ type Expression interface {
 	expression()
 }
 
-func (*ArrayExpression) expression()         {}
-func (*ArrowFunctionExpression) expression() {}
-func (*BinaryExpression) expression()        {}
-func (*BooleanLiteral) expression()          {}
-func (*CallExpression) expression()          {}
-func (*ConditionalExpression) expression()   {}
-func (*DateTimeLiteral) expression()         {}
-func (*DurationLiteral) expression()         {}
-func (*FloatLiteral) expression()            {}
-func (*Identifier) expression()              {}
-func (*IntegerLiteral) expression()          {}
-func (*LogicalExpression) expression()       {}
-func (*MemberExpression) expression()        {}
-func (*IndexExpression) expression()         {}
-func (*ObjectExpression) expression()        {}
-func (*PipeExpression) expression()          {}
-func (*PipeLiteral) expression()             {}
-func (*RegexpLiteral) expression()           {}
-func (*StringLiteral) expression()           {}
-func (*UnaryExpression) expression()         {}
-func (*UnsignedIntegerLiteral) expression()  {}
+func (*ArrayExpression) expression()        {}
+func (*FunctionExpression) expression()     {}
+func (*BinaryExpression) expression()       {}
+func (*BooleanLiteral) expression()         {}
+func (*CallExpression) expression()         {}
+func (*ConditionalExpression) expression()  {}
+func (*DateTimeLiteral) expression()        {}
+func (*DurationLiteral) expression()        {}
+func (*FloatLiteral) expression()           {}
+func (*Identifier) expression()             {}
+func (*IntegerLiteral) expression()         {}
+func (*LogicalExpression) expression()      {}
+func (*MemberExpression) expression()       {}
+func (*IndexExpression) expression()        {}
+func (*ObjectExpression) expression()       {}
+func (*PipeExpression) expression()         {}
+func (*PipeLiteral) expression()            {}
+func (*RegexpLiteral) expression()          {}
+func (*StringLiteral) expression()          {}
+func (*UnaryExpression) expression()        {}
+func (*UnsignedIntegerLiteral) expression() {}
 
 // CallExpression represents a function all whose callee may be an Identifier or MemberExpression
 type CallExpression struct {
@@ -361,20 +361,20 @@ func (e *IndexExpression) Copy() Node {
 	return ne
 }
 
-type ArrowFunctionExpression struct {
+type FunctionExpression struct {
 	BaseNode
 	Params []*Property `json:"params"`
 	Body   Node        `json:"body"`
 }
 
 // Type is the abstract type
-func (*ArrowFunctionExpression) Type() string { return "ArrowFunctionExpression" }
+func (*FunctionExpression) Type() string { return "FunctionExpression" }
 
-func (e *ArrowFunctionExpression) Copy() Node {
+func (e *FunctionExpression) Copy() Node {
 	if e == nil {
 		return e
 	}
-	ne := new(ArrowFunctionExpression)
+	ne := new(FunctionExpression)
 	*ne = *e
 
 	if len(e.Params) > 0 {

--- a/ast/asttest/cmpopts.go
+++ b/ast/asttest/cmpopts.go
@@ -10,7 +10,7 @@ import (
 
 var IgnoreBaseNodeOptions = []cmp.Option{
 	cmpopts.IgnoreFields(ast.ArrayExpression{}, "BaseNode"),
-	cmpopts.IgnoreFields(ast.ArrowFunctionExpression{}, "BaseNode"),
+	cmpopts.IgnoreFields(ast.FunctionExpression{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.BinaryExpression{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.Block{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.BooleanLiteral{}, "BaseNode"),

--- a/ast/format.go
+++ b/ast/format.go
@@ -142,7 +142,7 @@ func (f *formatter) formatArrayExpression(n *ArrayExpression) {
 	f.writeRune(']')
 }
 
-func (f *formatter) formatArrowFunctionExpression(n *ArrowFunctionExpression) {
+func (f *formatter) formatFunctionExpression(n *FunctionExpression) {
 	f.writeRune('(')
 
 	sep := ", "
@@ -152,7 +152,7 @@ func (f *formatter) formatArrowFunctionExpression(n *ArrowFunctionExpression) {
 		}
 
 		// treat properties differently than in general case
-		f.formatArrowFunctionArgument(c)
+		f.formatFunctionArgument(c)
 	}
 
 	f.writeString(") =>")
@@ -319,7 +319,7 @@ func (f *formatter) formatProperty(n *Property) {
 	f.formatNode(n.Value)
 }
 
-func (f *formatter) formatArrowFunctionArgument(n *Property) {
+func (f *formatter) formatFunctionArgument(n *Property) {
 	if n.Value == nil {
 		f.formatNode(n.Key)
 		return
@@ -444,8 +444,8 @@ func (f *formatter) formatNode(n Node) {
 		f.formatDurationLiteral(n)
 	case *DateTimeLiteral:
 		f.formatDateTimeLiteral(n)
-	case *ArrowFunctionExpression:
-		f.formatArrowFunctionExpression(n)
+	case *FunctionExpression:
+		f.formatFunctionExpression(n)
 	case *Property:
 		f.formatProperty(n)
 	default:

--- a/ast/json.go
+++ b/ast/json.go
@@ -332,8 +332,8 @@ func (e *IndexExpression) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
-func (e *ArrowFunctionExpression) MarshalJSON() ([]byte, error) {
-	type Alias ArrowFunctionExpression
+func (e *FunctionExpression) MarshalJSON() ([]byte, error) {
+	type Alias FunctionExpression
 	raw := struct {
 		Type string `json:"type"`
 		*Alias
@@ -343,8 +343,8 @@ func (e *ArrowFunctionExpression) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(raw)
 }
-func (e *ArrowFunctionExpression) UnmarshalJSON(data []byte) error {
-	type Alias ArrowFunctionExpression
+func (e *FunctionExpression) UnmarshalJSON(data []byte) error {
+	type Alias FunctionExpression
 	raw := struct {
 		*Alias
 		Body json.RawMessage `json:"body"`
@@ -353,7 +353,7 @@ func (e *ArrowFunctionExpression) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if raw.Alias != nil {
-		*e = *(*ArrowFunctionExpression)(raw.Alias)
+		*e = *(*FunctionExpression)(raw.Alias)
 	}
 
 	body, err := unmarshalNode(raw.Body)
@@ -880,8 +880,8 @@ func unmarshalNode(msg json.RawMessage) (Node, error) {
 		node = new(DurationLiteral)
 	case "DateTimeLiteral":
 		node = new(DateTimeLiteral)
-	case "ArrowFunctionExpression":
-		node = new(ArrowFunctionExpression)
+	case "FunctionExpression":
+		node = new(FunctionExpression)
 	case "Property":
 		node = new(Property)
 	default:

--- a/ast/json_test.go
+++ b/ast/json_test.go
@@ -135,11 +135,11 @@ func TestJSONMarshal(t *testing.T) {
 		},
 		{
 			name: "arrow function expression",
-			node: &ast.ArrowFunctionExpression{
+			node: &ast.FunctionExpression{
 				Params: []*ast.Property{{Key: &ast.Identifier{Name: "a"}}},
 				Body:   &ast.StringLiteral{Value: "hello"},
 			},
-			want: `{"type":"ArrowFunctionExpression","params":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":null}],"body":{"type":"StringLiteral","value":"hello"}}`,
+			want: `{"type":"FunctionExpression","params":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":null}],"body":{"type":"StringLiteral","value":"hello"}}`,
 		},
 		{
 			name: "binary expression",

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -144,7 +144,7 @@ func walk(v Visitor, n Node) {
 				walk(w, e)
 			}
 		}
-	case *ArrowFunctionExpression:
+	case *FunctionExpression:
 		w := v.Visit(n)
 		if w != nil {
 			for _, e := range n.Params {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -793,7 +793,7 @@ func (p *parser) parseParenBodyExpression(lparen token.Pos) ast.Expression {
 	switch _, tok, _ := p.peek(); tok {
 	case token.RPAREN:
 		p.consume()
-		return p.parseArrowExpression(lparen, nil)
+		return p.parseFunctionExpression(lparen, nil)
 	case token.IDENT:
 		ident := p.parseIdentifier()
 		return p.parseParenIdentExpression(lparen, ident)
@@ -809,7 +809,7 @@ func (p *parser) parseParenIdentExpression(lparen token.Pos, key *ast.Identifier
 	case token.RPAREN:
 		p.consume()
 		if _, tok, _ := p.peek(); tok == token.ARROW {
-			return p.parseArrowExpression(lparen, []*ast.Property{{
+			return p.parseFunctionExpression(lparen, []*ast.Property{{
 				Key: key,
 				BaseNode: ast.BaseNode{
 					Loc: &ast.SourceLocation{
@@ -840,7 +840,7 @@ func (p *parser) parseParenIdentExpression(lparen token.Pos, key *ast.Identifier
 			params = append(params, p.parseParameterList()...)
 		}
 		p.expect(token.RPAREN)
-		return p.parseArrowExpression(lparen, params)
+		return p.parseFunctionExpression(lparen, params)
 	case token.COMMA:
 		p.consume()
 		params := []*ast.Property{{
@@ -855,7 +855,7 @@ func (p *parser) parseParenIdentExpression(lparen token.Pos, key *ast.Identifier
 		}}
 		params = append(params, p.parseParameterList()...)
 		p.expect(token.RPAREN)
-		return p.parseArrowExpression(lparen, params)
+		return p.parseFunctionExpression(lparen, params)
 	default:
 		expr := p.parseExpressionSuffix(key)
 		p.expect(token.RPAREN)
@@ -933,14 +933,14 @@ func (p *parser) parseParameter() *ast.Property {
 	return param
 }
 
-func (p *parser) parseArrowExpression(lparen token.Pos, params []*ast.Property) ast.Expression {
+func (p *parser) parseFunctionExpression(lparen token.Pos, params []*ast.Property) ast.Expression {
 	p.expect(token.ARROW)
-	return p.parseArrowBodyExpression(lparen, params)
+	return p.parseFunctionBodyExpression(lparen, params)
 }
 
-func (p *parser) parseArrowBodyExpression(lparen token.Pos, params []*ast.Property) ast.Expression {
+func (p *parser) parseFunctionBodyExpression(lparen token.Pos, params []*ast.Property) ast.Expression {
 	_, tok, _ := p.peek()
-	fn := &ast.ArrowFunctionExpression{
+	fn := &ast.FunctionExpression{
 		Params: params,
 		Body: func() ast.Node {
 			switch tok {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1502,7 +1502,7 @@ a = 5.0
 							BaseNode: base("1:1", "1:8"),
 							Name:     "plusOne",
 						},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							BaseNode: base("1:11", "1:23"),
 							Params: []*ast.Property{
 								{
@@ -1570,7 +1570,7 @@ a = 5.0
 							BaseNode: base("1:1", "1:6"),
 							Name:     "toMap",
 						},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							BaseNode: base("1:9", "1:21"),
 							Params: []*ast.Property{
 								{
@@ -1614,7 +1614,7 @@ a = 5.0
 							BaseNode: base("1:1", "1:5"),
 							Name:     "addN",
 						},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							BaseNode: base("1:8", "1:25"),
 							Params: []*ast.Property{
 								{
@@ -1668,7 +1668,7 @@ a = 5.0
 							BaseNode: base("2:13", "2:20"),
 							Name:     "plusOne",
 						},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							BaseNode: base("2:23", "2:35"),
 							Params: []*ast.Property{
 								{
@@ -1755,7 +1755,7 @@ a = 5.0
 							BaseNode: base("1:1", "1:2"),
 							Name:     "f",
 						},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							BaseNode: base("1:5", "1:38"),
 							Params: []*ast.Property{
 								{
@@ -1805,7 +1805,7 @@ a = 5.0
 							BaseNode: base("1:1", "1:2"),
 							Name:     "f",
 						},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							BaseNode: base("1:5", "4:14"),
 							Params: []*ast.Property{
 								{
@@ -1911,7 +1911,7 @@ a = 5.0
 												BaseNode: base("1:40", "1:42"),
 												Name:     "fn",
 											},
-											Value: &ast.ArrowFunctionExpression{
+											Value: &ast.FunctionExpression{
 												BaseNode: base("1:44", "1:113"),
 												Params: []*ast.Property{
 													{
@@ -2603,7 +2603,7 @@ join(tables:[a,b], on:["host"], fn: (a,b) => a["_field"] + b["_field"])`,
 												BaseNode: base("4:33", "4:35"),
 												Name:     "fn",
 											},
-											Value: &ast.ArrowFunctionExpression{
+											Value: &ast.FunctionExpression{
 												BaseNode: base("4:37", "4:71"),
 												Params: []*ast.Property{
 													{
@@ -2724,7 +2724,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
 														BaseNode: base("3:12", "3:14"),
 														Name:     "fn",
 													},
-													Value: &ast.ArrowFunctionExpression{
+													Value: &ast.FunctionExpression{
 														BaseNode: base("3:16", "3:47"),
 														Params: []*ast.Property{
 															{
@@ -2848,7 +2848,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
 														BaseNode: base("7:12", "7:14"),
 														Name:     "fn",
 													},
-													Value: &ast.ArrowFunctionExpression{
+													Value: &ast.FunctionExpression{
 														BaseNode: base("7:16", "7:47"),
 														Params: []*ast.Property{
 															{
@@ -2975,7 +2975,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
 												BaseNode: base("10:31", "10:33"),
 												Name:     "fn",
 											},
-											Value: &ast.ArrowFunctionExpression{
+											Value: &ast.FunctionExpression{
 												BaseNode: base("10:35", "10:85"),
 												Params: []*ast.Property{
 													{

--- a/semantic/analyze.go
+++ b/semantic/analyze.go
@@ -128,8 +128,8 @@ func analyzeVariableAssignment(decl *ast.VariableAssignment) (*NativeVariableAss
 
 func analyzeExpression(expr ast.Expression) (Expression, error) {
 	switch expr := expr.(type) {
-	case *ast.ArrowFunctionExpression:
-		return analyzeArrowFunctionExpression(expr)
+	case *ast.FunctionExpression:
+		return analyzeFunctionExpression(expr)
 	case *ast.CallExpression:
 		return analyzeCallExpression(expr)
 	case *ast.MemberExpression:
@@ -182,7 +182,7 @@ func analyzeLiteral(lit ast.Literal) (Literal, error) {
 	}
 }
 
-func analyzeArrowFunctionExpression(arrow *ast.ArrowFunctionExpression) (*FunctionExpression, error) {
+func analyzeFunctionExpression(arrow *ast.FunctionExpression) (*FunctionExpression, error) {
 	var parameters *FunctionParameters
 	var defaults *ObjectExpression
 	if len(arrow.Params) > 0 {

--- a/semantic/graph_test.go
+++ b/semantic/graph_test.go
@@ -138,7 +138,7 @@ func TestNew(t *testing.T) {
 				Body: []ast.Statement{
 					&ast.VariableAssignment{
 						ID: &ast.Identifier{Name: "f"},
-						Init: &ast.ArrowFunctionExpression{
+						Init: &ast.FunctionExpression{
 							Params: []*ast.Property{
 								{Key: &ast.Identifier{Name: "a"}},
 								{Key: &ast.Identifier{Name: "b"}},


### PR DESCRIPTION
There is only one type of function expression remove the redundant
description Arrow from the name.