### PR TITLE
fix(stdlib): tagKeys should include a call to distinct

### DIFF
--- a/stdlib/influxdata/influxdb/v1/flux_gen.go
+++ b/stdlib/influxdata/influxdb/v1/flux_gen.go
@@ -22,10 +22,10 @@ var pkgAST = &ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 51,
-					Line:   44,
+					Line:   45,
 				},
 				File:   "v1.flux",
-				Source: "package v1\n\n// Json parses an InfluxDB 1.x json result into a table stream.\nbuiltin json\n\n// Databases returns the list of available databases, it has no parameters.\nbuiltin databases\n\n// fieldsAsCols is a special application of pivot that will automatically align fields within each measurement that have the same timestamp.\nfieldsAsCols = (tables=<-) =>\n    tables\n        |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\n// TagValues returns the unique values for a given tag.\n// The return value is always a single table with a single column \"_value\".\ntagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> group(columns: [tag])\n      |> distinct(column: tag)\n      |> keep(columns: [\"_value\"])\n\n// MeasurementTagValues returns a single table with a single column \"_value\" that contains the\n// The return value is always a single table with a single column \"_value\".\nmeasurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)\n\n// TagKeys returns the list of tag keys for all series that match the predicate.\n// The return value is always a single table with a single column \"_value\".\ntagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n\n// MeasurementTagKeys returns the list of tag keys for a specific measurement.\nmeasurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)\n\n// Measurements returns the list of measurements in a specific bucket.\nmeasurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+				Source: "package v1\n\n// Json parses an InfluxDB 1.x json result into a table stream.\nbuiltin json\n\n// Databases returns the list of available databases, it has no parameters.\nbuiltin databases\n\n// fieldsAsCols is a special application of pivot that will automatically align fields within each measurement that have the same timestamp.\nfieldsAsCols = (tables=<-) =>\n    tables\n        |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\n// TagValues returns the unique values for a given tag.\n// The return value is always a single table with a single column \"_value\".\ntagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> group(columns: [tag])\n      |> distinct(column: tag)\n      |> keep(columns: [\"_value\"])\n\n// MeasurementTagValues returns a single table with a single column \"_value\" that contains the\n// The return value is always a single table with a single column \"_value\".\nmeasurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)\n\n// TagKeys returns the list of tag keys for all series that match the predicate.\n// The return value is always a single table with a single column \"_value\".\ntagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()\n\n// MeasurementTagKeys returns the list of tag keys for a specific measurement.\nmeasurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)\n\n// Measurements returns the list of measurements in a specific bucket.\nmeasurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -2023,11 +2023,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 37,
-						Line:   36,
+						Column: 22,
+						Line:   37,
 					},
 					File:   "v1.flux",
-					Source: "tagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
+					Source: "tagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
 					Start: ast.Position{
 						Column: 1,
 						Line:   31,
@@ -2057,11 +2057,11 @@ var pkgAST = &ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 37,
-							Line:   36,
+							Column: 22,
+							Line:   37,
 						},
 						File:   "v1.flux",
