### PR TITLE
Feat/qualified options

### DIFF
--- a/ast/asttest/cmpopts.go
+++ b/ast/asttest/cmpopts.go
@@ -27,6 +27,7 @@ var IgnoreBaseNodeOptions = []cmp.Option{
 	cmpopts.IgnoreFields(ast.IndexExpression{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.IntegerLiteral{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.LogicalExpression{}, "BaseNode"),
+	cmpopts.IgnoreFields(ast.MemberAssignment{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.MemberExpression{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.ObjectExpression{}, "BaseNode"),
 	cmpopts.IgnoreFields(ast.OptionStatement{}, "BaseNode"),

--- a/ast/copy_test.go
+++ b/ast/copy_test.go
@@ -111,6 +111,23 @@ func TestCopy(t *testing.T) {
 			},
 		},
 		{
+			node: &ast.OptionStatement{
+				Assignment: &ast.MemberAssignment{
+					Member: &ast.MemberExpression{
+						Object: &ast.Identifier{
+							Name: "alert",
+						},
+						Property: &ast.Identifier{
+							Name: "state",
+						},
+					},
+					Init: &ast.StringLiteral{
+						Value: "Warning",
+					},
+				},
+			},
+		},
+		{
 			node: &ast.VariableAssignment{},
 		},
 		{

--- a/ast/edit/option_editor_test.go
+++ b/ast/edit/option_editor_test.go
@@ -39,6 +39,15 @@ func TestEditor(t *testing.T) {
 			},
 		},
 		{
+			name:   "qualified_option",
+			in:     `option alert.state = 0`,
+			edited: `option alert.state = 1`,
+			edit: func(node ast.Node) (bool, error) {
+				literal := edit.CreateLiteral(values.NewInt(int64(1)))
+				return edit.Option(node, "alert.state", edit.OptionValueFn(literal))
+			},
+		},
+		{
 			name: "sets_option",
 			in: `option foo = 1
 option bar = 1`,

--- a/ast/format.go
+++ b/ast/format.go
@@ -182,6 +182,12 @@ func (f *formatter) formatVariableAssignment(n *VariableAssignment) {
 	f.formatNode(n.Init)
 }
 
+func (f *formatter) formatMemberAssignment(n *MemberAssignment) {
+	f.formatNode(n.Member)
+	f.writeString(" = ")
+	f.formatNode(n.Init)
+}
+
 func (f *formatter) formatArrayExpression(n *ArrayExpression) {
 	f.writeRune('[')
 
@@ -490,6 +496,8 @@ func (f *formatter) formatNode(n Node) {
 		f.formatReturnStatement(n)
 	case *VariableAssignment:
 		f.formatVariableAssignment(n)
+	case *MemberAssignment:
+		f.formatMemberAssignment(n)
 	case *CallExpression:
 		f.formatCallExpression(n)
 	case *PipeExpression:

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -105,6 +105,10 @@ a[i]`,
 			script: `option foo = {a: 1}`,
 		},
 		{
+			name:   "qualified option",
+			script: `option alert.state = "Warning"`,
+		},
+		{
 			name: "nil_value_as_default",
 			script: `foo = (arg=[]) =>
 	(1)`,

--- a/ast/json_test.go
+++ b/ast/json_test.go
@@ -108,6 +108,25 @@ func TestJSONMarshal(t *testing.T) {
 			want: `{"type":"OptionStatement","assignment":{"type":"VariableAssignment","id":{"type":"Identifier","name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","values":[{"magnitude":1,"unit":"h"}]}}]}}}`,
 		},
 		{
+			name: "qualified option statement",
+			node: &ast.OptionStatement{
+				Assignment: &ast.MemberAssignment{
+					Member: &ast.MemberExpression{
+						Object: &ast.Identifier{
+							Name: "alert",
+						},
+						Property: &ast.Identifier{
+							Name: "state",
+						},
+					},
+					Init: &ast.StringLiteral{
+						Value: "Warning",
+					},
+				},
+			},
+			want: `{"type":"OptionStatement","assignment":{"type":"MemberAssignment","member":{"type":"MemberExpression","object":{"type":"Identifier","name":"alert"},"property":{"type":"Identifier","name":"state"}},"init":{"type":"StringLiteral","value":"Warning"}}}`,
+		},
+		{
 			name: "variable assignment",
 			node: &ast.VariableAssignment{
 				ID:   &ast.Identifier{Name: "a"},

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -143,6 +143,15 @@ func walk(v Visitor, node Node) {
 			walk(w, n.ID)
 			walk(w, n.Init)
 		}
+	case *MemberAssignment:
+		if n == nil {
+			return
+		}
+		w := v.Visit(n)
+		if w != nil {
+			walk(w, n.Member)
+			walk(w, n.Init)
+		}
 	case *CallExpression:
 		if n == nil {
 			return

--- a/internal/parser/grammar.md
+++ b/internal/parser/grammar.md
@@ -17,7 +17,10 @@ The parser directly implements the following grammar.
                                | ExpressionStatement .
     IdentStatement             = identifer ( AssignStatement | ExpressionSuffix ) .
     OptionStatement            = "option" OptionStatementSuffix .
-    OptionStatementSuffix      = AssignStatement | VariableAssignment | ExpressionSuffix
+    OptionStatementSuffix      = OptionAssignment | AssignStatement | ExpressionSuffix .
+    OptionAssignment           = identifier OptionAssignmentSuffix .
+    OptionAssignmentSuffix     = Assignment
+                               | "." identifier Assignment .
     VariableAssignment         = identifer AssignStatement .
     AssignStatement            = "=" Expression .
     ReturnStatement            = "return" Expression .

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -380,6 +380,36 @@ import "path/bar"
 			},
 		},
 		{
+			name: "qualified option",
+			raw:  `option alert.state = "Warning"`,
+			want: &ast.File{
+				BaseNode: base("1:1", "1:31"),
+				Body: []ast.Statement{
+					&ast.OptionStatement{
+						BaseNode: base("1:1", "1:31"),
+						Assignment: &ast.MemberAssignment{
+							BaseNode: base("1:8", "1:31"),
+							Member: &ast.MemberExpression{
+								BaseNode: base("1:8", "1:19"),
+								Object: &ast.Identifier{
+									BaseNode: base("1:8", "1:13"),
+									Name:     "alert",
+								},
+								Property: &ast.Identifier{
+									BaseNode: base("1:14", "1:19"),
+									Name:     "state",
+								},
+							},
+							Init: &ast.StringLiteral{
+								BaseNode: base("1:22", "1:31"),
+								Value:    "Warning",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "from",
 			raw:  `from()`,
 			want: &ast.File{

--- a/semantic/constraints.go
+++ b/semantic/constraints.go
@@ -127,6 +127,17 @@ func (v ConstraintGenerator) typeof(n Node) (PolyType, error) {
 		scheme := v.scheme(t)
 		v.env.Set(pkg.Name, scheme)
 		return nil, nil
+	case *MemberAssignment:
+		t, err := v.lookup(n.Init)
+		if err != nil {
+			return nil, err
+		}
+		propType, err := v.lookup(n.Member)
+		if err != nil {
+			return nil, err
+		}
+		v.cs.AddTypeConst(propType, t, n.Location())
+		return nil, nil
 	case *ExternalVariableAssignment:
 		// Do not trust external type variables,
 		// substitute them with fresh vars.
@@ -143,9 +154,7 @@ func (v ConstraintGenerator) typeof(n Node) (PolyType, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		v.constrainExistingIdent(n.Identifier.Name, t, n.Location())
-
 		scheme := v.scheme(t)
 		v.env.Set(n.Identifier.Name, scheme)
 		return nil, nil

--- a/semantic/graph_test.go
+++ b/semantic/graph_test.go
@@ -355,6 +355,45 @@ func TestNew(t *testing.T) {
 			}}},
 		},
 		{
+			name: "qualified option statement",
+			pkg: &ast.Package{Files: []*ast.File{&ast.File{
+				Body: []ast.Statement{
+					&ast.OptionStatement{
+						Assignment: &ast.MemberAssignment{
+							Member: &ast.MemberExpression{
+								Object: &ast.Identifier{
+									Name: "alert",
+								},
+								Property: &ast.Identifier{
+									Name: "state",
+								},
+							},
+							Init: &ast.StringLiteral{
+								Value: "Warning",
+							},
+						},
+					},
+				}}},
+			},
+			want: &semantic.Package{Files: []*semantic.File{&semantic.File{
+				Body: []semantic.Statement{
+					&semantic.OptionStatement{
+						Assignment: &semantic.MemberAssignment{
+							Member: &semantic.MemberExpression{
+								Object: &semantic.IdentifierExpression{
+									Name: "alert",
+								},
+								Property: "state",
+							},
+							Init: &semantic.StringLiteral{
+								Value: "Warning",
+							},
+						},
+					},
+				},
+			}}},
+		},
+		{
 			name: "function",
 			pkg: &ast.Package{Files: []*ast.File{&ast.File{
 				Body: []ast.Statement{

--- a/semantic/json_test.go
+++ b/semantic/json_test.go
@@ -96,6 +96,23 @@ func TestJSONMarshal(t *testing.T) {
 			want: `{"type":"OptionStatement","assignment":{"type":"NativeVariableAssignment","identifier":{"type":"Identifier","name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","value":"1h0m0s"}},{"type":"Property","key":{"type":"Identifier","name":"delay"},"value":{"type":"DurationLiteral","value":"10m0s"}},{"type":"Property","key":{"type":"Identifier","name":"cron"},"value":{"type":"StringLiteral","value":"0 2 * * *"}},{"type":"Property","key":{"type":"Identifier","name":"retry"},"value":{"type":"IntegerLiteral","value":"5"}}]}}}`,
 		},
 		{
+			name: "qualified option statement",
+			node: &semantic.OptionStatement{
+				Assignment: &semantic.MemberAssignment{
+					Member: &semantic.MemberExpression{
+						Object: &semantic.IdentifierExpression{
+							Name: "alert",
+						},
+						Property: "state",
+					},
+					Init: &semantic.StringLiteral{
+						Value: "Warning",
+					},
+				},
+			},
+			want: `{"type":"OptionStatement","assignment":{"type":"MemberAssignment","member":{"type":"MemberExpression","object":{"type":"IdentifierExpression","name":"alert"},"property":"state"},"init":{"type":"StringLiteral","value":"Warning"}}}`,
+		},
+		{
 			name: "expression statement",
 			node: &semantic.ExpressionStatement{
 				Expression: &semantic.StringLiteral{Value: "hello"},

--- a/semantic/package_test.go
+++ b/semantic/package_test.go
@@ -124,6 +124,59 @@ a = internal.a
 			},
 		},
 		{
+			name: "qualified option",
+			script: `
+package foo
+
+import "alert"
+
+option alert.state = "Warning"
+`,
+			importer: importer{
+				packages: map[string]semantic.PackageType{
+					"alert": semantic.PackageType{
+						Name: "alert",
+						Type: semantic.NewObjectPolyType(
+							map[string]semantic.PolyType{
+								"state": semantic.String,
+							},
+							nil,
+							semantic.LabelSet{"state"},
+						),
+					},
+				},
+			},
+			want: semantic.PackageType{
+				Name: "foo",
+				Type: semantic.NewEmptyObjectPolyType(),
+			},
+		},
+		{
+			name: "assign qualified option new type",
+			script: `
+package foo
+
+import "alert"
+
+option alert.state = 0
+`,
+			importer: importer{
+				packages: map[string]semantic.PackageType{
+					"alert": semantic.PackageType{
+						Name: "alert",
+						Type: semantic.NewObjectPolyType(
+							map[string]semantic.PolyType{
+								"state": semantic.String,
+							},
+							nil,
+							semantic.LabelSet{"state"},
+						),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "modify exported identifier",
 			script: `
 package foo

--- a/semantic/semantictest/cmp.go
+++ b/semantic/semantictest/cmp.go
@@ -21,6 +21,7 @@ var CmpOptions = []cmp.Option{
 	cmpopts.IgnoreUnexported(semantic.ExpressionStatement{}),
 	cmpopts.IgnoreUnexported(semantic.ReturnStatement{}),
 	cmpopts.IgnoreUnexported(semantic.NativeVariableAssignment{}),
+	cmpopts.IgnoreUnexported(semantic.MemberAssignment{}),
 	cmpopts.IgnoreUnexported(semantic.Extern{}),
 	cmpopts.IgnoreUnexported(semantic.ExternalVariableAssignment{}),
 	cmpopts.IgnoreUnexported(semantic.ArrayExpression{}),

--- a/semantic/walk.go
+++ b/semantic/walk.go
@@ -131,6 +131,15 @@ func walk(v Visitor, n Node) {
 			walk(w, n.Identifier)
 			walk(w, n.Init)
 		}
+	case *MemberAssignment:
+		if n == nil {
+			return
+		}
+		w := v.Visit(n)
+		if w != nil {
+			walk(w, n.Member)
+			walk(w, n.Init)
+		}
 	case *ExternalVariableAssignment:
 		if n == nil {
 			return


### PR DESCRIPTION
### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written

The spec is updated in #619 . This PR just adds namespace qualified options to Flux and nothing more. Changes are reflected from the parser through to the interpreter. There's no more need for separate global and option scope objects anymore in the interpreter but to keep current PR small this will come as a follow on PR. 