### PR TITLE
Rename plan types to omit stutter, add planner builder

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -488,7 +488,7 @@ type Query struct {
 	parentSpan, currentSpan *span
 	stats                   flux.Statistics
 
-	plan *plan.PlanSpec
+	plan *plan.Spec
 
 	done        sync.Once
 	concurrency int

--- a/control/controller_test.go
+++ b/control/controller_test.go
@@ -155,7 +155,7 @@ func TestController_EnqueueQuery_Failure(t *testing.T) {
 
 func TestController_ExecuteQuery_Failure(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+	executor.ExecuteFn = func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 		return nil, mock.NoMetadata, errors.New("expected")
 	}
 
@@ -206,7 +206,7 @@ func TestController_ExecuteQuery_Failure(t *testing.T) {
 
 func TestController_CancelQuery_Ready(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+	executor.ExecuteFn = func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 		// Return an empty result.
 		return map[string]flux.Result{}, mock.NoMetadata, nil
 	}
@@ -264,7 +264,7 @@ func TestController_CancelQuery_Execute(t *testing.T) {
 	defer close(executing)
 
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, spec *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+	executor.ExecuteFn = func(ctx context.Context, spec *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 		executing <- struct{}{}
 		<-ctx.Done()
 		return nil, mock.NoMetadata, ctx.Err()
@@ -335,7 +335,7 @@ func TestController_CancelQuery_Execute(t *testing.T) {
 // a race condition while testing under the race detector.
 func TestController_CancelQuery_Concurrent(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, spec *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+	executor.ExecuteFn = func(ctx context.Context, spec *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 		return map[string]flux.Result{}, mock.NoMetadata, nil
 	}
 
@@ -416,7 +416,7 @@ func TestController_BlockedExecutor(t *testing.T) {
 	done := make(chan struct{})
 
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+	executor.ExecuteFn = func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 		<-done
 		return nil, mock.NoMetadata, nil
 	}
@@ -467,7 +467,7 @@ func TestController_CancelledContextPropagatesToExecutor(t *testing.T) {
 	t.Parallel()
 
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, _ *plan.PlanSpec, _ *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+	executor.ExecuteFn = func(ctx context.Context, _ *plan.Spec, _ *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 		<-ctx.Done() // Unblock only when context has been cancelled
 		return nil, mock.NoMetadata, nil
 	}
@@ -529,7 +529,7 @@ func TestController_Shutdown(t *testing.T) {
 	var executeGroup sync.WaitGroup
 	executeGroup.Add(10)
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (results map[string]flux.Result, metaCh <-chan flux.Metadata, e error) {
+	executor.ExecuteFn = func(ctx context.Context, p *plan.Spec, a *memory.Allocator) (results map[string]flux.Result, metaCh <-chan flux.Metadata, e error) {
 		executeGroup.Done()
 		return nil, mock.NoMetadata, nil
 	}
@@ -611,7 +611,7 @@ func TestController_Shutdown(t *testing.T) {
 
 func TestController_Statistics(t *testing.T) {
 	executor := mock.NewExecutor()
-	executor.ExecuteFn = func(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (results map[string]flux.Result, metadata <-chan flux.Metadata, e error) {
+	executor.ExecuteFn = func(ctx context.Context, p *plan.Spec, a *memory.Allocator) (results map[string]flux.Result, metadata <-chan flux.Metadata, e error) {
 		// Create a metadata channel that we will use to simulate sending metadata
 		// from the executor.
 		metaCh := make(chan flux.Metadata, 2)

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -34,7 +34,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: `from`,
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{&executetest.Table{
 							KeyCols: []string{"_start", "_stop"},
@@ -81,7 +81,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: `from with filter`,
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{&executetest.Table{
 							KeyCols: []string{"_start", "_stop"},
@@ -149,7 +149,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: `from with filter with multiple tables`,
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{
 							{
@@ -254,7 +254,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: `multiple aggregates`,
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{
 							{
@@ -361,7 +361,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: `diamond join`,
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{
 							{
@@ -478,7 +478,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: "yield with successor",
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{&executetest.Table{
 							KeyCols: []string{"_start", "_stop"},
@@ -542,7 +542,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: "adjacent yields",
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{&executetest.Table{
 							KeyCols: []string{"_start", "_stop"},
@@ -601,7 +601,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: "terminal output function",
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{&executetest.Table{
 							KeyCols: []string{"_start", "_stop"},
@@ -646,7 +646,7 @@ func TestExecutor_Execute(t *testing.T) {
 		{
 			name: `yield preserves nulls`,
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from-test", executetest.NewFromProcedureSpec(
 						[]*executetest.Table{&executetest.Table{
 							KeyCols: []string{"_start", "_stop"},

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -15,19 +15,19 @@ var NoMetadata <-chan flux.Metadata
 
 // Executor is a mock implementation of an execute.Executor.
 type Executor struct {
-	ExecuteFn func(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error)
+	ExecuteFn func(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error)
 }
 
 // NewExecutor returns a mock Executor where its methods will return zero values.
 func NewExecutor() *Executor {
 	return &Executor{
-		ExecuteFn: func(context.Context, *plan.PlanSpec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+		ExecuteFn: func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 			return nil, NoMetadata, nil
 		},
 	}
 }
 
-func (e *Executor) Execute(ctx context.Context, p *plan.PlanSpec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
 	return e.ExecuteFn(ctx, p, a)
 }
 

--- a/plan/bounds.go
+++ b/plan/bounds.go
@@ -22,7 +22,7 @@ type BoundsAwareProcedureSpec interface {
 
 // ComputeBounds computes the time bounds for a
 // plan node from the bounds of its predecessors.
-func ComputeBounds(node PlanNode) error {
+func ComputeBounds(node Node) error {
 	var bounds *Bounds
 
 	for _, pred := range node.Predecessors() {

--- a/plan/bounds_test.go
+++ b/plan/bounds_test.go
@@ -290,16 +290,16 @@ func (m *mockBoundsShiftProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds
 	return nil
 }
 
-// Create a PlanNode with id and mockBoundsIntersectProcedureSpec
-func makeBoundsNode(id string, bounds *plan.Bounds) plan.PlanNode {
+// Create a Node with id and mockBoundsIntersectProcedureSpec
+func makeBoundsNode(id string, bounds *plan.Bounds) plan.Node {
 	return plan.CreatePhysicalNode(plan.NodeID(id),
 		&mockBoundsIntersectProcedureSpec{
 			bounds: bounds,
 		})
 }
 
-// Create a PlanNode with id and mockBoundsShiftProcedureSpec
-func makeShiftNode(id string, duration values.Duration) plan.PlanNode {
+// Create a Node with id and mockBoundsShiftProcedureSpec
+func makeShiftNode(id string, duration values.Duration) plan.Node {
 	return plan.CreateLogicalNode(plan.NodeID(id),
 		&mockBoundsShiftProcedureSpec{
 			by: duration,
@@ -326,7 +326,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 		{
 			name: "no bounds",
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 				},
 			},
@@ -338,7 +338,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 			name: "single time bounds",
 			// 0 -> 1 -> 2 -> 3 -> 4
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					plantest.CreatePhysicalMockNode("1"),
 					makeBoundsNode("2", bounds(5, 10)),
@@ -363,7 +363,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 			name: "multiple intersect time bounds",
 			// 0 -> 1 -> 2 -> 3 -> 4
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					makeBoundsNode("1", bounds(5, 10)),
 					plantest.CreatePhysicalMockNode("2"),
@@ -388,7 +388,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 			name: "shift nil time bounds",
 			// 0 -> 1 -> 2
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					makeShiftNode("1", values.Duration(5)),
 					plantest.CreatePhysicalMockNode("2"),
@@ -408,7 +408,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 			name: "shift bounds after intersecting bounds",
 			// 0 -> 1 -> 2 -> 3 -> 4
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					makeBoundsNode("1", bounds(5, 10)),
 					plantest.CreatePhysicalMockNode("2"),
@@ -435,7 +435,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 			//  / \
 			// 0   1
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					makeBoundsNode("0", bounds(5, 10)),
 					makeBoundsNode("1", bounds(12, 20)),
 					plantest.CreatePhysicalMockNode("2"),
@@ -459,7 +459,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 			//    \ /
 			//     0
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					makeBoundsNode("1", bounds(5, 10)),
 					plantest.CreatePhysicalMockNode("2"),
@@ -496,7 +496,7 @@ func TestBounds_ComputePlanBounds(t *testing.T) {
 
 			// Map NodeID -> Bounds
 			got := make(map[plan.NodeID]*plan.Bounds)
-			thePlan.BottomUpWalk(func(n plan.PlanNode) error {
+			thePlan.BottomUpWalk(func(n plan.Node) error {
 				got[n.ID()] = n.Bounds()
 				return nil
 			})

--- a/plan/builder.go
+++ b/plan/builder.go
@@ -1,0 +1,52 @@
+package plan
+
+import (
+	"github.com/influxdata/flux"
+)
+
+// PlannerBuilder provides clients with an easy way to create planners.
+type PlannerBuilder struct {
+	lopts []LogicalOption
+	popts []PhysicalOption
+}
+
+// AddLogicalOptions lets callers specify attributes of the logical planner
+// that will be part of the created planner.
+func (pb *PlannerBuilder) AddLogicalOptions(lopt ...LogicalOption) {
+	pb.lopts = append(pb.lopts, lopt...)
+}
+
+// AddPhysicalOptions lets callers specify attributes of the physical planner
+// that will be part of the created planner.
+func (pb *PlannerBuilder) AddPhysicalOption(popt ...PhysicalOption) {
+	pb.popts = append(pb.popts, popt...)
+}
+
+// Build builds a planner with specified attributes.
+func (pb *PlannerBuilder) Build() Planner {
+	return &planner{
+		lp: NewLogicalPlanner(pb.lopts...),
+		pp: NewPhysicalPlanner(pb.popts...),
+	}
+}
+
+type planner struct {
+	lp LogicalPlanner
+	pp PhysicalPlanner
+}
+
+func (p *planner) Plan(fspec *flux.Spec) (*Spec, error) {
+	ip, err := p.lp.CreateInitialPlan(fspec)
+	if err != nil {
+		return nil, err
+	}
+	lp, err := p.lp.Plan(ip)
+	if err != nil {
+		return nil, err
+	}
+	pp, err := p.pp.Plan(lp)
+	if err != nil {
+		return nil, err
+	}
+	return pp, nil
+}

--- a/plan/format.go
+++ b/plan/format.go
@@ -5,7 +5,7 @@ import "fmt"
 type FormatOption func(*formatter)
 
 // TODO(cwolff): enhance the this output to make it more useful
-func Formatted(p *PlanSpec, opts ...FormatOption) fmt.Formatter {
+func Formatted(p *Spec, opts ...FormatOption) fmt.Formatter {
 	f := formatter{
 		p: p,
 	}
@@ -16,13 +16,13 @@ func Formatted(p *PlanSpec, opts ...FormatOption) fmt.Formatter {
 }
 
 type formatter struct {
-	p *PlanSpec
+	p *Spec
 }
 
 func (f formatter) Format(fs fmt.State, c rune) {
 	fmt.Fprintf(fs, "\ndigraph {\n")
 	var edges []string
-	f.p.BottomUpWalk(func(pn PlanNode) error {
+	f.p.BottomUpWalk(func(pn Node) error {
 		fmt.Fprintf(fs, "  %v\n", pn.ID())
 		for _, pred := range pn.Predecessors() {
 			edges = append(edges, fmt.Sprintf("  %v -> %v", pred.ID(), pn.ID()))

--- a/plan/heuristic_planner.go
+++ b/plan/heuristic_planner.go
@@ -2,7 +2,7 @@ package plan
 
 import "sort"
 
-// heuristicPlanner applies a set of rules to the nodes in a PlanSpec
+// heuristicPlanner applies a set of rules to the nodes in a Spec
 // until a fixed point is reached and no more rules can be applied.
 type heuristicPlanner struct {
 	rules map[ProcedureKind][]Rule
@@ -27,7 +27,7 @@ func (p *heuristicPlanner) clearRules() {
 
 // matchRules applies any applicable rules to the given plan node,
 // and returns the rewritten plan node and whether or not any rewriting was done.
-func (p *heuristicPlanner) matchRules(node PlanNode) (PlanNode, bool, error) {
+func (p *heuristicPlanner) matchRules(node Node) (Node, bool, error) {
 	anyChanged := false
 
 	for _, rule := range p.rules[AnyKind] {
@@ -59,13 +59,13 @@ func (p *heuristicPlanner) matchRules(node PlanNode) (PlanNode, bool, error) {
 // It traverses the DAG depth-first, attempting to apply rewrite rules at each node.
 // Traversal is repeated until a pass over the DAG results in no changes with the given rule set.
 //
-// Plan may change its argument and/or return a new instance of PlanSpec, so the correct way to call Plan is:
+// Plan may change its argument and/or return a new instance of Spec, so the correct way to call Plan is:
 //     plan, err = plan.Plan(plan)
-func (p *heuristicPlanner) Plan(inputPlan *PlanSpec) (*PlanSpec, error) {
+func (p *heuristicPlanner) Plan(inputPlan *Spec) (*Spec, error) {
 	for anyChanged := true; anyChanged; {
-		visited := make(map[PlanNode]struct{})
+		visited := make(map[Node]struct{})
 
-		nodeStack := make([]PlanNode, 0, len(inputPlan.Roots))
+		nodeStack := make([]Node, 0, len(inputPlan.Roots))
 		for root := range inputPlan.Roots {
 			nodeStack = append(nodeStack, root)
 		}
@@ -118,7 +118,7 @@ func (p *heuristicPlanner) Plan(inputPlan *PlanSpec) (*PlanSpec, error) {
 //   node  becomes   newNode
 //   / \               / \
 //  D   E             D'  E'    <-- predecessors
-func updateSuccessors(plan *PlanSpec, oldNode, newNode PlanNode) {
+func updateSuccessors(plan *Spec, oldNode, newNode Node) {
 	// no need to update successors if the node hasn't actually changed
 	if oldNode == newNode {
 		return

--- a/plan/heuristic_planner_test.go
+++ b/plan/heuristic_planner_test.go
@@ -19,7 +19,7 @@ func TestPlanTraversal(t *testing.T) {
 			name: "simple",
 			//        0
 			plan: plantest.PlanSpec{
-				Nodes: []plan.PlanNode{plantest.CreatePhysicalMockNode("0")},
+				Nodes: []plan.Node{plantest.CreatePhysicalMockNode("0")},
 			},
 			nodeIDs: []plan.NodeID{"0"},
 		},
@@ -29,7 +29,7 @@ func TestPlanTraversal(t *testing.T) {
 			//        |
 			//        0
 			plan: plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					plantest.CreatePhysicalMockNode("1"),
 				},
@@ -45,7 +45,7 @@ func TestPlanTraversal(t *testing.T) {
 			//        |    |
 			//        0    2
 			plan: plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					plantest.CreatePhysicalMockNode("1"),
 					plantest.CreatePhysicalMockNode("2"),
@@ -66,7 +66,7 @@ func TestPlanTraversal(t *testing.T) {
 			//      |   |
 			//      0   2
 			plan: plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					plantest.CreatePhysicalMockNode("1"),
 					plantest.CreatePhysicalMockNode("2"),
@@ -94,7 +94,7 @@ func TestPlanTraversal(t *testing.T) {
 			//          |   |
 			//          0   2
 			plan: plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plantest.CreatePhysicalMockNode("0"),
 					plantest.CreatePhysicalMockNode("1"),
 					plantest.CreatePhysicalMockNode("2"),

--- a/plan/pattern.go
+++ b/plan/pattern.go
@@ -6,7 +6,7 @@ const AnyKind = "*** any procedure kind ***"
 // It can match itself against a query plan
 type Pattern interface {
 	Root() ProcedureKind
-	Match(PlanNode) bool
+	Match(Node) bool
 }
 
 // Pat returns a pattern that can match a plan node with the given ProcedureKind
@@ -43,7 +43,7 @@ func (p PhysicalOneKindPattern) Root() ProcedureKind {
 	return p.pattern.Root()
 }
 
-func (p PhysicalOneKindPattern) Match(node PlanNode) bool {
+func (p PhysicalOneKindPattern) Match(node Node) bool {
 	_, ok := node.(*PhysicalPlanNode)
 	return ok && p.pattern.Match(node)
 }
@@ -67,7 +67,7 @@ func (okp OneKindPattern) Root() ProcedureKind {
 	return okp.kind
 }
 
-func (okp OneKindPattern) Match(node PlanNode) bool {
+func (okp OneKindPattern) Match(node Node) bool {
 	if node.Kind() != okp.kind {
 		return false
 	}
@@ -99,6 +99,6 @@ func (AnyPattern) Root() ProcedureKind {
 	return AnyKind
 }
 
-func (AnyPattern) Match(node PlanNode) bool {
+func (AnyPattern) Match(node Node) bool {
 	return true
 }

--- a/plan/pattern_test.go
+++ b/plan/pattern_test.go
@@ -11,7 +11,7 @@ import (
 func TestAny(t *testing.T) {
 	pat := plan.Any()
 
-	node := &plan.LogicalPlanNode{
+	node := &plan.LogicalNode{
 		Spec: &influxdb.FromProcedureSpec{},
 	}
 
@@ -20,7 +20,7 @@ func TestAny(t *testing.T) {
 	}
 }
 
-func addEdge(pred plan.PlanNode, succ plan.PlanNode) {
+func addEdge(pred plan.Node, succ plan.Node) {
 	pred.AddSuccessors(succ)
 	succ.AddPredecessors(pred)
 }
@@ -35,11 +35,11 @@ func TestPat(t *testing.T) {
 	//   from(...) |> filter(...)
 	filterFromPat := plan.Pat(universe.FilterKind, plan.Pat(influxdb.FromKind))
 
-	from := &plan.LogicalPlanNode{
+	from := &plan.LogicalNode{
 		Spec: &influxdb.FromProcedureSpec{},
 	}
 
-	filter1 := &plan.LogicalPlanNode{
+	filter1 := &plan.LogicalNode{
 		Spec: &universe.FilterProcedureSpec{},
 	}
 
@@ -53,7 +53,7 @@ func TestPat(t *testing.T) {
 		t.Fatalf("Expected match")
 	}
 
-	filter2 := &plan.LogicalPlanNode{
+	filter2 := &plan.LogicalNode{
 		Spec: &universe.FilterProcedureSpec{},
 	}
 
@@ -72,7 +72,7 @@ func TestPat(t *testing.T) {
 
 	// Add another successor to filter1.  Thus should break the filter-filter pattern
 
-	filter3 := &plan.LogicalPlanNode{
+	filter3 := &plan.LogicalNode{
 		Spec: &universe.FilterProcedureSpec{},
 	}
 

--- a/plan/physical_test.go
+++ b/plan/physical_test.go
@@ -16,7 +16,7 @@ func TestPhysicalOptions(t *testing.T) {
 
 	for _, options := range configs {
 		spec := &plantest.PlanSpec{
-			Nodes: []plan.PlanNode{
+			Nodes: []plan.Node{
 				plantest.CreatePhysicalMockNode("0"),
 				plantest.CreatePhysicalMockNode("1"),
 			},
@@ -50,7 +50,7 @@ func TestPhysicalIntegrityCheckOption(t *testing.T) {
 	node0 := plantest.CreatePhysicalMockNode("0")
 	node1 := plantest.CreatePhysicalMockNode("1")
 	spec := &plantest.PlanSpec{
-		Nodes: []plan.PlanNode{
+		Nodes: []plan.Node{
 			node0,
 			node1,
 		},

--- a/plan/plantest/cmp.go
+++ b/plan/plantest/cmp.go
@@ -9,15 +9,15 @@ import (
 )
 
 // ComparePlans compares two query plans using an arbitrary comparator function f
-func ComparePlans(p, q *plan.PlanSpec, f func(p, q plan.PlanNode) error) error {
-	var w, v []plan.PlanNode
+func ComparePlans(p, q *plan.Spec, f func(p, q plan.Node) error) error {
+	var w, v []plan.Node
 
-	p.TopDownWalk(func(node plan.PlanNode) error {
+	p.TopDownWalk(func(node plan.Node) error {
 		w = append(w, node)
 		return nil
 	})
 
-	q.TopDownWalk(func(node plan.PlanNode) error {
+	q.TopDownWalk(func(node plan.Node) error {
 		v = append(v, node)
 		return nil
 	})
@@ -37,20 +37,20 @@ func ComparePlans(p, q *plan.PlanSpec, f func(p, q plan.PlanNode) error) error {
 }
 
 // CompareLogicalPlanNodes is a comparator fuction for LogicalPlanNodes
-func CompareLogicalPlanNodes(p, q plan.PlanNode) error {
-	if _, ok := p.(*plan.LogicalPlanNode); !ok {
-		return fmt.Errorf("expected %s to be a LogicalPlanNode", p.ID())
+func CompareLogicalPlanNodes(p, q plan.Node) error {
+	if _, ok := p.(*plan.LogicalNode); !ok {
+		return fmt.Errorf("expected %s to be a LogicalNode", p.ID())
 	}
 
-	if _, ok := q.(*plan.LogicalPlanNode); !ok {
-		return fmt.Errorf("expected %s to be a LogicalPlanNode", q.ID())
+	if _, ok := q.(*plan.LogicalNode); !ok {
+		return fmt.Errorf("expected %s to be a LogicalNode", q.ID())
 	}
 
 	return cmpPlanNode(p, q)
 }
 
 // ComparePhysicalPlanNodes is a comparator function for PhysicalPlanNodes
-func ComparePhysicalPlanNodes(p, q plan.PlanNode) error {
+func ComparePhysicalPlanNodes(p, q plan.Node) error {
 	var pp, qq *plan.PhysicalPlanNode
 	var ok bool
 
@@ -81,7 +81,7 @@ func ComparePhysicalPlanNodes(p, q plan.PlanNode) error {
 	return nil
 }
 
-func cmpPlanNode(p, q plan.PlanNode) error {
+func cmpPlanNode(p, q plan.Node) error {
 	// Both nodes must have the same ID
 	if p.ID() != q.ID() {
 		return fmt.Errorf("wanted %s, but got %s", p.ID(), q.ID())

--- a/plan/plantest/mock.go
+++ b/plan/plantest/mock.go
@@ -6,7 +6,7 @@ const MockKind = "mock"
 
 // CreateLogicalMockNode creates a mock plan node that doesn't match any rules
 // (other than rules that match any node)
-func CreateLogicalMockNode(id string) *plan.LogicalPlanNode {
+func CreateLogicalMockNode(id string) *plan.LogicalNode {
 	return plan.CreateLogicalNode(plan.NodeID(id), MockProcedureSpec{})
 }
 

--- a/plan/plantest/plan.go
+++ b/plan/plantest/plan.go
@@ -8,9 +8,9 @@ import (
 	"github.com/influxdata/flux/plan"
 )
 
-// PlanSpec is a set of nodes and edges of a logical query plan
+// Spec is a set of nodes and edges of a logical query plan
 type PlanSpec struct {
-	Nodes []plan.PlanNode
+	Nodes []plan.Node
 
 	// Edges is a list of predecessor-to-successor edges.
 	// [1, 3] => Nodes[1] is a predecessor of Nodes[3].
@@ -23,15 +23,15 @@ type PlanSpec struct {
 }
 
 // CreatePlanSpec creates a logical plan from a set of nodes and edges
-func CreatePlanSpec(spec *PlanSpec) *plan.PlanSpec {
+func CreatePlanSpec(spec *PlanSpec) *plan.Spec {
 	return createPlanSpec(spec.Nodes, spec.Edges, spec.Resources, spec.Now)
 }
 
-// Copy makes a copy of a PlanSpec.
+// Copy makes a copy of a Spec.
 func (ps *PlanSpec) Copy() *PlanSpec {
 	cps := new(PlanSpec)
 
-	cps.Nodes = make([]plan.PlanNode, len(ps.Nodes))
+	cps.Nodes = make([]plan.Node, len(ps.Nodes))
 	for i := range ps.Nodes {
 		cps.Nodes[i] = copyNode(ps.Nodes[i])
 	}
@@ -43,10 +43,10 @@ func (ps *PlanSpec) Copy() *PlanSpec {
 	return cps
 }
 
-func copyNode(n plan.PlanNode) plan.PlanNode {
-	var cn plan.PlanNode
+func copyNode(n plan.Node) plan.Node {
+	var cn plan.Node
 	switch n := n.(type) {
-	case *plan.LogicalPlanNode:
+	case *plan.LogicalNode:
 		cn = plan.CreateLogicalNode(n.ID(), n.ProcedureSpec().Copy())
 	case *plan.PhysicalPlanNode:
 		cn = plan.CreatePhysicalNode(n.ID(), n.ProcedureSpec().Copy().(plan.PhysicalProcedureSpec))
@@ -54,9 +54,9 @@ func copyNode(n plan.PlanNode) plan.PlanNode {
 	return cn
 }
 
-func createPlanSpec(nodes []plan.PlanNode, edges [][2]int, resources flux.ResourceManagement, now time.Time) *plan.PlanSpec {
-	predecessors := make(map[plan.PlanNode][]plan.PlanNode)
-	successors := make(map[plan.PlanNode][]plan.PlanNode)
+func createPlanSpec(nodes []plan.Node, edges [][2]int, resources flux.ResourceManagement, now time.Time) *plan.Spec {
+	predecessors := make(map[plan.Node][]plan.Node)
+	successors := make(map[plan.Node][]plan.Node)
 
 	// Compute predecessors and successors of each node
 	for _, edge := range edges {
@@ -68,7 +68,7 @@ func createPlanSpec(nodes []plan.PlanNode, edges [][2]int, resources flux.Resour
 		predecessors[child] = append(predecessors[child], parent)
 	}
 
-	roots := make([]plan.PlanNode, 0)
+	roots := make([]plan.Node, 0)
 
 	// Construct query plan
 	for _, node := range nodes {

--- a/plan/rules.go
+++ b/plan/rules.go
@@ -11,5 +11,5 @@ type Rule interface {
 	// Rewrite an operation into an equivalent one
 	// The returned node is the new root of the sub tree.
 	// The boolean return value should be true if anything changed during the rewrite.
-	Rewrite(PlanNode) (PlanNode, bool, error)
+	Rewrite(Node) (Node, bool, error)
 }

--- a/plan/triggers.go
+++ b/plan/triggers.go
@@ -27,7 +27,7 @@ type TriggerAwareProcedureSpec interface {
 	TriggerSpec() TriggerSpec
 }
 
-func SetTriggerSpec(node PlanNode) error {
+func SetTriggerSpec(node Node) error {
 	ppn, ok := node.(*PhysicalPlanNode)
 	if !ok {
 		return fmt.Errorf("cannot set trigger spec on plan node of type %T", node)

--- a/plan/triggers_test.go
+++ b/plan/triggers_test.go
@@ -26,7 +26,7 @@ func (s triggerAwareProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func TestTriggers(t *testing.T) {
 	testcases := []struct {
 		name    string
-		node    plan.PlanNode
+		node    plan.Node
 		want    plan.TriggerSpec
 		wantErr bool
 	}{
@@ -44,7 +44,7 @@ func TestTriggers(t *testing.T) {
 		},
 		{
 			name:    "cannot set trigger on logical node",
-			node:    &plan.LogicalPlanNode{},
+			node:    &plan.LogicalNode{},
 			wantErr: true,
 		},
 	}

--- a/plan/types.go
+++ b/plan/types.go
@@ -8,6 +8,10 @@ import (
 	"github.com/influxdata/flux"
 )
 
+type Planner interface {
+	Plan(*flux.Spec) (*Spec, error)
+}
+
 // Node defines the common interface for interacting with
 // logical and physical plan nodes.
 type Node interface {

--- a/plan/types_test.go
+++ b/plan/types_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestPlanSpec_CheckIntegrity(t *testing.T) {
 	ps := &plantest.PlanSpec{
-		Nodes: []plan.PlanNode{
+		Nodes: []plan.Node{
 			plantest.CreateLogicalMockNode("0"),
 			plantest.CreateLogicalMockNode("1"),
 			plantest.CreateLogicalMockNode("2"),
@@ -65,14 +65,14 @@ func TestPlanSpec_CheckIntegrity(t *testing.T) {
 	assertKO(t, p)
 }
 
-func assertOK(t *testing.T, p *plan.PlanSpec) {
+func assertOK(t *testing.T, p *plan.Spec) {
 	err := p.CheckIntegrity()
 	if err != nil {
 		t.Fatalf("unexpected integrity check fail: %v", err)
 	}
 }
 
-func assertKO(t *testing.T, p *plan.PlanSpec) {
+func assertKO(t *testing.T, p *plan.Spec) {
 	err := p.CheckIntegrity()
 	if err == nil {
 		t.Fatal("unexpected integrity check pass")

--- a/plan/walk_test.go
+++ b/plan/walk_test.go
@@ -15,7 +15,7 @@ func TestPlanSpec_BottomUpWalk(t *testing.T) {
 		//  3 4 5  additional edge (8->3)
 		//  |/|/|
 		//  6 7 8
-		Nodes: []plan.PlanNode{
+		Nodes: []plan.Node{
 			plantest.CreateLogicalMockNode("0"),
 			plantest.CreateLogicalMockNode("1"),
 			plantest.CreateLogicalMockNode("2"),
@@ -48,7 +48,7 @@ func TestPlanSpec_BottomUpWalk(t *testing.T) {
 	thePlan := plantest.CreatePlanSpec(spec)
 
 	got := make([]plan.NodeID, 0, 9)
-	thePlan.BottomUpWalk(func(n plan.PlanNode) error {
+	thePlan.BottomUpWalk(func(n plan.Node) error {
 		got = append(got, n.ID())
 		return nil
 	})
@@ -66,7 +66,7 @@ func TestPlanSpec_TopDownWalk(t *testing.T) {
 		//  3 4 5  additional edge (8->3)
 		//  |/|/|
 		//  6 7 8
-		Nodes: []plan.PlanNode{
+		Nodes: []plan.Node{
 			plantest.CreateLogicalMockNode("0"),
 			plantest.CreateLogicalMockNode("1"),
 			plantest.CreateLogicalMockNode("2"),
@@ -99,7 +99,7 @@ func TestPlanSpec_TopDownWalk(t *testing.T) {
 	thePlan := plantest.CreatePlanSpec(spec)
 
 	got := make([]plan.NodeID, 0, 9)
-	thePlan.TopDownWalk(func(n plan.PlanNode) error {
+	thePlan.TopDownWalk(func(n plan.Node) error {
 		got = append(got, n.ID())
 		return nil
 	})
@@ -117,7 +117,7 @@ func TestPlanSpec_TopologicalWalk(t *testing.T) {
 		//  3 4 5  additional edge (8->3)
 		//  |/|/|
 		//  6 7 8
-		Nodes: []plan.PlanNode{
+		Nodes: []plan.Node{
 			plantest.CreateLogicalMockNode("0"),
 			plantest.CreateLogicalMockNode("1"),
 			plantest.CreateLogicalMockNode("2"),
@@ -149,7 +149,7 @@ func TestPlanSpec_TopologicalWalk(t *testing.T) {
 
 	thePlan := plantest.CreatePlanSpec(spec)
 	got := make([]plan.NodeID, 0, 9)
-	thePlan.TopologicalWalk(func(n plan.PlanNode) error {
+	thePlan.TopologicalWalk(func(n plan.Node) error {
 		got = append(got, n.ID())
 		return nil
 	})
@@ -167,7 +167,7 @@ func TestPlanSpec_WalkPredecessorsSuccessors(t *testing.T) {
 		//  3 4 5  additional edge (8->3)
 		//  |/|/|
 		//  6 7 8
-		Nodes: []plan.PlanNode{
+		Nodes: []plan.Node{
 			plantest.CreateLogicalMockNode("0"),
 			plantest.CreateLogicalMockNode("1"),
 			plantest.CreateLogicalMockNode("2"),
@@ -198,9 +198,9 @@ func TestPlanSpec_WalkPredecessorsSuccessors(t *testing.T) {
 	}
 
 	plantest.CreatePlanSpec(spec)
-	roots := []plan.PlanNode{spec.Nodes[0], spec.Nodes[1], spec.Nodes[2]}
+	roots := []plan.Node{spec.Nodes[0], spec.Nodes[1], spec.Nodes[2]}
 	got := make([]plan.NodeID, 0, 9)
-	plan.WalkPredecessors(roots, func(n plan.PlanNode) error {
+	plan.WalkPredecessors(roots, func(n plan.Node) error {
 		got = append(got, n.ID())
 		return nil
 	})
@@ -210,9 +210,9 @@ func TestPlanSpec_WalkPredecessorsSuccessors(t *testing.T) {
 		t.Errorf("Did not get expected node traversal, -want/+got:\n%v", cmp.Diff(want, got))
 	}
 
-	roots = []plan.PlanNode{spec.Nodes[6], spec.Nodes[7], spec.Nodes[8]}
+	roots = []plan.Node{spec.Nodes[6], spec.Nodes[7], spec.Nodes[8]}
 	got = make([]plan.NodeID, 0, 9)
-	plan.WalkSuccessors(roots, func(n plan.PlanNode) error {
+	plan.WalkSuccessors(roots, func(n plan.Node) error {
 		got = append(got, n.ID())
 		return nil
 	})

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -189,7 +189,7 @@ func (RemoveTrivialFilterRule) Pattern() plan.Pattern {
 	return plan.Pat(FilterKind, plan.Any())
 }
 
-func (RemoveTrivialFilterRule) Rewrite(filterNode plan.PlanNode) (plan.PlanNode, bool, error) {
+func (RemoveTrivialFilterRule) Rewrite(filterNode plan.Node) (plan.Node, bool, error) {
 	filterSpec := filterNode.ProcedureSpec().(*FilterProcedureSpec)
 	if filterSpec.Fn == nil ||
 		filterSpec.Fn.Block == nil ||

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -621,7 +621,7 @@ func TestMergeFilterAnyRule(t *testing.T) {
 			// from -> filter => from -> filter
 			Rules: []plan.Rule{universe.RemoveTrivialFilterRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from", from),
 					plan.CreatePhysicalNode("filter", filterOther),
 				},
@@ -634,7 +634,7 @@ func TestMergeFilterAnyRule(t *testing.T) {
 			// from -> filter => from -> filter
 			Rules: []plan.Rule{universe.RemoveTrivialFilterRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from", from),
 					plan.CreatePhysicalNode("filter", filterFalse),
 				},
@@ -647,14 +647,14 @@ func TestMergeFilterAnyRule(t *testing.T) {
 			// from -> filter => from
 			Rules: []plan.Rule{universe.RemoveTrivialFilterRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from", from),
 					plan.CreatePhysicalNode("filter", filterTrue),
 				},
 				Edges: [][2]int{{0, 1}},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from", from),
 				},
 			},
@@ -664,14 +664,14 @@ func TestMergeFilterAnyRule(t *testing.T) {
 			// count -> filter => count
 			Rules: []plan.Rule{universe.RemoveTrivialFilterRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("count", count),
 					plan.CreatePhysicalNode("filter", filterTrue),
 				},
 				Edges: [][2]int{{0, 1}},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("count", count),
 				},
 			},
@@ -681,7 +681,7 @@ func TestMergeFilterAnyRule(t *testing.T) {
 			// from -> filter -> count => from -> count
 			Rules: []plan.Rule{universe.RemoveTrivialFilterRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from", from),
 					plan.CreatePhysicalNode("filter", filterTrue),
 					plan.CreatePhysicalNode("count", count),
@@ -689,7 +689,7 @@ func TestMergeFilterAnyRule(t *testing.T) {
 				Edges: [][2]int{{0, 1}, {1, 2}},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreatePhysicalNode("from", from),
 					plan.CreatePhysicalNode("count", count),
 				},

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -229,7 +229,7 @@ func (r MergeGroupRule) Pattern() plan.Pattern {
 	return plan.Pat(GroupKind, plan.Pat(GroupKind, plan.Any()))
 }
 
-func (r MergeGroupRule) Rewrite(lastGroup plan.PlanNode) (plan.PlanNode, bool, error) {
+func (r MergeGroupRule) Rewrite(lastGroup plan.Node) (plan.Node, bool, error) {
 	firstGroup := lastGroup.Predecessors()[0]
 	lastSpec := lastGroup.ProcedureSpec().(*GroupProcedureSpec)
 
@@ -238,7 +238,7 @@ func (r MergeGroupRule) Rewrite(lastGroup plan.PlanNode) (plan.PlanNode, bool, e
 		return lastGroup, false, nil
 	}
 
-	merged, err := plan.MergeToLogicalPlanNode(lastGroup, firstGroup, lastSpec.Copy())
+	merged, err := plan.MergeToLogicalNode(lastGroup, firstGroup, lastSpec.Copy())
 	if err != nil {
 		return nil, false, err
 	}

--- a/stdlib/universe/group_test.go
+++ b/stdlib/universe/group_test.go
@@ -795,7 +795,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "single group",
 			Rules: []plan.Rule{&universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group", groupBy),
 				},
@@ -809,7 +809,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "double group",
 			Rules: []plan.Rule{&universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group0", groupNone),
 					plan.CreateLogicalNode("group1", groupBy),
@@ -820,7 +820,7 @@ func TestMergeGroupRule(t *testing.T) {
 				},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("merged_group0_group1", groupBy),
 				},
@@ -833,7 +833,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "triple group",
 			Rules: []plan.Rule{&universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group0", groupNone),
 					plan.CreateLogicalNode("group1", groupBy),
@@ -846,7 +846,7 @@ func TestMergeGroupRule(t *testing.T) {
 				},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("merged_group0_group1_group2", groupExcept),
 				},
@@ -859,7 +859,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "double group not by nor except",
 			Rules: []plan.Rule{&universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group0", groupNone),
 					plan.CreateLogicalNode("group1", groupNotByNorExcept),
@@ -876,7 +876,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "triple group not by nor except",
 			Rules: []plan.Rule{&universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group0", groupNone),
 					plan.CreateLogicalNode("group1", groupNotByNorExcept),
@@ -889,7 +889,7 @@ func TestMergeGroupRule(t *testing.T) {
 				},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("merged_group0_group1_group2", groupExcept),
 				},
@@ -902,7 +902,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "quad group not by nor except",
 			Rules: []plan.Rule{&universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group0", groupNone),
 					plan.CreateLogicalNode("group1", groupNotByNorExcept),
@@ -917,7 +917,7 @@ func TestMergeGroupRule(t *testing.T) {
 				},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("merged_group0_group1_group2", groupExcept),
 					plan.CreateLogicalNode("group3", groupNotByNorExcept),
@@ -932,7 +932,7 @@ func TestMergeGroupRule(t *testing.T) {
 			Name:  "from group group filter",
 			Rules: []plan.Rule{universe.MergeGroupRule{}},
 			Before: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("group0", groupExcept),
 					plan.CreateLogicalNode("group1", groupBy),
@@ -945,7 +945,7 @@ func TestMergeGroupRule(t *testing.T) {
 				},
 			},
 			After: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from", from),
 					plan.CreateLogicalNode("merged_group0_group1", groupBy),
 					plan.CreateLogicalNode("filter", filter),

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -414,7 +414,7 @@ func (WindowTriggerPhysicalRule) Pattern() plan.Pattern {
 // Rewrite modifies a window's trigger spec so long as it doesn't have any
 // window descendents that occur earlier in the plan and as long as none
 // of its descendents merge multiple streams together like union and join.
-func (WindowTriggerPhysicalRule) Rewrite(window plan.PlanNode) (plan.PlanNode, bool, error) {
+func (WindowTriggerPhysicalRule) Rewrite(window plan.Node) (plan.Node, bool, error) {
 	// This rule's pattern ensures us only one predecessor
 	if !hasValidPredecessors(window.Predecessors()[0]) {
 		return window, false, nil
@@ -428,7 +428,7 @@ func (WindowTriggerPhysicalRule) Rewrite(window plan.PlanNode) (plan.PlanNode, b
 	return ppn, true, nil
 }
 
-func hasValidPredecessors(node plan.PlanNode) bool {
+func hasValidPredecessors(node plan.Node) bool {
 	pred := node.Predecessors()
 	// Source nodes might not produce uniform time bounds for all
 	// tables in which case we can't optimize window. However if a

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -902,19 +902,19 @@ func TestFixedWindow_Process(t *testing.T) {
 	}
 }
 
-func windowOp(id string) plan.PlanNode {
+func windowOp(id string) plan.Node {
 	return plan.CreatePhysicalNode(plan.NodeID(id), &universe.WindowProcedureSpec{})
 }
 
-func boundsOp(id string) plan.PlanNode {
+func boundsOp(id string) plan.Node {
 	return plan.CreatePhysicalNode(plan.NodeID(id), &universe.RangeProcedureSpec{})
 }
 
-func rangeOp(id string) plan.PlanNode {
+func rangeOp(id string) plan.Node {
 	return plan.CreatePhysicalNode(plan.NodeID(id), &universe.RangeProcedureSpec{})
 }
 
-func mockPred(id string) plan.PlanNode {
+func mockPred(id string) plan.Node {
 	// Create a dummy physical operation that is just a wrapper around a filter.
 	// Filter is one of the operators that is allowed to be a predecessor of window
 	// in order to perform the trigger optimization.
@@ -941,7 +941,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |       |
 			// b       b
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					boundsOp("0"),
 					mockPred("1"),
 					windowOp("2"),
@@ -961,7 +961,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |       |
 			// 0       0
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					mockPred("0"),
 					mockPred("1"),
 					windowOp("2"),
@@ -984,7 +984,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |       |
 			// b       b
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					boundsOp("0"),
 					mockPred("1"),
 					windowOp("2"),
@@ -1012,7 +1012,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |       |
 			// b       b
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					boundsOp("0"),
 					mockPred("1"),
 					windowOp("2"),
@@ -1040,7 +1040,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |       |
 			// 0       0
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					mockPred("0"),
 					mockPred("1"),
 					windowOp("2"),
@@ -1066,7 +1066,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |   |       |   |
 			// b   b       b   b
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					boundsOp("0"),
 					windowOp("1"),
 					boundsOp("2"),
@@ -1094,7 +1094,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |   |       |   |
 			// b   2       b   2
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					boundsOp("0"),
 					windowOp("1"),
 					mockPred("2"),
@@ -1124,7 +1124,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			// |   |       |   |
 			// b   2       b   2
 			spec: &plantest.PlanSpec{
-				Nodes: []plan.PlanNode{
+				Nodes: []plan.Node{
 					boundsOp("0"),
 					windowOp("1"),
 					mockPred("2"),
@@ -1160,7 +1160,7 @@ func TestWindowRewriteRule(t *testing.T) {
 			}
 
 			var got []plan.NodeID
-			pp.BottomUpWalk(func(node plan.PlanNode) error {
+			pp.BottomUpWalk(func(node plan.Node) error {
 				if _, ok := node.ProcedureSpec().(*universe.WindowProcedureSpec); !ok {
 					return nil
 				}


### PR DESCRIPTION
This PR renames several of the planner types to be more idiomatic to Go and avoid naming stutter:
- `plan.PlanSpec` -> `plan.Spec`
- `plan.PlanNode` -> `plan.Node`
- etc

I also added a builder to create planners so that client code can plan with just one method call, instead of the three that are required now.

Fixes #1097.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
