### PR TITLE
Fix/object type

### DIFF
--- a/interpreter/package.go
+++ b/interpreter/package.go
@@ -1,6 +1,7 @@
 package interpreter
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -127,6 +128,8 @@ func (p *Package) String() string {
 			builder.WriteString(", ")
 		}
 		builder.WriteString(k)
+		builder.WriteString(": ")
+		builder.WriteString(fmt.Sprintf("%v", v.PolyType()))
 		i++
 	})
 	builder.WriteRune('}')

--- a/stdlib/testing/testdata/aggregate_window.flux
+++ b/stdlib/testing/testdata/aggregate_window.flux
@@ -35,9 +35,8 @@ aggregate_window = (table=<-) =>
   |> range(start: 2018-05-22T00:00:00Z, stop:2018-05-22T00:01:00Z)
   |> aggregateWindow(every:30s,fn:mean)
 
-testFn = testing.test
-
-testFn(name: "aggregate_window",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: aggregate_window)
+testing.test(
+    name: "aggregate_window",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: aggregate_window)

--- a/stdlib/testing/testdata/columns.flux
+++ b/stdlib/testing/testdata/columns.flux
@@ -46,9 +46,8 @@ t_columns = (table=<-) =>
   |> range(start: 2018-05-20T19:53:26Z)
   |> columns()
 
-testFn = testing.test
-
-testFn(name: "columns",
+testing.test(
+    name: "columns",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_columns)

--- a/stdlib/testing/testdata/count.flux
+++ b/stdlib/testing/testdata/count.flux
@@ -75,9 +75,8 @@ t_count = (table=<-) => table
   |> range(start: -10m)
   |> count()
 
-testFn = testing.test
-
-testFn(name: "count",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_count)
+testing.test(
+    name: "count",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_count)

--- a/stdlib/testing/testdata/covariance.flux
+++ b/stdlib/testing/testdata/covariance.flux
@@ -28,9 +28,8 @@ t_covariance = (tables=<-) =>
     |> range(start: 2018-05-22T19:53:26Z)
     |> covariance(columns: ["x", "y"])
 
-testFn = testing.test
-
-testFn(name: "t_covariance",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_covariance)
+testing.test(
+    name: "t_covariance",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_covariance)

--- a/stdlib/testing/testdata/covariance_missing_column_1.flux
+++ b/stdlib/testing/testdata/covariance_missing_column_1.flux
@@ -24,10 +24,8 @@ covariance_missing_column_1 = (table=<-) =>
     |> covariance(columns: ["x", "r"])
 	|> yield(name: "0")
 
-
-testFn = testing.test
-
-testFn(name: "covariance_missing_column_1",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: covariance_missing_column_1)
+testing.test(
+    name: "covariance_missing_column_1",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: covariance_missing_column_1)

--- a/stdlib/testing/testdata/covariance_missing_column_2.flux
+++ b/stdlib/testing/testdata/covariance_missing_column_2.flux
@@ -21,13 +21,11 @@ outData = "
 covariance_missing_column_2 = (table=<-) =>
   table
 	|> range(start: 2018-05-22T19:53:26Z)
-  |> covariance(columns: ["x", "y"])
+    |> covariance(columns: ["x", "y"])
 	|> yield(name: "0")
 
-
-testFn = testing.test
-
-testFn(name: "covariance_missing_column_2",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: covariance_missing_column_2)
+testing.test(
+    name: "covariance_missing_column_2",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: covariance_missing_column_2)

--- a/stdlib/testing/testdata/cumulative_sum.flux
+++ b/stdlib/testing/testdata/cumulative_sum.flux
@@ -62,9 +62,8 @@ outData = "
 t_cumulative_sum = (table=<-) => table
   |> cumulativeSum(columns: ["v0", "v1"])
 
-testFn = testing.test
-
-testFn(name: "cumulative_sum",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_cumulative_sum)
+testing.test(
+    name: "cumulative_sum",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_cumulative_sum)

--- a/stdlib/testing/testdata/cumulative_sum_default.flux
+++ b/stdlib/testing/testdata/cumulative_sum_default.flux
@@ -60,11 +60,8 @@ outData = "
 t_cumulative_sum_default = (table=<-) => table
   |> cumulativeSum()
 
-testFn = testing.test
-
-testFn(
+testing.test(
     name: "cumulative_sum_default",
     input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-    testFn: t_cumulative_sum_default
-)
+    want: testing.loadMem(csv: outData),
+    testFn: t_cumulative_sum_default)

--- a/stdlib/testing/testdata/cumulative_sum_noop.flux
+++ b/stdlib/testing/testdata/cumulative_sum_noop.flux
@@ -60,11 +60,8 @@ outData = "
 t_cumulative_sum_noop = (table=<-) => table
   |> cumulativeSum()
 
-testFn = testing.test
-
-testFn(
+testing.test(
     name: "cumulative_sum_noop",
     input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-    testFn: t_cumulative_sum_noop
-)
+    want: testing.loadMem(csv: outData),
+    testFn: t_cumulative_sum_noop)

--- a/stdlib/testing/testdata/derivative.flux
+++ b/stdlib/testing/testdata/derivative.flux
@@ -29,9 +29,8 @@ t_derivative = (table=<-) =>
   |> range(start: 2018-05-22T19:53:24.421470485Z)
   |> derivative(unit:100ms)
 
-testFn = testing.test
-
-testFn(name: "derivative",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_derivative)
+testing.test(
+    name: "derivative",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_derivative)

--- a/stdlib/testing/testdata/derivative_nonnegative.flux
+++ b/stdlib/testing/testdata/derivative_nonnegative.flux
@@ -35,9 +35,8 @@ derivative_nonnegative = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> derivative(unit:100ms, nonNegative: true)
 
-testFn = testing.test
-
-testFn(name: "derivative_nonnegative",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: derivative_nonnegative)
+testing.test(
+    name: "derivative_nonnegative",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: derivative_nonnegative)

--- a/stdlib/testing/testdata/difference.flux
+++ b/stdlib/testing/testdata/difference.flux
@@ -40,9 +40,8 @@ t_difference = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> difference()
 
-testFn = testing.test
-
-testFn(name: "difference",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_difference)
+testing.test(
+    name: "difference",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_difference)

--- a/stdlib/testing/testdata/difference_columns.flux
+++ b/stdlib/testing/testdata/difference_columns.flux
@@ -41,9 +41,8 @@ t_difference = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> difference(columns: ["x", "y"])
 
-testFn = testing.test
-
-testFn(name: "difference_columns",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_difference)
+testing.test(
+    name: "difference_columns",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_difference)

--- a/stdlib/testing/testdata/difference_nonnegative.flux
+++ b/stdlib/testing/testdata/difference_nonnegative.flux
@@ -41,9 +41,8 @@ t_difference = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> difference(nonNegative: true)
 
-testFn = testing.test
-
-testFn(name: "difference_nonnegative",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_difference)
+testing.test(
+    name: "difference_nonnegative",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_difference)

--- a/stdlib/testing/testdata/difference_one_value.flux
+++ b/stdlib/testing/testdata/difference_one_value.flux
@@ -19,9 +19,8 @@ difference_one_value = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> difference(nonNegative:true)
 
-testFn = testing.test
-
-testFn(name: "difference_one_value",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: difference_one_value)
+testing.test(
+    name: "difference_one_value",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: difference_one_value)

--- a/stdlib/testing/testdata/difference_panic.flux
+++ b/stdlib/testing/testdata/difference_panic.flux
@@ -32,9 +32,8 @@ t_difference_panic = (table=<-) =>
     |> filter(fn: (r) => r._field == "no_exist")
     |> difference()
 
-testFn = testing.test
-
-testFn(name: "difference_panic",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_difference_panic)
+testing.test(
+    name: "difference_panic",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_difference_panic)

--- a/stdlib/testing/testdata/distinct.flux
+++ b/stdlib/testing/testdata/distinct.flux
@@ -38,9 +38,8 @@ t_distinct = (table=<-) =>
   |> distinct(column:"_value")
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "distinct",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_distinct)
+testing.test(
+    name: "distinct",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_distinct)

