### PR TITLE
fix(stdlib): deterministic sorting of input tables in join

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -1245,11 +1245,11 @@ func (b *ColListTableBuilder) ClearData() {
 }
 
 func (b *ColListTableBuilder) Sort(cols []string, desc bool) {
-	colIdxs := make([]int, len(cols))
-	for i, label := range cols {
+	colIdxs := make([]int, 0, len(cols))
+	for _, label := range cols {
 		for j, c := range b.colMeta {
 			if c.Label == label {
-				colIdxs[i] = j
+				colIdxs = append(colIdxs, j)
 				break
 			}
 		}

--- a/stdlib/socket/from_test.go
+++ b/stdlib/socket/from_test.go
@@ -161,6 +161,23 @@ source
 						{Label: "boolean", Type: flux.TBool},
 					},
 					Data: [][]interface{}{
+						{execute.Time(0), "b", "b", 0.42, false},
+						{execute.Time(0), "b", "b", 0.1, false},
+						{execute.Time(0), "b", "b", -0.3, false},
+						{execute.Time(0), "b", "b", 10.0, false},
+						{execute.Time(0), "b", "b", 5.33, false},
+					},
+				},
+				{
+					KeyCols: []string{"tag1", "tag2", "boolean"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "tag1", Type: flux.TString},
+						{Label: "tag2", Type: flux.TString},
+						{Label: "double", Type: flux.TFloat},
+						{Label: "boolean", Type: flux.TBool},
+					},
+					Data: [][]interface{}{
 						{execute.Time(0), "a", "b", 0.42, true},
 						{execute.Time(0), "a", "b", 0.1, true},
 						{execute.Time(0), "a", "b", -0.3, true},
@@ -183,23 +200,6 @@ source
 						{execute.Time(0), "b", "b", -0.3, true},
 						{execute.Time(0), "b", "b", 10.0, true},
 						{execute.Time(0), "b", "b", 5.33, true},
-					},
-				},
-				{
-					KeyCols: []string{"tag1", "tag2", "boolean"},
-					ColMeta: []flux.ColMeta{
-						{Label: "_time", Type: flux.TTime},
-						{Label: "tag1", Type: flux.TString},
-						{Label: "tag2", Type: flux.TString},
-						{Label: "double", Type: flux.TFloat},
-						{Label: "boolean", Type: flux.TBool},
-					},
-					Data: [][]interface{}{
-						{execute.Time(0), "b", "b", 0.42, false},
-						{execute.Time(0), "b", "b", 0.1, false},
-						{execute.Time(0), "b", "b", -0.3, false},
-						{execute.Time(0), "b", "b", 10.0, false},
-						{execute.Time(0), "b", "b", 5.33, false},
 					},
 				},
 			},

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -368,6 +368,7 @@ type MergeJoinCache struct {
 	buffers map[execute.DatasetID]*streamBuffer
 
 	on           map[string]bool
+	order        []string
 	intersection map[string]bool
 
 	schema    schema
@@ -517,6 +518,7 @@ func NewMergeJoinCache(alloc *memory.Allocator, datasetIDs []execute.DatasetID, 
 
 	return &MergeJoinCache{
 		on:            on,
+		order:         key,
 		intersection:  intersection,
 		leftID:        datasetIDs[0],
 		rightID:       datasetIDs[1],
@@ -844,16 +846,9 @@ func equalJoinkeys(left, right flux.GroupKey) bool {
 }
 
 func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Table, error) {
-	// Determine sort order for the joining tables
-	on := make([]string, len(c.on))
-
-	for k := range c.on {
-		on = append(on, k)
-	}
-
 	// Sort input tables
-	left.Sort(on, false)
-	right.Sort(on, false)
+	left.Sort(c.order, false)
+	right.Sort(c.order, false)
 
 	var leftSet, rightSet subset
 	var leftKey, rightKey flux.GroupKey


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

Previously join would sort the input tables according to the join
key (columns on which to join). But the join key was stored as a
map, so it was possible to get different sort orders for the rows
of a table.

Now the join key is stored as a column slice, hence for each table
output by the join, the rows of that table will have a deterministic
sort order.

This combined with a similar bug in the table
sort that caused it to use the first row for sorting if the column could
not be found.

Signed-off-by: Jonathan A. Sternberg <jonathan@influxdata.com>