### PR TITLE
refactor(stdlib/aggregates): aggregates now accept only a 'column' pa…

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1447,9 +1447,9 @@ Any output table will have the following properties:
 
 All aggregate operations have the following properties:
 
-| Name    | Type     | Description                                       |
-| ----    | ----     | -----------                                       |
-| columns | []string | Columns specifies a list of columns to aggregate. |
+| Name   | Type   | Description                             |
+| ----   | ----   | -----------                             |
+| column | string | Column specifies a column to aggregate. |
 
 ##### AggregateWindow
 
@@ -1460,14 +1460,14 @@ an output table for every input table.
 AggregateWindow has the following properties:
 
 
-| Name        | Type                                            | Description                                                                                                           |
-| ----        | ----                                            | -----------                                                                                                           |
-| every       | duration                                        | Every specifies the window size to aggregate.                                                                         |
-| fn          | (tables: <-stream, columns: []string) -> stream | Fn specifies the aggregate operation to perform. Any of the functions in this Aggregate section can be provided.      |
-| columns     | []string                                        | Columns specifies a list of columns to aggregate. Defaults to ["_value"].                                             |
-| timeSrc     | string                                          | TimeSrc is the name of a column from the group key to use as the source for the aggregated time. Defaults to "_stop". |
-| timeDst     | string                                          | TimeDst is the name of a new column in which the aggregated time is placed. Defaults to "_time".                      |
-| createEmpty | bool                                            | CreateEmpty, if true, will create empty windows and fill them with a null aggregate value.  Defaults to true.         |
+| Name        | Type                                            | Description                                                                                                                                                     |
+| ----        | ----                                            | -----------                                                                                                                                                     |
+| every       | duration                                        | Every specifies the window size to aggregate.                                                                                                                   |
+| fn          | (tables: <-stream, columns: []string) -> stream | Fn specifies the aggregate operation to perform. Any of the functions in this Aggregate section that accept a singular `column` parameter can be provided.      |
+| column      | string                                          | Columns specifies column to aggregate. Defaults to "_value".                                                                                                    |
+| timeSrc     | string                                          | TimeSrc is the name of a column from the group key to use as the source for the aggregated time. Defaults to "_stop".                                           |
+| timeDst     | string                                          | TimeDst is the name of a new column in which the aggregated time is placed. Defaults to "_time".                                                                |
+| createEmpty | bool                                            | CreateEmpty, if true, will create empty windows and fill them with a null aggregate value.  Defaults to true.                                                   |
 Example:
 
 ```
@@ -1485,11 +1485,11 @@ Covariance computes the covariance between two columns.
 
 Covariance has the following properties:
 
-| Name     | Type     | Description                                                                                 |
-| ----     | ----     | -----------                                                                                 |
-| columns  | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`.                 |
-| pearsonr | bool     | Pearsonr indicates whether the result should be normalized to be the Pearson R coefficient. |
-| valueDst | string   | ValueDst is the column into which the result will be placed. Defaults to `_value`.          |
+| Name     | Type     | Description                                                                                            |
+| ----     | ----     | -----------                                                                                            |
+| columns  | []string | Columns specifies a list of the two columns to aggregate. This property is required and has no default.|
+| pearsonr | bool     | Pearsonr indicates whether the result should be normalized to be the Pearson R coefficient.            |
+| valueDst | string   | ValueDst is the column into which the result will be placed. Defaults to `_value`.                     |
 
 Additionally exactly two columns must be provided to the `columns` property.
 
@@ -1530,9 +1530,9 @@ For each aggregated column, it outputs the number of records as an integer. It w
 
 Count has the following property:
 
-| Name    | Type     | Description                                                                 |
-| ----    | ----     | -----------                                                                 |
-| columns | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`. |
+| Name    | Type     | Description                                                      |
+| ----    | ----     | -----------                                                      |
+| column  | string   | Columns specifies a column to aggregate. Defaults to `"_value"`. |
 
 Example:
 ```
@@ -1553,7 +1553,7 @@ Integral has the following properties:
 
 | Name       | Type     | Description                                                                           |
 | ----       | ----     | -----------                                                                           |
