### PR TITLE
test(functions): add unit test for nulls in map

### DIFF
--- a/functions/transformations/map.go
+++ b/functions/transformations/map.go
@@ -177,8 +177,7 @@ func (t *mapTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 			builder, created := t.cache.TableBuilder(key)
 			if created {
 				if t.mergeKey {
-					err := execute.AddTableKeyCols(tbl.Key(), builder)
-					if err != nil {
+					if err := execute.AddTableKeyCols(tbl.Key(), builder); err != nil {
 						return err
 					}
 				}
@@ -187,11 +186,10 @@ func (t *mapTransformation) Process(id execute.DatasetID, tbl flux.Table) error 
 					if t.mergeKey && tbl.Key().HasCol(k) {
 						continue
 					}
-					_, err := builder.AddCol(flux.ColMeta{
+					if _, err := builder.AddCol(flux.ColMeta{
 						Label: k,
 						Type:  execute.ConvertFromKind(properties[k].Nature()),
-					})
-					if err != nil {
+					}); err != nil {
 						return err
 					}
 				}

--- a/functions/transformations/map_test.go
+++ b/functions/transformations/map_test.go
@@ -548,6 +548,73 @@ func TestMap_Process(t *testing.T) {
 			},
 		},
 		{
+			name: `_value+5 mergeKey=true with nulls`,
+			spec: &transformations.MapProcedureSpec{
+				MergeKey: true,
+				Fn: &semantic.FunctionExpression{
+					Block: &semantic.FunctionBlock{
+						Parameters: &semantic.FunctionParameters{
+							List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+						},
+						Body: &semantic.ObjectExpression{
+							Properties: []*semantic.Property{
+								{
+									Key: &semantic.Identifier{Name: "_time"},
+									Value: &semantic.MemberExpression{
+										Object: &semantic.IdentifierExpression{
+											Name: "r",
+										},
+										Property: "_time",
+									},
+								},
+								{
+									Key: &semantic.Identifier{Name: "_value"},
+									Value: &semantic.BinaryExpression{
+										Operator: ast.AdditionOperator,
+										Left: &semantic.MemberExpression{
+											Object: &semantic.IdentifierExpression{
+												Name: "r",
+											},
+											Property: "_value",
+										},
+										Right: &semantic.FloatLiteral{
+											Value: 5,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				KeyCols: []string{"_measurement", "host"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "host", Type: flux.TString},
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{"m", nil, execute.Time(1), 1.0},
+					{"m", nil, execute.Time(2), 6.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				KeyCols: []string{"_measurement", "host"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "host", Type: flux.TString},
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{"m", nil, execute.Time(1), 6.0},
+					{"m", nil, execute.Time(2), 11.0},
+				},
+			}},
+		},
+		{
 			name: `_value*_value`,
 			spec: &transformations.MapProcedureSpec{
 				MergeKey: false,


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The map eval does not support null yet and that is a separate issue.
Since all of the columns that aren't part of the group key are produced
by the result of the function, this doesn't include a test for that.

It does test if `mergeKey: true` is set and the value is null.

Fixes #682.