### PR TITLE
fix(execute): group key comparison works regardless of column ordering

### DIFF
--- a/execute/group_key_test.go
+++ b/execute/group_key_test.go
@@ -1,0 +1,344 @@
+package execute_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func TestGroupKey_Equal(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		left, right flux.GroupKey
+		want        bool
+	}{
+		{
+			name: "Identical",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			want: true,
+		},
+		{
+			name: "Transposed",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("c"),
+					values.NewString("b"),
+				},
+			),
+			want: true,
+		},
+		{
+			name: "Unequal",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("c"),
+				},
+			),
+			want: false,
+		},
+		{
+			name: "DifferentKeys",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			want: false,
+		},
+		{
+			name: "DifferentLengths",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			want: false,
+		},
+		{
+			name: "NullValue_Equal",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewNull(semantic.String),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewNull(semantic.String),
+				},
+			),
+			want: true,
+		},
+		{
+			name: "NullValue_NotEqual",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewNull(semantic.String),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			want: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if want, got := tt.want, tt.left.Equal(tt.right); want != got {
+				t.Errorf("unexpected result: want=%v got=%v", want, got)
+			}
+		})
+	}
+}
+
+func TestGroupKey_Less(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		left, right flux.GroupKey
+		want        [2]bool
+	}{
+		{
+			name: "Identical",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			want: [2]bool{false, false},
+		},
+		{
+			name: "Identical_Transposed",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("c"),
+					values.NewString("b"),
+				},
+			),
+			want: [2]bool{false, false},
+		},
+		{
+			name: "LessThan",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("c"),
+				},
+			),
+			want: [2]bool{true, false},
+		},
+		{
+			name: "LessThan_Transposed",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+					values.NewString("c"),
+				},
+			),
+			want: [2]bool{true, false},
+		},
+		{
+			name: "DifferentKeys",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			want: [2]bool{false, true},
+		},
+		{
+			name: "NullValue_Equal",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewNull(semantic.String),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewNull(semantic.String),
+				},
+			),
+			want: [2]bool{false, false},
+		},
+		{
+			name: "NullValue_LessThan",
+			left: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewNull(semantic.String),
+				},
+			),
+			right: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b"),
+				},
+			),
+			want: [2]bool{true, false},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if want, got := tt.want[0], tt.left.Less(tt.right); want != got {
+				t.Errorf("unexpected result for left < right: want=%v got=%v", want, got)
+			}
+			if want, got := tt.want[1], tt.right.Less(tt.left); want != got {
+				t.Errorf("unexpected result for right < left: want=%v got=%v", want, got)
+			}
+		})
+	}
+}

--- a/execute/table.go
+++ b/execute/table.go
@@ -1245,11 +1245,11 @@ func (b *ColListTableBuilder) ClearData() {
 }
 
 func (b *ColListTableBuilder) Sort(cols []string, desc bool) {
-	colIdxs := make([]int, len(cols))
-	for i, label := range cols {
+	colIdxs := make([]int, 0, len(cols))
+	for _, label := range cols {
 		for j, c := range b.colMeta {
 			if c.Label == label {
-				colIdxs[i] = j
+				colIdxs = append(colIdxs, j)
 				break
 			}
 		}

--- a/stdlib/socket/from_test.go
+++ b/stdlib/socket/from_test.go
@@ -161,6 +161,23 @@ source
 						{Label: "boolean", Type: flux.TBool},
 					},
 					Data: [][]interface{}{
+						{execute.Time(0), "b", "b", 0.42, false},
+						{execute.Time(0), "b", "b", 0.1, false},
+						{execute.Time(0), "b", "b", -0.3, false},
+						{execute.Time(0), "b", "b", 10.0, false},
+						{execute.Time(0), "b", "b", 5.33, false},
+					},
+				},
+				{
+					KeyCols: []string{"tag1", "tag2", "boolean"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "tag1", Type: flux.TString},
+						{Label: "tag2", Type: flux.TString},
+						{Label: "double", Type: flux.TFloat},
+						{Label: "boolean", Type: flux.TBool},
+					},
+					Data: [][]interface{}{
 						{execute.Time(0), "a", "b", 0.42, true},
 						{execute.Time(0), "a", "b", 0.1, true},
 						{execute.Time(0), "a", "b", -0.3, true},
@@ -183,23 +200,6 @@ source
 						{execute.Time(0), "b", "b", -0.3, true},
 						{execute.Time(0), "b", "b", 10.0, true},
 						{execute.Time(0), "b", "b", 5.33, true},
-					},
-				},
-				{
-					KeyCols: []string{"tag1", "tag2", "boolean"},
-					ColMeta: []flux.ColMeta{
-						{Label: "_time", Type: flux.TTime},
-						{Label: "tag1", Type: flux.TString},
-						{Label: "tag2", Type: flux.TString},
-						{Label: "double", Type: flux.TFloat},
-						{Label: "boolean", Type: flux.TBool},
-					},
-					Data: [][]interface{}{
-						{execute.Time(0), "b", "b", 0.42, false},
-						{execute.Time(0), "b", "b", 0.1, false},
-						{execute.Time(0), "b", "b", -0.3, false},
-						{execute.Time(0), "b", "b", 10.0, false},
-						{execute.Time(0), "b", "b", 5.33, false},
 					},
 				},
 			},

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -368,6 +368,7 @@ type MergeJoinCache struct {
 	buffers map[execute.DatasetID]*streamBuffer
 
 	on           map[string]bool
+	order        []string
 	intersection map[string]bool
 
 	schema    schema
@@ -517,6 +518,7 @@ func NewMergeJoinCache(alloc *memory.Allocator, datasetIDs []execute.DatasetID, 
 
 	return &MergeJoinCache{
 		on:            on,
+		order:         key,
 		intersection:  intersection,
 		leftID:        datasetIDs[0],
 		rightID:       datasetIDs[1],
@@ -844,16 +846,9 @@ func equalJoinkeys(left, right flux.GroupKey) bool {
 }
 
 func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Table, error) {
-	// Determine sort order for the joining tables
-	on := make([]string, len(c.on))
-
-	for k := range c.on {
-		on = append(on, k)
-	}
-
 	// Sort input tables
-	left.Sort(on, false)
-	right.Sort(on, false)
+	left.Sort(c.order, false)
+	right.Sort(c.order, false)
 
 	var leftSet, rightSet subset
 	var leftKey, rightKey flux.GroupKey


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

Group keys are considered identical if they have the same set of columns
and these columns have the same values. They are also sorted by a
similar metric where any missing column is considered null and nulls
sort before anything.

Previously, the sort algorithm that was employed assumed that the
columns were already sorted which only worked if the group key was
constructed that way. Otherwise, it would compare them as different.

The group key maintains its ordering for the purpose of a call to
`Cols()` so it is order preserving, but they are considered identical as
if to compare the values in a map so order doesn't matter.

Fixes #1023.