### PR TITLE
fix(ast): prettier formatting for package

### DIFF
--- a/ast/format.go
+++ b/ast/format.go
@@ -68,7 +68,11 @@ func (f *formatter) formatPackage(n *Package) {
 	f.formatPackageClause(&PackageClause{
 		Name: &Identifier{Name: n.Package},
 	})
-	for _, file := range n.Files {
+	for i, file := range n.Files {
+		if i != 0 {
+			f.writeRune('\n')
+			f.writeRune('\n')
+		}
 		f.writeComment(file.Name)
 		f.formatFile(file, false)
 	}

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -309,6 +309,44 @@ func TestFormat_Raw(t *testing.T) {
 			},
 			script: "\"foo \\\\ \\\" \r\n\"",
 		},
+		{
+			name: "package multiple files",
+			node: &ast.Package{
+				Package: "foo",
+				Files: []*ast.File{
+					{
+						Name: "a.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "foo"},
+						},
+						Body: []ast.Statement{
+							&ast.VariableAssignment{
+								ID:   &ast.Identifier{Name: "a"},
+								Init: &ast.IntegerLiteral{Value: 1},
+							},
+						},
+					},
+					{
+						Name: "b.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "foo"},
+						},
+						Body: []ast.Statement{
+							&ast.VariableAssignment{
+								ID:   &ast.Identifier{Name: "b"},
+								Init: &ast.IntegerLiteral{Value: 2},
+							},
+						},
+					},
+				},
+			},
+			script: `package foo
+// a.flux
+a = 1
+
+// b.flux
+b = 2`,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
When a package is composed of multiple files, the flux script is formatted by appending the content of each AST and preceding with a comment containing the file name. This fix add newline in between each file.

Before:

```
package foo
// a.flux
a = 1// b.flux
b = 2
```

After:

```
package foo
// a.flux
a = 1

// b.flux
b = 2
```

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