--- a/stdlib/testing/testdata/drop_after_rename.flux
+++ b/stdlib/testing/testdata/drop_after_rename.flux
@@ -55,9 +55,8 @@ drop_after_rename = (table=<-) =>
 	|> rename(columns: {old: "new"})
 	|> drop(columns: ["old"])
 
-testFn = testing.test
-
-testFn(name: "drop_after_rename",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: drop_after_rename)
+testing.test(
+    name: "drop_after_rename",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: drop_after_rename)

--- a/stdlib/testing/testdata/drop_before_rename.flux
+++ b/stdlib/testing/testdata/drop_before_rename.flux
@@ -39,10 +39,8 @@ drop_before_rename = (table=<-) =>
 	|> rename(columns: {old: "new"})
 	|> yield(name: "0")
 
-
-testFn = testing.test
-
-testFn(name: "drop_before_rename",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: drop_before_rename)
+testing.test(
+    name: "drop_before_rename",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: drop_before_rename)

--- a/stdlib/testing/testdata/drop_fn.flux
+++ b/stdlib/testing/testdata/drop_fn.flux
@@ -55,9 +55,8 @@ t_drop = (table=<-) =>
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> drop(fn: (column) => column =~ /dropme*/)
 
-testFn = testing.test
-
-testFn(name: "drop_fn",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_drop)
+testing.test(
+    name: "drop_fn",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_drop)

--- a/stdlib/testing/testdata/drop_newname_after.flux
+++ b/stdlib/testing/testdata/drop_newname_after.flux
@@ -55,9 +55,8 @@ drop_newname_after = (table=<-) =>
 	|> rename(columns:{old:"new"})
 	|> drop(columns: ["new"])
 
-testFn = testing.test
-
-testFn(name: "drop_newname_after",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: drop_newname_after)
+testing.test(
+    name: "drop_newname_after",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: drop_newname_after)

--- a/stdlib/testing/testdata/drop_newname_before.flux
+++ b/stdlib/testing/testdata/drop_newname_before.flux
@@ -55,9 +55,8 @@ drop_newname_before = (table=<-) =>
 	|> drop(columns:["new"])
 	|> rename(columns: {old:"new"})
 
-testFn = testing.test
-
-testFn(name: "drop_newname_before",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: drop_newname_before)
+testing.test(
+    name: "drop_newname_before",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: drop_newname_before)

--- a/stdlib/testing/testdata/drop_non_existent.flux
+++ b/stdlib/testing/testdata/drop_non_existent.flux
@@ -38,12 +38,15 @@ t_drop = (table=<-) =>
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> drop(columns: ["non_existent"])
 
-testFn = testing.test
+testing.test(
+    name: "drop_non_existent",
+    load: testLoadData,
+    infile: "drop_fn.in.csv",
+    outfile: "drop_non_existent.out.csv",
+    testFn: drop_fn)
 
-testFn(name: "drop_non_existent", load: testLoadData, infile: "drop_fn.in.csv", outfile: "drop_non_existent.out.csv", testFn: drop_fn)
-testFn = testing.test
-
-testFn(name: "drop_non_existent",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_drop)
+testing.test(
+    name: "drop_non_existent",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_drop)

--- a/stdlib/testing/testdata/drop_referenced.flux
+++ b/stdlib/testing/testdata/drop_referenced.flux
@@ -38,9 +38,8 @@ drop_referenced = (table=<-) =>
 	|> drop(columns: ["_field"])
 	|> filter(fn: (r) => r._field == "usage_guest")
 
-testFn = testing.test
-
-testFn(name: "drop_referenced",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: drop_referenced)
+testing.test(
+    name: "drop_referenced",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: drop_referenced)

--- a/stdlib/testing/testdata/drop_unused.flux
+++ b/stdlib/testing/testdata/drop_unused.flux
@@ -53,9 +53,8 @@ drop_unused = (table=<-) =>
 	|> drop(columns: ["_measurement"])
 	|> filter(fn: (r) => r._field == "usage_guest")
 
-testFn = testing.test
-
-testFn(name: "drop_unused",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: drop_unused)
+testing.test(
+    name: "drop_unused",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: drop_unused)

--- a/stdlib/testing/testdata/duplicate.flux
+++ b/stdlib/testing/testdata/duplicate.flux
@@ -42,9 +42,8 @@ t_duplicate = (table=<-) =>
 	|> range(start:2018-05-22T19:53:26Z)
 	|> duplicate(column: "host", as: "host_new")
 
-testFn = testing.test
-
-testFn(name: "duplicate",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_duplicate)
+testing.test(
+    name: "duplicate",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_duplicate)

--- a/stdlib/testing/testdata/fill_bool.flux
+++ b/stdlib/testing/testdata/fill_bool.flux
@@ -43,9 +43,8 @@ t_fill_bool = (table=<-) => table
   |> range(start: -5m)
   |> fill(value: false)
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_fill_bool)

