### PR TITLE
fix(scanner): handle rune errors correctly when decoding an illegal token

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"fmt"
 	"unicode/utf8"
 
 	"github.com/influxdata/flux/internal/token"
@@ -75,7 +74,7 @@ func (s *Scanner) scan(cs int) (pos token.Pos, tok token.Token, lit string) {
 		// Execution failed meaning we hit a pattern that we don't support and
 		// doesn't produce a token. Use the unicode library to decode the next character
 		// in the sequence so we don't break up any unicode tokens.
-		ch, size := utf8.DecodeRune(s.data[s.ts:])
+		_, size := utf8.DecodeRune(s.data[s.ts:])
 		if size == 0 {
 			// This should be impossible as we would have produced an EOF token
 			// instead, but going to handle this anyway as in this impossible scenario
@@ -84,7 +83,7 @@ func (s *Scanner) scan(cs int) (pos token.Pos, tok token.Token, lit string) {
 		}
 		// Advance the data pointer to after the character we just emitted.
 		s.p = s.ts + size
-		return s.f.Pos(s.ts), token.ILLEGAL, fmt.Sprintf("%c", ch)
+		return s.f.Pos(s.ts), token.ILLEGAL, string(s.data[s.ts : s.ts+size])
 	} else if s.token == token.ILLEGAL && s.p == s.eof {
 		return s.f.Pos(len(s.data)), token.EOF, ""
 	}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -340,21 +340,22 @@ func TestScanner_MultipleTokens(t *testing.T) {
 func TestScanner_IllegalToken(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		ch   rune
+		ch   string
 	}{
-		{name: "Ascii", ch: '@'},
-		{name: "Multibyte", ch: '£'},
+		{name: "Ascii", ch: fmt.Sprintf("%c", '@')},
+		{name: "Multibyte", ch: fmt.Sprintf("%c", '£')},
+		{name: "Invalid", ch: string([]byte{0xa2})},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			src := []byte(fmt.Sprintf(`%c x = 5`, tt.ch))
+			src := []byte(tt.ch + ` x = 5`)
 			f := token.NewFile("query.flux", len(src))
 			s := scanner.New(f, src)
 			_, tok, lit := s.ScanWithRegex()
 			if want, got := token.ILLEGAL, tok; want != got {
 				t.Errorf("unexpected token -want/+got\n\t- %d\n\t+ %d", want, got)
 			}
-			if want, got := fmt.Sprintf("%c", tt.ch), lit; want != got {
-				t.Errorf("unexpected literal -want/+got\n\t- %s\n\t+ %s", want, got)
+			if want, got := tt.ch, lit; want != got {
+				t.Errorf("unexpected literal -want/+got\n\t- %v\n\t+ %v", []byte(want), []byte(got))
 			}
 
 			// It should continue and read the next token.
@@ -363,7 +364,7 @@ func TestScanner_IllegalToken(t *testing.T) {
 				t.Errorf("unexpected token -want/+got\n\t- %d\n\t+ %d", want, got)
 			}
 			if want, got := "x", lit; want != got {
-				t.Errorf("unexpected literal -want/+got\n\t- %s\n\t+ %s", want, got)
+				t.Errorf("unexpected literal -want/+got\n\t- %v\n\t+ %v", []byte(want), []byte(got))
 			}
 
 			_, tok, lit = s.ScanWithRegex()
@@ -371,7 +372,7 @@ func TestScanner_IllegalToken(t *testing.T) {
 				t.Errorf("unexpected token -want/+got\n\t- %d\n\t+ %d", want, got)
 			}
 			if want, got := "=", lit; want != got {
-				t.Errorf("unexpected literal -want/+got\n\t- %s\n\t+ %s", want, got)
+				t.Errorf("unexpected literal -want/+got\n\t- %v\n\t+ %v", []byte(want), []byte(got))
 			}
 
 			_, tok, lit = s.ScanWithRegex()
@@ -379,7 +380,7 @@ func TestScanner_IllegalToken(t *testing.T) {
 				t.Errorf("unexpected token -want/+got\n\t- %d\n\t+ %d", want, got)
 			}
 			if want, got := "5", lit; want != got {
-				t.Errorf("unexpected literal -want/+got\n\t- %s\n\t+ %s", want, got)
+				t.Errorf("unexpected literal -want/+got\n\t- %v\n\t+ %v", []byte(want), []byte(got))
 			}
 
 			// Expect an EOF token.


### PR DESCRIPTION
When an invalid utf8 sequence was encountered, a `RuneError` would be
returned. When this was passed to `fmt.Sprintf("%c")` it would return a
string of size 3 and this size was used instead of the size of 1 that
the scanner actually read.

This fixes the scanner so instead of using `fmt.Sprintf("%c")`, it just
believes the size that was returned by the `utf8.DecodeRune` call and
references the byte slice from the source.