### PR TITLE
fix(parser): multiplicative operators are above additive operators in precedence

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -722,7 +722,23 @@ It is not possible to access an object's property using an arbitrary expression.
 #### Operators
 
 Operators combine operands into expressions.
-Operator precedence is encoded directly into the grammar.
+The precedence of the operators is given in the table below. Operators with a lower number have higher precedence.
+
+|Precedence| Operator |        Description        |
+|----------|----------|---------------------------|
+|     1    |  `a()`   |       Function call       |
+|          |  `a[]`   |  Member or index access   |
+|          |   `.`    |       Member access       |
+|     2    | `*` `/`  |Multiplication and division|
+|     3    | `+` `-`  | Addition and subtraction  |
+|     4    |`==` `!=` |   Comparison operators    |
+|          | `<` `<=` |                           |
+|          | `>` `>=` |                           |
+|          |`=~` `!~` |                           |
+|     5    |  `not`   | Unary logical expression  |
+|     6    |`and` `or`|    Logical AND and OR     |
+
+The operator precedence is encoded directly into the grammar as the following.
 
     Expression               = LogicalExpression .
     LogicalExpression        = UnaryLogicalExpression
@@ -734,12 +750,12 @@ Operator precedence is encoded directly into the grammar.
     ComparisonExpression     = MultiplicativeExpression
                              | ComparisonExpression ComparisonOperator MultiplicativeExpression .
     ComparisonOperator       = "==" | "!=" | "<" | "<=" | ">" | ">=" | "=~" | "!~" .
-    MultiplicativeExpression = AdditiveExpression
-                             | MultiplicativeExpression MultiplicativeOperator AdditiveExpression .
-    MultiplicativeOperator   = "*" | "/" .
-    AdditiveExpression       = PipeExpression
-                             | AdditiveExpression AdditiveOperator PipeExpression .
+    AdditiveExpression       = MultiplicativeExpression
+                             | AdditiveExpression AdditiveOperator MultiplicativeExpression .
     AdditiveOperator         = "+" | "-" .
+    MultiplicativeExpression = PipeExpression
+                             | MultiplicativeExpression MultiplicativeOperator PipeExpression .
+    MultiplicativeOperator   = "*" | "/" .
     PipeExpression           = PostfixExpression
                              | PipeExpression PipeOperator UnaryExpression .
     PipeOperator             = "|>" .
@@ -751,6 +767,7 @@ Operator precedence is encoded directly into the grammar.
     PostfixOperator          = MemberExpression
                              | CallExpression
                              | IndexExpression .
+                             
 ### Packages
 
 Flux source is organized into packages.

--- a/internal/parser/grammar.md
+++ b/internal/parser/grammar.md
@@ -6,85 +6,86 @@ For the parser, the SPEC grammar undergoes a process to have the left-recursion 
 
 The parser directly implements the following grammar.
 
