### PR TITLE
refactor(compiler): panic when compiled function errors

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -1097,7 +1097,10 @@ func (e *callEvaluator) eval(scope Scope) values.Value {
 	args := e.args.EvalObject(scope)
 	f := e.callee.EvalFunction(scope)
 	//TODO(nathanielc): What to do about error when calling functions?
-	v, _ := f.Call(args)
+	v, err := f.Call(args)
+	if err != nil {
+		panic(err)
+	}
 	return v
 }
 


### PR DESCRIPTION
Closes #978 .

**NOTE:** This change will not fix the panic from #978. A panic will
still occur, it just won't be a nil pointer dereference. The new error
message should help in debugging the issue. This change is instead
of refactoring the entire compiler package to return errors.

Previously if the compiler called a function and an error occurred
during the call, the compiler would just consume the error and
return a nil value. However most callers do not expect to get a
nil value and so nil pointer dereferences were possible. And the
resulting panics are not helpful in debugging what went wrong.

The Flux type conversion functions are quite susceptible in this
situation. See #978. When placed inside a map or filter, these
functions are evaluated by the compiler and so if a type conversion
error occurs so will a nil pointer dereference.

Now as soon as a function call errors in the compiler, a panic is
initiated using the error message obtained from the function call.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
