### PR TITLE
refactor(inputs): better error message for unbounded from

### DIFF
--- a/functions/inputs/from.go
+++ b/functions/inputs/from.go
@@ -168,7 +168,13 @@ func (s *FromProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bou
 
 func (s FromProcedureSpec) PostPhysicalValidate(id plan.NodeID) error {
 	if !s.BoundsSet || (s.Bounds.Start.IsZero() && s.Bounds.Stop.IsZero()) {
-		return fmt.Errorf(`result '%s' is unbounded. Add a 'range' call to bound the query`, id)
+		var bucket string
+		if len(s.Bucket) > 0 {
+			bucket = s.Bucket
+		} else {
+			bucket = s.BucketID
+		}
+		return fmt.Errorf(`%s: results from "%s" must be bounded`, id, bucket)
 	}
 
 	return nil


### PR DESCRIPTION
Sometimes it happens that the planner cannot push `range` to storage and complains that the query is unbounded:

```
result from0 is unbounded. Add a 'range' call to bound the query
```

Now the message helps the user to better understand what's happening and proposes solutions:

```
impossible to bound results from "telegraf/autogen" (from0).
Add a 'range' call to bound the query or move any 'range' call as close as possible to 'from'
```

Fixes #302 