-						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
+						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
 						Start: ast.Position{
 							Column: 11,
 							Line:   31,
@@ -2072,24 +2072,9 @@ var pkgAST = &ast.Package{
 					Argument: &ast.PipeExpression{
 						Argument: &ast.PipeExpression{
 							Argument: &ast.PipeExpression{
-								Argument: &ast.CallExpression{
-									Arguments: []ast.Expression{&ast.ObjectExpression{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 24,
-													Line:   32,
-												},
-												File:   "v1.flux",
-												Source: "bucket: bucket",
-												Start: ast.Position{
-													Column: 10,
-													Line:   32,
-												},
-											},
-										},
-										Properties: []*ast.Property{&ast.Property{
+								Argument: &ast.PipeExpression{
+									Argument: &ast.CallExpression{
+										Arguments: []ast.Expression{&ast.ObjectExpression{
 											BaseNode: ast.BaseNode{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
@@ -2105,25 +2090,7 @@ var pkgAST = &ast.Package{
 													},
 												},
 											},
-											Key: &ast.Identifier{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 16,
-															Line:   32,
-														},
-														File:   "v1.flux",
-														Source: "bucket",
-														Start: ast.Position{
-															Column: 10,
-															Line:   32,
-														},
-													},
-												},
-												Name: "bucket",
-											},
-											Value: &ast.Identifier{
+											Properties: []*ast.Property{&ast.Property{
 												BaseNode: ast.BaseNode{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
@@ -2132,84 +2099,102 @@ var pkgAST = &ast.Package{
 															Line:   32,
 														},
 														File:   "v1.flux",
-														Source: "bucket",
+														Source: "bucket: bucket",
 														Start: ast.Position{
-															Column: 18,
+															Column: 10,
 															Line:   32,
 														},
 													},
 												},
-												Name: "bucket",
-											},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 16,
+																Line:   32,
+															},
+															File:   "v1.flux",
+															Source: "bucket",
+															Start: ast.Position{
+																Column: 10,
+																Line:   32,
+															},
+														},
+													},
+													Name: "bucket",
+												},
+												Value: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 24,
+																Line:   32,
+															},
+															File:   "v1.flux",
+															Source: "bucket",
+															Start: ast.Position{
+																Column: 18,
+																Line:   32,
+															},
+														},
+													},
+													Name: "bucket",
+												},
+											}},
 										}},
-									}},
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 25,
-												Line:   32,
-											},
-											File:   "v1.flux",
-											Source: "from(bucket: bucket)",
-											Start: ast.Position{
-												Column: 5,
-												Line:   32,
-											},
-										},
-									},
-									Callee: &ast.Identifier{
 										BaseNode: ast.BaseNode{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 9,
+													Column: 25,
 													Line:   32,
 												},
 												File:   "v1.flux",
-												Source: "from",
+												Source: "from(bucket: bucket)",
 												Start: ast.Position{
 													Column: 5,
 													Line:   32,
 												},
 											},
 										},
-										Name: "from",
-									},
-								},
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 31,
-											Line:   33,
-										},
-										File:   "v1.flux",
-										Source: "from(bucket: bucket)\n        |> range(start: start)",
-										Start: ast.Position{
-											Column: 5,
-											Line:   32,
-										},
-									},
-								},
-								Call: &ast.CallExpression{
-									Arguments: []ast.Expression{&ast.ObjectExpression{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 30,
-													Line:   33,
-												},
-												File:   "v1.flux",
-												Source: "start: start",
-												Start: ast.Position{
-													Column: 18,
-													Line:   33,
+										Callee: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 9,
+														Line:   32,
+													},
+													File:   "v1.flux",
+													Source: "from",
+													Start: ast.Position{
+														Column: 5,
+														Line:   32,
+													},
 												},
 											},
+											Name: "from",
 										},
-										Properties: []*ast.Property{&ast.Property{
+									},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 31,
+												Line:   33,
+											},
+											File:   "v1.flux",
+											Source: "from(bucket: bucket)\n        |> range(start: start)",
+											Start: ast.Position{
+												Column: 5,
+												Line:   32,
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Arguments: []ast.Expression{&ast.ObjectExpression{
 											BaseNode: ast.BaseNode{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
@@ -2225,25 +2210,7 @@ var pkgAST = &ast.Package{
 													},
 												},
 											},
-											Key: &ast.Identifier{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 23,
-															Line:   33,
-														},
-														File:   "v1.flux",
-														Source: "start",
-														Start: ast.Position{
-															Column: 18,
-															Line:   33,
-														},
-													},
-												},
-												Name: "start",
-											},
-											Value: &ast.Identifier{
+											Properties: []*ast.Property{&ast.Property{
 												BaseNode: ast.BaseNode{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
@@ -2252,85 +2219,103 @@ var pkgAST = &ast.Package{
 															Line:   33,
 														},
 														File:   "v1.flux",
-														Source: "start",
+														Source: "start: start",
 														Start: ast.Position{
-															Column: 25,
+															Column: 18,
 															Line:   33,
 														},
 													},
 												},
-												Name: "start",
-											},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 23,
+																Line:   33,
+															},
+															File:   "v1.flux",
+															Source: "start",
+															Start: ast.Position{
+																Column: 18,
+																Line:   33,
+															},
+														},
+													},
+													Name: "start",
+												},
+												Value: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 30,
+																Line:   33,
+															},
+															File:   "v1.flux",
+															Source: "start",
+															Start: ast.Position{
+																Column: 25,
+																Line:   33,
+															},
+														},
+													},
+													Name: "start",
+												},
+											}},
 										}},
