### PR TITLE
fix(execute): check for equality in time columns correctly

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -314,7 +314,7 @@ func TablesEqual(left, right flux.Table, alloc *memory.Allocator) (bool, error) 
 				eq = cmp.Equal(leftBuffer.cols[j].(*stringColumnBuilder).data,
 					rightBuffer.cols[j].(*stringColumnBuilder).data)
 			case flux.TTime:
-				eq = cmp.Equal(rightBuffer.cols[j].(*timeColumnBuilder).data,
+				eq = cmp.Equal(leftBuffer.cols[j].(*timeColumnBuilder).data,
 					rightBuffer.cols[j].(*timeColumnBuilder).data)
 			default:
 				PanicUnknownType(c.Type)

--- a/stdlib/testing/testdata/derivative.flux
+++ b/stdlib/testing/testdata/derivative.flux
@@ -2,7 +2,7 @@ import "testing"
 
 inData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
-#group,false,false,false,false,false,false,true,true,true,true,true,true
+#group,false,false,true,true,false,false,true,true,true,true,true,true
 #default,_result,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
 ,,96,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:26Z,34.98234271799806,used_percent,disk,disk1s1,apfs,host.local,/
@@ -14,7 +14,7 @@ inData = "
 "
 outData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
-#group,false,false,false,false,false,false,true,true,true,true,true,true
+#group,false,false,true,true,false,false,true,true,true,true,true,true
 #default,_result,,,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
 ,,0,2018-05-22T19:53:24.421470485Z,2018-05-22T19:54:24.421470485Z,2018-05-22T19:53:36Z,0.00000006692848479872282,used_percent,disk,disk1s1,apfs,host.local,/
@@ -26,7 +26,7 @@ outData = "
 
 t_derivative = (table=<-) =>
   table
-  |> range(start: 2018-05-22T19:53:26Z)
+  |> range(start: 2018-05-22T19:53:24.421470485Z)
   |> derivative(unit:100ms)
 
 testFn = testing.test

--- a/stdlib/testing/testdata/fill_time.flux
+++ b/stdlib/testing/testdata/fill_time.flux
@@ -4,7 +4,7 @@ import "testing"
 
 inData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,dateTime:RFC3339,string
-#group,false,false,false,false,true,true,true,false,false
+#group,false,false,true,true,true,true,true,false,false
 #default,,,,,,,,,
 ,result,table,_start,_stop,_measurement,_field,t0,_time,_value
 ,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:13:30Z,A
@@ -22,13 +22,13 @@ inData = "
 "
 outData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,dateTime:RFC3339,string
-#group,false,false,false,false,true,true,true,false,false
+#group,false,false,true,true,true,true,true,false,false
 #default,_result,,,,,,,,
 ,result,table,_start,_stop,_measurement,_field,t0,_time,_value
 ,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:13:30Z,A
 ,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:13:40Z,A
 ,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:13:50Z,A
-,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:14:00Z,A
+,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2077-12-19T22:14:00Z,A
 ,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:14:10Z,A
 ,,0,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server01,2018-12-19T22:14:20Z,A
 ,,1,2018-12-19T22:13:30Z,2018-12-19T22:14:20Z,m1,f1,server02,2077-12-19T22:14:00Z,A
@@ -42,7 +42,6 @@ outData = "
 option now = () => 2018-12-19T22:15:00Z
 
 t_fill_float = (table=<-) => table
-  |> range(start: 1907-12-19T22:14:00Z)
   |> fill(column: "_time", value: 2077-12-19T22:14:00Z)
 
 testFn = testing.test

--- a/stdlib/testing/testdata/increase.flux
+++ b/stdlib/testing/testdata/increase.flux
@@ -27,7 +27,7 @@ outData = "
 #group,false,false,false,false,false,false,true,true,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,counter,_field,_measurement,cpu,host
-,,0,2018-05-22T19:53:26Z,2018-05-22T19:55:00Z,2018-05-22T19:53:26Z,1,usage_guest,cpu,cpu-total,host.local
+,,0,2018-05-22T19:53:26Z,2018-05-22T19:55:00Z,2018-05-22T19:53:36Z,1,usage_guest,cpu,cpu-total,host.local
 ,,0,2018-05-22T19:53:26Z,2018-05-22T19:55:00Z,2018-05-22T19:53:46Z,2,usage_guest,cpu,cpu-total,host.local
 ,,0,2018-05-22T19:53:26Z,2018-05-22T19:55:00Z,2018-05-22T19:53:56Z,4,usage_guest,cpu,cpu-total,host.local
 ,,0,2018-05-22T19:53:26Z,2018-05-22T19:55:00Z,2018-05-22T19:54:06Z,4,usage_guest,cpu,cpu-total,host.local

--- a/stdlib/universe/derivative.go
+++ b/stdlib/universe/derivative.go
@@ -664,7 +664,7 @@ func (t *derivativeTransformation) passThroughTime(ts *array.Int64, vs *array.In
 	l := vs.Len()
 	for ; i < l; i++ {
 		// If time is null, or did not advance from previous,
-		// don'cTime add any values to the result
+		// don't add any values to the result
 		if ts.IsNull(i) {
 			continue
 		}


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The previous code had a typo that caused it to compare the right buffer
to the right buffer for time columns which meant that time columns were
never actually checked when comparing tables.