### PR TITLE
fix(arrow): allow the memory allocator to be nil for arrow arrays

### DIFF
--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -8,7 +8,6 @@ import (
 	arrowmemory "github.com/apache/arrow/go/arrow/memory"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/arrow"
-	"github.com/influxdata/flux/memory"
 )
 
 func TestSum_Float64_Empty(t *testing.T) {
@@ -67,8 +66,7 @@ func TestSum_Uint64_Empty(t *testing.T) {
 
 func TestSlice_Int64(t *testing.T) {
 	values := []int64{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewInt(values, alloc)
+	arr := arrow.NewInt(values, nil)
 	defer arr.Release()
 
 	if got, want := arr.Len(), len(values); got != want {
@@ -149,8 +147,7 @@ func TestSlice_Int64(t *testing.T) {
 
 func TestSlice_OutOfBounds_Int64(t *testing.T) {
 	values := []int64{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewInt(values, alloc)
+	arr := arrow.NewInt(values, nil)
 	defer arr.Release()
 
 	slice := arrow.IntSlice(arr, 3, 8)
@@ -202,8 +199,7 @@ func TestSlice_OutOfBounds_Int64(t *testing.T) {
 
 func TestSlice_Uint64(t *testing.T) {
 	values := []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewUint(values, alloc)
+	arr := arrow.NewUint(values, nil)
 	defer arr.Release()
 
 	if got, want := arr.Len(), len(values); got != want {
@@ -284,8 +280,7 @@ func TestSlice_Uint64(t *testing.T) {
 
 func TestSlice_OutOfBounds_Uint64(t *testing.T) {
 	values := []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewUint(values, alloc)
+	arr := arrow.NewUint(values, nil)
 	defer arr.Release()
 
 	slice := arrow.UintSlice(arr, 3, 8)
@@ -337,8 +332,7 @@ func TestSlice_OutOfBounds_Uint64(t *testing.T) {
 
 func TestSlice_Float64(t *testing.T) {
 	values := []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewFloat(values, alloc)
+	arr := arrow.NewFloat(values, nil)
 	defer arr.Release()
 
 	if got, want := arr.Len(), len(values); got != want {
@@ -419,8 +413,7 @@ func TestSlice_Float64(t *testing.T) {
 
 func TestSlice_OutOfBounds_Float64(t *testing.T) {
 	values := []float64{0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewFloat(values, alloc)
+	arr := arrow.NewFloat(values, nil)
 	defer arr.Release()
 
 	slice := arrow.FloatSlice(arr, 3, 8)
@@ -474,8 +467,7 @@ func TestSlice_String(t *testing.T) {
 	t.Skip("https://github.com/apache/arrow/issues/3270")
 
 	values := []string{"a", "bc", "def", "g", "hijk", "lm", "n", "opq", "rs", "tu"}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewString(values, alloc)
+	arr := arrow.NewString(values, nil)
 	defer arr.Release()
 
 	l := arr.Len()
@@ -568,8 +560,7 @@ func TestSlice_OutOfBounds_String(t *testing.T) {
 	t.Skip("https://github.com/apache/arrow/issues/3270")
 
 	values := []string{"a", "bc", "def", "g", "hijk", "lm", "n", "opq", "rs", "tu"}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewString(values, alloc)
+	arr := arrow.NewString(values, nil)
 	defer arr.Release()
 
 	slice := arrow.StringSlice(arr, 3, 8)
@@ -623,8 +614,7 @@ func TestSlice_Bool(t *testing.T) {
 	t.Skip("https://issues.apache.org/jira/browse/ARROW-4126")
 
 	values := []bool{true, false, true, false, true, false, true, false, true, false}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewBool(values, alloc)
+	arr := arrow.NewBool(values, nil)
 	defer arr.Release()
 
 	l := arr.Len()
@@ -717,8 +707,7 @@ func TestSlice_OutOfBounds_Bool(t *testing.T) {
 	t.Skip("https://issues.apache.org/jira/browse/ARROW-4126")
 
 	values := []bool{true, false, true, false, true, false, true, false, true, false}
-	alloc := &memory.Allocator{}
-	arr := arrow.NewBool(values, alloc)
+	arr := arrow.NewBool(values, nil)
 	defer arr.Release()
 
 	slice := arrow.BoolSlice(arr, 3, 8)

--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -24,8 +24,12 @@ func BoolSlice(arr *array.Boolean, i, j int) *array.Boolean {
 }
 
 func NewBoolBuilder(a *memory.Allocator) *array.BooleanBuilder {
-	return array.NewBooleanBuilder(&allocator{
-		Allocator: arrowmemory.NewGoAllocator(),
-		alloc:     a,
-	})
+	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
+	if a != nil {
+		alloc = &allocator{
+			Allocator: alloc,
+			alloc:     a,
+		}
+	}
+	return array.NewBooleanBuilder(alloc)
 }

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -24,8 +24,12 @@ func FloatSlice(arr *array.Float64, i, j int) *array.Float64 {
 }
 
 func NewFloatBuilder(a *memory.Allocator) *array.Float64Builder {
-	return array.NewFloat64Builder(&allocator{
-		Allocator: arrowmemory.NewGoAllocator(),
-		alloc:     a,
-	})
+	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
+	if a != nil {
+		alloc = &allocator{
+			Allocator: alloc,
+			alloc:     a,
+		}
+	}
+	return array.NewFloat64Builder(alloc)
 }

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -24,8 +24,12 @@ func IntSlice(arr *array.Int64, i, j int) *array.Int64 {
 }
 
 func NewIntBuilder(a *memory.Allocator) *array.Int64Builder {
-	return array.NewInt64Builder(&allocator{
-		Allocator: arrowmemory.NewGoAllocator(),
-		alloc:     a,
-	})
+	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
+	if a != nil {
+		alloc = &allocator{
+			Allocator: alloc,
+			alloc:     a,
+		}
+	}
+	return array.NewInt64Builder(alloc)
 }

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -25,8 +25,12 @@ func StringSlice(arr *array.Binary, i, j int) *array.Binary {
 }
 
 func NewStringBuilder(a *memory.Allocator) *array.BinaryBuilder {
-	return array.NewBinaryBuilder(&allocator{
-		Allocator: arrowmemory.NewGoAllocator(),
-		alloc:     a,
-	}, arrow.BinaryTypes.String)
+	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
+	if a != nil {
+		alloc = &allocator{
+			Allocator: alloc,
+			alloc:     a,
+		}
+	}
+	return array.NewBinaryBuilder(alloc, arrow.BinaryTypes.String)
 }

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -24,8 +24,12 @@ func UintSlice(arr *array.Uint64, i, j int) *array.Uint64 {
 }
 
 func NewUintBuilder(a *memory.Allocator) *array.Uint64Builder {
-	return array.NewUint64Builder(&allocator{
-		Allocator: arrowmemory.NewGoAllocator(),
-		alloc:     a,
-	})
+	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
+	if a != nil {
+		alloc = &allocator{
+			Allocator: alloc,
+			alloc:     a,
+		}
+	}
+	return array.NewUint64Builder(alloc)
 }

--- a/execute/executetest/aggregate.go
+++ b/execute/executetest/aggregate.go
@@ -9,7 +9,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/flux/memory"
 )
 
 // AggFuncTestHelper splits the data in half, runs Do over each split and compares
@@ -20,9 +19,9 @@ func AggFuncTestHelper(t *testing.T, agg execute.Aggregate, data []float64, want
 	// Call Do twice, since this is possible according to the interface.
 	h := len(data) / 2
 	vf := agg.NewFloatAgg()
-	vf.DoFloat(arrow.NewFloat(data[:h], &memory.Allocator{}))
+	vf.DoFloat(arrow.NewFloat(data[:h], nil))
 	if h < len(data) {
-		vf.DoFloat(arrow.NewFloat(data[h:], &memory.Allocator{}))
+		vf.DoFloat(arrow.NewFloat(data[h:], nil))
 	}
 
 	var got interface{}

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -7,7 +7,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -92,42 +91,42 @@ func (t *Table) DoArrow(f func(flux.ArrowColReader) error) error {
 	for j, col := range t.ColMeta {
 		switch col.Type {
 		case flux.TBool:
-			b := arrow.NewBoolBuilder(&memory.Allocator{})
+			b := arrow.NewBoolBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(bool))
 			}
 			cols[j] = b.NewBooleanArray()
 			b.Release()
 		case flux.TFloat:
-			b := arrow.NewFloatBuilder(&memory.Allocator{})
+			b := arrow.NewFloatBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(float64))
 			}
 			cols[j] = b.NewFloat64Array()
 			b.Release()
 		case flux.TInt:
-			b := arrow.NewIntBuilder(&memory.Allocator{})
+			b := arrow.NewIntBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(int64))
 			}
 			cols[j] = b.NewInt64Array()
 			b.Release()
 		case flux.TString:
-			b := arrow.NewStringBuilder(&memory.Allocator{})
+			b := arrow.NewStringBuilder(nil)
 			for i := range t.Data {
 				b.AppendString(t.Data[i][j].(string))
 			}
 			cols[j] = b.NewBinaryArray()
 			b.Release()
 		case flux.TTime:
-			b := arrow.NewIntBuilder(&memory.Allocator{})
+			b := arrow.NewIntBuilder(nil)
 			for i := range t.Data {
 				b.Append(int64(t.Data[i][j].(values.Time)))
 			}
 			cols[j] = b.NewInt64Array()
 			b.Release()
 		case flux.TUInt:
-			b := arrow.NewUintBuilder(&memory.Allocator{})
+			b := arrow.NewUintBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(uint64))
 			}


### PR DESCRIPTION
If the memory allocator is nil, that means we don't care to track the
memory usage and it will pass the default go allocator directly instead
of acting as a proxy.