### PR TITLE
refactor(lang): rename SpecCompiler to ReplCompiler

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	FluxCompilerType = "flux"
-	SpecCompilerType = "spec"
 	ASTCompilerType  = "ast"
 )
 
@@ -35,9 +34,7 @@ func AddCompilerMappings(mappings flux.CompilerMappings) error {
 	}); err != nil {
 		return err
 	}
-	return mappings.Add(SpecCompilerType, func() flux.Compiler {
-		return new(SpecCompiler)
-	})
+	return nil
 }
 
 // CompileOption represents an option for compilation.
@@ -155,26 +152,6 @@ func (c FluxCompiler) Compile(ctx context.Context) (flux.Program, error) {
 
 func (c FluxCompiler) CompilerType() flux.CompilerType {
 	return FluxCompilerType
-}
-
-// SpecCompiler implements Compiler by returning a known spec.
-type SpecCompiler struct {
-	Spec *flux.Spec `json:"spec"`
-}
-
-func (c SpecCompiler) Compile(ctx context.Context) (flux.Program, error) {
-	// Ignore context, it will be provided upon Program Start.
-	ps, err := buildPlan(c.Spec, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "error in building plan while compiling")
-	}
-	return &Program{
-		PlanSpec: ps,
-	}, nil
-}
-
-func (c SpecCompiler) CompilerType() flux.CompilerType {
-	return SpecCompilerType
 }
 
 // ASTCompiler implements Compiler by producing a Spec from an AST.

--- a/repl/compiler.go
+++ b/repl/compiler.go
@@ -1,0 +1,39 @@
+package repl
+
+import (
+	"context"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/plan"
+)
+
+// CompilerType specific to the Flux REPL
+const CompilerType = "REPL"
+
+// Compiler specific to the Flux REPL
+type Compiler struct {
+	Spec *flux.Spec `json:"spec"`
+}
+
+func (c Compiler) Compile(ctx context.Context) (flux.Program, error) {
+	planner := plan.PlannerBuilder{}.Build()
+	ps, err := planner.Plan(c.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lang.Program{
+		PlanSpec: ps,
+	}, err
+}
+
+func (c Compiler) CompilerType() flux.CompilerType {
+	return CompilerType
+}
+
+func AddCompilerToMappings(mappings flux.CompilerMappings) error {
+	return mappings.Add(CompilerType, func() flux.Compiler {
+		return new(Compiler)
+	})
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/interpreter"
-	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -191,11 +190,11 @@ func (r *REPL) doQuery(spec *flux.Spec) error {
 	defer cancelFunc()
 	defer r.clearCancel()
 
-	compiler := lang.SpecCompiler{
+	replCompiler := Compiler{
 		Spec: spec,
 	}
 
-	results, err := r.querier.Query(ctx, compiler)
+	results, err := r.querier.Query(ctx, replCompiler)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #13220 .

Once https://github.com/influxdata/influxdb/pull/13222 is merged, the flux version can be updated on the `refactor/private-spec` branch.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
