### PR TITLE
refactor(arrow): switching the slice utilities to use int instead of int64

### DIFF
--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -17,8 +17,8 @@ func NewBool(vs []bool, alloc *memory.Allocator) *array.Boolean {
 	return a
 }
 
-func BoolSlice(arr *array.Boolean, i, j int64) *array.Boolean {
-	data := array.NewSliceData(arr.Data(), i, j)
+func BoolSlice(arr *array.Boolean, i, j int) *array.Boolean {
+	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
 	defer data.Release()
 	return array.NewBooleanData(data)
 }

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -17,8 +17,8 @@ func NewFloat(vs []float64, alloc *memory.Allocator) *array.Float64 {
 	return a
 }
 
-func FloatSlice(arr *array.Float64, i, j int64) *array.Float64 {
-	data := array.NewSliceData(arr.Data(), i, j)
+func FloatSlice(arr *array.Float64, i, j int) *array.Float64 {
+	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
 	defer data.Release()
 	return array.NewFloat64Data(data)
 }

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -17,8 +17,8 @@ func NewInt(vs []int64, alloc *memory.Allocator) *array.Int64 {
 	return a
 }
 
-func IntSlice(arr *array.Int64, i, j int64) *array.Int64 {
-	data := array.NewSliceData(arr.Data(), i, j)
+func IntSlice(arr *array.Int64, i, j int) *array.Int64 {
+	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
 	defer data.Release()
 	return array.NewInt64Data(data)
 }

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -18,8 +18,8 @@ func NewString(vs []string, alloc *memory.Allocator) *array.Binary {
 	return a
 }
 
-func StringSlice(arr *array.Binary, i, j int64) *array.Binary {
-	data := array.NewSliceData(arr.Data(), i, j)
+func StringSlice(arr *array.Binary, i, j int) *array.Binary {
+	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
 	defer data.Release()
 	return array.NewBinaryData(data)
 }

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -17,8 +17,8 @@ func NewUint(vs []uint64, alloc *memory.Allocator) *array.Uint64 {
 	return a
 }
 
-func UintSlice(arr *array.Uint64, i, j int64) *array.Uint64 {
-	data := array.NewSliceData(arr.Data(), i, j)
+func UintSlice(arr *array.Uint64, i, j int) *array.Uint64 {
+	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
 	defer data.Release()
 	return array.NewUint64Data(data)
 }


### PR DESCRIPTION
Using `int` is more common than `int64` for lengths so, even if arrow
uses `int64`, the slice lengths should still use `int`. Additionally,
the arrow `Len()` method for slices uses `int` as the return value so
this is better for that anyway.