### PR TITLE
fix(functions): suppress group push down for _time and _value

### DIFF
--- a/functions/inputs/from.go
+++ b/functions/inputs/from.go
@@ -505,17 +505,27 @@ func (MergeFromGroupRule) Rewrite(groupNode plan.PlanNode) (plan.PlanNode, bool,
 	groupSpec := groupNode.ProcedureSpec().(*transformations.GroupProcedureSpec)
 	fromSpec := fromNode.ProcedureSpec().(*FromProcedureSpec)
 
-	if !fromSpec.GroupingSet && !fromSpec.LimitSet && groupSpec.GroupMode != functions.GroupModeExcept {
-		newFromSpec := fromSpec.Copy().(*FromProcedureSpec)
-		newFromSpec.GroupingSet = true
-		newFromSpec.GroupMode = groupSpec.GroupMode
-		newFromSpec.GroupKeys = groupSpec.GroupKeys
-		merged, err := plan.MergePhysicalPlanNodes(groupNode, fromNode, newFromSpec)
-		if err != nil {
-			return nil, false, err
-		}
-		return merged, true, nil
+	if fromSpec.GroupingSet ||
+		fromSpec.LimitSet ||
+		groupSpec.GroupMode != functions.GroupModeBy {
+		return groupNode, false, nil
 	}
 
-	return groupNode, false, nil
+	for _, c := range groupSpec.GroupKeys {
+		// Storage can only do grouping over tag keys.
+		// Note: _start and _stop are okay, since storage is always implicitly grouping by them anyway.
+		if c == execute.DefaultTimeColLabel || c == execute.DefaultValueColLabel {
+			return groupNode, false, nil
+		}
+	}
+
+	newFromSpec := fromSpec.Copy().(*FromProcedureSpec)
+	newFromSpec.GroupingSet = true
+	newFromSpec.GroupMode = groupSpec.GroupMode
+	newFromSpec.GroupKeys = groupSpec.GroupKeys
+	merged, err := plan.MergePhysicalPlanNodes(groupNode, fromNode, newFromSpec)
+	if err != nil {
+		return nil, false, err
+	}
+	return merged, true, nil
 }

--- a/functions/inputs/from_test.go
+++ b/functions/inputs/from_test.go
@@ -598,6 +598,42 @@ func TestFromGroupRule(t *testing.T) {
 			},
 			NoChange: true,
 		},
+		{
+			Name: "from group _time",
+			// We should not push down group(columns: ["_time"])
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", from),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeExcept,
+						GroupKeys: []string{"_time"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
+		{
+			Name: "from group _value",
+			// We should not push down group(columns: ["_value"])
+			Rules: []plan.Rule{inputs.MergeFromGroupRule{}},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.PlanNode{
+					plan.CreatePhysicalNode("from", from),
+					plan.CreatePhysicalNode("group", &transformations.GroupProcedureSpec{
+						GroupMode: functions.GroupModeExcept,
+						GroupKeys: []string{"_value"},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			NoChange: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Storage can only group by tag keys, so Flux will need to evaluate
grouping operations over `_value` or `_time`.

Fixes #349