### PR TITLE
wip(compiler): support null in typed eval functions

### DIFF
--- a/values/float.go
+++ b/values/float.go
@@ -1,0 +1,49 @@
+package values
+
+import (
+	"regexp"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// Float represents a float value.
+type Float struct {
+	Value float64
+	Null  bool
+}
+
+func (Float) Type() semantic.Type {
+	return semantic.Float
+}
+
+func (Float) PolyType() semantic.PolyType {
+	return semantic.Float
+}
+
+func (v Float) Float() float64 {
+	return v.Value
+}
+
+func (v Float) IsNull() bool {
+	return v.Null
+}
+
+func (Float) Str() string            { panic(UnexpectedKind(semantic.String, semantic.Float)) }
+func (Float) Int() int64             { panic(UnexpectedKind(semantic.Int, semantic.Float)) }
+func (Float) UInt() uint64           { panic(UnexpectedKind(semantic.UInt, semantic.Float)) }
+func (Float) Bool() bool             { panic(UnexpectedKind(semantic.Bool, semantic.Float)) }
+func (Float) Time() Time             { panic(UnexpectedKind(semantic.Time, semantic.Float)) }
+func (Float) Duration() Duration     { panic(UnexpectedKind(semantic.Duration, semantic.Float)) }
+func (Float) Regexp() *regexp.Regexp { panic(UnexpectedKind(semantic.Regexp, semantic.Float)) }
+func (Float) Array() Array           { panic(UnexpectedKind(semantic.Array, semantic.Float)) }
+func (Float) Object() Object         { panic(UnexpectedKind(semantic.Object, semantic.Float)) }
+func (Float) Function() Function     { panic(UnexpectedKind(semantic.Function, semantic.Float)) }
+
+func (v Float) Equal(other Value) bool {
+	if v.Type() != other.Type() {
+		return false
+	} else if v.IsNull() || other.IsNull() {
+		return false
+	}
+	return v.Float() == other.Float()
+}

--- a/values/values.go
+++ b/values/values.go
@@ -158,9 +158,14 @@ func New(v interface{}) Value {
 }
 
 func NewNull(t semantic.Type) Value {
-	return value{
-		t: t,
-		v: nil,
+	switch t {
+	case semantic.Float:
+		return Float{Null: true}
+	default:
+		return value{
+			t: t,
+			v: nil,
+		}
 	}
 }
 
@@ -183,10 +188,7 @@ func NewUInt(v uint64) Value {
 	}
 }
 func NewFloat(v float64) Value {
-	return value{
-		t: semantic.Float,
-		v: v,
-	}
+	return Float{Value: v}
 }
 func NewBool(v bool) Value {
 	return value{


### PR DESCRIPTION
- [ ] docs/SPEC.md updated
- [ ] Test cases written

The eval functions had typed equivalents that would use the native type.
Unfortunately, this meant that there was no way to pass the null value
from these evaluators.

This modifies the `values` package to include a separate struct for each
type that has a `Value` and `Null` attribute so the typed evaluars can
use this instead of the builtin types so they can know whether a type is
null or not.

The inspiration for these types is taken from the `database/sql`
package.

Fixes #936.