### PR TITLE
refactor(functions): Make window() use arrow buffers

### DIFF
--- a/functions/transformations/window.go
+++ b/functions/transformations/window.go
@@ -333,10 +333,10 @@ func (t *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table
 		}
 	}
 
-	return tbl.Do(func(cr flux.ColReader) error {
+	return tbl.DoArrow(func(cr flux.ArrowColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			tm := cr.Times(timeIdx)[i]
+			tm := values.Time(cr.Times(timeIdx).Value(i))
 			bounds := t.getWindowBounds(tm)
 
 			for _, bnds := range bounds {
@@ -362,7 +362,7 @@ func (t *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table
 							return err
 						}
 					default:
-						if err := builder.AppendValue(j, execute.ValueForRow(cr, i, j)); err != nil {
+						if err := builder.AppendValue(j, execute.ValueForRowArrow(cr, i, j)); err != nil {
 							return err
 						}
 					}


### PR DESCRIPTION
Fixes #530.

There are some inconsistencies between the SPEC and the code in `window.go`.  I don't have enough context to know what parameters are required, so I'm just submitting this PR to progress with the Arrow refactoring.  I will file a separate issue for updating `window` parameters and the SPEC.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
