### PR TITLE
fix: make staticcheck pass

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1146,7 +1146,7 @@ func (l *RegexpLiteral) Copy() Node {
 	nl.BaseNode = l.BaseNode.Copy()
 
 	if l.Value != nil {
-		nl.Value = l.Value.Copy()
+		nl.Value = l.Value
 	}
 	return nl
 }

--- a/ast/asttest/cmpgen/main.go
+++ b/ast/asttest/cmpgen/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"go/importer"
+	"go/token"
 	"go/types"
 	"log"
 	"os"
@@ -21,7 +22,7 @@ func main() {
 	}
 	defer f.Close()
 
-	pkg, err := importer.For("source", nil).Import("github.com/influxdata/flux/ast")
+	pkg, err := importer.ForCompiler(&token.FileSet{}, "source", nil).Import("github.com/influxdata/flux/ast")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/semantic/graph.go
+++ b/semantic/graph.go
@@ -957,7 +957,7 @@ func (l *RegexpLiteral) Copy() Node {
 	nl := new(RegexpLiteral)
 	*nl = *l
 
-	nl.Value = l.Value.Copy()
+	nl.Value = l.Value
 
 	return nl
 }


### PR DESCRIPTION
I removed calls to `regexp.Copy()`, since the warning says they are unneeded except
fpr when using `Longest` which is not called anywhere in this repo.

I also update the `cmpgen` tool to use `importer.ForCompiler` since `importer.For`
is deprecated.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