-| columns    | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`.           |
+| column     | string   | Columns specifies a column to aggregate. Defaults to `"_value"`.                      |
 | unit       | duration | Unit is the time duration to use when computing the integral.  Defaults to `1s`       |
 | timeColumn | string   | TimeColumn is the name of the column containing the time value.  Defaults to `_time`. |
 
@@ -1575,7 +1575,7 @@ Mean has the following property:
 
 | Name    | Type     | Description                                                                 |
 | ----    | ----     | -----------                                                                 |
-| columns | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`. |
+| column  | string   | Columns specifies a column to aggregate. Defaults to `"_value"`.            |
 
 Example:
 ```
@@ -1616,7 +1616,7 @@ Quantile has the following properties:
 
 | Name        | Type     | Description                                                                                                                                                                                   |
 | ----        | ----     | -----------                                                                                                                                                                                   |
-| columns     | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`                                                                                                                    |
+| column      | string   | Column specifies a column to aggregate. Defaults to `"_value"`                                                                                                                                |
 | q           | float    | q is a value between 0 and 1 indicating the desired quantile.                                                                                                                                 |
 | method      | string   | Method must be one of: estimate_tdigest, exact_mean, or exact_selector.                                                                                                                       |
 | compression | float    | Compression indicates how many centroids to use when compressing the dataset. A larger number produces a more accurate result at the cost of increased memory requirements. Defaults to 1000. |
@@ -1646,7 +1646,7 @@ Skew has the following parameter:
 
 | Name    | Type     | Description                                                                 |
 | ----    | ----     | -----------                                                                 |
-| columns | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`. |
+| column  | string   | Column specifies a columns to aggregate. Defaults to `"_value"`.            |
 
 Example:
 
@@ -1666,9 +1666,9 @@ All other input types are invalid.
 
 Spread has the following parameter:
 
-| Name    | Type     | Description                                                                 |
-| ----    | ----     | -----------                                                                 |
-| columns | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`. |
+| Name    | Type     | Description                                                     |
+| ----    | ----     | -----------                                                     |
+| column  | string   | Column specifies a column to aggregate. Defaults to `"_value"`. |
 
 Example:
 ```
@@ -1684,9 +1684,9 @@ For each aggregated column, it outputs the standard deviation of the non null re
 
 Stddev has the following parameter:
 
-| Name    | Type     | Description                                                                 |
-| ----    | ----     | -----------                                                                 |
-| columns | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`. |
+| Name    | Type     | Description                                                      |
+| ----    | ----     | -----------                                                      |
+| column  | string   | Columns specifies a column to aggregate. Defaults to `"_value"`. |
 
 Example:
 
@@ -1705,9 +1705,9 @@ The output column type is the same as the input column type.
 
 Sum has the following parameter:
 
