### PR TITLE
feat(transformations): add function assertEquals to transformations

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1363,6 +1363,30 @@ Example:
 
 **Note:** The `yield` function produces side effects.
 
+#### AssertEquals
+
+AssertEquals is a function that will test whether two streams have identical data.  It also outputs the data from the tested stream unchanged, so that this function can be used to perform in-line tests in a query.  
+
+AssertEquals has the following properties: 
+* `name` string
+    unique name given to this assertion. 
+* `got` stream
+    the stream you are testing.  May be piped-forward from another function.  
+* `want` stream
+    A copy of the expected stream. 
+
+Example: 
+
+```
+want = from(bucket: "backup-telegraf/autogen") |> range(start: -5m)
+// in-line assertion
+from(bucket: "telegraf/autogen") |> range(start: -5m) |> assertEquals(want: want)
+
+// equivalent: 
+got = from(bucket: "telegraf/autogen") |> range(start: -5m)
+assertEquals(got: got, want: want)
+```
+
 #### Aggregate operations
 
 Aggregate operations output a table for every input table they receive.

--- a/execute/allocator.go
+++ b/execute/allocator.go
@@ -48,6 +48,7 @@ func (a *Allocator) AppendBools(slice []bool, vs ...bool) []bool {
 	return s
 }
 
