### PR TITLE
fix(ast): omit space between unary operator and operand

### DIFF
--- a/ast/format.go
+++ b/ast/format.go
@@ -359,7 +359,6 @@ func (f *formatter) formatFunctionExpression(n *FunctionExpression) {
 
 func (f *formatter) formatUnaryExpression(n *UnaryExpression) {
 	f.writeString(n.Operator.String())
-	f.writeRune(' ')
 	f.formatChildWithParens(n, n.Argument)
 }
 


### PR DESCRIPTION
This makes it so Flux is formatted more natually, e.g, `range(start: -30s)`
In other words, no space between `-` and `30s`.
This difference was causing some tests to fail in influxdb.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
