### PR TITLE
bug(options): Add key instead of erroring when option doesn't have key

### DIFF
--- a/ast/edit/option_editor.go
+++ b/ast/edit/option_editor.go
@@ -53,11 +53,11 @@ func OptionObjectFn(keyMap map[string]ast.Expression) OptionFn {
 		// check that every specified property exists in the object
 		found := make(map[string]bool, len(obj.Properties))
 		for _, p := range obj.Properties {
-			found[p.Key.Key()] = false
+			found[p.Key.Key()] = true
 		}
 
 		for k := range keyMap {
-			if _, ok := found[k]; !ok {
+			if !found[k] {
 				obj.Properties = append(obj.Properties, &ast.Property{
 					Key:   &ast.Identifier{Name: k},
 					Value: keyMap[k],

--- a/ast/edit/option_editor_test.go
+++ b/ast/edit/option_editor_test.go
@@ -100,15 +100,23 @@ option task = {
 	delay: 1m,
 	cron: "20 * * *",
 	retry: 5,
+}`, edited: `option foo = 1
+option task = {
+	name: "bar",
+	every: 2hr,
+	delay: 1m,
+	cron: "20 * * *",
+	retry: 5,
+	foo: "foo",
 }`,
-			errorWanted: true,
+			errorWanted: false,
 			edit: func(node ast.Node) (bool, error) {
 				every, err := ast.ParseDuration("2hr")
 				if err != nil {
 					t.Fatal(err)
 				}
 				return edit.Option(node, "task", edit.OptionObjectFn(map[string]ast.Expression{
-					"foo":   &ast.StringLiteral{Value: "foo"}, // should cause error
+					"foo":   &ast.StringLiteral{Value: "foo"}, // should add a foo string
 					"every": &ast.DurationLiteral{Values: every},
 				}))
 			},


### PR DESCRIPTION
This adds a key to options if the key doesn't already exist in the option instead of erroring.
Closes #974 
### Done checklist
- [x ] Test cases written