### PR TITLE
feat(parser): add tests for multi-line and escaped strings

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -747,6 +747,7 @@ func (i *PipeLiteral) Copy() Node {
 // StringLiteral expressions begin and end with double quote marks.
 type StringLiteral struct {
 	BaseNode
+	// Value is the unescaped value of the string literal
 	Value string `json:"value"`
 }
 

--- a/ast/format.go
+++ b/ast/format.go
@@ -376,9 +376,32 @@ func (f *formatter) formatIdentifier(n *Identifier) {
 }
 
 func (f *formatter) formatStringLiteral(n *StringLiteral) {
+	if n.Loc != nil && n.Loc.Source != "" {
+		// Preserve the exact literal if we have it
+		f.writeString(n.Loc.Source)
+		return
+	}
+	// Write out escaped string value
 	f.writeRune('"')
-	f.writeString(n.Value)
+	f.writeString(escapeStr(n.Value))
 	f.writeRune('"')
+}
+
+func escapeStr(s string) string {
+	if !strings.ContainsAny(s, `"\`) {
+		return s
+	}
+	var builder strings.Builder
+	// Allocate for worst case where every rune needs to be escaped.
+	builder.Grow(len(s) * 2)
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			builder.WriteRune('\\')
+		}
+		builder.WriteRune(r)
+	}
+	return builder.String()
 }
 
 func (f *formatter) formatBooleanLiteral(n *BooleanLiteral) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -3390,6 +3390,79 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
 			raw:       `from() |> range() |> map(fn: (r) => { return r._value )`,
 			parseOnly: true,
 		},
+		{
+			name: "string with utf-8",
+			raw:  `"日本語"`,
+			want: &ast.Program{
+				BaseNode: base("1:1", "1:12"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:12"),
+						Expression: &ast.StringLiteral{
+							BaseNode: base("1:1", "1:12"),
+							Value:    "日本語",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "string with byte values",
+			raw:  `"\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"`,
+			want: &ast.Program{
+				BaseNode: base("1:1", "1:39"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:39"),
+						Expression: &ast.StringLiteral{
+							BaseNode: base("1:1", "1:39"),
+							Value:    "日本語",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "string with escapes",
+			raw: `"newline \n
+carriage return \r
+horizontal tab \t
+double quote \"
+backslash \\
+"`,
+			want: &ast.Program{
+				BaseNode: base("1:1", "6:2"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "6:2"),
+						Expression: &ast.StringLiteral{
+							BaseNode: base("1:1", "6:2"),
+							Value:    "newline \n\ncarriage return \r\nhorizontal tab \t\ndouble quote \"\nbackslash \\\n",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiline string",
+			raw: `"
+ this is a
+multiline
+string"
+`,
+			want: &ast.Program{
+				BaseNode: base("1:1", "4:8"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "4:8"),
+						Expression: &ast.StringLiteral{
+							BaseNode: base("1:1", "4:8"),
+							Value:    "\n this is a\nmultiline\nstring",
+						},
+					},
+				},
+			},
+		},
 	} {
 		runFn(tt.name, func(tb testing.TB) {
 			defer func() {


### PR DESCRIPTION
Byte values in strings are now fully unescaped.

Fixes #544 

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
