### PR TITLE
fix(semantic): collision between external and fresh type vars

### DIFF
--- a/semantic/constraints.go
+++ b/semantic/constraints.go
@@ -96,7 +96,11 @@ func (v ConstraintGenerator) typeof(n Node) (PolyType, error) {
 		ftv := n.ExternType.freeVars(nil)
 		subst := make(Substitution, len(ftv))
 		for _, tv := range ftv {
-			subst[tv] = v.cs.f.Fresh()
+			f := v.cs.f.Fresh()
+			for ftv.contains(f) {
+				f = v.cs.f.Fresh()
+			}
+			subst[tv] = f
 		}
 		t := subst.ApplyType(n.ExternType)
 		// Check if this type knows about its kind constraints

--- a/semantic/inference_test.go
+++ b/semantic/inference_test.go
@@ -448,6 +448,65 @@ identity(x:identity)(x:2)
 			},
 		},
 		{
+			name: "extern type variables",
+			node: &semantic.Extern{
+				Assignments: []*semantic.ExternalVariableAssignment{
+					{
+						Identifier: &semantic.Identifier{Name: "f"},
+						ExternType: semantic.NewFunctionPolyType(
+							semantic.FunctionPolySignature{
+								Return: semantic.Tvar(3),
+							},
+						),
+					},
+					{
+						Identifier: &semantic.Identifier{Name: "g"},
+						ExternType: semantic.NewFunctionPolyType(
+							semantic.FunctionPolySignature{
+								Return: semantic.Tvar(5),
+							},
+						),
+					},
+				},
+				Block: &semantic.ExternBlock{
+					Node: &semantic.Program{
+						Body: []semantic.Statement{
+							&semantic.NativeVariableAssignment{
+								Identifier: &semantic.Identifier{Name: "a"},
+								Init:       &semantic.IdentifierExpression{Name: "f"},
+							},
+							&semantic.NativeVariableAssignment{
+								Identifier: &semantic.Identifier{Name: "b"},
+								Init:       &semantic.IdentifierExpression{Name: "g"},
+							},
+						},
+					},
+				},
+			},
+			solution: &solutionVisitor{
+				f: func(node semantic.Node) semantic.PolyType {
+					f := semantic.NewFunctionPolyType(
+						semantic.FunctionPolySignature{
+							Return: semantic.Tvar(7),
+						})
+					g := semantic.NewFunctionPolyType(
+						semantic.FunctionPolySignature{
+							Return: semantic.Tvar(8),
+						})
+					switch n := node.(type) {
+					case *semantic.IdentifierExpression:
+						switch n.Name {
+						case "f":
+							return f
+						case "g":
+							return g
+						}
+					}
+					return nil
+				},
+			},
+		},
+		{
 			name: "nested functions",
 			script: `
 (r) => {


### PR DESCRIPTION
Fixes #263.

Type inference replaces any external free type variables with new
fresh type variables. The result is a new but completely equivalent
type expression. Previously during the substitution process
collisions could occur between the names of old type variables and
the names of the new freshly generated type variables. This would
render the new type expression invalid.

To remedy this problem, fresh type variables are now generated
before being substituted into the original type expression. If
there is a collision, that type variable is discarded and a new
one is generated.

Note: Not sure how to create a test case for this. Although the flaky test from #263 that this
PR fixes is no longer flaky.