### PR TITLE
refactor(stdlib): fixup the window null test

### DIFF
--- a/stdlib/testing/testdata/window_null.flux
+++ b/stdlib/testing/testdata/window_null.flux
@@ -33,9 +33,7 @@ t_window_null = (table=<-) => table
 		|> range(start: -5m)
     |> window(every: 30s)
 
-testFn = testing.test
-
-testFn(
+testing.test(
 	name: "window_null",
 	input: testing.loadStorage(csv: inData),
 	want: testing.loadMem(csv: outData),


### PR DESCRIPTION
It used the `testFn = testing.test` trick because calling it directly
was broken at the time the test was created. This removes that.