--- a/stdlib/testing/testdata/fill_float.flux
+++ b/stdlib/testing/testdata/fill_float.flux
@@ -43,9 +43,8 @@ t_fill_float = (table=<-) => table
   |> range(start: -5m)
   |> fill(value: 0.01)
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_fill_float)

--- a/stdlib/testing/testdata/fill_int.flux
+++ b/stdlib/testing/testdata/fill_int.flux
@@ -43,9 +43,8 @@ t_fill_int = (table=<-) => table
   |> range(start: -5m)
   |> fill(column: "_value", value: -1)
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_fill_int)

--- a/stdlib/testing/testdata/fill_previous.flux
+++ b/stdlib/testing/testdata/fill_previous.flux
@@ -45,9 +45,8 @@ t_fill_int = (table=<-) => table
   |> range(start: -5m)
   |> fill(usePrevious: true)
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: csv.from(csv: inData),
     want: csv.from(csv: outData),
     testFn: t_fill_int)

--- a/stdlib/testing/testdata/fill_string.flux
+++ b/stdlib/testing/testdata/fill_string.flux
@@ -43,9 +43,8 @@ t_fill_float = (table=<-) => table
   |> range(start: -5m)
   |> fill(column: "_value", value: "A")
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_fill_float)

--- a/stdlib/testing/testdata/fill_time.flux
+++ b/stdlib/testing/testdata/fill_time.flux
@@ -44,9 +44,8 @@ option now = () => 2018-12-19T22:15:00Z
 t_fill_float = (table=<-) => table
   |> fill(column: "_time", value: 2077-12-19T22:14:00Z)
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_fill_float)

--- a/stdlib/testing/testdata/fill_uint.flux
+++ b/stdlib/testing/testdata/fill_uint.flux
@@ -43,9 +43,8 @@ t_fill_uint = (table=<-) => table
   |> range(start: -5m)
   |> fill(column: "_value", value: uint(v:0))
 
-testFn = testing.test
-
-testFn(name: "fill",
+testing.test(
+    name: "fill",
     input: testing.loadStorage(csv: inData),
     want: testing.loadMem(csv: outData),
     testFn: t_fill_uint)

--- a/stdlib/testing/testdata/filter_by_regex.flux
+++ b/stdlib/testing/testdata/filter_by_regex.flux
@@ -39,9 +39,8 @@ table
   |> map(fn: (r) => ({_time: r._time, io_time: r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "filter_by_regex",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_filter_by_regex)
+testing.test(
+    name: "filter_by_regex",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_filter_by_regex)

--- a/stdlib/testing/testdata/filter_by_regex_function.flux
+++ b/stdlib/testing/testdata/filter_by_regex_function.flux
@@ -42,10 +42,9 @@ t_filter_by_regex_function = (table=<-) =>
   table
   |> regexFunc(regLiteral: /io.*/)
 
-testFn = testing.test
-
-testFn(name: "filter_by_regex_function",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_filter_by_regex_function)
+testing.test(
+    name: "filter_by_regex_function",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_filter_by_regex_function)
 

--- a/stdlib/testing/testdata/filter_by_tags.flux
+++ b/stdlib/testing/testdata/filter_by_tags.flux
@@ -39,9 +39,8 @@ t_filter_by_tags = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, io_time: r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "filter_by_tags",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_filter_by_tags)
+testing.test(
+    name: "filter_by_tags",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_filter_by_tags)

--- a/stdlib/testing/testdata/first.flux
+++ b/stdlib/testing/testdata/first.flux
@@ -44,9 +44,9 @@ outData = "
 t_first = (table=<-) =>
   table
   |> first()
-testFn = testing.test
 
-testFn(name: "first",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_first)
+testing.test(
+    name: "first",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_first)

--- a/stdlib/testing/testdata/group.flux
+++ b/stdlib/testing/testdata/group.flux
@@ -36,9 +36,8 @@ t_group = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, max: r._value}))
   |> yield(name: "0")
 
-testFn = testing.test
-
-testFn(name: "group",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_group)
+testing.test(
+    name: "group",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_group)

--- a/stdlib/testing/testdata/group_by_field.flux
+++ b/stdlib/testing/testdata/group_by_field.flux
@@ -29,9 +29,9 @@ t_group_by_field = (table=<-) =>
   table
     |> range(start:2018-05-22T19:53:26Z)
     |> group(columns: ["_value"])
-testFn = testing.test
 
-testFn(name: "group_by_field",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_group_by_field)
+testing.test(
+    name: "group_by_field",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_group_by_field)

--- a/stdlib/testing/testdata/group_by_irregular.flux
+++ b/stdlib/testing/testdata/group_by_irregular.flux
@@ -42,9 +42,8 @@ t_group_by_irregular = (table=<-) =>
   |> group(columns: ["runID"])
   |> yield(name:"r1")
 
-testFn = testing.test
-
-testFn(name: "group_by_irregular",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_group_by_irregular)
+testing.test(
+    name: "group_by_irregular",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_group_by_irregular)

--- a/stdlib/testing/testdata/group_except.flux
+++ b/stdlib/testing/testdata/group_except.flux
@@ -33,9 +33,8 @@ t_group_except = (table=<-) =>
     |> group(columns:["_measurement", "_time", "_value"], mode: "except")
     |> max()
 
-testFn = testing.test
-
-testFn(name: "group_except",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_group_except)
+testing.test(
+    name: "group_except",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_group_except)

--- a/stdlib/testing/testdata/group_nulls.flux
+++ b/stdlib/testing/testdata/group_nulls.flux
@@ -88,9 +88,8 @@ t_group = (table=<-) =>
   |> range(start: 1902-05-22T19:53:26Z)
   |> group(columns: ["host"])
 
-testFn = testing.test
-
-testFn(name: "group",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_group)
+testing.test(
+    name: "group",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_group)

--- a/stdlib/testing/testdata/group_ungroup.flux
+++ b/stdlib/testing/testdata/group_ungroup.flux
@@ -45,9 +45,8 @@ t_group_ungroup = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, io_time:r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "group_ungroup",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_group_ungroup)
+testing.test(
+    name: "group_ungroup",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_group_ungroup)

--- a/stdlib/testing/testdata/highestAverage.flux
+++ b/stdlib/testing/testdata/highestAverage.flux
@@ -35,9 +35,8 @@ t_highestAverage = (table=<-) =>
   table
     |> highestAverage(n: 3, groupColumns: ["_measurement", "host"])
 
