### PR TITLE
ci: use go1.12 for builds

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,5 +1,8 @@
-# This file describes an image that is capabale of building Flux.
+# This file describes an image that is capable of building Flux.
 
-FROM golang:1.11.4
+FROM golang:1.12
 
-RUN apt-get update && apt-get install -y ruby ragel=6.9-1.1+b1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		ruby \
+		ragel=6.9-1.1+b1 \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
And use --no-install-recommends flag to apt-get install, and clear out
apt lists cache at the end to reduce image size, like various official
Docker images do.

----

If I'm following this correctly:

- CircleCI uses Docker image nathanielc/flux-build
- Docker image nathanielc/flux-build uses master of flux as the source of the Dockerfile
- There is no `make` step to build from the local Dockerfile_build
- Therefore CI did not actually test these changes

That being said, I ran the tests locally with go1.12 and they passed.
