### PR TITLE
docs(SPEC): fix examples with group(by)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -3286,9 +3286,9 @@ For context the following example tables encode fictitious data in response to t
 
     from(bucket:"mydb/autogen")
         |> range(start:2018-05-08T20:50:00Z, stop:2018-05-08T20:51:00Z)
-        |> group(by:["_start","_stop", "region", "host"])
+        |> group(columns:["_start","_stop", "region", "host"])
         |> mean()
-        |> group(by:["_start","_stop", "region"])
+        |> group(columns:["_start","_stop", "region"])
         |> yield(name:"mean")
 
 


### PR DESCRIPTION
Fix the outdated example to use group(columns) instead.