-testFn = testing.test
-
-testFn(name: "highestAverage",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_highestAverage)
+testing.test(
+    name: "highestAverage",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_highestAverage)

--- a/stdlib/testing/testdata/highestCurrent.flux
+++ b/stdlib/testing/testdata/highestCurrent.flux
@@ -36,9 +36,8 @@ t_highestCurrent = (table=<-) =>
     |> range(start: 2018-11-07T00:00:00Z)
     |> highestCurrent(n: 3, groupColumns: ["_measurement", "host"])
 
-testFn = testing.test
-
-testFn(name: "highestCurrent",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_highestCurrent)
+testing.test(
+    name: "highestCurrent",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_highestCurrent)

--- a/stdlib/testing/testdata/highestMax.flux
+++ b/stdlib/testing/testdata/highestMax.flux
@@ -35,9 +35,8 @@ t_highestMax = (table=<-) =>
   table
     |> highestMax(n: 3, groupColumns: ["_measurement", "host"])
 
-testFn = testing.test
-
-testFn(name: "highestMax",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_highestMax)
+testing.test(
+    name: "highestMax",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_highestMax)

--- a/stdlib/testing/testdata/histogram.flux
+++ b/stdlib/testing/testdata/histogram.flux
@@ -30,9 +30,8 @@ t_histogram = (table=<-) =>
   table
     |> histogram(bins:[-1.0,0.0,1.0,2.0])
 
-testFn = testing.test
-
-testFn(name: "histogram",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_histogram)
+testing.test(
+    name: "histogram",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_histogram)

--- a/stdlib/testing/testdata/histogram_normalize.flux
+++ b/stdlib/testing/testdata/histogram_normalize.flux
@@ -34,9 +34,8 @@ t_histogram = (table=<-) =>
            countColumn: "theCount",
            upperBoundColumn: "ub")
 
-testFn = testing.test
-
-testFn(name: "histogram",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_histogram)
+testing.test(
+    name: "histogram",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_histogram)

--- a/stdlib/testing/testdata/histogram_quantile.flux
+++ b/stdlib/testing/testdata/histogram_quantile.flux
@@ -40,9 +40,8 @@ t_histogram_quantile = (table=<-) =>
            countColumn:"count",
            valueColumn:"quant")
 
-testFn = testing.test
-
-testFn(name: "histogram_quantile",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_histogram_quantile)
+testing.test(
+    name: "histogram_quantile",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_histogram_quantile)

--- a/stdlib/testing/testdata/histogram_quantile_minvalue.flux
+++ b/stdlib/testing/testdata/histogram_quantile_minvalue.flux
@@ -29,9 +29,8 @@ t_histogram_quantile = (table=<-) =>
     |> range(start: 2018-05-22T19:53:00Z)
     |> histogramQuantile(quantile:0.25, minValue: -100.0)
 
-testFn = testing.test
-
-testFn(name: "histogram_quantile_minvalue",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_histogram_quantile)
+testing.test(
+    name: "histogram_quantile_minvalue",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_histogram_quantile)

--- a/stdlib/testing/testdata/increase.flux
+++ b/stdlib/testing/testdata/increase.flux
@@ -48,10 +48,8 @@ t_increase = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> increase(columns:["counter"])
 
-
-testFn = testing.test
-
-testFn(name: "increase",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_increase)
+testing.test(
+    name: "increase",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_increase)

--- a/stdlib/testing/testdata/influxFieldsAsCols.flux
+++ b/stdlib/testing/testdata/influxFieldsAsCols.flux
@@ -59,9 +59,9 @@ t_influxFieldsAsCols = (table=<-) =>
   |> range(start: 2018-05-22T19:53:26Z, stop: 2018-05-22T19:54:17Z)
   |> influxFieldsAsCols()
   |> yield(name:"0")
-testFn = testing.test
 
-testFn(name: "influxFieldsAsCols",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_influxFieldsAsCols)
+testing.test(
+    name: "influxFieldsAsCols",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_influxFieldsAsCols)

--- a/stdlib/testing/testdata/integral.flux
+++ b/stdlib/testing/testdata/integral.flux
@@ -43,11 +43,8 @@ outData =
 t_integral = (table=<-) =>
   table |> integral(unit: 10s)
 
-testFn = testing.test
-
-testFn(
+testing.test(
     name: "integral",
-     input: testing.loadStorage(csv: inData),
-     want: testing.loadMem(csv: outData),
-     testFn:  t_integral,
-)
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn:  t_integral)

--- a/stdlib/testing/testdata/integral_columns.flux
+++ b/stdlib/testing/testdata/integral_columns.flux
@@ -43,11 +43,8 @@ outData =
 t_integral_columns = (table=<-) =>
   table |> integral(columns: ["v1", "v2"], unit: 10s)
 
-testFn = testing.test
-
-testFn(
+testing.test(
     name: "integral_columns",
-     input: testing.loadStorage(csv: inData),
-     want: testing.loadMem(csv: outData),
-     testFn:  t_integral_columns,
-)
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn:  t_integral_columns)

--- a/stdlib/testing/testdata/keep.flux
+++ b/stdlib/testing/testdata/keep.flux
@@ -54,9 +54,8 @@ t_keep = (table=<-) =>
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> keep(columns: ["_time", "_value", "_field"])
 
-testFn = testing.test
-
-testFn(name: "keep",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_keep)
+testing.test(
+    name: "keep",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_keep)

--- a/stdlib/testing/testdata/keep_fn.flux
+++ b/stdlib/testing/testdata/keep_fn.flux
@@ -55,9 +55,8 @@ t_keep_fn = (table=<-) =>
 	|> keep(fn: (column) => column == "_field" or column == "_value")
     |> keep(fn: (column) =>  {return column == "_value"})
 
-testFn = testing.test
-
-testFn(name: "keep_fn",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_keep_fn)
+testing.test(
+    name: "keep_fn",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_keep_fn)

--- a/stdlib/testing/testdata/keep_non_existent.flux
+++ b/stdlib/testing/testdata/keep_non_existent.flux
@@ -38,9 +38,8 @@ t_keep = (table=<-) =>
 	|> range(start: 2018-05-22T19:53:26Z)
 	|> keep(columns: ["non_existent"])
 
-testFn = testing.test
-
-testFn(name: "keep_non_existent",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_keep)
+testing.test(
+    name: "keep_non_existent",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_keep)

