### PR TITLE
fix(stdlib/universe): fix reducer so that it resets the reduce value to the neutral element value for each new group key, and report an error when two reducers write to the same destination group key.

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2070,7 +2070,7 @@ from(bucket:"telegraf/autogen")
 #### Reduce
 Reduce aggregates records in each table according to the reducer `fn`.  The output for each table will be the group key of the table, plus columns corresponding to each field in the reducer object.  
 
-If the reducer record contains a column with the same name as a group key column, then the group key column's value is overwritten and the the resulting record is regrouped into the appropriate table.
+If the reducer record contains a column with the same name as a group key column, then the group key column's value is overwritten, and the outgoing group key is changed.  However, if two reduced tables write to the same destination group key, then the function will error.
 
 Reduce has the following properties:
 

--- a/stdlib/testing/testdata/reduce.flux
+++ b/stdlib/testing/testdata/reduce.flux
@@ -15,6 +15,9 @@ inData = "
 ,,3,2018-05-22T19:53:56Z,1,used_percent,swap,host.local
 ,,3,2018-05-22T19:54:06Z,1,used_percent,swap,host.local
 ,,3,2018-05-22T19:54:16Z,1,used_percent,swap,host.local
+,,4,2018-05-22T19:53:26Z,1,used_percent,swap,host.local2
+,,4,2018-05-22T19:53:36Z,1,used_percent,swap,host.local2
+,,4,2018-05-22T19:53:46Z,1,used_percent,swap,host.local2
 "
 outData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double
@@ -22,6 +25,7 @@ outData = "
 #default,got,,,,,,,
 ,result,table,_start,_stop,_field,_measurement,host,sum
 ,,0,2018-05-21T13:09:22.885021542Z,2030-01-01T00:00:00Z,used_percent,swap,host.local,6
+,,1,2018-05-21T13:09:22.885021542Z,2030-01-01T00:00:00Z,used_percent,swap,host.local2,3
 "
 t_reduce = (table=<-) =>
 	(table


### PR DESCRIPTION


fixes #1200 

### Done checklist
- [X] docs/SPEC.md updated
- [X] Test cases written
