### PR TITLE
fix(execute): properly use RefCount to reference count tables

### DIFF
--- a/execute/dataset.go
+++ b/execute/dataset.go
@@ -136,7 +136,6 @@ func (d *dataset) triggerTable(key flux.GroupKey) error {
 	if err != nil {
 		return err
 	}
-	b.RefCount(len(d.ts))
 	switch d.accMode {
 	case DiscardingMode:
 		for _, t := range d.ts {

--- a/execute/result.go
+++ b/execute/result.go
@@ -42,6 +42,7 @@ func (s *result) RetractTable(DatasetID, flux.GroupKey) error {
 }
 
 func (s *result) Process(id DatasetID, tbl flux.Table) error {
+	tbl.RefCount(1)
 	select {
 	case s.tables <- resultMessage{
 		table: tbl,
@@ -68,8 +69,10 @@ func (s *result) Do(f func(flux.Table) error) error {
 				return msg.err
 			}
 			if err := f(msg.table); err != nil {
+				msg.table.RefCount(-1)
 				return err
 			}
+			msg.table.RefCount(-1)
 		}
 	}
 }

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -68,6 +68,7 @@ func (t *consecutiveTransport) RetractTable(id DatasetID, key flux.GroupKey) err
 }
 
 func (t *consecutiveTransport) Process(id DatasetID, tbl flux.Table) error {
+	tbl.RefCount(1)
 	select {
 	case <-t.finished:
 		return t.err()


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The consecutive transport and the result both use goroutines to process
the tables and so need to have their own references to the tables. But,
previously, the dataset was the only one that increased the reference
count even though there was no guarantee it was using the consecutive
transport and no guarantee that the reference count would be
decremented.

This modifies these two areas so that the reference count is increased
on the call to `Process()` to signal that it will keep a reference to
the table and then it decrements the reference count after it discards
its usage of the table.