+// GrowBools increases the size of the input slice by n
 func (a *Allocator) GrowBools(slice []bool, n int) []bool {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -60,6 +61,14 @@ func (a *Allocator) GrowBools(slice []bool, n int) []bool {
 	diff := cap(s) - cap(slice)
 	a.account(diff, boolSize)
 	return s
+}
+
+// SliceBools reduces the input slice to slice[start:stop]
+func (a *Allocator) SliceBools(slice []bool, start, stop int) []bool {
+	origLen := len(slice)
+	slice = slice[start:stop]
+	a.Free(origLen-len(slice), boolSize)
+	return slice
 }
 
 // Ints makes a slice of int64 values.
@@ -79,6 +88,7 @@ func (a *Allocator) AppendInts(slice []int64, vs ...int64) []int64 {
 	return s
 }
 
+// GrowInts increases the size of the input slice by n
 func (a *Allocator) GrowInts(slice []int64, n int) []int64 {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -91,6 +101,14 @@ func (a *Allocator) GrowInts(slice []int64, n int) []int64 {
 	diff := cap(s) - cap(slice)
 	a.account(diff, int64Size)
 	return s
+}
+
+// SliceInts reduces the input slice to slice[start:stop]
+func (a *Allocator) SliceInts(slice []int64, start, stop int) []int64 {
+	origLen := len(slice)
+	slice = slice[start:stop]
+	a.Free(origLen-len(slice), int64Size)
+	return slice
 }
 
 // UInts makes a slice of uint64 values.
@@ -110,6 +128,7 @@ func (a *Allocator) AppendUInts(slice []uint64, vs ...uint64) []uint64 {
 	return s
 }
 
+// GrowUInts increases the size of the input slice by n
 func (a *Allocator) GrowUInts(slice []uint64, n int) []uint64 {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -122,6 +141,14 @@ func (a *Allocator) GrowUInts(slice []uint64, n int) []uint64 {
 	diff := cap(s) - cap(slice)
 	a.account(diff, uint64Size)
 	return s
+}
+
+// SliceUInts reduces the input slice to slice[start:stop]
+func (a *Allocator) SliceUInts(slice []uint64, start, stop int) []uint64 {
+	origLen := len(slice)
+	slice = slice[start:stop]
+	a.Free(origLen-len(slice), uint64Size)
+	return slice
 }
 
 // Floats makes a slice of float64 values.
@@ -141,6 +168,7 @@ func (a *Allocator) AppendFloats(slice []float64, vs ...float64) []float64 {
 	return s
 }
 
+// GrowFloats increases the size of the input slice by n
 func (a *Allocator) GrowFloats(slice []float64, n int) []float64 {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -153,6 +181,14 @@ func (a *Allocator) GrowFloats(slice []float64, n int) []float64 {
 	diff := cap(s) - cap(slice)
 	a.account(diff, float64Size)
 	return s
+}
+
+// SliceFloats reduces the input slice to slice[start:stop]
+func (a *Allocator) SliceFloats(slice []float64, start, stop int) []float64 {
+	origLen := len(slice)
+	slice = slice[start:stop]
+	a.Free(origLen-len(slice), float64Size)
+	return slice
 }
 
 // Strings makes a slice of string values.
@@ -175,6 +211,7 @@ func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
 	return s
 }
 
+// GrowStrings increases the size of the input slice by n
 func (a *Allocator) GrowStrings(slice []string, n int) []string {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -187,6 +224,14 @@ func (a *Allocator) GrowStrings(slice []string, n int) []string {
 	diff := cap(s) - cap(slice)
 	a.account(diff, stringSize)
 	return s
+}
+
+// SliceStrings reduces the input slice to slice[start:stop]
+func (a *Allocator) SliceStrings(slice []string, start, stop int) []string {
+	origLen := len(slice)
+	slice = slice[start:stop]
+	a.Free(origLen-len(slice), stringSize)
+	return slice
 }
 
 // Times makes a slice of Time values.
@@ -206,6 +251,7 @@ func (a *Allocator) AppendTimes(slice []Time, vs ...Time) []Time {
 	return s
 }
 
+// GrowTimes increases the size of the input slice by n
 func (a *Allocator) GrowTimes(slice []Time, n int) []Time {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -218,4 +264,12 @@ func (a *Allocator) GrowTimes(slice []Time, n int) []Time {
 	diff := cap(s) - cap(slice)
 	a.account(diff, timeSize)
 	return s
+}
+
+// SliceTimes reduces the input slice to slice[start:stop]
+func (a *Allocator) SliceTimes(slice []Time, start, stop int) []Time {
+	origLen := len(slice)
+	slice = slice[start:stop]
+	a.Free(origLen-len(slice), timeSize)
+	return slice
 }

--- a/execute/allocator.go
+++ b/execute/allocator.go
@@ -48,7 +48,6 @@ func (a *Allocator) AppendBools(slice []bool, vs ...bool) []bool {
 	return s
 }
 
-// GrowBools increases the size of the input slice by n
 func (a *Allocator) GrowBools(slice []bool, n int) []bool {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -61,14 +60,6 @@ func (a *Allocator) GrowBools(slice []bool, n int) []bool {
 	diff := cap(s) - cap(slice)
 	a.account(diff, boolSize)
 	return s
-}
-
-// SliceBools reduces the input slice to slice[start:stop]
-func (a *Allocator) SliceBools(slice []bool, start, stop int) []bool {
-	origLen := len(slice)
-	slice = slice[start:stop]
-	a.Free(origLen-len(slice), boolSize)
-	return slice
 }
 
 // Ints makes a slice of int64 values.
@@ -88,7 +79,6 @@ func (a *Allocator) AppendInts(slice []int64, vs ...int64) []int64 {
 	return s
 }
 
-// GrowInts increases the size of the input slice by n
 func (a *Allocator) GrowInts(slice []int64, n int) []int64 {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -101,14 +91,6 @@ func (a *Allocator) GrowInts(slice []int64, n int) []int64 {
 	diff := cap(s) - cap(slice)
 	a.account(diff, int64Size)
 	return s
-}
-
-// SliceInts reduces the input slice to slice[start:stop]
-func (a *Allocator) SliceInts(slice []int64, start, stop int) []int64 {
-	origLen := len(slice)
-	slice = slice[start:stop]
-	a.Free(origLen-len(slice), int64Size)
-	return slice
 }
 
 // UInts makes a slice of uint64 values.
@@ -128,7 +110,6 @@ func (a *Allocator) AppendUInts(slice []uint64, vs ...uint64) []uint64 {
 	return s
 }
 
-// GrowUInts increases the size of the input slice by n
 func (a *Allocator) GrowUInts(slice []uint64, n int) []uint64 {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -141,14 +122,6 @@ func (a *Allocator) GrowUInts(slice []uint64, n int) []uint64 {
 	diff := cap(s) - cap(slice)
 	a.account(diff, uint64Size)
 	return s
-}
-
-// SliceUInts reduces the input slice to slice[start:stop]
-func (a *Allocator) SliceUInts(slice []uint64, start, stop int) []uint64 {
-	origLen := len(slice)
-	slice = slice[start:stop]
-	a.Free(origLen-len(slice), uint64Size)
-	return slice
 }
 
 // Floats makes a slice of float64 values.
@@ -168,7 +141,6 @@ func (a *Allocator) AppendFloats(slice []float64, vs ...float64) []float64 {
 	return s
 }
 
-// GrowFloats increases the size of the input slice by n
 func (a *Allocator) GrowFloats(slice []float64, n int) []float64 {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -181,14 +153,6 @@ func (a *Allocator) GrowFloats(slice []float64, n int) []float64 {
 	diff := cap(s) - cap(slice)
 	a.account(diff, float64Size)
 	return s
-}
-
-// SliceFloats reduces the input slice to slice[start:stop]
-func (a *Allocator) SliceFloats(slice []float64, start, stop int) []float64 {
-	origLen := len(slice)
-	slice = slice[start:stop]
-	a.Free(origLen-len(slice), float64Size)
-	return slice
 }
 
 // Strings makes a slice of string values.
@@ -211,7 +175,6 @@ func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
 	return s
 }
 
-// GrowStrings increases the size of the input slice by n
 func (a *Allocator) GrowStrings(slice []string, n int) []string {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -224,14 +187,6 @@ func (a *Allocator) GrowStrings(slice []string, n int) []string {
 	diff := cap(s) - cap(slice)
 	a.account(diff, stringSize)
 	return s
-}
-
-// SliceStrings reduces the input slice to slice[start:stop]
-func (a *Allocator) SliceStrings(slice []string, start, stop int) []string {
-	origLen := len(slice)
-	slice = slice[start:stop]
-	a.Free(origLen-len(slice), stringSize)
-	return slice
 }
 
 // Times makes a slice of Time values.
@@ -251,7 +206,6 @@ func (a *Allocator) AppendTimes(slice []Time, vs ...Time) []Time {
 	return s
 }
 
-// GrowTimes increases the size of the input slice by n
 func (a *Allocator) GrowTimes(slice []Time, n int) []Time {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
@@ -264,12 +218,4 @@ func (a *Allocator) GrowTimes(slice []Time, n int) []Time {
 	diff := cap(s) - cap(slice)
 	a.account(diff, timeSize)
 	return s
-}
-
-// SliceTimes reduces the input slice to slice[start:stop]
-func (a *Allocator) SliceTimes(slice []Time, start, stop int) []Time {
-	origLen := len(slice)
-	slice = slice[start:stop]
-	a.Free(origLen-len(slice), timeSize)
-	return slice
 }

--- a/execute/table.go
+++ b/execute/table.go
@@ -3,10 +3,10 @@ package execute
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"sort"
 	"sync/atomic"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -1,0 +1,169 @@
+package execute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+)
+
+func TestTablesEqual(t *testing.T) {
+
+	testCases := []struct {
+		skip    bool
+		name    string
+		data0   *executetest.Table // data from parent 0
+		data1   *executetest.Table // data from parent 1
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "simple equality",
+
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), 3.0},
+				},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), 3.0},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "left empty",
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), 3.0},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "right empty",
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), 3.0},
+				},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{},
+			},
+			want: false,
+		},
+		{
+			name: "left short",
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+				},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), 3.0},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "right short",
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), 3.0},
+				},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip {
+				t.Skip()
+			}
+
+			// this is used to normalize tables
+			tc.data0.Key()
+			tc.data1.Key()
+
+			equal, err := execute.TablesEqual(tc.data0, tc.data1, executetest.UnlimitedAllocator)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal(fmt.Errorf("case %s expected an error, got none", tc.name))
+				} else {
+					return
+				}
+
+			} else if !equal {
+				t.Errorf("%s: expected equal tables, got false", tc.name)
+			}
+		})
+	}
+}