-    File                       = [ PackageClause ] [ ImportList ] StatementList .
-    PackageClause              = "package" identifier .
-    ImportList                 = { ImportDeclaration } .
-    ImportDeclaration          = "import" [identifier] string_lit
-    StatementList              = { Statement } .
-    Statement                  = OptionAssignment
-                               | BuiltinStatement
-                               | IdentStatement
-                               | ReturnStatement
-                               | ExpressionStatement .
-    IdentStatement             = identifer ( AssignStatement | ExpressionSuffix ) .
-    OptionAssignment           = "option" identifier OptionAssignmentSuffix .
-    OptionAssignmentSuffix     = AssignStatement
-                               | "." identifier AssignStatement .
-    BuiltinStatement           = "builtin" identifier .
-    AssignStatement            = "=" Expression .
-    ReturnStatement            = "return" Expression .
-    ExpressionStatement        = Expression .
-    Expression                 = LogicalExpression .
-    ExpressionSuffix           = { PostfixOperator } { PipeExpressionSuffix } { AdditiveExpressionSuffix } { MultiplicativeExpressionSuffix } { ComparisonExpressionSuffix } { LogicalExpressionSuffix } .
-    LogicalExpression          = UnaryLogicalExpression { LogicalExpressionSuffix } .
-    LogicalExpressionSuffix    = LogicalOperator UnaryLogicalExpression .
-    LogicalOperator            = "and" | "or" .
-    UnaryLogicalExpression     = ComparisonExpression
-                               | UnaryLogicalOperator UnaryLogicalExpression .
-    UnaryLogicalOperator       = "not" .
-    ComparisonExpression       = MultiplicativeExpression { ComparisonExpressionSuffix } .
-    ComparisonExpressionSuffix = ComparisonOperator MultiplicativeExpr .
-    ComparisonOperator         = "==" | "!=" | "<" | "<=" | ">" | ">=" | "=~" | "!~" .
-    MultiplicativeExpression   = AdditiveExpression { MultiplicativeOperator AdditiveExpression } .
-    MultiplicativeOperator     = "*"| "/".
-    AdditiveExpression         = PipeExpression { AdditiveExpressionSuffix } .
-    AdditiveExpressionSuffix   = AdditiveOperator PipeExpression .
-    AdditiveOperator           = "+" | "-" .
-    PipeExpression             = UnaryExpression { PipeExpressionSuffix } .
-    PipeExpressionSuffix       = PipeOperator UnaryExpression .
-    PipeOperator               = pipe_forward .
-    UnaryExpression            = PostfixExpression
-                               | PrefixOperator UnaryExpression .
-    PrefixOperator             = "+" | "-" .
-    PostfixExpression          = PrimaryExpression { PostfixOperator } .
-    PostfixOperator            = MemberExpression
-                               | CallExpression
-                               | IndexExpression .
-    MemberExpression           = DotExpression  | MemberBracketExpression
-    DotExpression              = "." identifer
-    MemberBracketExpression    = "[" string "]" .
-    CallExpression             = "(" ParameterList ")" .
-    IndexExpression            = "[" Expression "]" .
-    PrimaryExpression          = identifer
-                               | int_lit
-                               | float_lit
-                               | string_lit
-                               | regex_lit
-                               | duration_lit
-                               | pipe_receive_lit
-                               | ObjectLiteral
-                               | ArrayLiteral
-                               | ParenExpression .
-    ObjectLiteral              = "{" PropertyList "}" .
-    ArrayLiteral               = "[" ExpressionList "]" .
-    ParenExpression            = "(" ParenExpressionBody .
-    ParenExpressionBody        = ")" FunctionExpressionSuffix
-                               | identifer ParenIdentExpression
-                               | Expression ")" .
-    ParenIdentExpression       = ")" [ FunctionExpressionSuffix ]
-                               | "=" Expression [ "," ParameterList ] ")" FunctionExpressionSuffix .
-                               | "," ParameterList ")" FunctionExpressionSuffix
-                               | ExpressionSuffix ")" .
-    ParenExpression            = "(" Expression ")" .
-    FunctionExpressionSuffix   = "=>" FunctionBodyExpression .
-    FunctionBodyExpression     = Block | Expression .
-    Block                      = "{" StatementList "}" .
-    ExpressionList             = [ Expression { "," Expression } ] .
-    PropertyList               = [ Property { "," Property } ] .
-    Property                   = identifier [ ":" Expression ]
-                               | string_lit ":" Expression .
-    ParameterList              = [ Parameter { "," Parameter } ] .
-    Parameter                  = identifer [ "=" Expression ] .
+    File                           = [ PackageClause ] [ ImportList ] StatementList .
+    PackageClause                  = "package" identifier .
+    ImportList                     = { ImportDeclaration } .
+    ImportDeclaration              = "import" [identifier] string_lit
+    StatementList                  = { Statement } .
+    Statement                      = OptionAssignment
+                                   | BuiltinStatement
+                                   | IdentStatement
+                                   | ReturnStatement
+                                   | ExpressionStatement .
+    IdentStatement                 = identifer ( AssignStatement | ExpressionSuffix ) .
+    OptionAssignment               = "option" identifier OptionAssignmentSuffix .
+    OptionAssignmentSuffix         = AssignStatement
+                                   | "." identifier AssignStatement .
+    BuiltinStatement               = "builtin" identifier .
+    AssignStatement                = "=" Expression .
+    ReturnStatement                = "return" Expression .
+    ExpressionStatement            = Expression .
+    Expression                     = LogicalExpression .
+    ExpressionSuffix               = { PostfixOperator } { PipeExpressionSuffix } { MultiplicativeExpressionSuffix } { AdditiveExpressionSuffix } { ComparisonExpressionSuffix } { LogicalExpressionSuffix } .
+    LogicalExpression              = UnaryLogicalExpression { LogicalExpressionSuffix } .
+    LogicalExpressionSuffix        = LogicalOperator UnaryLogicalExpression .
+    LogicalOperator                = "and" | "or" .
+    UnaryLogicalExpression         = ComparisonExpression
+                                   | UnaryLogicalOperator UnaryLogicalExpression .
+    UnaryLogicalOperator           = "not" .
+    ComparisonExpression           = AdditiveExpression { ComparisonExpressionSuffix } .
+    ComparisonExpressionSuffix     = ComparisonOperator AdditiveExpression .
+    ComparisonOperator             = "==" | "!=" | "<" | "<=" | ">" | ">=" | "=~" | "!~" .
+    AdditiveExpression             = MultiplicativeExpression { AdditiveExpressionSuffix } .
+    AdditiveExpressionSuffix       = AdditiveOperator MultiplicativeExpression .
+    AdditiveOperator               = "+" | "-" .
+    MultiplicativeExpression       = PipeExpression { MultiplicativeExpressionSuffix } .
+    MultiplicativeExpressionSuffix = MultiplicativeOperator PipeExpression .
+    MultiplicativeOperator         = "*"| "/".
+    PipeExpression                 = UnaryExpression { PipeExpressionSuffix } .
+    PipeExpressionSuffix           = PipeOperator UnaryExpression .
+    PipeOperator                   = pipe_forward .
+    UnaryExpression                = PostfixExpression
+                                   | PrefixOperator UnaryExpression .
+    PrefixOperator                 = "+" | "-" .
+    PostfixExpression              = PrimaryExpression { PostfixOperator } .
+    PostfixOperator                = MemberExpression
+                                   | CallExpression
+                                   | IndexExpression .
+    MemberExpression               = DotExpression  | MemberBracketExpression
+    DotExpression                  = "." identifer
+    MemberBracketExpression        = "[" string "]" .
+    CallExpression                 = "(" ParameterList ")" .
+    IndexExpression                = "[" Expression "]" .
+    PrimaryExpression              = identifer
+                                   | int_lit
+                                   | float_lit
+                                   | string_lit
+                                   | regex_lit
+                                   | duration_lit
+                                   | pipe_receive_lit
+                                   | ObjectLiteral
+                                   | ArrayLiteral
+                                   | ParenExpression .
+    ObjectLiteral                  = "{" PropertyList "}" .
+    ArrayLiteral                   = "[" ExpressionList "]" .
+    ParenExpression                = "(" ParenExpressionBody .
+    ParenExpressionBody            = ")" FunctionExpressionSuffix
+                                   | identifer ParenIdentExpression
+                                   | Expression ")" .
+    ParenIdentExpression           = ")" [ FunctionExpressionSuffix ]
+                                   | "=" Expression [ "," ParameterList ] ")" FunctionExpressionSuffix .
+                                   | "," ParameterList ")" FunctionExpressionSuffix
+                                   | ExpressionSuffix ")" .
+    ParenExpression                = "(" Expression ")" .
+    FunctionExpressionSuffix       = "=>" FunctionBodyExpression .
+    FunctionBodyExpression         = Block | Expression .
+    Block                          = "{" StatementList "}" .
+    ExpressionList                 = [ Expression { "," Expression } ] .
+    PropertyList                   = [ Property { "," Property } ] .
+    Property                       = identifier [ ":" Expression ]
+                                   | string_lit ":" Expression .
+    ParameterList                  = [ Parameter { "," Parameter } ] .
+    Parameter                      = identifer [ "=" Expression ] .
 
 When processing the grammar, the parser follows a few simple rules.
 
