### PR TITLE
fix(lang): make ASTCompiler marshalable

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -55,14 +55,14 @@ func (c SpecCompiler) CompilerType() flux.CompilerType {
 // ASTCompiler implements Compiler by producing a Spec from an AST.
 type ASTCompiler struct {
 	AST *ast.Package `json:"ast"`
-	Now func() time.Time
+	Now time.Time
 }
 
 func (c ASTCompiler) Compile(ctx context.Context) (*flux.Spec, error) {
-	if c.Now != nil {
-		return flux.CompileAST(ctx, c.AST, c.Now())
+	if c.Now.IsZero() {
+		return flux.CompileAST(ctx, c.AST, time.Now())
 	}
-	return flux.CompileAST(ctx, c.AST, time.Now())
+	return flux.CompileAST(ctx, c.AST, c.Now)
 }
 
 func (ASTCompiler) CompilerType() flux.CompilerType {

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -18,14 +18,14 @@ import (
 func TestASTCompiler(t *testing.T) {
 	testcases := []struct {
 		name   string
-		now    func() time.Time
-		file *ast.File
+		now    time.Time
+		file   *ast.File
 		script string
 		want   *flux.Spec
 	}{
 		{
 			name: "override now time using now option",
-			now:  func() time.Time { return time.Unix(1, 1) },
+			now:  time.Unix(1, 1),
 			script: `
 import "csv"
 option now = () => 2017-10-10T00:01:00Z
@@ -51,7 +51,7 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 		},
 		{
 			name: "get now time from compiler",
-			now:  func() time.Time { return time.Unix(1, 1) },
+			now:  time.Unix(1, 1),
 			script: `
 import "csv"
 csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)


### PR DESCRIPTION
BREAKING CHANGES: ASTCompiler.Now is of type time.Time and no longer
a function type. This ensures it can be marshaled.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
