### PR TITLE
refactor(lang): Update Compiler interface to produce a Program

### DIFF
--- a/cmd/flux/cmd/repl.go
+++ b/cmd/flux/cmd/repl.go
@@ -15,7 +15,7 @@ import (
 var replCmd = &cobra.Command{
 	Use:   "repl",
 	Short: "Launch a Flux REPL",
-	Long:  "Launch a Flux REPL (Run-Execute-Print-Loop)",
+	Long:  "Launch a Flux REPL (Read-Eval-Print-Loop)",
 	Run: func(cmd *cobra.Command, args []string) {
 		q := NewQuerier()
 		r := repl.New(q)

--- a/compiler.go
+++ b/compiler.go
@@ -3,12 +3,14 @@ package flux
 import (
 	"context"
 	"fmt"
+
+	"github.com/influxdata/flux/memory"
 )
 
 // Compiler produces a specification for the query.
 type Compiler interface {
 	// Compile produces a specification for the query.
-	Compile(ctx context.Context) (*Spec, error)
+	Compile(ctx context.Context) (Program, error)
 	CompilerType() CompilerType
 }
 
@@ -23,4 +25,12 @@ func (m CompilerMappings) Add(t CompilerType, c CreateCompiler) error {
 	}
 	m[t] = c
 	return nil
+}
+
+// Program defines a Flux script which has been compiled.
+type Program interface {
+	// Start begins execution of the program and returns immediately.
+	// As results are produced they arrive on the channel.
+	// The program is finished once the result channel is closed and all results have been consumed.
+	Start(context.Context, *memory.Allocator) (Query, error)
 }

--- a/internal/cmd/refactortests/cmd/refactortests.go
+++ b/internal/cmd/refactortests/cmd/refactortests.go
@@ -183,7 +183,7 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 		return "", "", errors.Wrap(err, "error during compilation, check your script and retry")
 	}
 	defer r.Done()
-	results, ok := <-r.Ready()
+	results, ok := <-r.Results()
 	if !ok {
 		return "", "", errors.Wrap(r.Err(), "error retrieving query result")
 	}

--- a/lang/query.go
+++ b/lang/query.go
@@ -1,0 +1,30 @@
+package lang
+
+import (
+	"github.com/influxdata/flux"
+)
+
+// Query implements the flux.Query interface.
+type Query struct {
+	ch   chan flux.Result
+}
+
+func (q *Query) Results() <-chan flux.Result {
+	return q.ch
+}
+
+func (q *Query) Done() {
+	// consume all remaining elements so channel can be closed
+	for ok := true; ok == true; _, ok = <-q.ch {}
+}
+
+func (*Query) Cancel() {
+}
+
+func (*Query) Err() error {
+	return nil
+}
+
+func (*Query) Statistics() flux.Statistics {
+	return flux.Statistics{}
+}

--- a/query.go
+++ b/query.go
@@ -6,14 +6,10 @@ import (
 
 // Query represents an active query.
 type Query interface {
-	// Spec returns the spec used to execute this query.
-	// Spec must not be modified.
-	Spec() *Spec
-
-	// Ready returns a channel that will deliver the query results.
+	// Results returns a channel that will deliver the query results.
 	// Its possible that the channel is closed before any results arrive,
 	// in which case the query should be inspected for an error using Err().
-	Ready() <-chan map[string]Result
+	Results() <-chan Result
 
 	// Done must always be called to free resources. It is safe to call Done
 	// multiple times.

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -99,7 +99,7 @@ func doTestRun(t testing.TB, querier *querytest.Querier, c flux.Compiler) {
 		t.Fatalf("unexpected error while executing testing.run: %v", err)
 	}
 	defer r.Done()
-	result, ok := <-r.Ready()
+	result, ok := <-r.Results()
 	if !ok {
 		t.Fatalf("unexpected error retrieving testing.run result: %s", r.Err())
 	}
@@ -120,7 +120,7 @@ func doTestInspect(t testing.TB, querier *querytest.Querier, c flux.Compiler) {
 		t.Fatalf("unexpected error while executing testing.inspect: %v", err)
 	}
 	defer r.Done()
-	result, ok := <-r.Ready()
+	result, ok := <-r.Results()
 	if !ok {
 		t.Fatalf("unexpected error retrieving testing.inspect result: %s", r.Err())
 	}


### PR DESCRIPTION
I did as little as possible to enable the vanilla Flux REPL to work.

Unit tests are not yet passing, I thought I would get feedback before I went to the trouble of fixing them to avoid unnecessary work.

I made `Controller.Query()` just trivially compile and run the `Program` produced by its `Compiler` argument.  As a result, `Controller.compileQuery` is totally unneeded now and caused compiler errors, so I just deleted its body.

Fixes #1086.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
