### PR TITLE
refactor(plan): make physical planning convert logical nodes to physical

### DIFF
--- a/plan/heuristic_planner_test.go
+++ b/plan/heuristic_planner_test.go
@@ -19,7 +19,7 @@ func TestPlanTraversal(t *testing.T) {
 			name: "simple",
 			//        0
 			plan: plantest.PlanSpec{
-				Nodes: []plan.PlanNode{plantest.CreateLogicalMockNode("0")},
+				Nodes: []plan.PlanNode{plantest.CreatePhysicalMockNode("0")},
 			},
 			nodeIDs: []plan.NodeID{"0"},
 		},
@@ -30,8 +30,8 @@ func TestPlanTraversal(t *testing.T) {
 			//        0
 			plan: plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plantest.CreateLogicalMockNode("0"),
-					plantest.CreateLogicalMockNode("1"),
+					plantest.CreatePhysicalMockNode("0"),
+					plantest.CreatePhysicalMockNode("1"),
 				},
 				Edges: [][2]int{
 					{0, 1},
@@ -46,10 +46,10 @@ func TestPlanTraversal(t *testing.T) {
 			//        0    2
 			plan: plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plantest.CreateLogicalMockNode("0"),
-					plantest.CreateLogicalMockNode("1"),
-					plantest.CreateLogicalMockNode("2"),
-					plantest.CreateLogicalMockNode("3"),
+					plantest.CreatePhysicalMockNode("0"),
+					plantest.CreatePhysicalMockNode("1"),
+					plantest.CreatePhysicalMockNode("2"),
+					plantest.CreatePhysicalMockNode("3"),
 				},
 				Edges: [][2]int{
 					{0, 1},
@@ -67,11 +67,11 @@ func TestPlanTraversal(t *testing.T) {
 			//      0   2
 			plan: plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plantest.CreateLogicalMockNode("0"),
-					plantest.CreateLogicalMockNode("1"),
-					plantest.CreateLogicalMockNode("2"),
-					plantest.CreateLogicalMockNode("3"),
-					plantest.CreateLogicalMockNode("4"),
+					plantest.CreatePhysicalMockNode("0"),
+					plantest.CreatePhysicalMockNode("1"),
+					plantest.CreatePhysicalMockNode("2"),
+					plantest.CreatePhysicalMockNode("3"),
+					plantest.CreatePhysicalMockNode("4"),
 				},
 				Edges: [][2]int{
 					{0, 1},
@@ -95,14 +95,14 @@ func TestPlanTraversal(t *testing.T) {
 			//          0   2
 			plan: plantest.PlanSpec{
 				Nodes: []plan.PlanNode{
-					plantest.CreateLogicalMockNode("0"),
-					plantest.CreateLogicalMockNode("1"),
-					plantest.CreateLogicalMockNode("2"),
-					plantest.CreateLogicalMockNode("3"),
-					plantest.CreateLogicalMockNode("4"),
-					plantest.CreateLogicalMockNode("5"),
-					plantest.CreateLogicalMockNode("6"),
-					plantest.CreateLogicalMockNode("7"),
+					plantest.CreatePhysicalMockNode("0"),
+					plantest.CreatePhysicalMockNode("1"),
+					plantest.CreatePhysicalMockNode("2"),
+					plantest.CreatePhysicalMockNode("3"),
+					plantest.CreatePhysicalMockNode("4"),
+					plantest.CreatePhysicalMockNode("5"),
+					plantest.CreatePhysicalMockNode("6"),
+					plantest.CreatePhysicalMockNode("7"),
 				},
 				Edges: [][2]int{
 					{0, 1},

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -3,6 +3,8 @@ package plan
 import (
 	"fmt"
 	"math"
+
+	"github.com/pkg/errors"
 )
 
 // PhysicalPlanner performs transforms a logical plan to a physical plan,
@@ -27,6 +29,8 @@ func NewPhysicalPlanner(options ...PhysicalOption) PhysicalPlanner {
 	}
 
 	pp.addRules(rules...)
+
+	pp.addRules(physicalConverterRule{})
 
 	// Options may add or remove rules, so process them after we've
 	// added registered rules.
@@ -74,6 +78,11 @@ func validatePhysicalPlan(plan *PlanSpec) error {
 		if validator, ok := pn.ProcedureSpec().(PostPhysicalValidator); ok {
 			return validator.PostPhysicalValidate(pn.ID())
 		}
+
+		if _, ok := pn.(*PhysicalPlanNode); !ok {
+			return errors.Errorf("logical node \"%v\" could not be converted to a physical node", pn.ID())
+		}
+
 		return nil
 	})
 	return err
@@ -112,10 +121,48 @@ func OnlyPhysicalRules(rules ...Rule) PhysicalOption {
 	})
 }
 
-func DisableValidatation() PhysicalOption {
+func DisableValidation() PhysicalOption {
 	return physicalOption(func(p *physicalPlanner) {
 		p.disableValidation = true
 	})
+}
+
+// physicalConverterRule rewrites logical nodes that have a ProcedureSpec that implements
+// PhysicalProcedureSpec as a physical node.  For operations that have a 1:1 relationship
+// between their physical and logical operations, this is the default behavior.
+type physicalConverterRule struct {
+}
+
+func (physicalConverterRule) Name() string {
+	return "physicalConverterRule"
+}
+
+func (physicalConverterRule) Pattern() Pattern {
+	return Any()
+}
+
+func (physicalConverterRule) Rewrite(pn PlanNode) (PlanNode, bool, error) {
+	if _, ok := pn.(*PhysicalPlanNode); ok {
+		// Already converted
+		return pn, false, nil
+	}
+
+	ln := pn.(*LogicalPlanNode)
+	pspec, ok := ln.Spec.(PhysicalProcedureSpec)
+	if !ok {
+		// A different rule will do the conversion
+		return pn, false, nil
+	}
+
+	newNode := PhysicalPlanNode{
+		bounds: ln.bounds,
+		id:     ln.id,
+		Spec:   pspec,
+	}
+
+	ReplaceNode(pn, &newNode)
+
+	return &newNode, true, nil
 }
 
 // PhysicalProcedureSpec is similar to its logical counterpart but must provide a method to determine cost.

--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -51,7 +51,7 @@ func RuleTestHelper(t *testing.T, tc *RuleTestCase) {
 	// Disable validation so that we can avoid having to push a range into every from
 	physicalPlanner := plan.NewPhysicalPlanner(
 		plan.OnlyPhysicalRules(tc.Rules...),
-		plan.DisableValidatation(),
+		plan.DisableValidation(),
 	)
 
 	pp, err := physicalPlanner.Plan(before)

--- a/plan/yield.go
+++ b/plan/yield.go
@@ -1,14 +1,21 @@
 package plan
 
-const generatedYieldKind = "generatedYield"
+// DefaultYieldName is the name of a result that doesn't
+// have any name assigned.
+const DefaultYieldName = "_result"
 
+// YieldProcedureSpec is a special procedure that has the side effect of
+// returning a result to the client.
 type YieldProcedureSpec interface {
 	YieldName() string
 }
 
+const generatedYieldKind = "generatedYield"
+
 // GeneratedYieldProcedureSpec provides a special planner-generated yield for queries that don't
 // have explicit calls to yield().
 type GeneratedYieldProcedureSpec struct {
+	DefaultCost
 	Name string
 }
 


### PR DESCRIPTION
Currently the physical planner never actually produces physical nodes.  It just inherits the logical nodes from logical planning.  This commit addresses that, by adding a rule that does the conversion.

Currently all of our procedure specs are both logical and physical because they implement a `Cost` method, so this is just a refactoring with no change in behavior.  The next step will be to separate `from` into distinct logical and physical procedure specs.