### PR TITLE
feat(parser): construct invalid binary expressions when given multiple expressions

### DIFF
--- a/ast/errors.go
+++ b/ast/errors.go
@@ -33,6 +33,22 @@ func check(n Node) int {
 				Msg: "pipe destination is missing",
 			})
 		}
+	case *BinaryExpression:
+		if n.Left == nil {
+			n.Errors = append(n.Errors, Error{
+				Msg: "missing left hand side of expression",
+			})
+		}
+		if n.Right == nil {
+			n.Errors = append(n.Errors, Error{
+				Msg: "missing right hand side of expression",
+			})
+		}
+		if n.Operator == 0 {
+			n.Errors = append(n.Errors, Error{
+				Msg: "expected an operator between two expressions",
+			})
+		}
 	}
 
 	return 0

--- a/stdlib/testing/testdata/totime.flux
+++ b/stdlib/testing/testdata/totime.flux
@@ -29,8 +29,7 @@ outData = "
 ,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,k,m,2018-05-22T19:00:00Z
 "
 
-t_toTime = (table=<-) =>
-	(table
+t_toTime = (table=<-) => table
 		|> range(start: 2018-05-22T19:52:00Z)
 		|> toTime()
 


### PR DESCRIPTION
When the parser is in a context where it is expecting a single expression,
the parser will now check to see if more tokens should be read. If more
tokens can be read before reaching the end of a block, it will parse
another expression and create a binary expression with no operator to
signify that the operator was missing.

The parser has also been tested and works properly with a missing left hand
side or right hand side operator. This will now properly produce an error.

- [x] docs/SPEC.md updated
- [x] Test cases written