-									}},
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 31,
-												Line:   33,
-											},
-											File:   "v1.flux",
-											Source: "range(start: start)",
-											Start: ast.Position{
-												Column: 12,
-												Line:   33,
-											},
-										},
-									},
-									Callee: &ast.Identifier{
 										BaseNode: ast.BaseNode{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 17,
+													Column: 31,
 													Line:   33,
 												},
 												File:   "v1.flux",
-												Source: "range",
+												Source: "range(start: start)",
 												Start: ast.Position{
 													Column: 12,
 													Line:   33,
 												},
 											},
 										},
-										Name: "range",
-									},
-								},
-							},
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 33,
-										Line:   34,
-									},
-									File:   "v1.flux",
-									Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)",
-									Start: ast.Position{
-										Column: 5,
-										Line:   32,
-									},
-								},
-							},
-							Call: &ast.CallExpression{
-								Arguments: []ast.Expression{&ast.ObjectExpression{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 32,
-												Line:   34,
+										Callee: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 17,
+														Line:   33,
+													},
+													File:   "v1.flux",
+													Source: "range",
+													Start: ast.Position{
+														Column: 12,
+														Line:   33,
+													},
+												},
 											},
-											File:   "v1.flux",
-											Source: "fn: predicate",
-											Start: ast.Position{
-												Column: 19,
-												Line:   34,
-											},
+											Name: "range",
 										},
 									},
-									Properties: []*ast.Property{&ast.Property{
+								},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   34,
+										},
+										File:   "v1.flux",
+										Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)",
+										Start: ast.Position{
+											Column: 5,
+											Line:   32,
+										},
+									},
+								},
+								Call: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
 										BaseNode: ast.BaseNode{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
@@ -2346,25 +2331,7 @@ var pkgAST = &ast.Package{
 												},
 											},
 										},
-										Key: &ast.Identifier{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 21,
-														Line:   34,
-													},
-													File:   "v1.flux",
-													Source: "fn",
-													Start: ast.Position{
-														Column: 19,
-														Line:   34,
-													},
-												},
-											},
-											Name: "fn",
-										},
-										Value: &ast.Identifier{
+										Properties: []*ast.Property{&ast.Property{
 											BaseNode: ast.BaseNode{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
@@ -2373,69 +2340,86 @@ var pkgAST = &ast.Package{
 														Line:   34,
 													},
 													File:   "v1.flux",
-													Source: "predicate",
+													Source: "fn: predicate",
 													Start: ast.Position{
-														Column: 23,
+														Column: 19,
 														Line:   34,
 													},
 												},
 											},
-											Name: "predicate",
-										},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 21,
+															Line:   34,
+														},
+														File:   "v1.flux",
+														Source: "fn",
+														Start: ast.Position{
+															Column: 19,
+															Line:   34,
+														},
+													},
+												},
+												Name: "fn",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 32,
+															Line:   34,
+														},
+														File:   "v1.flux",
+														Source: "predicate",
+														Start: ast.Position{
+															Column: 23,
+															Line:   34,
+														},
+													},
+												},
+												Name: "predicate",
+											},
+										}},
 									}},
