### PR TITLE
fix(execute): check for schema collision when appending columns to a table

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -113,9 +113,13 @@ func AddNewTableCols(t flux.Table, builder TableBuilder, colMap []int) ([]int, e
 		found := false
 		for ej, ec := range existing {
 			if c.Label == ec.Label {
-				colMap[ej] = j
-				found = true
-				break
+				if c.Type == ec.Type {
+					colMap[ej] = j
+					found = true
+					break
+				} else {
+					return nil, fmt.Errorf("schema collision detected: column \"%s\" is both of type %s and %s", c.Label, c.Type, ec.Type)
+				}
 			}
 		}
 		if !found {


### PR DESCRIPTION
Must be merged after #877, the second commit is the relevant one.

Fixes the Flux side of #321 by checking column types when columns are added to an existing table and returning a meaningful error if they have the same label and different type.

Still, the InfluxDB side of #321 has to be fixed.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
