### PR TITLE
refactor(execute): change sort order of group keys to match InfluxDB

### DIFF
--- a/execute/group_key.go
+++ b/execute/group_key.go
@@ -132,13 +132,18 @@ func groupKeyEqual(a, b flux.GroupKey) bool {
 	return true
 }
 
+// groupKeyLess determines if the former key is lexicographically less than the
+// latter.
 func groupKeyLess(a, b flux.GroupKey) bool {
 	aCols := a.Cols()
 	bCols := b.Cols()
-	if av, bv := len(aCols), len(bCols); av != bv {
-		return av < bv
+	min := len(aCols)
+
+	if min > len(bCols) {
+		min = len(bCols)
 	}
-	for j, c := range aCols {
+
+	for j := 0; j < min; j++ {
 		if av, bv := aCols[j].Label, bCols[j].Label; av != bv {
 			return av < bv
 		}
@@ -153,7 +158,7 @@ func groupKeyLess(a, b flux.GroupKey) bool {
 		} else if bv.IsNull() {
 			return false
 		}
-		switch c.Type {
+		switch aCols[j].Type {
 		case flux.TBool:
 			if av, bv := a.ValueBool(j), b.ValueBool(j); av != bv {
 				return av
@@ -180,5 +185,9 @@ func groupKeyLess(a, b flux.GroupKey) bool {
 			}
 		}
 	}
-	return false
+
+	// In this case, min columns have been compared and found to be equal.
+	// Whichever key has the greater number of columns is lexicographically
+	// greater than the other.
+	return len(aCols) < len(bCols)
 }

--- a/result.go
+++ b/result.go
@@ -166,6 +166,22 @@ type GroupKey interface {
 	String() string
 }
 
+// GroupKeys provides a sortable collection of group keys.
+type GroupKeys []GroupKey
+
+func (a GroupKeys) Len() int           { return len(a) }
+func (a GroupKeys) Less(i, j int) bool { return a[i].Less(a[j]) }
+func (a GroupKeys) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+// String returns a string representation of the keys
+func (a GroupKeys) String() string {
+	var result string
+	for _, key := range a {
+		result += key.String() + "\n"
+	}
+	return result
+}
+
 // ResultDecoder can decode a result from a reader.
 type ResultDecoder interface {
 	// Decode decodes data from r into a result.

--- a/stdlib/testing/end_to_end_test.go
+++ b/stdlib/testing/end_to_end_test.go
@@ -29,7 +29,6 @@ var skipTests = map[string]string{
 	"drop_non_existent":           "need to support known errors in new test framework (https://github.com/influxdata/flux/issues/536)",
 	"keep_non_existent":           "need to support known errors in new test framework (https://github.com/influxdata/flux/issues/536)",
 	"yield":                       "yield requires special test case (https://github.com/influxdata/flux/issues/535)",
-	"show_all_tag_keys":           "group keys not being sorted appropriately (https://github.com/influxdata/flux/issues/863)",
 }
 
 var querier = querytest.NewQuerier()

--- a/stdlib/testing/end_to_end_test.go
+++ b/stdlib/testing/end_to_end_test.go
@@ -29,6 +29,7 @@ var skipTests = map[string]string{
 	"drop_non_existent":           "need to support known errors in new test framework (https://github.com/influxdata/flux/issues/536)",
 	"keep_non_existent":           "need to support known errors in new test framework (https://github.com/influxdata/flux/issues/536)",
 	"yield":                       "yield requires special test case (https://github.com/influxdata/flux/issues/535)",
+	"show_all_tag_keys":           "group keys not being sorted appropriately (https://github.com/influxdata/flux/issues/863)",
 }
 
 var querier = querytest.NewQuerier()

--- a/stdlib/testing/testdata/show_all_tag_keys.flux
+++ b/stdlib/testing/testdata/show_all_tag_keys.flux
@@ -1092,11 +1092,11 @@ outData = "
 ,,0,_field
 ,,0,_measurement
 ,,0,host
-,,0,name
-,,0,cpu
 ,,0,device
 ,,0,fstype
 ,,0,path
+,,0,name
+,,0,cpu
 "
 
 t_show_all_tag_keys = (table=<-) =>


### PR DESCRIPTION
This PR changes the sort order of group keys to match the order of series keys emitted from InfluxDB.

In InfluxDB series keys are sorted in lexicographic order. Currently in flux however grouping keys are sorted first by the number of columns and then only lexicographically if both keys have the same number of columns.

For example, InfluxDB stores the following series keys in this order:

```
_f=temp,_m=cpu,region=east,server=a
_f=temp,_m=cpu,region=east,server=a
_f=value,_m=cpu,region=west,server=a,yaba=dabadoo
_f=value,_m=cpu,region=west,server=b
```

However, Because flux currently considers the number of columns in keys before looking at those column names, it will re-sort these keys to the following:

```
_f=temp,_m=cpu,region=east,server=a
_f=temp,_m=cpu,region=east,server=a
_f=value,_m=cpu,region=west,server=b
_f=value,_m=cpu,region=west,server=a,yaba=dabadoo
```

This can lead to significant performance overhead when dealing with many series keys.

In https://github.com/influxdata/influxdb/issues/10988 @russorat  has been seeing some really poor performance when running "meta query" style queries (essentially just getting series keys and identifying the unique set of measurement or tag keys.

For example. given a bucket cardinality of only `~5,000` the following query takes **~40s** to execute:

```
from(bucket: "default")  |> 
range(start: -30d)  |> 
keys()  |> group()  |> distinct()  |> 
keep(columns: ["_value"])  |> sort()  |> limit(n: 200)
```

This profile identifies significant amounts of sorting as the problem: [profile002.pdf](https://github.com/influxdata/flux/files/2764604/profile002.pdf)


With these proposed changes, the time to execute the above query drops from `~40s` to `~1.9s`, which is an improvement of about `21X`.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
