### PR TITLE
refactor(flux): TableObjectCompiler created, TableObject.ToSpec is no…

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -15,7 +15,7 @@ import (
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 )
 
@@ -451,7 +451,7 @@ func init() {
 	TableObjectMonoType, _ = TableObjectType.MonoType()
 }
 
-// IDer produces the mapping of table Objects to OpertionIDs
+// IDer produces the mapping of table Objects to OperationIDs
 type IDer interface {
 	ID(*TableObject) OperationID
 }
@@ -462,6 +462,10 @@ type IDerOpSpec interface {
 	IDer(ider IDer)
 }
 
+// TableObject represents the value returned by a transformation.
+// As such, it holds the OperationSpec of the transformation it is associated with,
+// and it is a values.Value (and, also, a values.Object).
+// It can be compiled and executed as a flux.Program by using a lang.TableObjectCompiler.
 type TableObject struct {
 	// TODO(Josh): Remove args once the
 	// OperationSpec interface has an Equal method.
@@ -538,17 +542,6 @@ func (i *ider) ID(t *TableObject) OperationID {
 		tableID = i.set(t, i.nextID())
 	}
 	return tableID
-}
-
-func (t *TableObject) ToSpec() *Spec {
-	ider := &ider{
-		id:     0,
-		lookup: make(map[*TableObject]OperationID),
-	}
-	spec := new(Spec)
-	visited := make(map[*TableObject]bool)
-	t.buildSpec(ider, spec, visited)
-	return spec
 }
 
 func (t *TableObject) buildSpec(ider IDer, spec *Spec, visited map[*TableObject]bool) {

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -1,20 +1,26 @@
 package lang_test
 
 import (
+	"bytes"
 	"context"
 	"math"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	_ "github.com/influxdata/flux/builtin"
+	fcsv "github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
 	"github.com/influxdata/flux/stdlib/csv"
 	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values"
 )
 
 func TestASTCompiler(t *testing.T) {
@@ -131,4 +137,187 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 			}
 		})
 	}
+}
+
+// TestTableObjectCompiler evaluates a simple `from |> range |> filter` script on csv data, and
+// extracts the TableObjects obtained from evaluation. It eventually compiles TableObjects and
+// compares obtained results with expected ones (obtained from decoding the raw csv data).
+func TestTableObjectCompiler(t *testing.T) {
+	dataRaw := `#datatype,string,long,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,false,false,false,false,true,true
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,host,name
+,,0,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
+,,1,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:06Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:16Z,648,io_time,diskio,host.local,disk2
+`
+
+	rangedDataRaw := `#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,true,true,false,false,false,false,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,0,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
+`
+
+	filteredDataRaw := `#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,true,true,false,false,false,false,true,true
+#default,_result,0,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,,,,,host.local,disk0
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,true,true,false,false,false,false,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
+`
+
+	script := `import "csv"
+data = "` + dataRaw + `"
+csv.from(csv: data)
+	|> range(start: 2017-10-10T00:00:00Z, stop: 2018-05-22T19:54:00Z)
+	|> filter(fn: (r) => r._value < 1000)`
+
+	wantFrom := getTablesFromRawOrFail(t, dataRaw)
+	wantRange := getTablesFromRawOrFail(t, rangedDataRaw)
+	wantFilter := getTablesFromRawOrFail(t, filteredDataRaw)
+
+	vs, _, err := flux.Eval(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tos := getTableObjects(vs)
+	if len(tos) != 3 {
+		t.Fatalf("wrong number of table objects, got %d", len(tos))
+	}
+
+	fromCsvTO := tos[2]
+	if fromCsvTO.Kind != csv.FromCSVKind {
+		t.Fatalf("unexpected kind for fromCSV: %s", fromCsvTO.Kind)
+	}
+	rangeTO := tos[1]
+	if rangeTO.Kind != universe.RangeKind {
+		t.Fatalf("unexpected kind for range: %s", rangeTO.Kind)
+	}
+	filterTO := tos[0]
+	if filterTO.Kind != universe.FilterKind {
+		t.Fatalf("unexpected kind for filter: %s", filterTO.Kind)
+	}
+
+	compareTableObjectWithTables(t, fromCsvTO, wantFrom)
+	compareTableObjectWithTables(t, rangeTO, wantRange)
+	compareTableObjectWithTables(t, filterTO, wantFilter)
+	// run it twice to ensure compilation is idempotent and there are no side-effects
+	compareTableObjectWithTables(t, fromCsvTO, wantFrom)
+	compareTableObjectWithTables(t, rangeTO, wantRange)
+	compareTableObjectWithTables(t, filterTO, wantFilter)
+}
+
+func compareTableObjectWithTables(t *testing.T, to *flux.TableObject, want []*executetest.Table) {
+	t.Helper()
+
+	got := getTableObjectTablesOrFail(t, to)
+	if !cmp.Equal(want, got) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(want, got))
+	}
+}
+
+func getTablesFromRawOrFail(t *testing.T, rawData string) []*executetest.Table {
+	t.Helper()
+
+	b := bytes.NewReader([]byte(rawData))
+	result, err := fcsv.NewResultDecoder(fcsv.ResultDecoderConfig{}).Decode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return getTablesFromResultOrFail(t, result)
+}
+
+func getTableObjectTablesOrFail(t *testing.T, to *flux.TableObject) []*executetest.Table {
+	t.Helper()
+
+	toc := lang.TableObjectCompiler{
+		Tables: to,
+	}
+
+	program, err := toc.Compile(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := program.Start(context.Background(), &memory.Allocator{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := <-q.Results()
+	if r := <-q.Results(); r != nil {
+		t.Fatalf("got more then one result for %s", to.Kind)
+	}
+	q.Done()
+	if err := q.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	return getTablesFromResultOrFail(t, result)
+}
+
+func getTablesFromResultOrFail(t *testing.T, result flux.Result) []*executetest.Table {
+	t.Helper()
+
+	tables := make([]*executetest.Table, 0)
+	if err := result.Tables().Do(func(table flux.Table) error {
+		converted, err := executetest.ConvertTable(table)
+		if err != nil {
+			return err
+		}
+		tables = append(tables, converted)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	executetest.NormalizeTables(tables)
+	return tables
+}
+
+func getTableObjects(vs []values.Value) []*flux.TableObject {
+	tos := make([]*flux.TableObject, 0)
+	for _, v := range vs {
+		if to, ok := v.(*flux.TableObject); ok {
+			tos = append(tos, to)
+			tos = append(tos, getTableObjectsFromArray(to.Parents)...)
+		}
+	}
+	return tos
+}
+
+func getTableObjectsFromArray(parents values.Array) []*flux.TableObject {
+	tos := make([]*flux.TableObject, 0)
+	parents.Range(func(i int, v values.Value) {
+		if to, ok := v.(*flux.TableObject); ok {
+			tos = append(tos, to)
+			tos = append(tos, getTableObjectsFromArray(to.Parents)...)
+		}
+	})
+	return tos
 }


### PR DESCRIPTION
…w private

Closes #1088 

For cyclic dependencies issues, it was not trivial to make TableObject implement Compiler.  
I created a TableObjectCompiler that does the job and duplicated some code (see comments in the code).

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