-								}},
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 33,
-											Line:   34,
-										},
-										File:   "v1.flux",
-										Source: "filter(fn: predicate)",
-										Start: ast.Position{
-											Column: 12,
-											Line:   34,
-										},
-									},
-								},
-								Callee: &ast.Identifier{
 									BaseNode: ast.BaseNode{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 18,
+												Column: 33,
 												Line:   34,
 											},
 											File:   "v1.flux",
-											Source: "filter",
+											Source: "filter(fn: predicate)",
 											Start: ast.Position{
 												Column: 12,
 												Line:   34,
 											},
 										},
 									},
-									Name: "filter",
+									Callee: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 18,
+													Line:   34,
+												},
+												File:   "v1.flux",
+												Source: "filter",
+												Start: ast.Position{
+													Column: 12,
+													Line:   34,
+												},
+											},
+										},
+										Name: "filter",
+									},
 								},
 							},
-						},
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 18,
-									Line:   35,
-								},
-								File:   "v1.flux",
-								Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()",
-								Start: ast.Position{
-									Column: 5,
-									Line:   32,
-								},
-							},
-						},
-						Call: &ast.CallExpression{
-							Arguments: nil,
 							BaseNode: ast.BaseNode{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
@@ -2444,66 +2428,67 @@ var pkgAST = &ast.Package{
 										Line:   35,
 									},
 									File:   "v1.flux",
-									Source: "keys()",
+									Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()",
 									Start: ast.Position{
-										Column: 12,
-										Line:   35,
+										Column: 5,
+										Line:   32,
 									},
 								},
 							},
-							Callee: &ast.Identifier{
+							Call: &ast.CallExpression{
+								Arguments: nil,
 								BaseNode: ast.BaseNode{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 16,
+											Column: 18,
 											Line:   35,
 										},
 										File:   "v1.flux",
-										Source: "keys",
+										Source: "keys()",
 										Start: ast.Position{
 											Column: 12,
 											Line:   35,
 										},
 									},
 								},
-								Name: "keys",
-							},
-						},
-					},
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 37,
-								Line:   36,
-							},
-							File:   "v1.flux",
-							Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
-							Start: ast.Position{
-								Column: 5,
-								Line:   32,
-							},
-						},
-					},
-					Call: &ast.CallExpression{
-						Arguments: []ast.Expression{&ast.ObjectExpression{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 36,
-										Line:   36,
+								Callee: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 16,
+												Line:   35,
+											},
+											File:   "v1.flux",
+											Source: "keys",
+											Start: ast.Position{
+												Column: 12,
+												Line:   35,
+											},
+										},
 									},
-									File:   "v1.flux",
-									Source: "columns: [\"_value\"]",
-									Start: ast.Position{
-										Column: 17,
-										Line:   36,
-									},
+									Name: "keys",
 								},
 							},
-							Properties: []*ast.Property{&ast.Property{
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 37,
+									Line:   36,
+								},
+								File:   "v1.flux",
+								Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
+								Start: ast.Position{
+									Column: 5,
+									Line:   32,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
 								BaseNode: ast.BaseNode{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
@@ -2519,25 +2504,7 @@ var pkgAST = &ast.Package{
 										},
 									},
 								},
-								Key: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 24,
-												Line:   36,
-											},
-											File:   "v1.flux",
-											Source: "columns",
-											Start: ast.Position{
-												Column: 17,
-												Line:   36,
-											},
-										},
-									},
-									Name: "columns",
-								},
-								Value: &ast.ArrayExpression{
+								Properties: []*ast.Property{&ast.Property{
 									BaseNode: ast.BaseNode{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
@@ -2546,46 +2513,132 @@ var pkgAST = &ast.Package{
 												Line:   36,
 											},
 											File:   "v1.flux",
-											Source: "[\"_value\"]",
+											Source: "columns: [\"_value\"]",
 											Start: ast.Position{
-												Column: 26,
+												Column: 17,
 												Line:   36,
 											},
 										},
 									},
-									Elements: []ast.Expression{&ast.StringLiteral{
+									Key: &ast.Identifier{
 										BaseNode: ast.BaseNode{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 35,
+													Column: 24,
 													Line:   36,
 												},
 												File:   "v1.flux",
-												Source: "\"_value\"",
+												Source: "columns",
 												Start: ast.Position{
-													Column: 27,
+													Column: 17,
 													Line:   36,
 												},
 											},
 										},
-										Value: "_value",
-									}},
-								},
+										Name: "columns",
+									},
+									Value: &ast.ArrayExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 36,
+													Line:   36,
+												},
+												File:   "v1.flux",
+												Source: "[\"_value\"]",
+												Start: ast.Position{
+													Column: 26,
+													Line:   36,
+												},
+											},
+										},
+										Elements: []ast.Expression{&ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 35,
+														Line:   36,
+													},
+													File:   "v1.flux",
+													Source: "\"_value\"",
+													Start: ast.Position{
+														Column: 27,
+														Line:   36,
+													},
+												},
+											},
+											Value: "_value",
+										}},
+									},
+								}},
 							}},
