### PR TITLE
fix(functions): embed plan.DefaultCost in input and output functions

### DIFF
--- a/functions/inputs/buckets.go
+++ b/functions/inputs/buckets.go
@@ -37,6 +37,7 @@ func (s *BucketsOpSpec) Kind() flux.OperationKind {
 }
 
 type BucketsProcedureSpec struct {
+	plan.DefaultCost
 }
 
 func newBucketsProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {

--- a/functions/outputs/to_http.go
+++ b/functions/outputs/to_http.go
@@ -209,6 +209,7 @@ func (ToHTTPOpSpec) Kind() flux.OperationKind {
 }
 
 type ToHTTPProcedureSpec struct {
+	plan.DefaultCost
 	Spec *ToHTTPOpSpec
 }
 

--- a/functions/outputs/to_kafka.go
+++ b/functions/outputs/to_kafka.go
@@ -175,6 +175,7 @@ func (ToKafkaOpSpec) Kind() flux.OperationKind {
 }
 
 type ToKafkaProcedureSpec struct {
+	plan.DefaultCost
 	Spec     *ToKafkaOpSpec
 	balancer kafka.Balancer
 }


### PR DESCRIPTION
This addresses issues about "failed to create physical plan" in
input/output functions.  This was not caught earlier because there
are no end-to-end tests for input/output functions.

Fixes #584


### Done checklist
- [x] docs/SPEC.md updated (no change needed)
- [x] Test cases written (need end-to-end tests for i/o functions)
