### PR TITLE
fix(ast): member expressions using a string literal use the incorrect end bracket

### DIFF
--- a/ast/format.go
+++ b/ast/format.go
@@ -312,7 +312,7 @@ func (f *formatter) formatMemberExpression(n *MemberExpression) {
 	if _, ok := n.Property.(*StringLiteral); ok {
 		f.writeRune('[')
 		f.formatNode(n.Property)
-		f.writeRune('[')
+		f.writeRune(']')
 	} else {
 		f.writeRune('.')
 		f.formatNode(n.Property)

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -55,8 +55,12 @@ func TestFormat(t *testing.T) {
 			script: `{"a": 1, b: 2}`,
 		},
 		{
-			name:   "member",
+			name:   "member ident",
 			script: `object.property`,
+		},
+		{
+			name:   "member string literal",
+			script: `object["property"]`,
 		},
 		{
 			name: "array",


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The member expression should be closed by `]`, but it was accidentally
closed with `[`.