-						}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 37,
+										Line:   36,
+									},
+									File:   "v1.flux",
+									Source: "keep(columns: [\"_value\"])",
+									Start: ast.Position{
+										Column: 12,
+										Line:   36,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 16,
+											Line:   36,
+										},
+										File:   "v1.flux",
+										Source: "keep",
+										Start: ast.Position{
+											Column: 12,
+											Line:   36,
+										},
+									},
+								},
+								Name: "keep",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 22,
+								Line:   37,
+							},
+							File:   "v1.flux",
+							Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+							Start: ast.Position{
+								Column: 5,
+								Line:   32,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: nil,
 						BaseNode: ast.BaseNode{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 37,
-									Line:   36,
+									Column: 22,
+									Line:   37,
 								},
 								File:   "v1.flux",
-								Source: "keep(columns: [\"_value\"])",
+								Source: "distinct()",
 								Start: ast.Position{
 									Column: 12,
-									Line:   36,
+									Line:   37,
 								},
 							},
 						},
@@ -2594,18 +2647,18 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 16,
-										Line:   36,
+										Column: 20,
+										Line:   37,
 									},
 									File:   "v1.flux",
-									Source: "keep",
+									Source: "distinct",
 									Start: ast.Position{
 										Column: 12,
-										Line:   36,
+										Line:   37,
 									},
 								},
 							},
-							Name: "keep",
+							Name: "distinct",
 						},
 					},
 				},
@@ -2830,13 +2883,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 77,
-						Line:   40,
+						Line:   41,
 					},
 					File:   "v1.flux",
 					Source: "measurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   39,
+						Line:   40,
 					},
 				},
 			},
@@ -2846,13 +2899,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 19,
-							Line:   39,
+							Line:   40,
 						},
 						File:   "v1.flux",
 						Source: "measurementTagKeys",
 						Start: ast.Position{
 							Column: 1,
-							Line:   39,
+							Line:   40,
 						},
 					},
 				},
@@ -2864,13 +2917,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 77,
-							Line:   40,
+							Line:   41,
 						},
 						File:   "v1.flux",
 						Source: "(bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 						Start: ast.Position{
 							Column: 22,
-							Line:   39,
+							Line:   40,
 						},
 					},
 				},
@@ -2881,13 +2934,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 76,
-									Line:   40,
+									Line:   41,
 								},
 								File:   "v1.flux",
 								Source: "bucket: bucket, predicate: (r) => r._measurement == measurement",
 								Start: ast.Position{
 									Column: 13,
-									Line:   40,
+									Line:   41,
 								},
 							},
 						},
@@ -2897,13 +2950,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 27,
-										Line:   40,
+										Line:   41,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 13,
-										Line:   40,
+										Line:   41,
 									},
 								},
 							},
@@ -2913,13 +2966,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 19,
-											Line:   40,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 13,
-											Line:   40,
+											Line:   41,
 										},
 									},
 								},
@@ -2931,13 +2984,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 27,
-											Line:   40,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 21,
-											Line:   40,
+											Line:   41,
 										},
 									},
 								},
@@ -2949,13 +3002,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 76,
-										Line:   40,
+										Line:   41,
 									},
 									File:   "v1.flux",
 									Source: "predicate: (r) => r._measurement == measurement",
 									Start: ast.Position{
 										Column: 29,
-										Line:   40,
+										Line:   41,
 									},
 								},
 							},
