### PR TITLE
fix(control): make controller return planner failures

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -77,7 +77,7 @@ func runHttp() {
 		q, err := querier.c.Query(ctx, pr.Compiler)
 		if err != nil {
 			log.Println("error executing query:", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		defer func() {


### PR DESCRIPTION
Previously planner errors would be returned at runtime, even though
execution had not yet begun.  This change makes it so that errors will
be returned (with http error code 400) for unplannable queries.

Fixes #149