### PR TITLE
fix: require a github token to perform a release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,12 @@ cd $DIR
 
 set -e
 
+# Ensure that the GITHUB_TOKEN is exposed in the environment.
+if ! env | grep GITHUB_TOKEN= > /dev/null; then
+  echo "GITHUB_TOKEN must be exported in the environment to perform a release." 2>&1
+  exit 1
+fi
+
 export GO111MODULE=on
 
 version=$(go run ./internal/cmd/changelog nextver)


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The release would fail when attempting to upload release notes if a
github token wasn't in the environment. This will check the environment
before running the commands so we don't have to back out a tag midway
through.