### PR TITLE
Fix/memory consumption

### DIFF
--- a/execute/aggregate_test.go
+++ b/execute/aggregate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/stdlib/universe"
 )
 
@@ -552,7 +553,7 @@ func TestAggregate_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
 			agg := execute.NewAggregateTransformation(d, c, tc.agg, tc.config)
 

--- a/execute/dataset.go
+++ b/execute/dataset.go
@@ -15,7 +15,7 @@ type Dataset interface {
 	UpdateWatermark(mark Time) error
 	Finish(error)
 
-	SetTriggerSpec(t flux.TriggerSpec)
+	SetTriggerSpec(t plan.TriggerSpec)
 }
 
 // DataCache holds all working data for a transformation.
@@ -28,7 +28,7 @@ type DataCache interface {
 	DiscardTable(flux.GroupKey)
 	ExpireTable(flux.GroupKey)
 
-	SetTriggerSpec(t flux.TriggerSpec)
+	SetTriggerSpec(t plan.TriggerSpec)
 }
 
 type AccumulationMode int
@@ -79,7 +79,7 @@ func (d *dataset) AddTransformation(t Transformation) {
 	d.ts = append(d.ts, t)
 }
 
-func (d *dataset) SetTriggerSpec(spec flux.TriggerSpec) {
+func (d *dataset) SetTriggerSpec(spec plan.TriggerSpec) {
 	d.cache.SetTriggerSpec(spec)
 }
 

--- a/execute/executetest/dataset.go
+++ b/execute/executetest/dataset.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -55,7 +56,7 @@ func (d *Dataset) Finish(err error) {
 	d.FinishedErr = err
 }
 
-func (d *Dataset) SetTriggerSpec(t flux.TriggerSpec) {
+func (d *Dataset) SetTriggerSpec(t plan.TriggerSpec) {
 	panic("not implemented")
 }
 
@@ -67,7 +68,7 @@ func TransformationPassThroughTestHelper(t *testing.T, newTr NewTransformation) 
 	now := execute.Now()
 	d := NewDataset(RandomDatasetID())
 	c := execute.NewTableBuilderCache(UnlimitedAllocator)
-	c.SetTriggerSpec(execute.DefaultTriggerSpec)
+	c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
 	parentID := RandomDatasetID()
 	tr := newTr(d, c)

--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
 	"gonum.org/v1/gonum/floats"
 )
 
@@ -53,7 +54,7 @@ func ProcessTestHelper(
 
 	d := NewDataset(RandomDatasetID())
 	c := execute.NewTableBuilderCache(UnlimitedAllocator)
-	c.SetTriggerSpec(execute.DefaultTriggerSpec)
+	c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
 	tx := create(d, c)
 

--- a/execute/selector_test.go
+++ b/execute/selector_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/stdlib/universe"
 )
 
@@ -180,7 +181,7 @@ func TestRowSelector_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
 			selector := execute.NewRowSelectorTransformation(d, c, new(universe.MinSelector), tc.config)
 
@@ -338,7 +339,7 @@ func TestIndexSelector_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
 			selector := execute.NewIndexSelectorTransformation(d, c, new(universe.FirstSelector), tc.config)
 

--- a/execute/table.go
+++ b/execute/table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -1962,7 +1963,7 @@ type tableBuilderCache struct {
 	tables *GroupLookup
 	alloc  *memory.Allocator
 
-	triggerSpec flux.TriggerSpec
+	triggerSpec plan.TriggerSpec
 }
 
 func NewTableBuilderCache(a *memory.Allocator) *tableBuilderCache {
@@ -1977,7 +1978,7 @@ type tableState struct {
 	trigger Trigger
 }
 
-func (d *tableBuilderCache) SetTriggerSpec(ts flux.TriggerSpec) {
+func (d *tableBuilderCache) SetTriggerSpec(ts plan.TriggerSpec) {
 	d.triggerSpec = ts
 }
 

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -141,7 +142,7 @@ func Input(schema Schema) (flux.ResultIterator, error) {
 	}
 
 	cache := execute.NewTableBuilderCache(&memory.Allocator{})
-	cache.SetTriggerSpec(flux.DefaultTrigger)
+	cache.SetTriggerSpec(plan.DefaultTriggerSpec)
 	for {
 		if len(groups) == 0 {
 			break

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -52,6 +52,11 @@ func (pp *physicalPlanner) Plan(spec *PlanSpec) (*PlanSpec, error) {
 		return nil, err
 	}
 
+	// Set all default and/or registered trigger specs
+	if err := transformedSpec.TopDownWalk(SetTriggerSpec); err != nil {
+		return nil, err
+	}
+
 	// Ensure that the plan is valid
 	if !pp.disableValidation {
 		err := transformedSpec.CheckIntegrity()
@@ -184,6 +189,10 @@ type PhysicalPlanNode struct {
 	bounds
 	id   NodeID
 	Spec PhysicalProcedureSpec
+
+	// The trigger spec defines how and when a transformation
+	// sends its tables to downstream operators
+	TriggerSpec TriggerSpec
 
 	// The attributes required from inputs to this node
 	RequiredAttrs []PhysicalAttributes

--- a/plan/triggers_test.go
+++ b/plan/triggers_test.go
@@ -1,0 +1,69 @@
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/plan"
+)
+
+type triggerAwareProcedureSpec struct {
+	plan.DefaultCost
+}
+
+func (s triggerAwareProcedureSpec) Copy() plan.ProcedureSpec {
+	return s
+}
+
+func (s triggerAwareProcedureSpec) Kind() plan.ProcedureKind {
+	return "TriggerAwareProcedure"
+}
+
+func (s triggerAwareProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
+func TestTriggers(t *testing.T) {
+	testcases := []struct {
+		name    string
+		node    plan.PlanNode
+		want    plan.TriggerSpec
+		wantErr bool
+	}{
+		{
+			name: "default trigger spec",
+			node: &plan.PhysicalPlanNode{},
+			want: plan.AfterWatermarkTriggerSpec{},
+		},
+		{
+			name: "trigger aware procedure",
+			node: &plan.PhysicalPlanNode{
+				Spec: triggerAwareProcedureSpec{},
+			},
+			want: plan.NarrowTransformationTriggerSpec{},
+		},
+		{
+			name:    "cannot set trigger on logical node",
+			node:    &plan.LogicalPlanNode{},
+			wantErr: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := plan.SetTriggerSpec(tc.node)
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error setting default triggers: %v", err)
+			}
+			if tc.wantErr && err == nil {
+				t.Fatal("expected error setting default triggers, but got nothing")
+			}
+			if tc.wantErr == (err != nil) {
+				return
+			}
+			n := tc.node.(*plan.PhysicalPlanNode)
+			if !cmp.Equal(tc.want, n.TriggerSpec) {
+				t.Fatalf("unexpected trigger spec: -want/+got\n%s", cmp.Diff(tc.want, n.TriggerSpec))
+			}
+		})
+	}
+}

--- a/stdlib/socket/from_test.go
+++ b/stdlib/socket/from_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/mock"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/socket"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -212,7 +213,7 @@ source
 			id := executetest.RandomDatasetID()
 			d := executetest.NewDataset(id)
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(flux.DefaultTrigger)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 			r := ioutil.NopCloser(bytes.NewReader([]byte(tc.input)))
 			ss, err := socket.NewSocketSource(tc.spec, r, &mock.AscendingTimeProvider{}, id)
 			if err != nil {

--- a/stdlib/testing/assert_equals_test.go
+++ b/stdlib/testing/assert_equals_test.go
@@ -518,7 +518,7 @@ func TestAssertEquals_Process(t *testing.T) {
 
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 			jt := fluxtesting.NewAssertEqualsTransformation(d, c, tc.spec, parents[0], parents[1], executetest.UnlimitedAllocator)
 
 			executetest.NormalizeTables(tc.data0)

--- a/stdlib/testing/diff_test.go
+++ b/stdlib/testing/diff_test.go
@@ -233,7 +233,7 @@ func TestDiff_Process(t *testing.T) {
 
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 			jt := fluxtesting.NewDiffTransformation(d, c, tc.spec, parents[0], parents[1], executetest.UnlimitedAllocator)
 
 			executetest.NormalizeTables(tc.data0)

--- a/stdlib/universe/count.go
+++ b/stdlib/universe/count.go
@@ -73,6 +73,11 @@ func (s *CountProcedureSpec) ReAggregateSpec() plan.ProcedureSpec {
 	return new(SumProcedureSpec)
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *CountProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type CountAgg struct {
 	count int64
 }

--- a/stdlib/universe/covariance.go
+++ b/stdlib/universe/covariance.go
@@ -105,6 +105,11 @@ func (s *CovarianceProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *CovarianceProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type CovarianceTransformation struct {
 	d     execute.Dataset
 	cache execute.TableBuilderCache

--- a/stdlib/universe/cumulative_sum.go
+++ b/stdlib/universe/cumulative_sum.go
@@ -87,6 +87,11 @@ func (s *CumulativeSumProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *CumulativeSumProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createCumulativeSumTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*CumulativeSumProcedureSpec)
 	if !ok {

--- a/stdlib/universe/derivative.go
+++ b/stdlib/universe/derivative.go
@@ -125,6 +125,11 @@ func (s *DerivativeProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *DerivativeProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createDerivativeTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*DerivativeProcedureSpec)
 	if !ok {

--- a/stdlib/universe/difference.go
+++ b/stdlib/universe/difference.go
@@ -106,6 +106,11 @@ func (s *DifferenceProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *DifferenceProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createDifferenceTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*DifferenceProcedureSpec)
 	if !ok {

--- a/stdlib/universe/distinct.go
+++ b/stdlib/universe/distinct.go
@@ -84,6 +84,11 @@ func (s *DistinctProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *DistinctProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createDistinctTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*DistinctProcedureSpec)
 	if !ok {

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -91,6 +91,11 @@ func (s *FilterProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *FilterProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createFilterTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*FilterProcedureSpec)
 	if !ok {

--- a/stdlib/universe/first.go
+++ b/stdlib/universe/first.go
@@ -70,6 +70,11 @@ func (s *FirstProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *FirstProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type FirstSelector struct {
 	selected bool
 }

--- a/stdlib/universe/integral.go
+++ b/stdlib/universe/integral.go
@@ -103,6 +103,11 @@ func (s *IntegralProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *IntegralProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createIntegralTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*IntegralProcedureSpec)
 	if !ok {

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -380,7 +380,7 @@ type MergeJoinCache struct {
 
 	tables      map[flux.GroupKey]flux.Table
 	alloc       *memory.Allocator
-	triggerSpec flux.TriggerSpec
+	triggerSpec plan.TriggerSpec
 }
 
 type streamBuffer struct {
@@ -664,7 +664,7 @@ func (c *MergeJoinCache) ExpireTable(key flux.GroupKey) {
 }
 
 // SetTriggerSpec sets the trigger rule for this cache
-func (c *MergeJoinCache) SetTriggerSpec(spec flux.TriggerSpec) {
+func (c *MergeJoinCache) SetTriggerSpec(spec plan.TriggerSpec) {
 	c.triggerSpec = spec
 }
 

--- a/stdlib/universe/join_test.go
+++ b/stdlib/universe/join_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -1525,7 +1526,7 @@ func TestMergeJoin_Process(t *testing.T) {
 
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := universe.NewMergeJoinCache(executetest.UnlimitedAllocator, parents, tableNames, tc.spec.On)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 			jt := universe.NewMergeJoinTransformation(d, c, tc.spec, parents, tableNames)
 
 			l := len(tc.data0)

--- a/stdlib/universe/key_values.go
+++ b/stdlib/universe/key_values.go
@@ -108,6 +108,11 @@ func (s *KeyValuesProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *KeyValuesProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type keyValuesTransformation struct {
 	d        execute.Dataset
 	cache    execute.TableBuilderCache

--- a/stdlib/universe/keys.go
+++ b/stdlib/universe/keys.go
@@ -79,6 +79,11 @@ func (s *KeysProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *KeysProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createKeysTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*KeysProcedureSpec)
 	if !ok {

--- a/stdlib/universe/last.go
+++ b/stdlib/universe/last.go
@@ -68,6 +68,11 @@ func (s *LastProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *LastProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type LastSelector struct {
 	rows []execute.Row
 }

--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -91,6 +91,11 @@ func (s *LimitProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *LimitProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createLimitTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*LimitProcedureSpec)
 	if !ok {

--- a/stdlib/universe/max.go
+++ b/stdlib/universe/max.go
@@ -68,6 +68,11 @@ func (s *MaxProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *MaxProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type MaxSelector struct {
 	set  bool
 	rows []execute.Row

--- a/stdlib/universe/mean.go
+++ b/stdlib/universe/mean.go
@@ -68,6 +68,11 @@ func (s *MeanProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *MeanProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type MeanAgg struct {
 	count int64
 	sum   float64

--- a/stdlib/universe/min.go
+++ b/stdlib/universe/min.go
@@ -68,6 +68,11 @@ func (s *MinProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *MinProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type MinSelector struct {
 	set  bool
 	rows []execute.Row

--- a/stdlib/universe/percentile.go
+++ b/stdlib/universe/percentile.go
@@ -128,6 +128,11 @@ func (s *TDigestPercentileProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *TDigestPercentileProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type ExactPercentileAggProcedureSpec struct {
 	Percentile float64 `json:"percentile"`
 	execute.AggregateConfig
@@ -140,6 +145,11 @@ func (s *ExactPercentileAggProcedureSpec) Copy() plan.ProcedureSpec {
 	return &ExactPercentileAggProcedureSpec{Percentile: s.Percentile, AggregateConfig: s.AggregateConfig}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *ExactPercentileAggProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type ExactPercentileSelectProcedureSpec struct {
 	Percentile float64 `json:"percentile"`
 	execute.SelectorConfig
@@ -150,6 +160,11 @@ func (s *ExactPercentileSelectProcedureSpec) Kind() plan.ProcedureKind {
 }
 func (s *ExactPercentileSelectProcedureSpec) Copy() plan.ProcedureSpec {
 	return &ExactPercentileSelectProcedureSpec{Percentile: s.Percentile}
+}
+
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *ExactPercentileSelectProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
 }
 
 func newPercentileProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {

--- a/stdlib/universe/range.go
+++ b/stdlib/universe/range.go
@@ -162,6 +162,11 @@ func (s *RangeProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *RangeProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createRangeTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*RangeProcedureSpec)
 	if !ok {

--- a/stdlib/universe/sample.go
+++ b/stdlib/universe/sample.go
@@ -105,6 +105,11 @@ func (s *SampleProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *SampleProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type SampleSelector struct {
 	N   int
 	Pos int

--- a/stdlib/universe/shift.go
+++ b/stdlib/universe/shift.go
@@ -116,6 +116,11 @@ func (s *ShiftProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *ShiftProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createShiftTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*ShiftProcedureSpec)
 	if !ok {

--- a/stdlib/universe/skew.go
+++ b/stdlib/universe/skew.go
@@ -68,6 +68,11 @@ func (s *SkewProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *SkewProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type SkewAgg struct {
 	n, m1, m2, m3 float64
 }

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -100,6 +100,11 @@ func (s *SortProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *SortProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createSortTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SortProcedureSpec)
 	if !ok {

--- a/stdlib/universe/spread.go
+++ b/stdlib/universe/spread.go
@@ -74,6 +74,11 @@ func (s *SpreadProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *SpreadProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createSpreadTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SpreadProcedureSpec)
 	if !ok {

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -141,6 +141,11 @@ func (s *StateTrackingProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *StateTrackingProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createStateTrackingTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*StateTrackingProcedureSpec)
 	if !ok {

--- a/stdlib/universe/stddev.go
+++ b/stdlib/universe/stddev.go
@@ -66,6 +66,11 @@ func (s *StddevProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *StddevProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 type StddevAgg struct {
 	n, m2, mean float64
 }

--- a/stdlib/universe/sum.go
+++ b/stdlib/universe/sum.go
@@ -68,6 +68,11 @@ func (s *SumProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *SumProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func (s *SumProcedureSpec) AggregateMethod() string {
 	return SumKind
 }

--- a/stdlib/universe/union_test.go
+++ b/stdlib/universe/union_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -754,7 +755,7 @@ func TestUnion_Process(t *testing.T) {
 
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 			ut := universe.NewUnionTransformation(d, c, spec, parentIds)
 
 			for i, s := range tc.data {

--- a/stdlib/universe/unique.go
+++ b/stdlib/universe/unique.go
@@ -82,6 +82,11 @@ func (s *UniqueProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *UniqueProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
 func createUniqueTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*UniqueProcedureSpec)
 	if !ok {

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -831,7 +832,7 @@ func TestFixedWindow_Process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := executetest.NewDataset(executetest.RandomDatasetID())
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
-			c.SetTriggerSpec(execute.DefaultTriggerSpec)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
 			fw := universe.NewFixedWindowTransformation(
 				d,


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

This PR does several things:

First, it adds a new `TriggerSpec` field to a physical plan node. The trigger spec defines (partly) how a transformation is implemented and therefore should be part of physical query planning.

Next it defines a registration method for registering procedures with specific trigger specifications. In addition a method has been added to the physical planning stage that walks the plan graph and sets the `TriggerSpec` field on each plan node. For procedures that do not have a trigger spec registered, the default `AfterWatermarkTriggerSpec` is used.

It moves all the different trigger spec definitions into the plan package. It also defines a new triggering spec called the `NarrowTranformationTriggerSpec` that fires immediately and finishes immediately.

Finally it changes all narrow transformations to use this new trigger, ensuring that for such transformations, their data caches only ever contain at most one table, thereby reducing the total memory consumption of queries composed of narrow transformations.
