### PR TITLE
fix(control): enforce memory and concurrency limits in controller

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -42,7 +42,10 @@ func execute(cmd *cobra.Command, args []string) error {
 		Query: script,
 	}
 
-	querier := NewQuerier()
+	querier, err := NewQuerier()
+	if err != nil {
+		return err
+	}
 	result, err := querier.Query(context.Background(), c)
 	if err != nil {
 		return err

--- a/control/controller.go
+++ b/control/controller.go
@@ -37,11 +37,17 @@ import (
 // Controller provides a central location to manage all incoming queries.
 // The controller is responsible for compiling, queueing, and executing queries.
 type Controller struct {
-	lastID    uint64
-	queriesMu sync.RWMutex
-	queries   map[QueryID]*Query
-	shutdown  bool
-	done      chan struct{}
+	lastID     uint64
+	queriesMu  sync.RWMutex
+	queries    map[QueryID]*Query
+	queryQueue chan *Query
+	wg         sync.WaitGroup
+	shutdown   bool
+	done       chan struct{}
+	abortOnce  sync.Once
+	abort      chan struct{}
+
+	memoryBytesQuotaPerQuery int64
 
 	metrics   *controllerMetrics
 	labelKeys []string
@@ -52,11 +58,18 @@ type Controller struct {
 }
 
 type Config struct {
-	// TODO(jsternberg): Integrate the concurrency and memory bytes quotas.
-	ConcurrencyQuota         int
-	MemoryBytesQuota         int64
+	// ConcurrencyQuota is the number of queries that are allowed to execute concurrently.
+	ConcurrencyQuota int
+	// MemoryBytesQuotaPerQuery is the maximum number of bytes (in table memory) a query is allowed to use at
+	// any given time.
+	//
+	// The maximum amount of memory the controller is allowed to consume is
+	//   ConcurrencyQuota * MemoryBytesQuotaPerQuery
 	MemoryBytesQuotaPerQuery int64
-	Logger                   *zap.Logger
+	// QueueSize is the number of queries that are allowed to be awaiting execution before new queries are
+	// rejected.
+	QueueSize int
+	Logger    *zap.Logger
 	// MetricLabelKeys is a list of labels to add to the metrics produced by the controller.
 	// The value for a given key will be read off the context.
 	// The context value must be a string or an implementation of the Stringer interface.
@@ -65,22 +78,48 @@ type Config struct {
 	ExecutorDependencies execute.Dependencies
 }
 
+func (c *Config) Validate() error {
+	if c.ConcurrencyQuota <= 0 {
+		return errors.New("ConcurrencyQuota must be positive")
+	}
+	if c.MemoryBytesQuotaPerQuery <= 0 {
+		return errors.New("MemoryBytesQuotaPerQuery must be positive")
+	}
+	if c.QueueSize <= 0 {
+		return errors.New("QueueSize must be positive")
+	}
+	return nil
+}
+
 type QueryID uint64
 
-func New(c Config) *Controller {
+func New(c Config) (*Controller, error) {
+	if err := c.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid controller config")
+	}
 	logger := c.Logger
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	ctrl := &Controller{
-		queries:      make(map[QueryID]*Query),
-		done:         make(chan struct{}),
-		logger:       logger,
-		metrics:      newControllerMetrics(c.MetricLabelKeys),
-		labelKeys:    c.MetricLabelKeys,
-		dependencies: c.ExecutorDependencies,
+		queries:                  make(map[QueryID]*Query),
+		queryQueue:               make(chan *Query, c.QueueSize),
+		done:                     make(chan struct{}),
+		abort:                    make(chan struct{}),
+		memoryBytesQuotaPerQuery: c.MemoryBytesQuotaPerQuery,
+		logger:                   logger,
+		metrics:                  newControllerMetrics(c.MetricLabelKeys),
+		labelKeys:                c.MetricLabelKeys,
+		dependencies:             c.ExecutorDependencies,
 	}
-	return ctrl
+	ctrl.wg.Add(c.ConcurrencyQuota)
+	for i := 0; i < c.ConcurrencyQuota; i++ {
+		go func() {
+			defer ctrl.wg.Done()
+			ctrl.processQueryQueue()
+		}()
+	}
+	return ctrl, nil
 }
 
 // Query submits a query for execution returning immediately.
@@ -204,32 +243,46 @@ func (c *Controller) enqueueQuery(q *Query) error {
 		return errors.New("failed to transition query to queueing state")
 	}
 
-	// TODO(jsternberg): We should have a real queue! It should only
-	// start the query when we know we have a minimum amount of memory
-	// available and at least one goroutine we can use. Since we don't
-	// implement a queue at the moment, the rest just fakes it by
-	// immediately switching to the execute state and then calling
-	// start which should start the query in a new goroutine and return
-	// the underlying results.
-	return c.executeQuery(q)
-}
-
-func (c *Controller) executeQuery(q *Query) error {
-	ctx, ok := q.tryExec()
-	if !ok {
-		return errors.New("failed to transition query into executing state")
+	select {
+	case c.queryQueue <- q:
+	default:
+		return errors.New("queue length exceeded")
 	}
 
-	// TODO(jsternberg): Introduce memory restrictions.
+	return nil
+}
+
+func (c *Controller) processQueryQueue() {
+	for {
+		select {
+		case <-c.done:
+			return
+		case q := <-c.queryQueue:
+			c.executeQuery(q)
+		}
+	}
+}
+
+func (c *Controller) executeQuery(q *Query) {
+	ctx, ok := q.tryExec()
+	if !ok {
+		// This may happen if the query was cancelled (either because the
+		// client cancelled it, or because the controller is shutting down)
+		// In the case of cancellation, SetErr() should reset the error to an
+		// appropriate message.
+		q.setErr(errors.New("impossible state transition"))
+		return
+	}
+
 	q.alloc = new(memory.Allocator)
+	q.alloc.Limit = func(v int64) *int64 { return &v }(c.memoryBytesQuotaPerQuery)
 	exec, err := q.program.Start(ctx, q.alloc)
 	if err != nil {
 		q.setErr(err)
-		return nil
+		return
 	}
 	q.exec = exec
-	go q.pump(exec, ctx.Done())
-	return nil
+	q.pump(exec, ctx.Done())
 }
 
 func (c *Controller) finish(q *Query) {
@@ -274,12 +327,18 @@ func (c *Controller) Shutdown(ctx context.Context) error {
 	}
 	c.queriesMu.RUnlock()
 
+	// Wait for query processing goroutines to finish.
+	defer c.wg.Wait()
+
 	// Wait for all of the queries to be cleaned up or until the
 	// context is done.
 	select {
 	case <-c.done:
 		return nil
 	case <-ctx.Done():
+		c.abortOnce.Do(func() {
+			close(c.abort)
+		})
 		return ctx.Err()
 	}
 }
@@ -562,6 +621,10 @@ func (q *Query) pump(exec flux.Query, done <-chan struct{}) {
 			// Set the done channel to nil so we don't do this again
 			// and we continue to drain the results.
 			signalCh = nil
+		case <-q.c.abort:
+			// If we get here, then any running queries should have been cancelled
+			// in controller.Shutdown().
+			return
 		}
 	}
 }

--- a/examples/library/library_example_test.go
+++ b/examples/library/library_example_test.go
@@ -30,7 +30,10 @@ g.from(start: 1993-02-16T00:00:00Z, stop: 1993-02-16T00:03:00Z, count: 5, fn: (n
 		AST: astPkg,
 	}
 
-	querier := cmd.NewQuerier()
+	querier, err := cmd.NewQuerier()
+	if err != nil {
+		panic(err)
+	}
 
 	results, err := querier.Query(ctx, compiler)
 	if err != nil {

--- a/mock/program.go
+++ b/mock/program.go
@@ -24,6 +24,7 @@ func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Quer
 			q := &Query{
 				ResultsCh: results,
 				CancelFn:  cancel,
+				Canceled:  make(chan struct{}),
 			}
 			go func() {
 				defer close(results)

--- a/querytest/execute.go
+++ b/querytest/execute.go
@@ -28,12 +28,18 @@ func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flu
 
 func NewQuerier() *Querier {
 	config := control.Config{
-		ConcurrencyQuota: 1,
-		MemoryBytesQuota: math.MaxInt64,
+		ConcurrencyQuota:         1,
+		MemoryBytesQuotaPerQuery: math.MaxInt64,
+		QueueSize:                1,
+	}
+
+	ctrl, err := control.New(config)
+	if err != nil {
+		panic(err)
 	}
 
 	// Because this is for use in test, ensure that consumers properly clean up queries.
-	c := controltest.New(control.New(config))
+	c := controltest.New(ctrl)
 
 	return &Querier{
 		C: c,


### PR DESCRIPTION
This set of changes adds three tunable "knobs" to the Flux controller:
- ConcurrencyQuota
- MemoryBytesQuotaPerQuery
- QueueSize

And also adds unit tests that ensure that these parameters are enforced.  This should address the OOMs being observed in queryd.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
