### PR TITLE
refactor(functions): convert filter, map, and state tracking to use arrow

### DIFF
--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -113,9 +113,9 @@ func ConvertFromKind(k semantic.Nature) flux.ColType {
 	}
 }
 
-func (f *rowFn) eval(row int, cr flux.ColReader) (values.Value, error) {
+func (f *rowFn) eval(row int, cr flux.ArrowColReader) (values.Value, error) {
 	for _, r := range f.references {
-		f.record.Set(r, ValueForRow(cr, row, f.recordCols[r]))
+		f.record.Set(r, ValueForRowArrow(cr, row, f.recordCols[r]))
 	}
 	f.inRecord.Set(f.recordName, f.record)
 	return f.preparedFn.Eval(f.inRecord)
@@ -146,7 +146,7 @@ func (f *RowPredicateFn) Prepare(cols []flux.ColMeta) error {
 	return nil
 }
 
-func (f *RowPredicateFn) Eval(row int, cr flux.ColReader) (bool, error) {
+func (f *RowPredicateFn) Eval(row int, cr flux.ArrowColReader) (bool, error) {
 	v, err := f.rowFn.eval(row, cr)
 	if err != nil {
 		return false, err
@@ -193,7 +193,7 @@ func (f *RowMapFn) Type() semantic.Type {
 	return f.preparedFn.Type()
 }
 
-func (f *RowMapFn) Eval(row int, cr flux.ColReader) (values.Object, error) {
+func (f *RowMapFn) Eval(row int, cr flux.ArrowColReader) (values.Object, error) {
 	v, err := f.rowFn.eval(row, cr)
 	if err != nil {
 		return nil, err

--- a/functions/transformations/filter.go
+++ b/functions/transformations/filter.go
@@ -143,7 +143,7 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 	}
 
 	// Append only matching rows to table
-	return tbl.Do(func(cr flux.ColReader) error {
+	return tbl.DoArrow(func(cr flux.ArrowColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
 			if pass, err := t.fn.Eval(i, cr); err != nil {
@@ -153,7 +153,7 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 				// No match, skipping
 				continue
 			}
-			if err := execute.AppendRecord(i, cr, builder); err != nil {
+			if err := execute.AppendRecordArrow(i, cr, builder); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

These three functions all use row predicates so they are related to
each other. They have been converted over to use arrow buffers instead
of the old column reader.

Fixes #497, #509, and #523.