--- a/stdlib/testing/testdata/key_values.flux
+++ b/stdlib/testing/testdata/key_values.flux
@@ -41,10 +41,8 @@ t_key_values = (table=<-) =>
   table
   |> keyValues(keyColumns: ["_value"])
 
-testFn = testing.test
-
-testFn(name: "key_values",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_key_values,
-)
+testing.test(
+    name: "key_values",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_key_values)

--- a/stdlib/testing/testdata/key_values_host_name.flux
+++ b/stdlib/testing/testdata/key_values_host_name.flux
@@ -57,10 +57,9 @@ outData = "
 t_key_values_host_name = (table=<-) =>
   table
   |> keyValues(keyColumns: ["host", "name"])
-testFn = testing.test
 
-testFn(name: "key_values_host_name",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_key_values_host_name,
-)
+testing.test(
+    name: "key_values_host_name",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_key_values_host_name)

--- a/stdlib/testing/testdata/keys.flux
+++ b/stdlib/testing/testdata/keys.flux
@@ -34,9 +34,8 @@ t_keys = (table=<-) =>
   |> range(start: 2018-05-20T19:53:26Z)
   |> keys()
 
-testFn = testing.test
-
-testFn(name: "keys",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_keys)
+testing.test(
+    name: "keys",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_keys)

--- a/stdlib/testing/testdata/last.flux
+++ b/stdlib/testing/testdata/last.flux
@@ -44,9 +44,9 @@ outData = "
 t_last = (table=<-) =>
   table
   |> last()
-testFn = testing.test
 
-testFn(name: "last",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_last)
+testing.test(
+    name: "last",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_last)

--- a/stdlib/testing/testdata/limit.flux
+++ b/stdlib/testing/testdata/limit.flux
@@ -47,9 +47,8 @@ t_limit = (table=<-) =>
     |> range(start: 2018-05-22T19:00:00Z, stop: 2018-05-22T20:00:00Z)
     |> limit(n: 1)
 
-testFn = testing.test
-
-testFn(name: "limit",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_limit)
+testing.test(
+    name: "limit",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_limit)

--- a/stdlib/testing/testdata/limit_offset.flux
+++ b/stdlib/testing/testdata/limit_offset.flux
@@ -51,9 +51,8 @@ t_limit = (table=<-) =>
     |> range(start: 2018-05-22T19:00:00Z, stop: 2018-05-22T20:00:00Z)
     |> limit(n: 2, offset: 1)
 
-testFn = testing.test
-
-testFn(name: "limit_offset",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_limit)
+testing.test(
+    name: "limit_offset",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_limit)

--- a/stdlib/testing/testdata/lowestAverage.flux
+++ b/stdlib/testing/testdata/lowestAverage.flux
@@ -36,9 +36,8 @@ t_lowestAverage = (table=<-) =>
     |> range(start: 2018-11-07T00:00:00Z)
     |> lowestAverage(n: 3, groupColumns: ["_measurement", "host"])
 
-testFn = testing.test
-
-testFn(name: "lowestAverage",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_lowestAverage)
+testing.test(
+    name: "lowestAverage",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_lowestAverage)

--- a/stdlib/testing/testdata/lowestCurrent.flux
+++ b/stdlib/testing/testdata/lowestCurrent.flux
@@ -36,9 +36,8 @@ t_lowestCurrent = (table=<-) =>
     |> range(start: 2018-11-07T00:00:00Z)
     |> lowestCurrent(n: 3, groupColumns: ["_measurement", "host"])
 
-testFn = testing.test
-
-testFn(name: "lowestCurrent",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_lowestCurrent)
+testing.test(
+    name: "lowestCurrent",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_lowestCurrent)

--- a/stdlib/testing/testdata/lowestMin.flux
+++ b/stdlib/testing/testdata/lowestMin.flux
@@ -36,9 +36,8 @@ t_lowestMin = (table=<-) =>
     |> range(start: 2018-11-07T00:00:00Z)
     |> lowestMin(n: 3, groupColumns: ["_measurement", "host"])
 
-testFn = testing.test
-
-testFn(name: "lowestMin",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_lowestMin)
+testing.test(
+    name: "lowestMin",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_lowestMin)

--- a/stdlib/testing/testdata/max.flux
+++ b/stdlib/testing/testdata/max.flux
@@ -44,9 +44,9 @@ outData = "
 t_max = (table=<-) =>
   table
   |> max()
-testFn = testing.test
 
-testFn(name: "max",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_max)
+testing.test(
+    name: "max",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_max)

--- a/stdlib/testing/testdata/mean.flux
+++ b/stdlib/testing/testdata/mean.flux
@@ -50,9 +50,8 @@ t_mean = (table=<-) => table
   |> range(start: -5m)
   |> mean()
 
-testFn = testing.test
-
-testFn(name: "mean",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_mean)
+testing.test(
+    name: "mean",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_mean)

--- a/stdlib/testing/testdata/meta_query_fields.flux
+++ b/stdlib/testing/testdata/meta_query_fields.flux
@@ -51,9 +51,9 @@ t_meta_query_fields = (table=<-) =>
     |> group(columns: ["_field"])
     |> distinct(column: "_field")
     |> group()
-testFn = testing.test
 
-testFn(name: "meta_query_fields",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_meta_query_fields)
+testing.test(
+    name: "meta_query_fields",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_meta_query_fields)

--- a/stdlib/testing/testdata/meta_query_keys.flux
+++ b/stdlib/testing/testdata/meta_query_keys.flux
@@ -85,9 +85,9 @@ t_meta_query_keys = (table=<-) => {
     |> yield(name:"1")
   return union(tables: [zero, one])
 }
-testFn = testing.test
 
-testFn(name: "meta_query_keys",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_meta_query_keys)
+testing.test(
+    name: "meta_query_keys",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_meta_query_keys)

--- a/stdlib/testing/testdata/meta_query_measurements.flux
+++ b/stdlib/testing/testdata/meta_query_measurements.flux
@@ -36,9 +36,9 @@ t_meta_query_measurements = (table=<-) =>
     |> group(columns: ["_measurement"])
     |> distinct(column: "_measurement")
     |> group()
-testFn = testing.test
 
-testFn(name: "meta_query_measurements",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_meta_query_measurements)
+testing.test(
+    name: "meta_query_measurements",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_meta_query_measurements)