-| Name    | Type     | Description                                                                 |
-| ----    | ----     | -----------                                                                 |
-| columns | []string | Columns specifies a list of columns to aggregate. Defaults to `["_value"]`. |
+| Name    | Type     | Description                                                     |
+| ----    | ----     | -----------                                                     |
+| column  | string   | Column specifies a column to aggregate. Defaults to `"_value"`. |
 
 Example:
 ```

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -22,7 +21,7 @@ type aggregateTransformation struct {
 
 type AggregateConfig struct {
 	plan.DefaultCost
-	Columns []string `json:"columns"`
+	Columns []string `json:"column"`
 }
 
 var DefaultAggregateConfig = AggregateConfig{
@@ -35,7 +34,7 @@ func AggregateSignature(args map[string]semantic.PolyType, required []string) se
 	if args == nil {
 		args = make(map[string]semantic.PolyType)
 	}
-	args["columns"] = semantic.NewArrayPolyType(semantic.String)
+	args["column"] = semantic.String
 	return flux.FunctionSignature(args, required)
 }
 
@@ -49,14 +48,10 @@ func (c AggregateConfig) Copy() AggregateConfig {
 }
 
 func (c *AggregateConfig) ReadArgs(args flux.Arguments) error {
-	if cols, ok, err := args.GetArray("columns", semantic.String); err != nil {
+	if col, ok, err := args.GetString("column"); err != nil {
 		return err
 	} else if ok {
-		columns, err := interpreter.ToStringArray(cols)
-		if err != nil {
-			return err
-		}
-		c.Columns = columns
+		c.Columns = []string{col}
 	} else {
 		c.Columns = DefaultAggregateConfig.Columns
 	}

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -34,6 +34,7 @@ var skip = map[string]string{
 	"task_per_line":               "join produces inconsistent/racy results when table schemas do not match (https://github.com/influxdata/flux/issues/855)",
 	"rowfn_with_import":           "imported libraries are not visible in user-defined functions (https://github.com/influxdata/flux/issues/1000)",
 	"string_trim":                 "cannot reference a package function from within a row function",
+	"integral_columns":            "aggregates changed to operate on just a single columnm.",
 }
 
 var querier = querytest.NewQuerier()

--- a/stdlib/testing/testdata/aggregate_window_max.flux
+++ b/stdlib/testing/testdata/aggregate_window_max.flux
@@ -1,0 +1,43 @@
+package testdata_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string,string
+#group,false,false,false,false,true,true,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,path
+,,0,2018-05-22T00:00:00Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:10Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:20Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:30Z,40,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:40Z,40,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:50Z,40,used_percent,disk,disk1s1,apfs,host.local,/
+,,1,2018-05-22T00:00:00Z,35,used_percent,disk,disk1s1,apfs,host.local,/tmp
+,,1,2018-05-22T00:00:10Z,35,used_percent,disk,disk1s1,apfs,host.local,/tmp
+,,1,2018-05-22T00:00:20Z,35,used_percent,disk,disk1s1,apfs,host.local,/tmp
+,,1,2018-05-22T00:00:30Z,45,used_percent,disk,disk1s1,apfs,host.local,/tmp
+,,1,2018-05-22T00:00:40Z,45,used_percent,disk,disk1s1,apfs,host.local,/tmp
+,,1,2018-05-22T00:00:50Z,45,used_percent,disk,disk1s1,apfs,host.local,/tmp
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double
+#group,false,false,true,true,false,true,true,true,true,true,true,false
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_time,_field,_measurement,device,fstype,host,path,_value
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,2018-05-22T00:00:30Z,used_percent,disk,disk1s1,apfs,host.local,/,30
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40
+,,1,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,2018-05-22T00:00:30Z,used_percent,disk,disk1s1,apfs,host.local,/tmp,35
+,,1,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/tmp,45
+"
+aggregate_window = (table=<-) =>
+	(table
+		|> range(start: 2018-05-22T00:00:00Z, stop: 2018-05-22T00:01:00Z)
+		|> aggregateWindow(every: 30s, fn: max))
+
+test _aggregate_window = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: aggregate_window})
+

--- a/stdlib/universe/covariance_test.go
+++ b/stdlib/universe/covariance_test.go
@@ -33,9 +33,7 @@ func TestCovariance_NewQuery(t *testing.T) {
 						ID: "covariance1",
 						Spec: &universe.CovarianceOpSpec{
 							ValueDst: execute.DefaultValueColLabel,
-							AggregateConfig: execute.AggregateConfig{
-								Columns: []string{"a", "b"},
-							},
+							Columns:  []string{"a", "b"},
 						},
 					},
 				},
@@ -60,9 +58,7 @@ func TestCovariance_NewQuery(t *testing.T) {
 						Spec: &universe.CovarianceOpSpec{
 							ValueDst:           execute.DefaultValueColLabel,
 							PearsonCorrelation: true,
-							AggregateConfig: execute.AggregateConfig{
-								Columns: []string{"a", "b"},
-							},
+							Columns:            []string{"a", "b"},
 						},
 					},
 				},
@@ -104,9 +100,7 @@ func TestCovariance_NewQuery(t *testing.T) {
 						Spec: &universe.CovarianceOpSpec{
 							ValueDst:           execute.DefaultValueColLabel,
 							PearsonCorrelation: true,
-							AggregateConfig: execute.AggregateConfig{
-								Columns: []string{"_value_x", "_value_y"},
-							},
+							Columns:            []string{"_value_x", "_value_y"},
 						},
 					},
 				},
@@ -155,9 +149,7 @@ func TestCovariance_Process(t *testing.T) {
 			name: "variance",
 			spec: &universe.CovarianceProcedureSpec{
 				ValueLabel: execute.DefaultValueColLabel,
-				AggregateConfig: execute.AggregateConfig{
-					Columns: []string{"x", "y"},
-				},
+				Columns:    []string{"x", "y"},
 			},
 			data: []flux.Table{&executetest.Table{
 				KeyCols: []string{"_start", "_stop"},
@@ -192,9 +184,7 @@ func TestCovariance_Process(t *testing.T) {
 			name: "negative covariance",
 			spec: &universe.CovarianceProcedureSpec{
 				ValueLabel: execute.DefaultValueColLabel,
-				AggregateConfig: execute.AggregateConfig{
-					Columns: []string{"x", "y"},
-				},
+				Columns:    []string{"x", "y"},
 			},
 			data: []flux.Table{&executetest.Table{
 				KeyCols: []string{"_start", "_stop"},
@@ -229,9 +219,7 @@ func TestCovariance_Process(t *testing.T) {
 			name: "small covariance",
 			spec: &universe.CovarianceProcedureSpec{
 				ValueLabel: execute.DefaultValueColLabel,
-				AggregateConfig: execute.AggregateConfig{
-					Columns: []string{"x", "y"},
-				},
+				Columns:    []string{"x", "y"},
 			},
 			data: []flux.Table{&executetest.Table{
 				KeyCols: []string{"_start", "_stop"},
@@ -267,9 +255,7 @@ func TestCovariance_Process(t *testing.T) {
 			spec: &universe.CovarianceProcedureSpec{
 				ValueLabel:         execute.DefaultValueColLabel,
 				PearsonCorrelation: true,
-				AggregateConfig: execute.AggregateConfig{
-					Columns: []string{"x", "y"},
-				},
+				Columns:            []string{"x", "y"},
 			},
 			data: []flux.Table{&executetest.Table{
 				KeyCols: []string{"_start", "_stop"},
@@ -305,9 +291,7 @@ func TestCovariance_Process(t *testing.T) {
 			spec: &universe.CovarianceProcedureSpec{
 				ValueLabel:         execute.DefaultValueColLabel,
 				PearsonCorrelation: true,
-				AggregateConfig: execute.AggregateConfig{
-					Columns: []string{"x", "y"},
-				},
+				Columns:            []string{"x", "y"},
 			},
 			data: []flux.Table{&executetest.Table{
 				KeyCols: []string{"_start", "_stop"},
@@ -342,9 +326,7 @@ func TestCovariance_Process(t *testing.T) {
 			name: "variance with nulls",
 			spec: &universe.CovarianceProcedureSpec{
 				ValueLabel: execute.DefaultValueColLabel,
-				AggregateConfig: execute.AggregateConfig{
-					Columns: []string{"x", "y"},
-				},
+				Columns:    []string{"x", "y"},
 			},
 			data: []flux.Table{&executetest.Table{
 				KeyCols: []string{"_start", "_stop"},

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -38,8 +38,7 @@ type QuantileOpSpec struct {
 func init() {
 	quantileSignature := flux.FunctionSignature(
 		map[string]semantic.PolyType{
-			"column":      semantic.String,                            // selector
-			"columns":     semantic.NewArrayPolyType(semantic.String), // aggregate
+			"column":      semantic.String,
 			"q":           semantic.Float,
 			"compression": semantic.Float,
 			"method":      semantic.String,

--- a/stdlib/universe/quantile_test.go
+++ b/stdlib/universe/quantile_test.go
@@ -142,49 +142,6 @@ func TestQuantile_NewQuery(t *testing.T) {
 			},
 		},
 		{
-			Name: "custom cols",
-			Raw:  `from(bucket:"testdb") |> range(start: -1h) |> quantile(q: 0.99, method: "exact_mean", columns: ["foo", "bar"])`,
-			Want: &flux.Spec{
-				Operations: []*flux.Operation{
-					{
-						ID: "from0",
-						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
-						},
-					},
-					{
-						ID: "range1",
-						Spec: &universe.RangeOpSpec{
-							Start: flux.Time{
-								Relative:   -1 * time.Hour,
-								IsRelative: true,
-							},
-							Stop: flux.Time{
-								IsRelative: true,
-							},
-							TimeColumn:  "_time",
-							StartColumn: "_start",
-							StopColumn:  "_stop",
-						},
-					},
-					{
-						ID: "quantile2",
-						Spec: &universe.QuantileOpSpec{
-							Quantile: 0.99,
-							Method:   "exact_mean",
-							AggregateConfig: execute.AggregateConfig{
-								Columns: []string{"foo", "bar"},
-							},
-						},
-					},
-				},
-				Edges: []flux.Edge{
-					{Parent: "from0", Child: "range1"},
-					{Parent: "range1", Child: "quantile2"},
-				},
-			},
-		},
-		{
 			Name: "custom col",
 			Raw:  `from(bucket:"testdb") |> range(start: -1h) |> quantile(q: 0.99, method: "exact_selector", column: "foo")`,
 			Want: &flux.Spec{
@@ -227,6 +184,49 @@ func TestQuantile_NewQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "custom column",
+			Raw:  `from(bucket:"testdb") |> range(start: -1h) |> quantile(q: 0.99, method: "exact_mean", column: "foo")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: "testdb",
+						},
+					},
+					{
+						ID: "range1",
+						Spec: &universe.RangeOpSpec{
+							Start: flux.Time{
+								Relative:   -1 * time.Hour,
+								IsRelative: true,
+							},
+							Stop: flux.Time{
+								IsRelative: true,
+							},
+							TimeColumn:  "_time",
+							StartColumn: "_start",
+							StopColumn:  "_stop",
+						},
+					},
+					{
+						ID: "quantile2",
+						Spec: &universe.QuantileOpSpec{
+							Quantile: 0.99,
+							Method:   "exact_mean",
+							AggregateConfig: execute.AggregateConfig{
+								Columns: []string{"foo"},
+							},
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "range1"},
+					{Parent: "range1", Child: "quantile2"},
+				},
+			},
+		},
 		// errors
 		{
 			Name:    "wrong method",
@@ -241,11 +241,6 @@ func TestQuantile_NewQuery(t *testing.T) {
 		{
 			Name:    "selector with columns",
 			Raw:     `from(bucket:"testdb") |> range(start: -1h) |> quantile(q: 0.99, method: "exact_selector", columns: ["1", "2"])`,
-			WantErr: true,
-		},
-		{
-			Name:    "aggregate with column",
-			Raw:     `from(bucket:"testdb") |> range(start: -1h) |> quantile(q: 0.99, method: "estimate_tdigest", column: "1")`,
 			WantErr: true,
 		},
 	}

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -86,10 +86,10 @@ pearsonr = (x,y,on) => cov(x:x, y:y, on:on, pearsonr:true)
 // AggregateWindow applies an aggregate function to fixed windows of time.
 // The procedure is to window the data, perform an aggregate operation,
 // and then undo the windowing to produce an output table for every input table.
-aggregateWindow = (every, fn, columns=["_value"], timeSrc="_stop",timeDst="_time", createEmpty=true, tables=<-) =>
+aggregateWindow = (every, fn, column="_value", timeSrc="_stop",timeDst="_time", createEmpty=true, tables=<-) =>
     tables
         |> window(every:every, createEmpty: createEmpty)
-        |> fn(columns:columns)
+        |> fn(column:column)
         |> duplicate(column:timeSrc,as:timeDst)
         |> window(every:inf, timeColumn:timeDst)
 
@@ -158,80 +158,80 @@ bottom = (n, columns=["_value"], tables=<-) =>
         |> _sortLimit(n:n, columns:columns, desc:false)
 
 // _highestOrLowest is a helper function, which reduces all groups into a single group by specific tags and a reducer function,
-// then it selects the highest or lowest records based on the columns and the _sortLimit function.
+// then it selects the highest or lowest records based on the column and the _sortLimit function.
 // The default reducer assumes no reducing needs to be performed.
-_highestOrLowest = (n, _sortLimit, reducer, columns=["_value"], groupColumns=[], tables=<-) =>
+_highestOrLowest = (n, _sortLimit, reducer, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> group(columns:groupColumns)
         |> reducer()
         |> group(columns:[])
-        |> _sortLimit(n:n, columns:columns)
+        |> _sortLimit(n:n, columns:[column])
 
 // highestMax returns the top N records from all groups using the maximum of each group.
-highestMax = (n, columns=["_value"], groupColumns=[], tables=<-) =>
+highestMax = (n, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> _highestOrLowest(
                 n:n,
-                columns:columns,
+                column:column,
                 groupColumns:groupColumns,
                 // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.
-                reducer: (tables=<-) => tables |> max(column:columns[0]),
+                reducer: (tables=<-) => tables |> max(column:column),
                 _sortLimit: top,
             )
 
 // highestAverage returns the top N records from all groups using the average of each group.
-highestAverage = (n, columns=["_value"], groupColumns=[], tables=<-) =>
+highestAverage = (n, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> _highestOrLowest(
                 n:n,
-                columns:columns,
+                column:column,
                 groupColumns:groupColumns,
-                reducer: (tables=<-) => tables |> mean(columns:[columns[0]]),
+                reducer: (tables=<-) => tables |> mean(column:column),
                 _sortLimit: top,
             )
 
 // highestCurrent returns the top N records from all groups using the last value of each group.
-highestCurrent = (n, columns=["_value"], groupColumns=[], tables=<-) =>
+highestCurrent = (n, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> _highestOrLowest(
                 n:n,
-                columns:columns,
+                column:column,
                 groupColumns:groupColumns,
-                reducer: (tables=<-) => tables |> last(column:columns[0]),
+                reducer: (tables=<-) => tables |> last(column:column),
                 _sortLimit: top,
             )
 
 // lowestMin returns the bottom N records from all groups using the minimum of each group.
-lowestMin = (n, columns=["_value"], groupColumns=[], tables=<-) =>
+lowestMin = (n, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> _highestOrLowest(
                 n:n,
-                columns:columns,
+                column:column,
                 groupColumns:groupColumns,
                 // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.
-                reducer: (tables=<-) => tables |> min(column:columns[0]),
+                reducer: (tables=<-) => tables |> min(column:column),
                 _sortLimit: bottom,
             )
 
 // lowestAverage returns the bottom N records from all groups using the average of each group.
-lowestAverage = (n, columns=["_value"], groupColumns=[], tables=<-) =>
+lowestAverage = (n, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> _highestOrLowest(
                 n:n,
-                columns:columns,
+                column:column,
                 groupColumns:groupColumns,
-                reducer: (tables=<-) => tables |> mean(columns:[columns[0]]),
+                reducer: (tables=<-) => tables |> mean(column:column),
                 _sortLimit: bottom,
             )
 
 // lowestCurrent returns the bottom N records from all groups using the last value of each group.
-lowestCurrent = (n, columns=["_value"], groupColumns=[], tables=<-) =>
+lowestCurrent = (n, column="_value", groupColumns=[], tables=<-) =>
     tables
         |> _highestOrLowest(
                 n:n,
-                columns:columns,
+                column:column,
                 groupColumns:groupColumns,
-                reducer: (tables=<-) => tables |> last(column:columns[0]),
+                reducer: (tables=<-) => tables |> last(column:column),
                 _sortLimit: bottom,
             )
 


### PR DESCRIPTION
…rameter, columns not used.

BREAKING CHANGE: aggregates no longer accept multiple columns to aggregate, but rather a single 'column' parameter.

spec updated with new paramter set for aggregates
add test demonstrating use of max in aggregateWindow

closes #336.


### Done checklist
- [X] docs/SPEC.md updated
- [X] Test cases written
