### PR TITLE
perf(execute): optimize group lookup for non ordered access patterns

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1279,12 +1279,14 @@ The _null_ value can be of any data type.
 
 Transformations define a change to a stream.
 Transformations may consume an input stream and always produce a new output stream.
+The order of group keys for the output stream will have a stable output order based on the input stream.
+The specific ordering may change between releases and it would not be considered a breaking change.
 
 Most transformations output one table for every table they receive from the input stream.
 Transformations that modify the group keys or values will need to regroup the tables in the output stream.
 A transformation produces side effects when it is constructed from a function that produces side effects.
 
-Transformations are repsented using function types.
+Transformations are represented using function types.
 
 ### Built-in transformations
 

--- a/execute/group_lookup.go
+++ b/execute/group_lookup.go
@@ -7,66 +7,198 @@ import (
 )
 
 type GroupLookup struct {
-	groups groupEntries
+	// groups contains groups of group keys in sorted order.
+	// These are optimized for appending access.
+	groups []*groupKeyList
 
-	//  range state
-	rangeIdx int
+	// lastIndex contains the last group that an entry was
+	// found in or appended to. This is used to optimize appending.
+	lastIndex int
 
-	// Indicates whether the group needs to be sorted.
-	needSort bool
+	// nextID is the next id that will be assigned to a key group.
+	nextID int
 }
 
