### PR TITLE
fix(control): Cancel all queries after timeout elapses.

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -268,8 +268,18 @@ func (c *Controller) Shutdown(ctx context.Context) error {
 	case <-c.done:
 		return nil
 	case <-ctx.Done():
+		c.CancelAll()
 		return ctx.Err()
 	}
+}
+
+// CancelAll cancels all executing queries.
+func (c *Controller) CancelAll() {
+	c.queriesMu.RLock()
+	for _, q := range c.queries {
+		q.Cancel()
+	}
+	c.queriesMu.RUnlock()
 }
 
 func (c *Controller) run() {


### PR DESCRIPTION
This commit cancels all queries if a shutdown has occurred but has not completed before `ctx.Done()` returns. This can occur when a long running query is executing during shutdown.