### PR TITLE
fix(values): make read-like access patterns for objects thread-safe

### DIFF
--- a/complete/complete_test.go
+++ b/complete/complete_test.go
@@ -45,8 +45,10 @@ func TestValue(t *testing.T) {
 func TestFunctionNames(t *testing.T) {
 	boom := values.NewFunction(
 		"boom",
-		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{}),
-		func(values.Object) (values.Value, error) { return nil, nil },
+		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+			Return: semantic.Int,
+		}),
+		func(values.Object) (values.Value, error) { return values.NewInt(5), nil },
 		false,
 	)
 	s := interpreter.NewScope()
@@ -72,8 +74,9 @@ func TestFunctionSuggestion(t *testing.T) {
 				"start": semantic.Time,
 				"stop":  semantic.Time,
 			},
+			Return: semantic.Int,
 		}),
-		func(values.Object) (values.Value, error) { return nil, nil },
+		func(values.Object) (values.Value, error) { return values.NewInt(5), nil },
 		false,
 	)
 	s := interpreter.NewScope()


### PR DESCRIPTION
A Flux object has a type associated with it. Instead of updating that
type for each entry added to the object, a Flux object would update
its type lazily. Only when its Type and PolyType methods were called
would it construct the corresponding types. This way was not thread-
safe however.

In particular if an object was ever declared inside of the Flux prelude,
its fields would be set during construction of the prelude, but its
type and polytype would not be constructed until they were needed.
Unfortunately this construction would occur when the next bit of Flux
source was compiled.

The interpreter's Eval method accepts a scope object with pre-computed
values. The interpreter then calls the PolyType method on each one of
these values when it builds an enclosing extern block for the program
that it is about to evaluate. This means that when two Flux scripts
are compiled concurrently, the PolyType method is called concurrently
on each value in the prelude. In the case of an object value, this
would result in a data race. A race never occurred however becuase there
were (until recently) no Flux objects declared in the Flux prelude.
When this changed, a data race occurred during parallel unit tests
that compiled flux scripts like those in the universe package.

This change makes Flux objects safe to read from different threads.
Updates are no longer lazy. The type information is updated with every
update to the object itself.

Fixes #1062.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
