### PR TITLE
fix(ast): omit space between unary operator and operand

### DIFF
--- a/ast/format.go
+++ b/ast/format.go
@@ -359,7 +359,10 @@ func (f *formatter) formatFunctionExpression(n *FunctionExpression) {
 
 func (f *formatter) formatUnaryExpression(n *UnaryExpression) {
 	f.writeString(n.Operator.String())
-	f.writeRune(' ')
+	if n.Operator != SubtractionOperator &&
+		n.Operator != AdditionOperator {
+		f.WriteRune(' ')
+	}
 	f.formatChildWithParens(n, n.Argument)
 }
 

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -362,6 +362,14 @@ func TestFormat_Associativity(t *testing.T) {
 			script: `not (b and c)`,
 		},
 		{
+			name:   "unary negative duration",
+			script: `-30s`,
+		},
+		{
+			name:   "unary positive duration",
+			script: `+30s`,
+		},
+		{
 			name:   "function call with pars",
 			script: `(a + b * c == 0)(foo: "bar")`,
 		},


### PR DESCRIPTION
This makes it so Flux is formatted more natually, e.g, `range(start: -30s)`
In other words, no space between `-` and `30s`.
This difference was causing some tests to fail in influxdb.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
