### PR TITLE
refactor(stdlib): add null support to sort

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2163,15 +2163,17 @@ from(bucket: "telegraf/autogen") |> set(key: "mykey", value: "myvalue")
 Sorts orders the records within each table.
 One output table is produced for each input table.
 The output tables will have the same schema as their corresponding input tables.
+When sorting, nulls will always be first. When `desc: false` is set, then nulls are less than every other value. When `desc: true`, nulls are greater than every value.
 
 Sort has the following properties:
 
 | Name    | Type     | Description                                                                               |
 | ----    | ----     | -----------                                                                               |
 | columns | []string | Columns is the sort order to use; precedence from left to right. Default is `["_value"]`. |
-| desc    | bool     | Desc indicates results should be sorted in descending order.                              |
+| desc    | bool     | Desc indicates results should be sorted in descending order. Default is `false`.          |
 
 Example:
+
 ```
 from(bucket:"telegraf/autogen")
     |> filter(fn: (r) => r._measurement == "system" AND
@@ -2179,6 +2181,7 @@ from(bucket:"telegraf/autogen")
     |> range(start:-12h)
     |> sort(columns:["region", "host", "value"])
 ```
+
 #### Group
 
 Group groups records based on their values for specific columns.

--- a/stdlib/universe/sort_test.go
+++ b/stdlib/universe/sort_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
-	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/querytest"
+	"github.com/influxdata/flux/stdlib/universe"
 )
 
 func TestSortOperation_Marshaling(t *testing.T) {
@@ -331,6 +331,64 @@ func TestSort_Process(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "one table with null",
+			spec: &universe.SortProcedureSpec{
+				Columns: []string{"_value"},
+				Desc:    false,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 1.0},
+					{execute.Time(3), nil},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), nil},
+					{execute.Time(2), 1.0},
+					{execute.Time(1), 2.0},
+				},
+			}},
+		},
+		{
+			name: "one table descending",
+			spec: &universe.SortProcedureSpec{
+				Columns: []string{"_value"},
+				Desc:    true,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 2.0},
+					{execute.Time(3), nil},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), nil},
+					{execute.Time(2), 2.0},
+					{execute.Time(1), 1.0},
+				},
+			}},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

When sorting, null values are always first so they are less than in
ascending mode and greater than in descending mode. This is to match
with the behavior of SQL.

Fixes #652.