@@ -99,3 +100,23 @@ To determine which tokens a production accepts, compute `FIRST(X)` for each prod
 1. For a terminal, `FIRST(X) = {X}`.
 2. For a alternation, calculate `FIRST(X)` for each production and form the union.
 3. For concatentation, calculate `FIRST(X)` for the first production. If this set contains the empty set, calculate `FIRST(X)` for the next production. Continue until you hit a production that does not contain the empty set or, if all productions have been evaluated, then the empty set is accepted for this production.
+
+## Operator Precedence
+
+Operator precedence is defined within the grammar itself so a precedence table is not needed. While the table itself is not needed and not used in the parser itself, a table is provided below for human readability with verifying the grammar.
+
+|Precedence| Operator |        Description        |
+|----------|----------|---------------------------|
+|     1    |  `a()`   |       Function call       |
+|          |  `a[]`   |  Member or index access   |
+|          |   `.`    |       Member access       |
+|     2    | `*` `/`  |Multiplication and division|
+|     3    | `+` `-`  | Addition and subtraction  |
+|     4    |`==` `!=` |   Comparison operators    |
+|          | `<` `<=` |                           |
+|          | `>` `>=` |                           |
+|          |`=~` `!~` |                           |
+|     5    |  `not`   | Unary logical expression  |
+|     6    |`and` `or`|    Logical AND and OR     |
+
+Within the grammar itself, precedence is reversed so lower precedence operators appear above higher precedence operators. This ensures that the higher precedence values are nested within lower precedence operators.

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1930,6 +1930,70 @@ a = 5.0
 			},
 		},
 		{
+			name: "binary operator precedence",
+			raw:  `a / b - 1.0`,
+			want: &ast.File{
+				BaseNode: base("1:1", "1:12"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:12"),
+						Expression: &ast.BinaryExpression{
+							BaseNode: base("1:1", "1:12"),
+							Operator: ast.SubtractionOperator,
+							Left: &ast.BinaryExpression{
+								BaseNode: base("1:1", "1:6"),
+								Operator: ast.DivisionOperator,
+								Left: &ast.Identifier{
+									BaseNode: base("1:1", "1:2"),
+									Name:     "a",
+								},
+								Right: &ast.Identifier{
+									BaseNode: base("1:5", "1:6"),
+									Name:     "b",
+								},
+							},
+							Right: &ast.FloatLiteral{
+								BaseNode: base("1:9", "1:12"),
+								Value:    1.0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "binary operator precedence - literals only",
+			raw:  `2 / "a" - 1.0`,
+			want: &ast.File{
+				BaseNode: base("1:1", "1:14"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:14"),
+						Expression: &ast.BinaryExpression{
+							BaseNode: base("1:1", "1:14"),
+							Operator: ast.SubtractionOperator,
+							Left: &ast.BinaryExpression{
+								BaseNode: base("1:1", "1:8"),
+								Operator: ast.DivisionOperator,
+								Left: &ast.IntegerLiteral{
+									BaseNode: base("1:1", "1:2"),
+									Value:    2,
+								},
+								Right: &ast.StringLiteral{
+									BaseNode: base("1:5", "1:8"),
+									Value:    "a",
+								},
+							},
+							Right: &ast.FloatLiteral{
+								BaseNode: base("1:11", "1:14"),
+								Value:    1.0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "logical unary operator precedence",
 			raw:  `not -1 == a`,
 			want: &ast.File{
@@ -1954,6 +2018,233 @@ a = 5.0
 								Right: &ast.Identifier{
 									BaseNode: base("1:11", "1:12"),
 									Name:     "a",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all operators precedence",
+			raw: `a() == b.a + b.c * d < 100 and e != f[g] and h > i * j and
+k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/`,
+			want: &ast.File{
+				BaseNode: base("1:1", "2:72"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "2:72"),
+						Expression: &ast.LogicalExpression{
+							BaseNode: base("1:1", "2:72"),
+							Operator: ast.AndOperator,
+							Left: &ast.LogicalExpression{
+								BaseNode: base("1:1", "2:59"),
+								Operator: ast.AndOperator,
+								Left: &ast.LogicalExpression{
+									BaseNode: base("1:1", "2:42"),
+									Operator: ast.OrOperator,
+									Left: &ast.LogicalExpression{
+										BaseNode: base("1:1", "2:32"),
+										Operator: ast.OrOperator,
+										Left: &ast.LogicalExpression{
+											BaseNode: base("1:1", "2:18"),
+											Operator: ast.AndOperator,
+											Left: &ast.LogicalExpression{
+												BaseNode: base("1:1", "1:55"),
+												Operator: ast.AndOperator,
+												Left: &ast.LogicalExpression{
+													BaseNode: base("1:1", "1:41"),
+													Operator: ast.AndOperator,
+													Left: &ast.BinaryExpression{
+														BaseNode: base("1:1", "1:27"),
+														Operator: ast.LessThanOperator,
+														Left: &ast.BinaryExpression{
+															BaseNode: base("1:1", "1:21"),
+															Operator: ast.EqualOperator,
+															Left: &ast.CallExpression{
+																BaseNode: base("1:1", "1:4"),
+																Callee: &ast.Identifier{
+																	BaseNode: base("1:1", "1:2"),
+																	Name:     "a",
+																},
+															},
+															Right: &ast.BinaryExpression{
+																BaseNode: base("1:8", "1:21"),
+																Operator: ast.AdditionOperator,
+																Left: &ast.MemberExpression{
+																	BaseNode: base("1:8", "1:11"),
+																	Object: &ast.Identifier{
+																		BaseNode: base("1:8", "1:9"),
+																		Name:     "b",
+																	},
+																	Property: &ast.Identifier{
+																		BaseNode: base("1:10", "1:11"),
+																		Name:     "a",
+																	},
+																},
+																Right: &ast.BinaryExpression{
+																	BaseNode: base("1:14", "1:21"),
+																	Operator: ast.MultiplicationOperator,
+																	Left: &ast.MemberExpression{
+																		BaseNode: base("1:14", "1:17"),
+																		Object: &ast.Identifier{
+																			BaseNode: base("1:14", "1:15"),
+																			Name:     "b",
+																		},
+																		Property: &ast.Identifier{
+																			BaseNode: base("1:16", "1:17"),
+																			Name:     "c",
+																		},
+																	},
+																	Right: &ast.Identifier{
+																		BaseNode: base("1:20", "1:21"),
+																		Name:     "d",
+																	},
+																},
+															},
+														},
+														Right: &ast.IntegerLiteral{
+															BaseNode: base("1:24", "1:27"),
+															Value:    100,
+														},
+													},
+													Right: &ast.BinaryExpression{
+														BaseNode: base("1:32", "1:41"),
+														Operator: ast.NotEqualOperator,
+														Left: &ast.Identifier{
+															BaseNode: base("1:32", "1:33"),
+															Name:     "e",
+														},
+														Right: &ast.IndexExpression{
+															BaseNode: base("1:37", "1:41"),
+															Array: &ast.Identifier{
+																BaseNode: base("1:37", "1:38"),
+																Name:     "f",
+															},
+															Index: &ast.Identifier{
+																BaseNode: base("1:39", "1:40"),
+																Name:     "g",
+															},
+														},
+													},
+												},
+												Right: &ast.BinaryExpression{
+													BaseNode: base("1:46", "1:55"),
+													Operator: ast.GreaterThanOperator,
+													Left: &ast.Identifier{
+														BaseNode: base("1:46", "1:47"),
+														Name:     "h",
+													},
+													Right: &ast.BinaryExpression{
+														BaseNode: base("1:50", "1:55"),
+														Operator: ast.MultiplicationOperator,
+														Left: &ast.Identifier{
+															BaseNode: base("1:50", "1:51"),
+															Name:     "i",
+														},
+														Right: &ast.Identifier{
+															BaseNode: base("1:54", "1:55"),
+															Name:     "j",
+														},
+													},
+												},
+											},
+											Right: &ast.BinaryExpression{
+												BaseNode: base("2:1", "2:18"),
+												Operator: ast.LessThanOperator,
+												Left: &ast.BinaryExpression{
+													BaseNode: base("2:1", "2:6"),
+													Operator: ast.DivisionOperator,
+													Left: &ast.Identifier{
+														BaseNode: base("2:1", "2:2"),
+														Name:     "k",
+													},
+													Right: &ast.Identifier{
+														BaseNode: base("2:5", "2:6"),
+														Name:     "l",
+													},
+												},
+												Right: &ast.BinaryExpression{
+													BaseNode: base("2:9", "2:18"),
+													Operator: ast.SubtractionOperator,
+													Left: &ast.BinaryExpression{
+														BaseNode: base("2:9", "2:14"),
+														Operator: ast.AdditionOperator,
+														Left: &ast.Identifier{
+															BaseNode: base("2:9", "2:10"),
+															Name:     "m",
+														},
+														Right: &ast.Identifier{
+															BaseNode: base("2:13", "2:14"),
+															Name:     "n",
+														},
+													},
+													Right: &ast.Identifier{
+														BaseNode: base("2:17", "2:18"),
+														Name:     "o",
+													},
+												},
+											},
+										},
+										Right: &ast.BinaryExpression{
+											BaseNode: base("2:22", "2:32"),
+											Operator: ast.LessThanEqualOperator,
+											Left: &ast.CallExpression{
+												BaseNode: base("2:22", "2:25"),
+												Callee: &ast.Identifier{
+													BaseNode: base("2:22", "2:23"),
+													Name:     "p",
+												},
+											},
+											Right: &ast.CallExpression{
+												BaseNode: base("2:29", "2:32"),
+												Callee: &ast.Identifier{
+													BaseNode: base("2:29", "2:30"),
+													Name:     "q",
+												},
+											},
+										},
+									},
+									Right: &ast.BinaryExpression{
+										BaseNode: base("2:36", "2:42"),
+										Operator: ast.GreaterThanEqualOperator,
+										Left: &ast.Identifier{
+											BaseNode: base("2:36", "2:37"),
+											Name:     "r",
+										},
+										Right: &ast.Identifier{
+											BaseNode: base("2:41", "2:42"),
+											Name:     "s",
+										},
+									},
+								},
+								Right: &ast.UnaryExpression{
+									BaseNode: base("2:47", "2:59"),
+									Operator: ast.NotOperator,
+									Argument: &ast.BinaryExpression{
+										BaseNode: base("2:51", "2:59"),
+										Operator: ast.RegexpMatchOperator,
+										Left: &ast.Identifier{
+											BaseNode: base("2:51", "2:52"),
+											Name:     "t",
+										},
+										Right: &ast.RegexpLiteral{
+											BaseNode: base("2:56", "2:59"),
+											Value:    regexp.MustCompile(`a`),
+										},
+									},
+								},
+							},
+							Right: &ast.BinaryExpression{
+								BaseNode: base("2:64", "2:72"),
+								Operator: ast.NotRegexpMatchOperator,
+								Left: &ast.Identifier{
+									BaseNode: base("2:64", "2:65"),
+									Name:     "u",
+								},
+								Right: &ast.RegexpLiteral{
+									BaseNode: base("2:69", "2:72"),
+									Value:    regexp.MustCompile(`a`),
 								},
 							},
 						},


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The multiplicative operators are a higher precedence, but were accidentally put in the EBNF at a lower precedence. This adds a precedence table to the docs and fixes the EBNF so multiplication/division are higher precedence than addition/subtraction.

Fixes #903.