### PR TITLE
feat(control): support attaching arbitrary query metadata from the executor

### DIFF
--- a/execute/executetest/output.go
+++ b/execute/executetest/output.go
@@ -32,10 +32,6 @@ func (s *ToProcedureSpec) Cost(inStats []plan.Statistics) (plan.Cost, plan.Stati
 	return plan.Cost{}, plan.Statistics{}
 }
 
-func (s *ToProcedureSpec) Statistics() flux.Statistics {
-	return flux.Statistics{}
-}
-
 // ToTransformation simulates an output or an identity transformation
 type ToTransformation struct {
 	d execute.Dataset

--- a/execute/executetest/result.go
+++ b/execute/executetest/result.go
@@ -8,10 +8,9 @@ import (
 )
 
 type Result struct {
-	Nm    string
-	Tbls  []*Table
-	Err   error
-	Stats flux.Statistics
+	Nm   string
+	Tbls []*Table
+	Err  error
 }
 
 func NewResult(tables []*Table) *Result {
@@ -33,16 +32,10 @@ func (r *Result) Normalize() {
 	NormalizeTables(r.Tbls)
 }
 
-func (r *Result) Statistics() flux.Statistics {
-	return r.Stats
-}
-
 type TableIterator struct {
 	tables []*Table
 	err    error
 }
-
-func (ti *TableIterator) Statistics() flux.Statistics { return flux.Statistics{} }
 
 func (ti *TableIterator) Do(f func(flux.Table) error) error {
 	if ti.err != nil {

--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -3,7 +3,6 @@ package executetest
 import (
 	"context"
 
-	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	uuid "github.com/satori/go.uuid"
@@ -59,14 +58,6 @@ func (src *FromProcedureSpec) Run(ctx context.Context) {
 		t.UpdateWatermark(id, max)
 		t.Finish(id, nil)
 	}
-}
-
-func (src *FromProcedureSpec) Statistics() flux.Statistics {
-	var stats flux.Statistics
-	for _, tbl := range src.data {
-		stats = stats.Add(tbl.Statistics())
-	}
-	return stats
 }
 
 func CreateFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -159,8 +159,6 @@ func (t *Table) Do(f func(flux.ColReader) error) error {
 	return f(cr)
 }
 
-func (t *Table) Statistics() flux.Statistics { return flux.Statistics{} }
-
 type ColReader struct {
 	key  flux.GroupKey
 	meta []flux.ColMeta

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -711,7 +711,7 @@ func TestExecutor_Execute(t *testing.T) {
 			plan := plantest.CreatePlanSpec(tc.spec)
 
 			exe := execute.NewExecutor(nil, zaptest.NewLogger(t))
-			results, err := exe.Execute(context.Background(), plan, executetest.UnlimitedAllocator)
+			results, _, err := exe.Execute(context.Background(), plan, executetest.UnlimitedAllocator)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/execute/result.go
+++ b/execute/result.go
@@ -16,8 +16,6 @@ type result struct {
 
 	abortErr chan error
 	aborted  chan struct{}
-
-	stats flux.Statistics
 }
 
 type resultMessage struct {
@@ -53,8 +51,6 @@ func (s *result) Process(id DatasetID, tbl flux.Table) error {
 	return nil
 }
 
-func (s *result) Statistics() flux.Statistics { return s.stats }
-
 func (s *result) Tables() flux.TableIterator {
 	return s
 }
@@ -74,7 +70,6 @@ func (s *result) Do(f func(flux.Table) error) error {
 			if err := f(msg.table); err != nil {
 				return err
 			}
-			s.stats = s.stats.Add(msg.table.Statistics())
 		}
 	}
 }

--- a/execute/source.go
+++ b/execute/source.go
@@ -4,11 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/plan"
 )
 
 type Node interface {
 	AddTransformation(t Transformation)
+}
+
+// MetadataNode is a node that has additional metadata
+// that should be added to the result after it is
+// processed.
+type MetadataNode interface {
+	Node
+	Metadata() flux.Metadata
 }
 
 type Source interface {

--- a/execute/table.go
+++ b/execute/table.go
@@ -1291,9 +1291,6 @@ func (t *ColListTable) Empty() bool {
 func (t *ColListTable) NRows() int {
 	return t.nrows
 }
-func (t *ColListTable) Statistics() flux.Statistics {
-	return flux.Statistics{}
-}
 
 func (t *ColListTable) Len() int {
 	return t.nrows

--- a/influxql/decoder.go
+++ b/influxql/decoder.go
@@ -59,7 +59,9 @@ func (ri *resultIterator) Err() error {
 	return nil
 }
 
-func (ri *resultIterator) Statistics() flux.Statistics { return flux.Statistics{} }
+func (ri *resultIterator) Statistics() flux.Statistics {
+	return flux.Statistics{}
+}
 
 type result struct {
 	res *Result
@@ -196,5 +198,3 @@ func (r *result) Do(f func(tbl flux.Table) error) error {
 	}
 	return nil
 }
-
-func (ri *result) Statistics() flux.Statistics { return flux.Statistics{} }

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -475,7 +475,3 @@ func (r *result) Name() string {
 func (r *result) Tables() flux.TableIterator {
 	return r
 }
-
-func (r *result) Statistics() flux.Statistics {
-	return flux.Statistics{}
-}

--- a/line/result.go
+++ b/line/result.go
@@ -20,7 +20,6 @@ import (
 // ResultDecoder outputs one table once the reader reaches EOF.
 type ResultDecoder struct {
 	reader *bufio.Reader
-	stats  flux.Statistics
 	config *ResultDecoderConfig
 }
 
@@ -79,9 +78,6 @@ func (rd *ResultDecoder) Do(f func(flux.Table) error) error {
 	if err != nil {
 		return err
 	}
-
-	rd.stats = tbl.Statistics()
-
 	return f(tbl)
 }
 
@@ -91,10 +87,6 @@ func (*ResultDecoder) Name() string {
 
 func (rd *ResultDecoder) Tables() flux.TableIterator {
 	return rd
-}
-
-func (rd *ResultDecoder) Statistics() flux.Statistics {
-	return rd.stats
 }
 
 func (rd *ResultDecoder) Decode(r io.Reader) (flux.Result, error) {

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -11,20 +11,28 @@ import (
 
 var _ execute.Executor = (*Executor)(nil)
 
+var NoMetadata <-chan flux.Metadata
+
 // Executor is a mock implementation of an execute.Executor.
 type Executor struct {
-	ExecuteFn func(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, error)
+	ExecuteFn func(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error)
 }
 
 // NewExecutor returns a mock Executor where its methods will return zero values.
 func NewExecutor() *Executor {
 	return &Executor{
-		ExecuteFn: func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, error) {
-			return nil, nil
+		ExecuteFn: func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+			return nil, NoMetadata, nil
 		},
 	}
 }
 
-func (e *Executor) Execute(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, error) {
+func (e *Executor) Execute(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 	return e.ExecuteFn(ctx, p, a)
+}
+
+func init() {
+	noMetaCh := make(chan flux.Metadata)
+	close(noMetaCh)
+	NoMetadata = noMetaCh
 }

--- a/query.go
+++ b/query.go
@@ -1,6 +1,8 @@
 package flux
 
-import "time"
+import (
+	"time"
+)
 
 // Query represents an active query.
 type Query interface {
@@ -25,17 +27,41 @@ type Query interface {
 	// Err reports any error the query may have encountered.
 	Err() error
 
-	Statisticser
-}
-
-// Statisticser reports statisitcs about query processing.
-type Statisticser interface {
-	// Statistics reports the statisitcs for the query.
-	// The statisitcs are not complete until the query is finished.
+	// Statistics reports the statistics for the query.
+	// The statistics are not complete until Done is called.
 	Statistics() Statistics
 }
 
-// Statistics is a collection of statisitcs about the processing of a query.
+type Metadata map[string][]interface{}
+
+func (md Metadata) Add(key string, value interface{}) {
+	md[key] = append(md[key], value)
+}
+
+func (md Metadata) AddAll(other Metadata) {
+	for key, values := range other {
+		md[key] = append(md[key], values...)
+	}
+}
+
+// Range will iterate over the Metadata. It will invoke the function for each
+// key/value pair. If there are multiple values for a single key, then this will
+// be called with the same key once for each value.
+func (md Metadata) Range(fn func(key string, value interface{}) bool) {
+	for key, values := range md {
+		for _, value := range values {
+			if ok := fn(key, value); !ok {
+				return
+			}
+		}
+	}
+}
+
+func (md Metadata) Del(key string) {
+	delete(md, key)
+}
+
+// Statistics is a collection of statistics about the processing of a query.
 type Statistics struct {
 	// TotalDuration is the total amount of time in nanoseconds spent.
 	TotalDuration time.Duration `json:"total_duration"`
@@ -55,6 +81,9 @@ type Statistics struct {
 	// MaxAllocated is the maximum number of bytes the query allocated.
 	MaxAllocated int64 `json:"max_allocated"`
 
+	// Metadata contains metadata key/value pairs that have been attached during execution.
+	Metadata Metadata `json:"metadata"`
+
 	// ScannedValues is the number of values scanned.
 	ScannedValues int `json:"scanned_values"`
 	// ScannedBytes number of uncompressed bytes scanned.
@@ -63,6 +92,9 @@ type Statistics struct {
 
 // Add returns the sum of s and other.
 func (s Statistics) Add(other Statistics) Statistics {
+	md := make(Metadata)
+	md.AddAll(s.Metadata)
+	md.AddAll(other.Metadata)
 	return Statistics{
 		TotalDuration:   s.TotalDuration + other.TotalDuration,
 		CompileDuration: s.CompileDuration + other.CompileDuration,
@@ -74,5 +106,6 @@ func (s Statistics) Add(other Statistics) Statistics {
 		MaxAllocated:    s.MaxAllocated + other.MaxAllocated,
 		ScannedValues:   s.ScannedValues + other.ScannedValues,
 		ScannedBytes:    s.ScannedBytes + other.ScannedBytes,
+		Metadata:        md,
 	}
 }

--- a/result.go
+++ b/result.go
@@ -14,13 +14,10 @@ type Result interface {
 	Name() string
 	// Tables returns a TableIterator for iterating through results
 	Tables() TableIterator
-	// Statistics returns statistics collected the processing of the result.
-	Statistics() Statistics
 }
 
 type TableIterator interface {
 	Do(f func(Table) error) error
-	Statistics() Statistics
 }
 
 type Table interface {
@@ -38,9 +35,6 @@ type Table interface {
 
 	// Empty returns whether the table contains no records.
 	Empty() bool
-
-	// Stats returns collected statistics about this table during processing.
-	Statistics() Statistics
 }
 
 // ColMeta contains the information about the column metadata.

--- a/result_iterator.go
+++ b/result_iterator.go
@@ -6,7 +6,7 @@ import (
 
 // ResultIterator allows iterating through all results synchronously.
 // A ResultIterator is not thread-safe and all of the methods are expected to be
-// called within the same goroutine. A ResultIterator may implement Statisticser.
+// called within the same goroutine.
 type ResultIterator interface {
 	// More indicates if there are more results.
 	More() bool
@@ -25,7 +25,8 @@ type ResultIterator interface {
 	// or the query has been cancelled.
 	Err() error
 
-	// Statistics returns any statistics computed by the resultset.
+	// Statistics reports the statistics for the query.
+	// The statistics are not complete until Release is called.
 	Statistics() Statistics
 }
 
@@ -74,11 +75,7 @@ func (r *queryResultIterator) Err() error {
 }
 
 func (r *queryResultIterator) Statistics() Statistics {
-	stats := r.query.Statistics()
-	if r.results != nil {
-		stats = stats.Add(r.results.Statistics())
-	}
-	return stats
+	return r.query.Statistics()
 }
 
 type mapResultIterator struct {
@@ -118,11 +115,7 @@ func (r *mapResultIterator) Err() error {
 }
 
 func (r *mapResultIterator) Statistics() Statistics {
-	var stats Statistics
-	for _, result := range r.results {
-		stats = stats.Add(result.Statistics())
-	}
-	return stats
+	return Statistics{}
 }
 
 type sliceResultIterator struct {
@@ -155,9 +148,5 @@ func (r *sliceResultIterator) Err() error {
 }
 
 func (r *sliceResultIterator) Statistics() Statistics {
-	var stats Statistics
-	for _, result := range r.results {
-		stats = stats.Add(result.Statistics())
-	}
-	return stats
+	return Statistics{}
 }


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

A source node can expose statistics for its execution and the executor
will attach this metadata to the query returned from the controller.
This metadata can be any arbitrary set of key/value pairs. The metadata
is formatted similar to http headers where one key may have multiple
values. This means that a consumer can decide what to do with multiple
values with the same key such as whether to average or sum the values.

This removes the `flux.Statistics` from arbitrary `flux.Result` values
and the table iterators because the statistics are mostly meaningless
for most iterators.

BREAKING CHANGE: The `Statistics() flux.Statistics` method has been
removed from all interfaces not related to `flux.Query` or
`flux.ResultIterator`. The `flux.ResultIterator` should be considered a
wrapper of `flux.Query` so it exposes the statistics too.