### PR TITLE
fix(parser): handle when a non-call expression is parsed as the pipe destination

### DIFF
--- a/ast/errors.go
+++ b/ast/errors.go
@@ -27,6 +27,12 @@ func check(n Node) int {
 			Msg: fmt.Sprintf("invalid statement %s@%d:%d-%d:%d: %s", loc.File, loc.Start.Line, loc.Start.Column, loc.End.Line, loc.End.Column, n.Text),
 		})
 		return len(n.Errors)
+	case *PipeExpression:
+		if n.Call == nil {
+			n.Errors = append(n.Errors, Error{
+				Msg: "pipe destination is missing",
+			})
+		}
 	}
 
 	return 0

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -960,6 +960,36 @@ import "path/bar"
 			},
 		},
 		{
+			name: "pipe expression into non-call expression",
+			raw:  `foo() |> bar`,
+			want: &ast.File{
+				BaseNode: base("1:1", "1:13"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:13"),
+						Expression: &ast.PipeExpression{
+							BaseNode: base("1:1", "1:13"),
+							Argument: &ast.CallExpression{
+								BaseNode: base("1:1", "1:6"),
+								Callee: &ast.Identifier{
+									BaseNode: base("1:1", "1:4"),
+									Name:     "foo",
+								},
+							},
+							Call: &ast.CallExpression{
+								BaseNode: ast.BaseNode{
+									Loc: loc("1:10", "1:13"),
+									Errors: []ast.Error{
+										{Msg: "pipe destination must be a function call"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "two variables for two froms",
 			raw: `howdy = from()
 			doody = from()


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The pipe requires a call expression, but the ebnf does not explicitly
state this for ease of implementation. So we need to do some extra work
in the parser to catch when the pipe destination is not a call
expression.

Fixes #969.