### PR TITLE
fix(executetest): process test helper had bad logic to check for errors

### DIFF
--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -58,16 +58,23 @@ func ProcessTestHelper(
 	tx := create(d, c)
 
 	parentID := RandomDatasetID()
+	var gotErr error
 	for _, b := range data {
 		if err := tx.Process(parentID, b); err != nil {
-			if wantErr != nil && wantErr.Error() != err.Error() {
-				t.Fatalf("unexpected error -want/+got\n%s", cmp.Diff(wantErr.Error(), err.Error()))
-			} else if wantErr == nil {
-				t.Fatalf("expected no error, got %s", err.Error())
-			}
+			gotErr = err
+			break
+		}
+	}
+
+	if gotErr == nil && wantErr != nil {
+		t.Fatalf("expected error %s, got none", wantErr.Error())
+	} else if gotErr != nil && wantErr == nil {
+		t.Fatalf("expected no error, got %s", gotErr.Error())
+	} else if gotErr != nil && wantErr != nil {
+		if wantErr.Error() != gotErr.Error() {
+			t.Fatalf("unexpected error -want/+got\n%s", cmp.Diff(wantErr.Error(), gotErr.Error()))
+		} else {
 			return
-		} else if wantErr != nil {
-			t.Fatalf("expected error %s, got none", wantErr.Error())
 		}
 	}
 


### PR DESCRIPTION
If a `Test*_Process` expected an error, that should happen at the first input table processing iteration, otherwise the test failed with `expected error, got none`.

Now the helper performs the processing, and later checks for the error.

The test for `pivot` has been moved because it was a check on the function arguments and not on the `Process` function. It passed because it provided no data and `Process` wasn't invoked, so, `got == want == nil`. The error provided wasn't checked.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
