### PR TITLE
refactor(arrow): export the ColReader wrapper for ArrowColReader

### DIFF
--- a/arrow/col_reader.go
+++ b/arrow/col_reader.go
@@ -1,4 +1,4 @@
-package arrowutil
+package arrow
 
 import (
 	"github.com/influxdata/flux"
@@ -81,6 +81,12 @@ func (cr *colReader) Times(j int) []values.Time {
 	return c
 }
 
+// ColReader creates a wrapper around an ArrowColReader that will implement the
+// flux.ColReader interface. If the relevant type cannot be returned directly from
+// the arrow array, this reader will lazily memoize a copy of the array as a slice.
+//
+// This method will be removed when the flux.ColReader interface is replaced by the
+// flux.ArrowColReader interface.
 func ColReader(cr flux.ArrowColReader) flux.ColReader {
 	return &colReader{
 		cr:   cr,

--- a/execute/table.go
+++ b/execute/table.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
-	"github.com/influxdata/flux/internal/arrowutil"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -1183,7 +1182,7 @@ func (t *ColListTable) Len() int {
 
 func (t *ColListTable) Do(f func(flux.ColReader) error) error {
 	return t.DoArrow(func(cr flux.ArrowColReader) error {
-		return f(arrowutil.ColReader(cr))
+		return f(arrow.ColReader(cr))
 	})
 }
 


### PR DESCRIPTION
This was previously an internal package but it would be useful in the
other projects during the migration.