### PR TITLE
fix(control): fix a flaky test in the controller shutdown

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -32,7 +32,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"


### PR DESCRIPTION
There were a few problems in the controller shutdown test that caused it
to be flaky.

First, it didn't wait for all 10 queries to get into the controller
queue before checking the queue length. This caused it to call `Fatal`
and abort the test, but `Shutdown` had already been called and the
active queries needed to be finished.

After that, it attempted to run a query before the shutdown may have
been initiated so the query got enqueued correctly even though it was
not expecting that to happen. It now attempts to create the query and
tries multiple times to get the failure with a wait in between if it
can't.

It now succeeds when run with the following command line:

    go test -c ./control
    cpulimit -z -i -l 100 ./control.test -test.v -test.cpu 1

I was able to reproduce the issue by using the above.

Fixes #611.