### PR TITLE
fix(execute/executetest): remove unneeded use of memory allocator

### DIFF
--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -98,42 +98,42 @@ func (t *RowWiseArrowTable) DoArrow(f func(flux.ArrowColReader) error) error {
 	for j, col := range t.ColMeta {
 		switch col.Type {
 		case flux.TBool:
-			b := arrow.NewBoolBuilder(&memory.Allocator{})
+			b := arrow.NewBoolBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(bool))
 			}
 			cols[j] = b.NewBooleanArray()
 			b.Release()
 		case flux.TFloat:
-			b := arrow.NewFloatBuilder(&memory.Allocator{})
+			b := arrow.NewFloatBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(float64))
 			}
 			cols[j] = b.NewFloat64Array()
 			b.Release()
 		case flux.TInt:
-			b := arrow.NewIntBuilder(&memory.Allocator{})
+			b := arrow.NewIntBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(int64))
 			}
 			cols[j] = b.NewInt64Array()
 			b.Release()
 		case flux.TString:
-			b := arrow.NewStringBuilder(&memory.Allocator{})
+			b := arrow.NewStringBuilder(nil)
 			for i := range t.Data {
 				b.AppendString(t.Data[i][j].(string))
 			}
 			cols[j] = b.NewBinaryArray()
 			b.Release()
 		case flux.TTime:
-			b := arrow.NewIntBuilder(&memory.Allocator{})
+			b := arrow.NewIntBuilder(nil)
 			for i := range t.Data {
 				b.Append(int64(t.Data[i][j].(values.Time)))
 			}
 			cols[j] = b.NewInt64Array()
 			b.Release()
 		case flux.TUInt:
-			b := arrow.NewUintBuilder(&memory.Allocator{})
+			b := arrow.NewUintBuilder(nil)
 			for i := range t.Data {
 				b.Append(t.Data[i][j].(uint64))
 			}


### PR DESCRIPTION
The memory allocator is now optional for the arrow builders so we can
pass nil if we don't care to track memory usage.

This functionality was added in #610, but this code was added after the
PR was tested so this specific test code wasn't caught and changed.