### PR TITLE
feat(parser): embed errors into the ast from the parser

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -25,6 +25,10 @@ func (p Position) Less(o Position) bool {
 	return p.Line < o.Line
 }
 
+func (p Position) IsValid() bool {
+	return p.Line > 0 && p.Column > 0
+}
+
 // SourceLocation represents the location of a node in the AST
 type SourceLocation struct {
 	Start  Position `json:"start"`            // Start is the location in the source the node starts
@@ -41,6 +45,10 @@ func (l SourceLocation) Less(o SourceLocation) bool {
 		return l.End.Less(o.End)
 	}
 	return l.Start.Less(o.Start)
+}
+
+func (l SourceLocation) IsValid() bool {
+	return l.Start.IsValid() && l.End.IsValid()
 }
 
 func (l *SourceLocation) Copy() *SourceLocation {

--- a/internal/parser/parser_default.go
+++ b/internal/parser/parser_default.go
@@ -2,28 +2,54 @@
 
 package parser
 
-import "github.com/influxdata/flux/internal/token"
+import (
+	"fmt"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/internal/token"
+)
 
 // expect will continuously scan the input until it reads the requested
 // token. If a token has been buffered by peek, then the token will
 // be read if it matches or will be discarded if it is the wrong token.
-// todo(jsternberg): Find a way to let this method handle errors.
-// There are also parts of the code that use expect to get the tail
-// of an expression. These locations should pass the expected token
-// to the non-terminal so the non-terminal knows the token that is
-// being expected, but they don't use that yet.
 func (p *parser) expect(exp token.Token) (token.Pos, string) {
 	if p.buffered {
 		p.buffered = false
 		if p.tok == exp || p.tok == token.EOF {
+			if p.tok == token.EOF {
+				p.errs = append(p.errs, ast.Error{
+					Msg: fmt.Sprintf("expected %s, got EOF", exp),
+				})
+			}
 			return p.pos, p.lit
 		}
+		p.errs = append(p.errs, ast.Error{
+			Msg: fmt.Sprintf("expected %s, got %s (%q) at %s",
+				exp,
+				p.tok,
+				p.lit,
+				p.s.File().Position(p.pos),
+			),
+		})
 	}
 
 	for {
 		pos, tok, lit := p.scan()
 		if tok == token.EOF || tok == exp {
+			if tok == token.EOF {
+				p.errs = append(p.errs, ast.Error{
+					Msg: fmt.Sprintf("expected %s, got EOF", exp),
+				})
+			}
 			return pos, lit
 		}
+		p.errs = append(p.errs, ast.Error{
+			Msg: fmt.Sprintf("expected %s, got %s (%q) at %s",
+				exp,
+				tok,
+				lit,
+				p.s.File().Position(pos),
+			),
+		})
 	}
 }


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

This change embeds errors into the AST when it is produced by the
parser.

Ideally, we want to have the parser generate the best AST it can and the
current parser doesn't do that. But, making that parser will take too
long at the current moment and we still need to record when we see an
invalid token. This change modifies `expect()` to record that it saw the
wrong token and then continue doing what it was already doing. When a
node is materialized, these aggregated errors are attached to the node.

Expect this functionality to change in the future while the mechanisms
for accessing errors will stay the same. This method does not give very
informative error messages and also does not retain the ability to
recreate the source code from the AST, but it does tell you if there's
a valid or invalid input that was consumed by the parser.

Fixes #305.