### PR TITLE
fix(scanner): makefile for generating the scanner after clean was incorrect

### DIFF
--- a/internal/scanner/Makefile
+++ b/internal/scanner/Makefile
@@ -2,7 +2,7 @@ GO_GENERATE := go generate $(GO_ARGS)
 
 all: scanner.gen.go
 
-scanner.gen.go: scanner.rl unicode.rl unicode2ragel.rb
+scanner.gen.go: scanner.rl unicode2ragel.rb
 	$(GO_GENERATE) -x
 
 clean:


### PR DESCRIPTION
The problem is that the Makefile target for generating the scanner had
`unicode.rl` as a dependency in it. This file gets generated by the same
command so I didn't want to include it twice because then we would call
`go generate` twice. Since `unicode.rl` is an intermediate output,
removing it from the list of inputs and keeping `unicode2ragel.rb` as an
input works for the intended purpose.

Fixes #380.