-type groupEntry struct {
-	key   flux.GroupKey
-	value interface{}
+// groupKeyList is a group of keys in sorted order.
+type groupKeyList struct {
+	id       int // unique id for the key group within the group lookup
+	elements []groupKeyListElement
+	deleted  int
+}
+
+type groupKeyListElement struct {
+	key     flux.GroupKey
+	value   interface{}
+	deleted bool
+}
+
+func (kg *groupKeyList) First() flux.GroupKey {
+	return kg.elements[0].key
+}
+
+func (kg *groupKeyList) Last() flux.GroupKey {
+	return kg.elements[len(kg.elements)-1].key
+}
+
+func (kg *groupKeyList) set(i int, value interface{}) {
+	if kg.elements[i].deleted {
+		kg.elements[i].deleted = false
+		kg.deleted--
+	}
+	kg.elements[i].value = value
+}
+
+func (kg *groupKeyList) delete(i int) {
+	kg.elements[i].value = nil
+	kg.elements[i].deleted = true
+	kg.deleted++
+}
+
+// Index determines the location of this key within the key group.
+// It returns -1 if this key does not exist within the group.
+// It will return -1 if the entry is present, but deleted.
+func (kg *groupKeyList) Index(key flux.GroupKey) int {
+	i := kg.InsertAt(key)
+	if i >= len(kg.elements) || kg.elements[i].deleted || !kg.elements[i].key.Equal(key) {
+		return -1
+	}
+	return i
+}
+
+// InsertAt will return the index where this key should be inserted.
+// If this key would be inserted before the first element, this will
+// return 0. If the element exists, then this will return the index
+// where that element is located. If the key should be inserted at the
+// end of the array, it will return an index the size of the array.
+func (kg *groupKeyList) InsertAt(key flux.GroupKey) int {
+	if kg.Last().Less(key) {
+		return len(kg.elements)
+	}
+	return sort.Search(len(kg.elements), func(i int) bool {
+		return !kg.elements[i].key.Less(key)
+	})
+}
+
+func (kg *groupKeyList) At(i int) interface{} {
+	return kg.elements[i].value
 }
 
 func NewGroupLookup() *GroupLookup {
 	return &GroupLookup{
-		groups: make(groupEntries, 0, 100),
+		lastIndex: -1,
+		nextID:    1,
 	}
-}
-
-func (l *GroupLookup) findIdx(key flux.GroupKey) int {
-	if l.needSort {
-		sort.Sort(l.groups)
-		l.needSort = false
-	}
-
-	i := sort.Search(len(l.groups), func(i int) bool {
-		return !l.groups[i].key.Less(key)
-	})
-	if i < len(l.groups) && l.groups[i].key.Equal(key) {
-		return i
-	}
-	return -1
 }
 
 func (l *GroupLookup) Lookup(key flux.GroupKey) (interface{}, bool) {
-	if key == nil {
+	if key == nil || len(l.groups) == 0 {
 		return nil, false
 	}
-	i := l.findIdx(key)
-	if i >= 0 {
-		return l.groups[i].value, true
+
+	group := l.lookupGroup(key)
+	if group == -1 {
+		return nil, false
+	}
+
+	i := l.groups[group].Index(key)
+	if i != -1 {
+		return l.groups[group].At(i), true
 	}
 	return nil, false
 }
 
 func (l *GroupLookup) Set(key flux.GroupKey, value interface{}) {
-	i := l.findIdx(key)
-	if i >= 0 {
-		l.groups[i].value = value
-	} else {
-		// There is no need to sort the keys if key is the largest key.
-		if !l.needSort && len(l.groups) > 0 {
-			l.needSort = key.Less(l.groups[len(l.groups)-1].key)
-		}
+	group := l.lookupGroup(key)
+	l.createOrSetInGroup(group, key, value)
+}
 
-		l.groups = append(l.groups, groupEntry{
+// lookupGroup finds the group index where this key would be located if it were to
+// be found or inserted. If no suitable group can be found, then this will return -1
+// which indicates that a group has to be created at index 0.
+func (l *GroupLookup) lookupGroup(key flux.GroupKey) int {
+	if l.lastIndex >= 0 {
+		kg := l.groups[l.lastIndex]
+		if !key.Less(kg.First()) {
+			// If the next group doesn't exist or has a first value that is
+			// greater than this key, then we can return the last index and
+			// avoid performing a binary search.
+			if l.lastIndex == len(l.groups)-1 || key.Less(l.groups[l.lastIndex+1].First()) {
+				return l.lastIndex
+			}
+		}
+	}
+
+	// Find the last group where the first key is less than or equal
+	// than the key we are looking for. This means we need to search for
+	// the first group where the first key is greater than the key we are setting
+	// and use the group before that one.
+	index := sort.Search(len(l.groups), func(i int) bool {
+		return key.Less(l.groups[i].First())
+	}) - 1
+	if index >= 0 {
+		l.lastIndex = index
+	}
+	return index
+}
+
+func (l *GroupLookup) createOrSetInGroup(index int, key flux.GroupKey, value interface{}) {
+	// If this index is at -1, then we are inserting a value with a smaller key
+	// than every group and we need to create a new group to insert it at the
+	// beginning.
+	if index == -1 {
+		l.groups = append(l.groups, nil)
+		copy(l.groups[1:], l.groups[:])
+		l.groups[0] = l.newKeyGroup([]groupKeyListElement{
+			{key: key, value: value},
+		})
+		l.lastIndex = 0
+		return
+	}
+
+	kg := l.groups[index]
+
+	// Find the location where this should be inserted.
+	i := kg.InsertAt(key)
+
+	// If this should be inserted after the last element, do it and leave.
+	if i == len(kg.elements) {
+		kg.elements = append(kg.elements, groupKeyListElement{
 			key:   key,
 			value: value,
 		})
+		return
+	} else if kg.elements[i].key.Equal(key) {
+		// If the entry already exists at this index, set the value.
+		kg.set(i, value)
+		return
+	}
+
+	// We have to split this entry into two new elements. First, we start
+	// by creating space for the new entry.
+	l.groups = append(l.groups, nil)
+	copy(l.groups[index+2:], l.groups[index+1:])
+	// Construct the new group entry and copy the end of the slice
+	// into the new key group.
+	l.groups[index+1] = func() *groupKeyList {
+		entries := make([]groupKeyListElement, len(kg.elements[i:]))
+		copy(entries, kg.elements[i:])
+		return l.newKeyGroup(entries)
+	}()
+	// Use a slice on the key group elements to remove the extra elements.
+	// Then append the new key group entry.
+	kg.elements = kg.elements[:i:cap(kg.elements)]
+	kg.elements = append(kg.elements, groupKeyListElement{
+		key:   key,
+		value: value,
+	})
+}
+
+func (l *GroupLookup) newKeyGroup(entries []groupKeyListElement) *groupKeyList {
+	id := l.nextID
+	l.nextID++
+	return &groupKeyList{
+		id:       id,
+		elements: entries,
 	}
 }
 
@@ -74,35 +206,43 @@ func (l *GroupLookup) Delete(key flux.GroupKey) (v interface{}, found bool) {
 	if key == nil {
 		return
 	}
-	i := l.findIdx(key)
-	found = i >= 0
-	if found {
-		if i <= l.rangeIdx {
-			l.rangeIdx--
-		}
-		v = l.groups[i].value
-		l.groups = append(l.groups[:i], l.groups[i+1:]...)
+
+	group := l.lookupGroup(key)
+	if group == -1 {
+		return nil, false
 	}
-	return
+
+	kg := l.groups[group]
+	i := kg.Index(key)
+	if i == -1 {
+		return nil, false
+	}
+	v = kg.At(i)
+	kg.delete(i)
+	if len(kg.elements) == kg.deleted {
+		// All elements in this have been deleted so delete this node.
+		copy(l.groups[group:], l.groups[group+1:])
+		l.groups = l.groups[: len(l.groups)-1 : cap(l.groups)]
+		l.lastIndex = -1
+	}
+	return v, true
 }
 
-// Range will iterate over all groups keys in sorted order.
+// Range will iterate over all groups keys in a stable ordering.
 // Range must not be called within another call to Range.
 // It is safe to call Set/Delete while ranging.
 func (l *GroupLookup) Range(f func(key flux.GroupKey, value interface{})) {
-	if l.needSort {
-		sort.Sort(l.groups)
-		l.needSort = false
-	}
-
-	for l.rangeIdx = 0; l.rangeIdx < len(l.groups); l.rangeIdx++ {
-		entry := l.groups[l.rangeIdx]
-		f(entry.key, entry.value)
+	for i := 0; i < len(l.groups); {
+		kg := l.groups[i]
+		for j := 0; j < len(kg.elements); j++ {
+			entry := kg.elements[j]
+			if entry.deleted {
+				continue
+			}
+			f(entry.key, entry.value)
+		}
+		if i < len(l.groups) && l.groups[i].id == kg.id {
+			i++
+		}
 	}
 }
-
-type groupEntries []groupEntry
-
-func (p groupEntries) Len() int               { return len(p) }
-func (p groupEntries) Less(i int, j int) bool { return p[i].key.Less(p[j].key) }
-func (p groupEntries) Swap(i int, j int)      { p[i], p[j] = p[j], p[i] }

--- a/execute/group_lookup_test.go
+++ b/execute/group_lookup_test.go
@@ -1,13 +1,16 @@
 package execute_test
 
 import (
+	"math/rand"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/gen"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -216,4 +219,147 @@ func TestGroupLookup_RangeWithDelete(t *testing.T) {
 type entry struct {
 	Key   flux.GroupKey
 	Value int
+}
+
+func testGroupLookup_LookupOrCreate(tb testing.TB, run func(name string, keys []flux.GroupKey)) {
+	// Generate a small schema to use for the group lookup.
+	schema := gen.Schema{
+		Start: time.Now(),
+		Tags: []gen.Tag{ // total cardinality is 105
+			{Name: "_measurement", Cardinality: 1},
+			{Name: "_field", Cardinality: 5},
+			{Name: "t0", Cardinality: 3},
+			{Name: "t1", Cardinality: 7},
+		},
+		NumPoints: 1,
+		Types: map[flux.ColType]int{
+			flux.TFloat: 1,
+		},
+		Seed: func(x int64) *int64 { return &x }(0),
+	}
+	input, err := gen.Input(schema)
+	if err != nil {
+		tb.Fatalf("unexpected error: %s", err)
+	}
+
+	// There should be one point per key so read from the input
+	// and put them into a slice.
+	canonicalKeys := make([]flux.GroupKey, 0, 105)
+	for input.More() {
+		res := input.Next()
+		if err := res.Tables().Do(func(table flux.Table) error {
+			canonicalKeys = append(canonicalKeys, table.Key())
+			return nil
+		}); err != nil {
+			tb.Fatalf("unexpected error: %s", err)
+		}
+	}
+
+	if len(canonicalKeys) != 105 {
+		tb.Fatalf("unexpected number of keys: %d", len(canonicalKeys))
+	}
+
+	run("Ordered", func() []flux.GroupKey {
+		keys := make([]flux.GroupKey, len(canonicalKeys))
+		copy(keys, canonicalKeys)
+		sort.Sort(flux.GroupKeys(keys))
+		return keys
+	}())
+
+	run("Interweaved", func() []flux.GroupKey {
+		keys := make([]flux.GroupKey, len(canonicalKeys))
+		copy(keys, canonicalKeys)
+		sort.Sort(flux.GroupKeys(keys))
+
+		// Fisher-yates shuffle with groups of 5.
+		tmp := make([]flux.GroupKey, 5)
+		for i := 100; i > 0; i -= 5 {
+			j := rand.Intn(i/5+1) * 5
+			if i == j {
+				continue
+			}
+			// Copy the current group into the tmp slice.
+			copy(tmp, keys[i:i+5])
+			// Copy the chosen range into the current group.
+			copy(keys[i:], keys[j:j+5])
+			// Copy the temporary keys into the chosen one.
+			copy(keys[j:], tmp)
+		}
+		return keys
+	}())
+
+	run("Unordered", func() []flux.GroupKey {
+		keys := make([]flux.GroupKey, len(canonicalKeys))
+		copy(keys, canonicalKeys)
+
+		// Fisher-yates shuffle.
+		for i := len(keys) - 1; i > 0; i-- {
+			j := rand.Intn(i + 1)
+			keys[i], keys[j] = keys[j], keys[i]
+		}
+		return keys
+	}())
+
+	run("Reversed", func() []flux.GroupKey {
+		keys := make([]flux.GroupKey, len(canonicalKeys))
+		copy(keys, canonicalKeys)
+
+		// Reverse the array.
+		for i, j := 0, len(keys)-1; i < j; i, j = i+1, j-1 {
+			keys[i], keys[j] = keys[j], keys[i]
+		}
+		return keys
+	}())
+
+	run("ManySplits", func() []flux.GroupKey {
+		keys := make([]flux.GroupKey, len(canonicalKeys))
+		copy(keys, canonicalKeys)
+
+		// Swap every 2nd element with every 3rd element to
+		// force a split to occur.
+		for i := 0; i < len(keys)-2; i += 3 {
+			keys[i+1], keys[i+2] = keys[i+2], keys[i+1]
+		}
+		return keys
+	}())
+}
+
+func TestGroupLookup_LookupOrCreate(t *testing.T) {
+	testGroupLookup_LookupOrCreate(t, func(name string, keys []flux.GroupKey) {
+		t.Run(name, func(t *testing.T) {
+			l := execute.NewGroupLookup()
+			for _, key := range keys {
+				if _, ok := l.Lookup(key); !ok {
+					l.Set(key, true)
+				} else {
+					t.Errorf("unexpected key lookup: %s", key)
+				}
+			}
+
+			// Lookup should work on everything.
+			for _, key := range keys {
+				if _, ok := l.Lookup(key); !ok {
+					t.Errorf("key lookup failed: %s", key)
+				}
+			}
+		})
+	})
+}
+
+func BenchmarkGroupLookup_LookupOrCreate(b *testing.B) {
+	testGroupLookup_LookupOrCreate(b, func(name string, keys []flux.GroupKey) {
+		b.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				l := execute.NewGroupLookup()
+				for _, key := range keys {
+					if _, ok := l.Lookup(key); !ok {
+						l.Set(key, true)
+					}
+				}
+			}
+		})
+	})
 }


### PR DESCRIPTION
This optimizes group lookup for the common scenario of ordered and
interweaved additions with some benefits to unordered. It reduces the
number of allocations and the usage of `sort.Search` by creating groups of
entries that are appended to.

The data structure contains a slice of time ranges. When adding a new
value, it will find which of the time ranges it can append to easily. So
when we are adding new values in sorted order, this results in a single
slice that is continuously appended to.

If the new value is sorted before all of the existing groups, it will
create a new group at the beginning and add the value to that group instead
of attempting to shift all of the values in the existing group like you
would have to do for a single slice.

If the new value would get inserted into the middle of a group such as with
unordered access, it will split the existing group into two so the values
after the currently added value would be in a new group and the new value
can be appended to the current group.

This means that if you add values in a sorted order, you will only get a
worst case scenario the first time you append a value rather than on every
insertion.

The worst case scenario for this data structure is adding the values in a
reverse sorted order.

The data structure could further be improved by having the top slice be
sorted backwards rather than sorted in the current direction. This would
likely eliminate the worst case scenario and would prevent the copy when
appending a key that is less than all of the other keys.

- [x] docs/SPEC.md updated
- [x] Test cases written

Fixes #1035.