### PR TITLE
fix(lang): make Program.Start start execution synchronously

### DIFF
--- a/control/controller.go
+++ b/control/controller.go
@@ -193,6 +193,7 @@ func (c *Controller) compileQuery(q *Query, compiler flux.Compiler) error {
 	//   dependencies, see https://github.com/influxdata/flux/issues/1126
 	if p, ok := prog.(*lang.Program); ok {
 		p.Dependencies = c.dependencies
+		p.Logger = c.logger
 	}
 
 	q.program = prog

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -12,16 +12,23 @@ import (
 	"github.com/influxdata/flux/ast"
 	_ "github.com/influxdata/flux/builtin"
 	fcsv "github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/mock"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
 	"github.com/influxdata/flux/stdlib/csv"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 )
+
+func init() {
+	execute.RegisterSource(influxdb.FromKind, mock.CreateMockFromSource)
+}
 
 func TestFluxCompiler(t *testing.T) {
 	ctx := context.Background()

--- a/mock/source.go
+++ b/mock/source.go
@@ -1,0 +1,33 @@
+package mock
+
+import (
+	"context"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/plan"
+)
+
+// Source is a mock source that performs the given functions.
+// By default it does nothing.
+type Source struct {
+	AddTransformationFn func(transformation execute.Transformation)
+	RunFn               func(ctx context.Context)
+}
+
+func (s *Source) AddTransformation(t execute.Transformation) {
+	if s.AddTransformationFn != nil {
+		s.AddTransformationFn(t)
+	}
+}
+
+func (s *Source) Run(ctx context.Context) {
+	if s.RunFn != nil {
+		s.RunFn(ctx)
+	}
+}
+
+// CreateMockFromSource will register a mock "from" source.  Use it like this in the init()
+// of your test:
+//    execute.RegisterSource(influxdb.FromKind, mock.CreateMockFromSource)
+func CreateMockFromSource(spec plan.ProcedureSpec, id execute.DatasetID, ctx execute.Administration) (execute.Source, error) {
+	return &Source{}, nil
+}


### PR DESCRIPTION
If an error occurred when setting up execution state, it would not be reported.  This
was causing a test to fail for a query like `from(bucket:"non-existent")`.
The call the `Execute` just walks the plan, creates the execution state, and returns, allowing
query execution to continue asynchronously, so it's okay to start execution synchronously to allow
errors to be reported.

Fixes influxdata/idpe#3073.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
