### PR TITLE
fix(execute): terminal output functions must produce results

### DIFF
--- a/execute/executetest/output.go
+++ b/execute/executetest/output.go
@@ -1,0 +1,78 @@
+package executetest
+
+import (
+	"errors"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
+)
+
+// ToTestKind represents an side-effect producing kind for testing
+const ToTestKind = "to-test"
+
+// ToProcedureSpec defines an output operation. That is, an
+// operation that does not transform its input data but performs a
+// side effect while passing its input data through to the next op.
+type ToProcedureSpec struct{}
+
+func NewToProcedure(flux.OperationSpec, plan.Administration) (plan.ProcedureSpec, error) {
+	return &ToProcedureSpec{}, nil
+}
+
+func (s *ToProcedureSpec) Kind() plan.ProcedureKind {
+	return ToTestKind
+}
+
+func (s *ToProcedureSpec) Copy() plan.ProcedureSpec {
+	return s
+}
+
+func (s *ToProcedureSpec) Cost(inStats []plan.Statistics) (plan.Cost, plan.Statistics) {
+	return plan.Cost{}, plan.Statistics{}
+}
+
+func (s *ToProcedureSpec) Statistics() flux.Statistics {
+	return flux.Statistics{}
+}
+
+// ToTransformation simulates an output or an identity transformation
+type ToTransformation struct {
+	d execute.Dataset
+	c execute.TableBuilderCache
+}
+
+func CreateToTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	c := execute.NewTableBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, c)
+	return &ToTransformation{d: d, c: c}, d, nil
+}
+
+func (t *ToTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	if builder, new := t.c.TableBuilder(tbl.Key()); new {
+		if err := execute.AddTableCols(tbl, builder); err != nil {
+			return err
+		}
+		if err := execute.AppendTable(tbl, builder); err != nil {
+			return err
+		}
+		return nil
+	}
+	return errors.New("duplicate group key")
+}
+
+func (t *ToTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	return t.d.RetractTable(key)
+}
+
+func (t *ToTransformation) UpdateWatermark(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateWatermark(pt)
+}
+
+func (t *ToTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
+}
+
+func (t *ToTransformation) Finish(id execute.DatasetID, err error) {
+	t.d.Finish(err)
+}

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -223,6 +223,13 @@ func (v *createExecutionNodeVisitor) Visit(node plan.PlanNode) error {
 			v.es.transports = append(v.es.transports, transport)
 			executionNode.AddTransformation(transport)
 		}
+
+		if plan.HasSideEffect(spec) && len(node.Successors()) == 0 {
+			name := string(node.ID())
+			r := newResult(name)
+			v.es.results[name] = r
+			v.nodes[skipYields(node)].AddTransformation(r)
+		}
 	}
 
 	return nil

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -223,7 +223,7 @@ func (v *fluxSpecVisitor) visitOperation(o *flux.Operation) error {
 
 	// no children => no successors => root node
 	if len(v.spec.Children(o.ID)) == 0 {
-		if isYield || hasSideEffects(procedureSpec) {
+		if isYield || HasSideEffect(procedureSpec) {
 			v.plan.Roots[logicalNode] = struct{}{}
 		} else {
 			// Generate a yield node

--- a/plan/registration.go
+++ b/plan/registration.go
@@ -65,7 +65,7 @@ func createProcedureFnsFromKind(kind flux.OperationKind) ([]CreateProcedureSpec,
 
 }
 
-func hasSideEffects(spec ProcedureSpec) bool {
+func HasSideEffect(spec ProcedureSpec) bool {
 	_, ok := createProcedureFns.sideEffectKind[spec.Kind()]
 	return ok
 }


### PR DESCRIPTION
Fixes https://github.com/influxdata/platform/issues/1311

Output or side effect producing functions operate as pass-throughs.
They don't transform the data they consume. They perform their
intended side effect and then pass the data along to the next
transformation.

Previously if an output function was a terminal node in a plan,
a result transformation was not generated for that plan. All
queries must have an associated result transformation, otherwise
the query context will be cancelled immediately and execution
will be cancelled before any work for the query has been done.

With this fix, a result transformation is generated for every
terminal node in a plan. Queries with terminal output functions
will now perform their side effects before the query returns.

Note that terminal output functions will return a result
consisting of all tables that were consumed by the output.