@@ -2965,13 +3018,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 38,
-											Line:   40,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "predicate",
 										Start: ast.Position{
 											Column: 29,
-											Line:   40,
+											Line:   41,
 										},
 									},
 								},
@@ -2983,13 +3036,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 76,
-											Line:   40,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "(r) => r._measurement == measurement",
 										Start: ast.Position{
 											Column: 40,
-											Line:   40,
+											Line:   41,
 										},
 									},
 								},
@@ -2999,13 +3052,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 76,
-												Line:   40,
+												Line:   41,
 											},
 											File:   "v1.flux",
 											Source: "r._measurement == measurement",
 											Start: ast.Position{
 												Column: 47,
-												Line:   40,
+												Line:   41,
 											},
 										},
 									},
@@ -3015,13 +3068,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 61,
-													Line:   40,
+													Line:   41,
 												},
 												File:   "v1.flux",
 												Source: "r._measurement",
 												Start: ast.Position{
 													Column: 47,
-													Line:   40,
+													Line:   41,
 												},
 											},
 										},
@@ -3031,13 +3084,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   40,
+														Line:   41,
 													},
 													File:   "v1.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   40,
+														Line:   41,
 													},
 												},
 											},
@@ -3049,13 +3102,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 61,
-														Line:   40,
+														Line:   41,
 													},
 													File:   "v1.flux",
 													Source: "_measurement",
 													Start: ast.Position{
 														Column: 49,
-														Line:   40,
+														Line:   41,
 													},
 												},
 											},
@@ -3069,13 +3122,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 76,
-													Line:   40,
+													Line:   41,
 												},
 												File:   "v1.flux",
 												Source: "measurement",
 												Start: ast.Position{
 													Column: 65,
-													Line:   40,
+													Line:   41,
 												},
 											},
 										},
@@ -3088,13 +3141,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   40,
+												Line:   41,
 											},
 											File:   "v1.flux",
 											Source: "r",
 											Start: ast.Position{
 												Column: 41,
-												Line:   40,
+												Line:   41,
 											},
 										},
 									},
@@ -3104,13 +3157,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 42,
-													Line:   40,
+													Line:   41,
 												},
 												File:   "v1.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 41,
-													Line:   40,
+													Line:   41,
 												},
 											},
 										},
@@ -3126,13 +3179,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 77,
-								Line:   40,
+								Line:   41,
 							},
 							File:   "v1.flux",
 							Source: "tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   40,
+								Line:   41,
 							},
 						},
 					},
@@ -3142,13 +3195,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 12,
-									Line:   40,
+									Line:   41,
 								},
 								File:   "v1.flux",
 								Source: "tagKeys",
 								Start: ast.Position{
 									Column: 5,
-									Line:   40,
+									Line:   41,
 								},
 							},
 						},
@@ -3161,13 +3214,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 29,
-								Line:   39,
+								Line:   40,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 23,
-								Line:   39,
+								Line:   40,
 							},
 						},
 					},
@@ -3177,13 +3230,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   39,
+									Line:   40,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 23,
-									Line:   39,
+									Line:   40,
 								},
 							},
 						},
@@ -3196,13 +3249,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 42,
-								Line:   39,
+								Line:   40,
 							},
 							File:   "v1.flux",
 							Source: "measurement",
 							Start: ast.Position{
 								Column: 31,
-								Line:   39,
+								Line:   40,
 							},
 						},
 					},
@@ -3212,13 +3265,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 42,
-									Line:   39,
+									Line:   40,
 								},
 								File:   "v1.flux",
 								Source: "measurement",
 								Start: ast.Position{
 									Column: 31,
-									Line:   39,
+									Line:   40,
 								},
 							},
 						},
@@ -3233,13 +3286,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 51,
-						Line:   44,
+						Line:   45,
 					},
 					File:   "v1.flux",
 					Source: "measurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 					Start: ast.Position{
 						Column: 1,
