### PR TITLE
test(functions): add test confirming that filter works with null values

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1709,7 +1709,7 @@ Filter has the following properties:
     Records which evaluate to true, will be included in the output tables.
     TODO(nathanielc): Do we need a syntax for expressing type signatures?
 
-Example: 
+Example:
 
 ```
 from(bucket:"telegraf/autogen")

--- a/functions/transformations/filter_test.go
+++ b/functions/transformations/filter_test.go
@@ -773,6 +773,50 @@ func TestFilter_Process(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: `_value>5 with unused nulls`,
+			spec: &transformations.FilterProcedureSpec{
+				Fn: &semantic.FunctionExpression{
+					Block: &semantic.FunctionBlock{
+						Parameters: &semantic.FunctionParameters{
+							List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+						},
+						Body: &semantic.BinaryExpression{
+							Operator: ast.GreaterThanOperator,
+							Left: &semantic.MemberExpression{
+								Object:   &semantic.IdentifierExpression{Name: "r"},
+								Property: "_value",
+							},
+							Right: &semantic.FloatLiteral{Value: 5},
+						},
+					},
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "host", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0, "server01"},
+					{execute.Time(2), 1.0, nil},
+					{execute.Time(3), 6.0, "server02"},
+					{execute.Time(4), 6.0, nil},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "host", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), 6.0, "server02"},
+					{execute.Time(4), 6.0, nil},
+				},
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

This test does not validate that a null value is actually used as part
of the function. It only asserts that if a null value is in a row that
it will get copied over if the row passes the filter.

Evaluating nulls in functions will be part of a different issue.

Fixes #674.