--- a/stdlib/testing/testdata/min.flux
+++ b/stdlib/testing/testdata/min.flux
@@ -44,9 +44,9 @@ outData = "
 t_min = (table=<-) =>
   table
   |> min()
-testFn = testing.test
 
-testFn(name: "min",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_min)
+testing.test(
+    name: "min",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_min)

--- a/stdlib/testing/testdata/multiple_range.flux
+++ b/stdlib/testing/testdata/multiple_range.flux
@@ -33,9 +33,8 @@ t_multiple_range = (table=<-) =>
 	|> range(start: 2018-05-22T19:53:26Z, stop: 2018-05-22T19:54:16Z)
 	|> range(start: 2018-05-22T19:54:06Z)
 
-testFn = testing.test
-
-testFn(name: "multiple_range",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_multiple_range)
+testing.test(
+    name: "multiple_range",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_multiple_range)

--- a/stdlib/testing/testdata/null_as_value.flux
+++ b/stdlib/testing/testdata/null_as_value.flux
@@ -11,9 +11,8 @@ t_null_as_value = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
 	|> filter(fn: (r) => r._value == null)
 
-testFn = testing.test
-
-testFn(name: "null_as_value",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_null_as_value)
+testing.test(
+    name: "null_as_value",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_null_as_value)

--- a/stdlib/testing/testdata/parse_regex.flux
+++ b/stdlib/testing/testdata/parse_regex.flux
@@ -35,9 +35,10 @@ t_parse_regex = (table=<-) =>
     |> range(start:2018-05-20T19:53:26Z)
     |> filter(fn: (r) => r._field =~ filterRegex)
     |> max()
-testFn = testing.test
 
-testFn(name: "parse_regex",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_parse_regex)
+
+testing.test(
+    name: "parse_regex",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_parse_regex)

--- a/stdlib/testing/testdata/percentile.flux
+++ b/stdlib/testing/testdata/percentile.flux
@@ -129,9 +129,8 @@ t_percentile = (table=<-) => table
     |> range(start: -5m)
     |> percentile(percentile: 0.75, method:"exact_selector")
 
-testFn = testing.test
-
-testFn(name: "percentile",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_percentile)
+testing.test(
+    name: "percentile",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_percentile)

--- a/stdlib/testing/testdata/percentile_aggregate.flux
+++ b/stdlib/testing/testdata/percentile_aggregate.flux
@@ -26,9 +26,8 @@ t_percentile = (table=<-) => table
     |> range(start: -2m)
     |> percentile(percentile: 0.75, method: "exact_mean")
 
-testFn = testing.test
-
-testFn(name: "percentile_aggregate",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_percentile)
+testing.test(
+    name: "percentile_aggregate",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_percentile)

--- a/stdlib/testing/testdata/percentile_tdigest.flux
+++ b/stdlib/testing/testdata/percentile_tdigest.flux
@@ -26,9 +26,8 @@ t_percentile = (table=<-) => table
     |> range(start: -2m)
     |> percentile(percentile: 0.75, method: "estimate_tdigest")
 
-testFn = testing.test
-
-testFn(name: "percentile_tdigest",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_percentile)
+testing.test(
+    name: "percentile_tdigest",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_percentile)

--- a/stdlib/testing/testdata/pivot.flux
+++ b/stdlib/testing/testdata/pivot.flux
@@ -49,9 +49,8 @@ t_pivot = (table=<-) =>
   |> pivot(rowKey: ["_time"], columnKey: ["_measurement", "_field"], valueColumn: "_value")
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "pivot",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_pivot)
+testing.test(
+    name: "pivot",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_pivot)

--- a/stdlib/testing/testdata/pivot_fields.flux
+++ b/stdlib/testing/testdata/pivot_fields.flux
@@ -60,9 +60,8 @@ t_pivot_fields = (table=<-) =>
   |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "pivot_fields",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_pivot_fields)
+testing.test(
+    name: "pivot_fields",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_pivot_fields)

--- a/stdlib/testing/testdata/pivot_mean.flux
+++ b/stdlib/testing/testdata/pivot_mean.flux
@@ -28,9 +28,8 @@ t_pivot_mean = (table=<-) =>
   |> pivot(rowKey: ["_stop"], columnKey: ["host"], valueColumn: "_value")
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "pivot_mean",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_pivot_mean)
+testing.test(
+    name: "pivot_mean",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_pivot_mean)

--- a/stdlib/testing/testdata/pivot_task_test.flux
+++ b/stdlib/testing/testdata/pivot_task_test.flux
@@ -40,9 +40,8 @@ t_pivot_task_test = (table=<-) =>
 	|> filter(fn: (r) => r._measurement == "records" and r.taskID == "02bac3c8f0f37000" )
 	|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
 
-testFn = testing.test
-
-testFn(name: "pivot_task_test",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_pivot_task_test)
+testing.test(
+    name: "pivot_task_test",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_pivot_task_test)

--- a/stdlib/testing/testdata/range.flux
+++ b/stdlib/testing/testdata/range.flux
@@ -39,10 +39,8 @@ t_range = (table=<-) =>
   table
     |> range(start:2018-05-22T19:53:36Z)
 
-
-testFn = testing.test
-
-testFn(name: "range",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_range)
+testing.test(
+    name: "range",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_range)

--- a/stdlib/testing/testdata/rename.flux
+++ b/stdlib/testing/testdata/rename.flux
@@ -55,10 +55,8 @@ t_rename = (table=<-) =>
 	|> rename(columns:{host:"server"})
 	|> drop(columns:["_start", "_stop"])
 
-
-testFn = testing.test
-
-testFn(name: "rename",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_rename)
+testing.test(
+    name: "rename",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_rename)

--- a/stdlib/testing/testdata/rename_fn.flux
+++ b/stdlib/testing/testdata/rename_fn.flux
@@ -53,9 +53,8 @@ t_rename = (table=<-) =>
 	|> rename(fn: (column) => column)
 	|> drop(fn: (column) => column == "_start" or column == "_stop")
 
-testFn = testing.test
-
-testFn(name: "rename_fn",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_rename)
+testing.test(
+    name: "rename_fn",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_rename)

--- a/stdlib/testing/testdata/rename_multiple.flux
+++ b/stdlib/testing/testdata/rename_multiple.flux
@@ -55,9 +55,8 @@ t_rename_multiple = (table=<-) =>
 	|> rename(columns: {old:"new"})
 	|> rename(columns: {new: "new1"})
 
