### PR TITLE
fix(parser): do not panic with unbalanced parenthesis

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -296,10 +296,10 @@ func (p *parser) parseExpressionStatement() *ast.ExpressionStatement {
 func (p *parser) parseBlock() *ast.Block {
 	start, _ := p.expect(token.LBRACE)
 	stmts := p.parseStatementList(token.RBRACE)
-	end, _ := p.expect(token.RBRACE)
+	end, rbrace := p.expect(token.RBRACE)
 	return &ast.Block{
 		Body:     stmts,
-		BaseNode: p.position(start, end+1),
+		BaseNode: p.position(start, end+token.Pos(len(rbrace))),
 	}
 }
 
@@ -644,13 +644,13 @@ func (p *parser) parseDotExpression(expr ast.Expression) ast.Expression {
 func (p *parser) parseCallExpression(callee ast.Expression) ast.Expression {
 	p.expect(token.LPAREN)
 	params := p.parsePropertyList()
-	end, _ := p.expect(token.RPAREN)
+	end, rparen := p.expect(token.RPAREN)
 	expr := &ast.CallExpression{
 		Callee: callee,
 		BaseNode: ast.BaseNode{
 			Loc: p.sourceLocation(
 				locStart(callee),
-				p.s.File().Position(end+1),
+				p.s.File().Position(end+token.Pos(len(rparen))),
 			),
 		},
 	}
@@ -673,7 +673,7 @@ func (p *parser) parseCallExpression(callee ast.Expression) ast.Expression {
 func (p *parser) parseIndexExpression(callee ast.Expression) ast.Expression {
 	p.expect(token.LBRACK)
 	expr := p.parseExpression()
-	end, _ := p.expect(token.RBRACK)
+	end, rbrack := p.expect(token.RBRACK)
 	if lit, ok := expr.(*ast.StringLiteral); ok {
 		return &ast.MemberExpression{
 			Object:   callee,
@@ -681,7 +681,7 @@ func (p *parser) parseIndexExpression(callee ast.Expression) ast.Expression {
 			BaseNode: ast.BaseNode{
 				Loc: p.sourceLocation(
 					locStart(callee),
-					p.s.File().Position(end+1),
+					p.s.File().Position(end+token.Pos(len(rbrack))),
 				),
 			},
 		}
@@ -692,7 +692,7 @@ func (p *parser) parseIndexExpression(callee ast.Expression) ast.Expression {
 		BaseNode: ast.BaseNode{
 			Loc: p.sourceLocation(
 				locStart(callee),
-				p.s.File().Position(end+1),
+				p.s.File().Position(end+token.Pos(len(rbrack))),
 			),
 		},
 	}
@@ -803,20 +803,20 @@ func (p *parser) parsePipeLiteral() *ast.PipeLiteral {
 func (p *parser) parseArrayLiteral() ast.Expression {
 	start, _ := p.expect(token.LBRACK)
 	exprs := p.parseExpressionList()
-	end, _ := p.expect(token.RBRACK)
+	end, rbrack := p.expect(token.RBRACK)
 	return &ast.ArrayExpression{
 		Elements: exprs,
-		BaseNode: p.position(start, end+1),
+		BaseNode: p.position(start, end+token.Pos(len(rbrack))),
 	}
 }
 
 func (p *parser) parseObjectLiteral() ast.Expression {
 	start, _ := p.expect(token.LBRACE)
 	properties := p.parsePropertyList()
-	end, _ := p.expect(token.RBRACE)
+	end, rbrace := p.expect(token.RBRACE)
 	return &ast.ObjectExpression{
 		Properties: properties,
-		BaseNode:   p.position(start, end+1),
+		BaseNode:   p.position(start, end+token.Pos(len(rbrace))),
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -86,7 +86,7 @@ func (s *Scanner) scan(cs int) (pos token.Pos, tok token.Token, lit string) {
 		s.p = s.ts + size
 		return s.f.Pos(s.ts), token.ILLEGAL, fmt.Sprintf("%c", ch)
 	} else if s.token == token.ILLEGAL && s.p == s.eof {
-		return s.f.Pos(s.ts), token.EOF, ""
+		return s.f.Pos(len(s.data)), token.EOF, ""
 	}
 	return s.f.Pos(s.ts), s.token, string(s.data[s.ts:s.te])
 }

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -480,3 +480,42 @@ line3`,
 		})
 	}
 }
+
+func TestScanner_EOF_Position(t *testing.T) {
+	f := token.NewFile("query.flux", 1)
+	s := scanner.New(f, []byte(`a`))
+
+	pos, tok, lit := s.Scan()
+	if want, got := token.Pos(1), pos; want != got {
+		t.Errorf("unexpected position -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if want, got := token.IDENT, tok; want != got {
+		t.Errorf("unexpected token -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if want, got := "a", lit; want != got {
+		t.Errorf("unexpected literal -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+
+	pos, tok, lit = s.Scan()
+	if want, got := token.Pos(2), pos; want != got {
+		t.Errorf("unexpected position -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if want, got := token.EOF, tok; want != got {
+		t.Errorf("unexpected token -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if want, got := "", lit; want != got {
+		t.Errorf("unexpected literal -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+
+	// Multiple scans of the EOF token should continue producing the same value.
+	pos, tok, lit = s.Scan()
+	if want, got := token.Pos(2), pos; want != got {
+		t.Errorf("unexpected position -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if want, got := token.EOF, tok; want != got {
+		t.Errorf("unexpected token -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if want, got := "", lit; want != got {
+		t.Errorf("unexpected literal -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+}


### PR DESCRIPTION
A set of unbalanced parenthesis caused the new parser to eventually hit
an EOF while it was looking for it. Because it assumed it found the
right parenthesis, it advanced the end position beyond the end of the
slice and caused a runtime panic.

This change does two things:

1. It verifies that the EOF token will have the proper position information.
2. The parser uses the literal length returned by `expect` when finding the end position.