--- a/functions/transformations/assert_equals.go
+++ b/functions/transformations/assert_equals.go
@@ -3,11 +3,11 @@ package transformations
 import (
 	"errors"
 	"fmt"
-	"github.com/influxdata/flux/memory"
 	"sync"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )

--- a/functions/transformations/assert_equals.go
+++ b/functions/transformations/assert_equals.go
@@ -1,0 +1,239 @@
+package transformations
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
+)
+
+const AssertEqualsKind = "assertEquals"
+
+type AssertEqualsOpSpec struct {
+	Name string `json:"name"`
+}
+
+func (s *AssertEqualsOpSpec) Kind() flux.OperationKind {
+	return AssertEqualsKind
+}
+
+func init() {
+	assertEqualsSignature := semantic.FunctionPolySignature{
+		Parameters: map[string]semantic.PolyType{
+			"name": semantic.String,
+			"got":  flux.TableObjectType,
+			"want": flux.TableObjectType,
+		},
+		Required: semantic.LabelSet{"name", "got", "want"},
+		Return:   flux.TableObjectType,
+	}
+
+	flux.RegisterFunction(AssertEqualsKind, createAssertEqualsOpSpec, assertEqualsSignature)
+	flux.RegisterOpSpec(AssertEqualsKind, newAssertEqualsOp)
+	plan.RegisterProcedureSpec(AssertEqualsKind, newAssertEqualsProcedure, AssertEqualsKind)
+	execute.RegisterTransformation(AssertEqualsKind, createAssertEqualsTransformation)
+}
+
+func createAssertEqualsOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	t, err := args.GetRequiredObject("got")
+	if err != nil {
+		return nil, err
+	}
+	p, ok := t.(*flux.TableObject)
+	if !ok {
+		err = errors.New("got input to assertEquals is not a table object")
+	}
+	a.AddParent(p)
+
+	t, err = args.GetRequiredObject("want")
+	if err != nil {
+		return nil, err
+	}
+	p, ok = t.(*flux.TableObject)
+	if !ok {
+		err = errors.New("want input to assertEquals is not a table object")
+	}
+	a.AddParent(p)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var name string
+	if name, err = args.GetRequiredString("name"); err != nil {
+		return nil, err
+	}
+
+	return &AssertEqualsOpSpec{Name: name}, nil
+}
+
+func newAssertEqualsOp() flux.OperationSpec {
+	return new(AssertEqualsOpSpec)
+}
+
+type AssertEqualsProcedureSpec struct {
+	plan.DefaultCost
+	Name string
+}
+
+func (s *AssertEqualsProcedureSpec) Kind() plan.ProcedureKind {
+	return AssertEqualsKind
+}
+
+func (s *AssertEqualsProcedureSpec) Copy() plan.ProcedureSpec {
+	return &AssertEqualsProcedureSpec{}
+}
+
+func newAssertEqualsProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*AssertEqualsOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+	return &AssertEqualsProcedureSpec{Name: spec.Name}, nil
+}
+
+type AssertEqualsTransformation struct {
+	mu sync.Mutex
+
+	gotParent  *assertEqualsParentState
+	wantParent *assertEqualsParentState
+
+	d     execute.Dataset
+	cache execute.TableBuilderCache
+
+	name string
+}
+
+type assertEqualsParentState struct {
+	id         execute.DatasetID
+	mark       execute.Time
+	processing execute.Time
+	finished   bool
+}
+
+func createAssertEqualsTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	if len(a.Parents()) != 2 {
+		return nil, nil, errors.New("assertEquals should have exactly 2 parents")
+	}
+
+	cache := execute.NewTableBuilderCache(a.Allocator())
+	dataset := execute.NewDataset(id, mode, cache)
+	pspec, ok := spec.(*AssertEqualsProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", pspec)
+	}
+
+	transform := NewAssertEqualsTransformation(dataset, cache, pspec, a.Parents()[0], a.Parents()[1])
+
+	return transform, dataset, nil
+}
+
+func NewAssertEqualsTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *AssertEqualsProcedureSpec, gotID, wantID execute.DatasetID) *AssertEqualsTransformation {
+	return &AssertEqualsTransformation{
+		gotParent:  &assertEqualsParentState{id: gotID},
+		wantParent: &assertEqualsParentState{id: wantID},
+		d:          d,
+		cache:      cache,
+		name:       spec.Name,
+	}
+}
+
+func (t *AssertEqualsTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	panic("not implemented")
+}
+
+func (t *AssertEqualsTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var colMap = make([]int, 0, len(tbl.Cols()))
+	var err error
+	builder, created := t.cache.TableBuilder(tbl.Key())
+	if created {
+		colMap, err = execute.AddNewTableCols(tbl, builder, colMap)
+		if err != nil {
+			return err
+		}
+		if err := execute.AppendMappedTable(tbl, builder, colMap); err != nil {
+			return err
+		}
+	} else {
+		cacheTable, err := builder.Table()
+		if err != nil {
+			return err
+		}
+		if ok, err := execute.TablesEqual(cacheTable, tbl); !ok {
+			return fmt.Errorf("test %s: tables not equal", t.name)
+		} else if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t *AssertEqualsTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	min := mark
+	if t.gotParent.id == id {
+		t.gotParent.mark = mark
+		if t.wantParent.mark < min {
+			min = t.wantParent.mark
+		}
+	} else if t.wantParent.id == id {
+		t.wantParent.mark = mark
+		if t.gotParent.mark < min {
+			min = t.gotParent.mark
+		}
+	} else {
+		return fmt.Errorf("unexpected dataset id: %v", id)
+	}
+
+	return t.d.UpdateWatermark(min)
+}
+
+func (t *AssertEqualsTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	min := pt
+	if t.gotParent.id == id {
+		t.gotParent.processing = pt
+		if t.wantParent.processing < min {
+			min = t.wantParent.processing
+		}
+	} else if t.wantParent.id == id {
+		t.wantParent.processing = pt
+		if t.gotParent.processing < min {
+			min = t.gotParent.processing
+		}
+	} else {
+		return fmt.Errorf("unexpected dataset id: %v", id)
+	}
+	return t.d.UpdateProcessingTime(min)
+}
+
+func (t *AssertEqualsTransformation) Finish(id execute.DatasetID, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.gotParent.id == id {
+		t.gotParent.finished = true
+	} else if t.wantParent.id == id {
+		t.wantParent.finished = true
+	} else {
+		t.d.Finish(fmt.Errorf("unexpected dataset id: %v", id))
+	}
+
+	if err != nil {
+		t.d.Finish(err)
+	}
+
+	if t.gotParent.finished && t.wantParent.finished {
+		t.d.Finish(nil)
+	}
+}

--- a/functions/transformations/assert_equals_test.go
+++ b/functions/transformations/assert_equals_test.go
@@ -1,15 +1,16 @@
 package transformations_test
 
 import (
-	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/flux/plan"
+	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/functions/transformations"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/querytest"
 )
 
@@ -28,12 +29,13 @@ func TestAssertEqualsOperation_Marshaling(t *testing.T) {
 func TestAssertEquals_Process(t *testing.T) {
 
 	testCases := []struct {
-		skip  bool
-		name  string
-		spec  *transformations.AssertEqualsProcedureSpec
-		data0 []*executetest.Table // data from parent 0
-		data1 []*executetest.Table // data from parent 1
-		want  []*executetest.Table
+		skip    bool
+		name    string
+		spec    *transformations.AssertEqualsProcedureSpec
+		data0   []*executetest.Table // data from parent 0
+		data1   []*executetest.Table // data from parent 1
+		want    []*executetest.Table
+		wantErr bool
 	}{
 		{
 			name: "simple equality",
@@ -81,6 +83,384 @@ func TestAssertEquals_Process(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "left empty",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "right empty",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "left short",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "right short",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "multiple Tables",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0},
+						{execute.Time(2), 20.0},
+						{execute.Time(3), 30.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 100.0},
+						{execute.Time(2), 200.0},
+						{execute.Time(3), 300.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0},
+						{execute.Time(2), 20.0},
+						{execute.Time(3), 30.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 100.0},
+						{execute.Time(2), 200.0},
+						{execute.Time(3), 300.0},
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+		},
+		{
+			name: "left short one table",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0},
+						{execute.Time(2), 20.0},
+						{execute.Time(3), 30.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0},
+						{execute.Time(2), 20.0},
+						{execute.Time(3), 30.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 100.0},
+						{execute.Time(2), 200.0},
+						{execute.Time(3), 300.0},
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+		},
+		{
+			name: "right short one table",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0},
+						{execute.Time(2), 20.0},
+						{execute.Time(3), 30.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 100.0},
+						{execute.Time(2), 200.0},
+						{execute.Time(3), 300.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0},
+						{execute.Time(2), 20.0},
+						{execute.Time(3), 30.0},
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -100,7 +480,7 @@ func TestAssertEquals_Process(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(execute.DefaultTriggerSpec)
-			jt := transformations.NewAssertEqualsTransformation(d, c, tc.spec, parents[0], parents[1])
+			jt := transformations.NewAssertEqualsTransformation(d, c, tc.spec, parents[0], parents[1], executetest.UnlimitedAllocator)
 
 			executetest.NormalizeTables(tc.data0)
 			executetest.NormalizeTables(tc.data1)
@@ -108,17 +488,27 @@ func TestAssertEquals_Process(t *testing.T) {
 			if len(tc.data1) > l {
 				l = len(tc.data1)
 			}
+			var err error
 			for i := 0; i < l; i++ {
 				if i < len(tc.data0) {
-					if err := jt.Process(parents[0], tc.data0[i]); err != nil {
-						t.Fatal(err)
+					if err = jt.Process(parents[0], tc.data0[i]); err != nil {
+						break
 					}
 				}
 				if i < len(tc.data1) {
-					if err := jt.Process(parents[1], tc.data1[i]); err != nil {
-						t.Fatal(err)
+					if err = jt.Process(parents[1], tc.data1[i]); err != nil {
+						break
 					}
 				}
+			}
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal(fmt.Errorf("case %s expected an error, got none", tc.name))
+				} else {
+					return
+				}
+
 			}
 
 			got, err := executetest.TablesFromCache(c)

--- a/functions/transformations/assert_equals_test.go
+++ b/functions/transformations/assert_equals_test.go
@@ -1,0 +1,140 @@
+package transformations_test
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/plan"
+	"sort"
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/functions/transformations"
+	"github.com/influxdata/flux/querytest"
+)
+
+func TestAssertEqualsOperation_Marshaling(t *testing.T) {
+	data := []byte(`{"id":"assertEquals","kind":"assertEquals","spec":{"name":"simple"}}`)
+	op := &flux.Operation{
+		ID: "assertEquals",
+		Spec: &transformations.AssertEqualsOpSpec{
+			Name: "simple",
+		},
+	}
+
+	querytest.OperationMarshalingTestHelper(t, data, op)
+}
+
+func TestAssertEquals_Process(t *testing.T) {
+
+	testCases := []struct {
+		skip  bool
+		name  string
+		spec  *transformations.AssertEqualsProcedureSpec
+		data0 []*executetest.Table // data from parent 0
+		data1 []*executetest.Table // data from parent 1
+		want  []*executetest.Table
+	}{
+		{
+			name: "simple equality",
+			spec: &transformations.AssertEqualsProcedureSpec{
+				DefaultCost: plan.DefaultCost{},
+				Name:        "simple",
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0},
+						{execute.Time(2), 2.0},
+						{execute.Time(3), 3.0},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip {
+				t.Skip()
+			}
+
+			id0 := executetest.RandomDatasetID()
+			id1 := executetest.RandomDatasetID()
+
+			parents := []execute.DatasetID{
+				execute.DatasetID(id0),
+				execute.DatasetID(id1),
+			}
+
+			d := executetest.NewDataset(executetest.RandomDatasetID())
+			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
+			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			jt := transformations.NewAssertEqualsTransformation(d, c, tc.spec, parents[0], parents[1])
+
+			executetest.NormalizeTables(tc.data0)
+			executetest.NormalizeTables(tc.data1)
+			l := len(tc.data0)
+			if len(tc.data1) > l {
+				l = len(tc.data1)
+			}
+			for i := 0; i < l; i++ {
+				if i < len(tc.data0) {
+					if err := jt.Process(parents[0], tc.data0[i]); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if i < len(tc.data1) {
+					if err := jt.Process(parents[1], tc.data1[i]); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			got, err := executetest.TablesFromCache(c)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			executetest.NormalizeTables(got)
+			executetest.NormalizeTables(tc.want)
+
+			sort.Sort(executetest.SortedTables(got))
+			sort.Sort(executetest.SortedTables(tc.want))
+
+			if !cmp.Equal(tc.want, got) {
+				t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}

--- a/functions/transformations/helpers.go
+++ b/functions/transformations/helpers.go
@@ -18,4 +18,11 @@ aggregateWindow = (every, fn, columns=["_value"], timeSrc="_stop",timeDst="_time
         |> fn(columns:columns)
         |> duplicate(column:timeSrc,as:timeDst)
         |> window(every:inf, timeColumn:timeDst)
+
+testingTest = (name, load, infile, outfile, test) => {
+  input = load(file: infile)
+  got = input |> test()
+  want = load(file: outfile)
+  return assertEquals(name: name, want: want, got: got)
+}
 `

--- a/functions/transformations/testdata/simple_max.flux
+++ b/functions/transformations/testdata/simple_max.flux
@@ -1,6 +1,8 @@
-from(bucket:"test")
+simpleMax = (table=<-) =>
+  table
   |> range(start:2018-04-17T00:00:00Z)
   |> group(columns: ["_measurement", "_start"])
   |> max(column: "_value")
   |> map(fn: (r) => ({_time: r._time,max:r._value}))
-  |> yield(name:"0")
+
+testingTest(name: "simple_max", load: fromCSV, infile: "testdata/simple_max.in.csv", outfile: "testdata/simple_max.out.csv", test: simpleMax)

--- a/functions/transformations/testdata/simple_max.out.csv
+++ b/functions/transformations/testdata/simple_max.out.csv
@@ -1,6 +1,6 @@
 #datatype,string,long,dateTime:RFC3339,string,dateTime:RFC3339,double
 #group,false,false,true,true,false,false
-#default,0,,,,,
+#default,_result,,,,,
 ,result,table,_start,_measurement,_time,max
 ,,0,2018-04-17T00:00:00Z,m1,2018-04-17T00:00:01Z,43
 


### PR DESCRIPTION
* added assertEquals, as well as extensions to the execute package to support the feautre.
* added builtin helper function testingTest to cover common usage of assertEquals
* updated functions/transformations/simple_max.flux to demo testingTest usage.
* added unit tests for assertEquals

closes #358 