-testFn = testing.test
-
-testFn(name: "rename_multiple",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_rename_multiple)
+testing.test(
+    name: "rename_multiple",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_rename_multiple)

--- a/stdlib/testing/testdata/sample.flux
+++ b/stdlib/testing/testdata/sample.flux
@@ -52,9 +52,9 @@ outData = "
 t_sample = (table=<-) =>
   table
   |> sample(n: 3, pos: 1)
-testFn = testing.test
 
-testFn(name: "sample",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_sample)
+testing.test(
+    name: "sample",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_sample)

--- a/stdlib/testing/testdata/select_measurement.flux
+++ b/stdlib/testing/testdata/select_measurement.flux
@@ -51,9 +51,8 @@ t_select_measurement = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, used_percent:r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "select_measurement",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_select_measurement)
+testing.test(
+    name: "select_measurement",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_select_measurement)

--- a/stdlib/testing/testdata/select_measurement_field.flux
+++ b/stdlib/testing/testdata/select_measurement_field.flux
@@ -57,9 +57,8 @@ t_select_measurement_field = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, load1:r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "select_measurement_field",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_select_measurement_field)
+testing.test(
+    name: "select_measurement_field",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_select_measurement_field)

--- a/stdlib/testing/testdata/selector_preserve_time.flux
+++ b/stdlib/testing/testdata/selector_preserve_time.flux
@@ -28,9 +28,8 @@ t_selector_preserve_time = (table=<-) =>
 	|> top(n:3)
 	|> group(columns:["host"])
 
-testFn = testing.test
-
-testFn(name: "selector_preserve_time",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_selector_preserve_time)
+testing.test(
+    name: "selector_preserve_time",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_selector_preserve_time)

--- a/stdlib/testing/testdata/set.flux
+++ b/stdlib/testing/testdata/set.flux
@@ -179,9 +179,8 @@ t_set = (table=<-) => table
   |> range(start: -5m)
   |> set(key: "t0", value: "server01")
 
-testFn = testing.test
-
-testFn(name: "set",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_set)
+testing.test(
+    name: "set",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_set)

--- a/stdlib/testing/testdata/set_new_column.flux
+++ b/stdlib/testing/testdata/set_new_column.flux
@@ -179,9 +179,8 @@ t_set_new_column = (table=<-) => table
   |> range(start: -5m)
   |> set(key: "t1", value: "server01")
 
-testFn = testing.test
-
-testFn(name: "set_new_column",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_set_new_column)
+testing.test(
+    name: "set_new_column",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_set_new_column)

--- a/stdlib/testing/testdata/shift.flux
+++ b/stdlib/testing/testdata/shift.flux
@@ -60,9 +60,8 @@ outData = "
 t_shift = (table=<-) => table
   |> shift(shift: 120s)
 
-testFn = testing.test
-
-testFn(name: "shift",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_shift)
+testing.test(
+    name: "shift",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_shift)

--- a/stdlib/testing/testdata/shift_negative_duration.flux
+++ b/stdlib/testing/testdata/shift_negative_duration.flux
@@ -60,9 +60,8 @@ outData = "
 t_shift_negative_duration = (table=<-) => table
   |> shift(shift: -5m)
 
-testFn = testing.test
-
-testFn(name: "shift_negative_duration",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_shift_negative_duration)
+testing.test(
+    name: "shift_negative_duration",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_shift_negative_duration)

--- a/stdlib/testing/testdata/show_all_tag_keys.flux
+++ b/stdlib/testing/testdata/show_all_tag_keys.flux
@@ -1107,9 +1107,8 @@ t_show_all_tag_keys = (table=<-) =>
   |> distinct()
   |> map(fn:(r) => r._value)
 
-testFn = testing.test
-
-testFn(name: "show_all_tag_keys",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_show_all_tag_keys)
+testing.test(
+    name: "show_all_tag_keys",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_show_all_tag_keys)

--- a/stdlib/testing/testdata/simple_max.flux
+++ b/stdlib/testing/testdata/simple_max.flux
@@ -23,9 +23,8 @@ simple_max = (table=<-) =>
   |> max(column: "_value")
   |> map(fn: (r) => ({_time: r._time,max:r._value}))
 
-testFn = testing.test
-
-testFn(name: "simple_max",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: simple_max)
+testing.test(
+    name: "simple_max",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: simple_max)

--- a/stdlib/testing/testdata/skew.flux
+++ b/stdlib/testing/testdata/skew.flux
@@ -50,9 +50,8 @@ t_skew = (table=<-) => table
   |> range(start: -5m)
   |> skew()
 
-testFn = testing.test
-
-testFn(name: "skew",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_skew)
+testing.test(
+    name: "skew",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_skew)

--- a/stdlib/testing/testdata/sort.flux
+++ b/stdlib/testing/testdata/sort.flux
@@ -78,9 +78,8 @@ t_sort = (table=<-) =>
   |> range(start: 2018-05-22T19:53:26Z)
   |> sort(columns:["_value", "_time"])
 
-testFn = testing.test
-
-testFn(name: "sort",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_sort)
+testing.test(
+    name: "sort",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_sort)

--- a/stdlib/testing/testdata/spread.flux
+++ b/stdlib/testing/testdata/spread.flux
@@ -60,9 +60,8 @@ t_spread = (table=<-) => table
   |> range(start: -5m)
   |> spread()
 
-testFn = testing.test
-
-testFn(name: "spread",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_spread)
+testing.test(
+    name: "spread",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_spread)

--- a/stdlib/testing/testdata/state_count.flux
+++ b/stdlib/testing/testdata/state_count.flux
@@ -42,9 +42,8 @@ t_state_count = (table=<-) =>
   |> range(start: 2018-05-22T19:53:26Z)
   |> stateCount(fn:(r) => r._value > 80)
 
-testFn = testing.test
-
-testFn(name: "state_count",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_state_count)
+testing.test(
+    name: "state_count",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_state_count)

--- a/stdlib/testing/testdata/state_duration.flux
+++ b/stdlib/testing/testdata/state_duration.flux
@@ -42,9 +42,8 @@ t_state_duration = (table=<-) =>
   |> range(start: 2018-05-22T19:53:26Z)
   |> stateDuration(fn:(r) => r._value > 80)
 
-testFn = testing.test
-
-testFn(name: "state_duration",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_state_duration)
+testing.test(
+    name: "state_duration",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_state_duration)

--- a/stdlib/testing/testdata/stddev.flux
+++ b/stdlib/testing/testdata/stddev.flux
@@ -50,9 +50,8 @@ t_stddev = (table=<-) => table
   |> range(start: -5m)
   |> stddev()
 
