### PR TITLE
feat(arrow): add utility methods for converting a slice into an arrow array buffer

### DIFF
--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -6,6 +6,17 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
+func NewBool(vs []bool, alloc *memory.Allocator) *array.Boolean {
+	b := NewBoolBuilder(alloc)
+	b.Reserve(len(vs))
+	for _, v := range vs {
+		b.UnsafeAppend(v)
+	}
+	a := b.NewBooleanArray()
+	b.Release()
+	return a
+}
+
 func NewBoolBuilder(a *memory.Allocator) *array.BooleanBuilder {
 	return array.NewBooleanBuilder(&allocator{
 		Allocator: arrowmemory.NewGoAllocator(),

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -6,6 +6,17 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
+func NewFloat(vs []float64, alloc *memory.Allocator) *array.Float64 {
+	b := NewFloatBuilder(alloc)
+	b.Reserve(len(vs))
+	for _, v := range vs {
+		b.UnsafeAppend(v)
+	}
+	a := b.NewFloat64Array()
+	b.Release()
+	return a
+}
+
 func NewFloatBuilder(a *memory.Allocator) *array.Float64Builder {
 	return array.NewFloat64Builder(&allocator{
 		Allocator: arrowmemory.NewGoAllocator(),

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -6,6 +6,17 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
+func NewInt(vs []int64, alloc *memory.Allocator) *array.Int64 {
+	b := NewIntBuilder(alloc)
+	b.Reserve(len(vs))
+	for _, v := range vs {
+		b.UnsafeAppend(v)
+	}
+	a := b.NewInt64Array()
+	b.Release()
+	return a
+}
+
 func NewIntBuilder(a *memory.Allocator) *array.Int64Builder {
 	return array.NewInt64Builder(&allocator{
 		Allocator: arrowmemory.NewGoAllocator(),

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -7,6 +7,17 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
+func NewString(vs []string, alloc *memory.Allocator) *array.Binary {
+	b := NewStringBuilder(alloc)
+	b.Reserve(len(vs))
+	for _, v := range vs {
+		b.AppendString(v)
+	}
+	a := b.NewBinaryArray()
+	b.Release()
+	return a
+}
+
 func NewStringBuilder(a *memory.Allocator) *array.BinaryBuilder {
 	return array.NewBinaryBuilder(&allocator{
 		Allocator: arrowmemory.NewGoAllocator(),

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -6,6 +6,17 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
+func NewUint(vs []uint64, alloc *memory.Allocator) *array.Uint64 {
+	b := NewUintBuilder(alloc)
+	b.Reserve(len(vs))
+	for _, v := range vs {
+		b.UnsafeAppend(v)
+	}
+	a := b.NewUint64Array()
+	b.Release()
+	return a
+}
+
 func NewUintBuilder(a *memory.Allocator) *array.Uint64Builder {
 	return array.NewUint64Builder(&allocator{
 		Allocator: arrowmemory.NewGoAllocator(),

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -3,8 +3,11 @@ package executetest
 import (
 	"fmt"
 
+	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -85,7 +88,60 @@ func (t *Table) Do(f func(flux.ColReader) error) error {
 }
 
 func (t *Table) DoArrow(f func(flux.ArrowColReader) error) error {
-	panic("implement me")
+	cols := make([]array.Interface, len(t.ColMeta))
+	for j, col := range t.ColMeta {
+		switch col.Type {
+		case flux.TBool:
+			b := arrow.NewBoolBuilder(&memory.Allocator{})
+			for i := range t.Data {
+				b.Append(t.Data[i][j].(bool))
+			}
+			cols[j] = b.NewBooleanArray()
+			b.Release()
+		case flux.TFloat:
+			b := arrow.NewFloatBuilder(&memory.Allocator{})
+			for i := range t.Data {
+				b.Append(t.Data[i][j].(float64))
+			}
+			cols[j] = b.NewFloat64Array()
+			b.Release()
+		case flux.TInt:
+			b := arrow.NewIntBuilder(&memory.Allocator{})
+			for i := range t.Data {
+				b.Append(t.Data[i][j].(int64))
+			}
+			cols[j] = b.NewInt64Array()
+			b.Release()
+		case flux.TString:
+			b := arrow.NewStringBuilder(&memory.Allocator{})
+			for i := range t.Data {
+				b.AppendString(t.Data[i][j].(string))
+			}
+			cols[j] = b.NewBinaryArray()
+			b.Release()
+		case flux.TTime:
+			b := arrow.NewIntBuilder(&memory.Allocator{})
+			for i := range t.Data {
+				b.Append(int64(t.Data[i][j].(values.Time)))
+			}
+			cols[j] = b.NewInt64Array()
+			b.Release()
+		case flux.TUInt:
+			b := arrow.NewUintBuilder(&memory.Allocator{})
+			for i := range t.Data {
+				b.Append(t.Data[i][j].(uint64))
+			}
+			cols[j] = b.NewUint64Array()
+			b.Release()
+		}
+	}
+
+	cr := &ArrowColReader{
+		key:  t.Key(),
+		meta: t.ColMeta,
+		cols: cols,
+	}
+	return f(cr)
 }
 
 func (t *Table) Statistics() flux.Statistics { return flux.Statistics{} }
@@ -129,6 +185,51 @@ func (cr ColReader) Strings(j int) []string {
 
 func (cr ColReader) Times(j int) []execute.Time {
 	return []execute.Time{cr.row[j].(execute.Time)}
+}
+
+type ArrowColReader struct {
+	key  flux.GroupKey
+	meta []flux.ColMeta
+	cols []array.Interface
+}
+
+func (cr *ArrowColReader) Key() flux.GroupKey {
+	return cr.key
+}
+
+func (cr *ArrowColReader) Cols() []flux.ColMeta {
+	return cr.meta
+}
+
+func (cr *ArrowColReader) Len() int {
+	if len(cr.cols) == 0 {
+		return 0
+	}
+	return cr.cols[0].Len()
+}
+
+func (cr *ArrowColReader) Bools(j int) *array.Boolean {
+	return cr.cols[j].(*array.Boolean)
+}
+
+func (cr *ArrowColReader) Ints(j int) *array.Int64 {
+	return cr.cols[j].(*array.Int64)
+}
+
+func (cr *ArrowColReader) UInts(j int) *array.Uint64 {
+	return cr.cols[j].(*array.Uint64)
+}
+
+func (cr *ArrowColReader) Floats(j int) *array.Float64 {
+	return cr.cols[j].(*array.Float64)
+}
+
+func (cr *ArrowColReader) Strings(j int) *array.Binary {
+	return cr.cols[j].(*array.Binary)
+}
+
+func (cr *ArrowColReader) Times(j int) *array.Int64 {
+	return cr.cols[j].(*array.Int64)
 }
 
 func TablesFromCache(c execute.DataCache) (tables []*Table, err error) {

--- a/execute/table.go
+++ b/execute/table.go
@@ -1340,16 +1340,11 @@ func (c *boolColumnBuilder) Clear() {
 	c.data = c.data[0:0]
 }
 func (c *boolColumnBuilder) Copy() column {
-	b := arrow.NewBoolBuilder(c.alloc.Allocator)
-	b.Reserve(len(c.data))
-	for _, v := range c.data {
-		b.UnsafeAppend(v)
-	}
+	data := arrow.NewBool(c.data, c.alloc.Allocator)
 	col := &boolColumn{
 		ColMeta: c.ColMeta,
-		data:    b.NewBooleanArray(),
+		data:    data,
 	}
-	b.Release()
 	return col
 }
 func (c *boolColumnBuilder) Len() int {
@@ -1406,16 +1401,11 @@ func (c *intColumnBuilder) Clear() {
 	c.data = c.data[0:0]
 }
 func (c *intColumnBuilder) Copy() column {
-	b := arrow.NewIntBuilder(c.alloc.Allocator)
-	b.Reserve(len(c.data))
-	for _, v := range c.data {
-		b.UnsafeAppend(v)
-	}
+	data := arrow.NewInt(c.data, c.alloc.Allocator)
 	col := &intColumn{
 		ColMeta: c.ColMeta,
-		data:    b.NewInt64Array(),
+		data:    data,
 	}
-	b.Release()
 	return col
 }
 func (c *intColumnBuilder) Len() int {
@@ -1469,16 +1459,11 @@ func (c *uintColumnBuilder) Clear() {
 	c.data = c.data[0:0]
 }
 func (c *uintColumnBuilder) Copy() column {
-	b := arrow.NewUintBuilder(c.alloc.Allocator)
-	b.Reserve(len(c.data))
-	for _, v := range c.data {
-		b.UnsafeAppend(v)
-	}
+	data := arrow.NewUint(c.data, c.alloc.Allocator)
 	col := &uintColumn{
 		ColMeta: c.ColMeta,
-		data:    b.NewUint64Array(),
+		data:    data,
 	}
-	b.Release()
 	return col
 }
 func (c *uintColumnBuilder) Len() int {
@@ -1532,16 +1517,11 @@ func (c *floatColumnBuilder) Clear() {
 	c.data = c.data[0:0]
 }
 func (c *floatColumnBuilder) Copy() column {
-	b := arrow.NewFloatBuilder(c.alloc.Allocator)
-	b.Reserve(len(c.data))
-	for _, v := range c.data {
-		b.UnsafeAppend(v)
-	}
+	data := arrow.NewFloat(c.data, c.alloc.Allocator)
 	col := &floatColumn{
 		ColMeta: c.ColMeta,
-		data:    b.NewFloat64Array(),
+		data:    data,
 	}
-	b.Release()
 	return col
 }
 func (c *floatColumnBuilder) Len() int {
@@ -1595,16 +1575,11 @@ func (c *stringColumnBuilder) Clear() {
 	c.data = c.data[0:0]
 }
 func (c *stringColumnBuilder) Copy() column {
-	b := arrow.NewStringBuilder(c.alloc.Allocator)
-	b.Reserve(len(c.data))
-	for _, v := range c.data {
-		b.AppendString(v)
-	}
+	data := arrow.NewString(c.data, c.alloc.Allocator)
 	col := &stringColumn{
 		ColMeta: c.ColMeta,
-		data:    b.NewBinaryArray(),
+		data:    data,
 	}
-	b.Release()
 	return col
 }
 func (c *stringColumnBuilder) Len() int {


### PR DESCRIPTION
This adds utility methods for converting a slice into an arrow array
buffer. These implementations were previously inside of the
`ColListTableBuilder` and have now been exposed for other
implementation to use.

This also updates the `executetest` package to implement `DoArrow`. This
was previously missed and would cause any test that used arrow buffers
to fail with a panic.