-						Line:   43,
+						Line:   44,
 					},
 				},
 			},
@@ -3249,13 +3302,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   43,
+							Line:   44,
 						},
 						File:   "v1.flux",
 						Source: "measurements",
 						Start: ast.Position{
 							Column: 1,
-							Line:   43,
+							Line:   44,
 						},
 					},
 				},
@@ -3267,13 +3320,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 51,
-							Line:   44,
+							Line:   45,
 						},
 						File:   "v1.flux",
 						Source: "(bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 						Start: ast.Position{
 							Column: 16,
-							Line:   43,
+							Line:   44,
 						},
 					},
 				},
@@ -3284,13 +3337,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 50,
-									Line:   44,
+									Line:   45,
 								},
 								File:   "v1.flux",
 								Source: "bucket: bucket, tag: \"_measurement\"",
 								Start: ast.Position{
 									Column: 15,
-									Line:   44,
+									Line:   45,
 								},
 							},
 						},
@@ -3300,13 +3353,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 29,
-										Line:   44,
+										Line:   45,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 15,
-										Line:   44,
+										Line:   45,
 									},
 								},
 							},
@@ -3316,13 +3369,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   44,
+											Line:   45,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 15,
-											Line:   44,
+											Line:   45,
 										},
 									},
 								},
@@ -3334,13 +3387,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   44,
+											Line:   45,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 23,
-											Line:   44,
+											Line:   45,
 										},
 									},
 								},
@@ -3352,13 +3405,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 50,
-										Line:   44,
+										Line:   45,
 									},
 									File:   "v1.flux",
 									Source: "tag: \"_measurement\"",
 									Start: ast.Position{
 										Column: 31,
-										Line:   44,
+										Line:   45,
 									},
 								},
 							},
@@ -3368,13 +3421,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 34,
-											Line:   44,
+											Line:   45,
 										},
 										File:   "v1.flux",
 										Source: "tag",
 										Start: ast.Position{
 											Column: 31,
-											Line:   44,
+											Line:   45,
 										},
 									},
 								},
@@ -3386,13 +3439,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 50,
-											Line:   44,
+											Line:   45,
 										},
 										File:   "v1.flux",
 										Source: "\"_measurement\"",
 										Start: ast.Position{
 											Column: 36,
-											Line:   44,
+											Line:   45,
 										},
 									},
 								},
@@ -3405,13 +3458,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 51,
-								Line:   44,
+								Line:   45,
 							},
 							File:   "v1.flux",
 							Source: "tagValues(bucket: bucket, tag: \"_measurement\")",
 							Start: ast.Position{
 								Column: 5,
-								Line:   44,
+								Line:   45,
 							},
 						},
 					},
@@ -3421,13 +3474,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   44,
+									Line:   45,
 								},
 								File:   "v1.flux",
 								Source: "tagValues",
 								Start: ast.Position{
 									Column: 5,
-									Line:   44,
+									Line:   45,
 								},
 							},
 						},
@@ -3440,13 +3493,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 23,
-								Line:   43,
+								Line:   44,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 17,
-								Line:   43,
+								Line:   44,
 							},
 						},
 					},
@@ -3456,13 +3509,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 23,
-									Line:   43,
+									Line:   44,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 17,
-									Line:   43,
+									Line:   44,
 								},
 							},
 						},

--- a/stdlib/influxdata/influxdb/v1/v1.flux
+++ b/stdlib/influxdata/influxdb/v1/v1.flux
@@ -34,6 +34,7 @@ tagKeys = (bucket, predicate=(r) => true, start=-30d) =>
         |> filter(fn: predicate)
         |> keys()
         |> keep(columns: ["_value"])
+        |> distinct()
 
 // MeasurementTagKeys returns the list of tag keys for a specific measurement.
 measurementTagKeys = (bucket, measurement) =>


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [ ] Test cases written

The full chain is to look only at distinct keys. This seems to have not
been included. This changes `v1.tagKeys()` to include `distinct()` at the
end.