-testFn = testing.test
-
-testFn(name: "stddev",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_stddev)
+testing.test(
+    name: "stddev",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_stddev)

--- a/stdlib/testing/testdata/string_interp.flux
+++ b/stdlib/testing/testdata/string_interp.flux
@@ -29,9 +29,9 @@ t_string_interp = (table=<-) =>
   table
     |> range(start:2018-05-22T19:53:26Z)
     |> filter(fn: (r) => r._field == fieldSelect)
-testFn = testing.test
 
-testFn(name: "string_interp",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_string_interp)
+testing.test(
+    name: "string_interp",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_string_interp)

--- a/stdlib/testing/testdata/string_max.flux
+++ b/stdlib/testing/testdata/string_max.flux
@@ -19,9 +19,9 @@ t_string_max = (table=<-) =>
   table
     |> range(start:2018-05-22T19:54:16Z)
     |> max()
-testFn = testing.test
 
-testFn(name: "string_max",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_string_max)
+testing.test(
+    name: "string_max",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_string_max)

--- a/stdlib/testing/testdata/string_sort.flux
+++ b/stdlib/testing/testdata/string_sort.flux
@@ -30,9 +30,8 @@ t_string_sort = (table=<-) =>
     |> range(start:2018-05-22T19:53:26Z)
     |> sort()
 
-testFn = testing.test
-
-testFn(name: "string_sort",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_string_sort)
+testing.test(
+    name: "string_sort",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_string_sort)

--- a/stdlib/testing/testdata/sum.flux
+++ b/stdlib/testing/testdata/sum.flux
@@ -60,9 +60,8 @@ t_sum = (table=<-) => table
   |> range(start: -5m)
   |> sum()
 
-testFn = testing.test
-
-testFn(name: "sum",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_sum)
+testing.test(
+    name: "sum",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_sum)

--- a/stdlib/testing/testdata/top.flux
+++ b/stdlib/testing/testdata/top.flux
@@ -34,9 +34,8 @@ t_top = (table=<-) =>
     |> range(start:2018-05-22T19:53:24.421470485Z)
     |> top(n:2)
 
-testFn = testing.test
-
-testFn(name: "top",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_top)
+testing.test(
+    name: "top",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_top)

--- a/stdlib/testing/testdata/unique.flux
+++ b/stdlib/testing/testdata/unique.flux
@@ -34,9 +34,8 @@ t_unique = (table=<-) =>
   table
   |> unique(column: "tag0")
 
-testFn = testing.test
-
-testFn(name: "unique",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_unique)
+testing.test(
+    name: "unique",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_unique)

--- a/stdlib/testing/testdata/window.flux
+++ b/stdlib/testing/testdata/window.flux
@@ -42,9 +42,8 @@ t_window = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, mean: r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "window",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_window)
+testing.test(
+    name: "window",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_window)

--- a/stdlib/testing/testdata/window_default_start_align.flux
+++ b/stdlib/testing/testdata/window_default_start_align.flux
@@ -29,9 +29,8 @@ t_window_default_start_align = (table=<-) =>
     |> range(start:2018-05-22T19:53:30Z, stop: 2018-05-22T19:59:00Z)
     |> window(every:1m)
 
-testFn = testing.test
-
-testFn(name: "window_default_start_align",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_window_default_start_align)
+testing.test(
+    name: "window_default_start_align",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_window_default_start_align)

--- a/stdlib/testing/testdata/window_generate_empty.flux
+++ b/stdlib/testing/testdata/window_generate_empty.flux
@@ -69,9 +69,9 @@ t_window_generate_empty = (table=<-) =>
 	|> range(start:2018-05-22T19:53:26Z, stop: 2018-05-22T19:55:00Z)
 	|> window(every: 30s, createEmpty: true)
 
-testFn = testing.test
 
-testFn(name: "window_generate_empty",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_window_generate_empty)
+testing.test(
+    name: "window_generate_empty",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_window_generate_empty)

--- a/stdlib/testing/testdata/window_group_mean_ungroup.flux
+++ b/stdlib/testing/testdata/window_group_mean_ungroup.flux
@@ -45,9 +45,8 @@ t_window_group_mean_ungroup = (table=<-) =>
   |> mean()
   |> group()
 
-testFn = testing.test
-
-testFn(name: "window_group_mean_ungroup",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_window_group_mean_ungroup)
+testing.test(
+    name: "window_group_mean_ungroup",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_window_group_mean_ungroup)

--- a/stdlib/testing/testdata/window_offset.flux
+++ b/stdlib/testing/testdata/window_offset.flux
@@ -42,9 +42,8 @@ t_window_offset = (table=<-) =>
   |> map(fn: (r) => ({_time: r._time, mean: r._value}))
   |> yield(name:"0")
 
-testFn = testing.test
-
-testFn(name: "window_offset",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_window_offset)
+testing.test(
+    name: "window_offset",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_window_offset)

--- a/stdlib/testing/testdata/window_start_bound.flux
+++ b/stdlib/testing/testdata/window_start_bound.flux
@@ -29,9 +29,9 @@ t_window_start_bound = (table=<-) =>
   table
     |> range(start:2018-05-22T19:53:00Z)
     |> window(start:2018-05-22T19:53:30Z,every: 1m)
-testFn = testing.test
 
-testFn(name: "window_start_bound",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_window_start_bound)
+testing.test(
+    name: "window_start_bound",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_window_start_bound)

--- a/stdlib/testing/testdata/yield.flux
+++ b/stdlib/testing/testdata/yield.flux
@@ -40,9 +40,9 @@ indata = testing.loadStorage(csv: inData)
 got = indata |> t_yield() |> yield(name: "5")
 want = testing.loadStorage(csv: outData) |> yield(name:"6")
 testing.assertEquals(name: "yield", want: want, got: got)
-testFn = testing.test
 
-testFn(name: "yield",
-            input: testing.loadStorage(csv: inData),
-            want: testing.loadMem(csv: outData),
-            testFn: t_yield)
+testing.test(
+    name: "yield",
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    testFn: t_yield)


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

An object can be a polytype meaning its type expression may contain type variables. Given an object `obj`, previously a call to `obj.PolyType()` would try to retrieve its polytype from its concrete type. This would result in an invalid type if `obj` contained any type variables.

We should remove the notion of `Type` altogether and just make everything poly-typed (see #208).