### PR TITLE
fix(arrow): preallocate data when constructing a new string array

### DIFF
--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestSum_Float64_Empty(t *testing.T) {
-	t.Skip("https://issues.apache.org/jira/browse/ARROW-4081")
-
 	b := array.NewFloat64Builder(arrowmemory.NewGoAllocator())
 	vs := b.NewFloat64Array()
 	b.Release()
@@ -29,8 +27,6 @@ func TestSum_Float64_Empty(t *testing.T) {
 }
 
 func TestSum_Int64_Empty(t *testing.T) {
-	t.Skip("https://issues.apache.org/jira/browse/ARROW-4081")
-
 	b := array.NewInt64Builder(arrowmemory.NewGoAllocator())
 	vs := b.NewInt64Array()
 	b.Release()
@@ -47,8 +43,6 @@ func TestSum_Int64_Empty(t *testing.T) {
 }
 
 func TestSum_Uint64_Empty(t *testing.T) {
-	t.Skip("https://issues.apache.org/jira/browse/ARROW-4081")
-
 	b := array.NewUint64Builder(arrowmemory.NewGoAllocator())
 	vs := b.NewUint64Array()
 	b.Release()

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -10,6 +10,11 @@ import (
 func NewString(vs []string, alloc *memory.Allocator) *array.Binary {
 	b := NewStringBuilder(alloc)
 	b.Reserve(len(vs))
+	sz := 0
+	for _, v := range vs {
+		sz += len(v)
+	}
+	b.ReserveData(sz)
 	for _, v := range vs {
 		b.AppendString(v)
 	}

--- a/execute/table.go
+++ b/execute/table.go
@@ -1840,6 +1840,14 @@ func (c *stringColumnBuilder) Copy() column {
 	if len(c.nils) > 0 {
 		b := arrow.NewStringBuilder(c.alloc.Allocator)
 		b.Reserve(len(c.data))
+		sz := 0
+		for i, v := range c.data {
+			if c.nils[i] {
+				continue
+			}
+			sz += len(v)
+		}
+		b.ReserveData(sz)
 		for i, v := range c.data {
 			if c.nils[i] {
 				b.AppendNull()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/semver v1.4.2
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
-	github.com/apache/arrow/go/arrow v0.0.0-20190107214733-134081bea48d
+	github.com/apache/arrow/go/arrow v0.0.0-20190426170622-338c62a2a205
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/c-bata/go-prompt v0.2.2
 	github.com/cespare/xxhash v1.1.0
@@ -22,7 +22,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
-	github.com/pkg/errors v0.8.0
+	github.com/pkg/errors v0.8.1
 	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 // indirect
 	github.com/prometheus/client_golang v0.0.0-20171201122222-661e31bf844d
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/apache/arrow/go/arrow v0.0.0-20190107214733-134081bea48d h1:YeyuRFfB3L0OeTishYaVDXN8ZjsmW//+xLkZ7N95nVg=
-github.com/apache/arrow/go/arrow v0.0.0-20190107214733-134081bea48d/go.mod h1:GjvccvtI06FGFvRU1In/maF7tKp3h7GBV9Sexo5rNPM=
+github.com/apache/arrow/go/arrow v0.0.0-20190426170622-338c62a2a205 h1:Q3Yr8G0gJVzxRCjt4lehWEGi+oG1ebN495o/mmh4Zss=
+github.com/apache/arrow/go/arrow v0.0.0-20190426170622-338c62a2a205/go.mod h1:W8yIftLTH1FLJvxuZc4tFnIlZ2tWg7RCoJR1HcETAso=
 github.com/apex/log v1.1.0 h1:J5rld6WVFi6NxA6m8GJ1LJqu3+GiTFIt3mYv27gdQWI=
 github.com/apex/log v1.1.0/go.mod h1:yA770aXIDQrhVOIGurT/pVdfCpSq1GQV/auzMN5fzvY=
 github.com/aws/aws-sdk-go v1.15.64 h1:xI5HhxebTF+jVqVOraUDqI3kr24n+yTvslwZCo3OhGA=
@@ -53,6 +53,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/flatbuffers v1.10.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -109,6 +110,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 h1:tFwafIEMf0B7NlcxV/zJ6leBIa81D3hgGSgsE5hCkOQ=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/stdlib/universe/mean.go
+++ b/stdlib/universe/mean.go
@@ -108,7 +108,6 @@ func (a *MeanAgg) NewStringAgg() execute.DoStringAgg {
 }
 
 func (a *MeanAgg) DoInt(vs *array.Int64) {
-	// https://issues.apache.org/jira/browse/ARROW-4081
 	if l := vs.Len() - vs.NullN(); l > 0 {
 		a.count += int64(l)
 		if vs.NullN() == 0 {
@@ -123,7 +122,6 @@ func (a *MeanAgg) DoInt(vs *array.Int64) {
 	}
 }
 func (a *MeanAgg) DoUInt(vs *array.Uint64) {
-	// https://issues.apache.org/jira/browse/ARROW-4081
 	if l := vs.Len() - vs.NullN(); l > 0 {
 		a.count += int64(l)
 		if vs.NullN() == 0 {
@@ -138,7 +136,6 @@ func (a *MeanAgg) DoUInt(vs *array.Uint64) {
 	}
 }
 func (a *MeanAgg) DoFloat(vs *array.Float64) {
-	// https://issues.apache.org/jira/browse/ARROW-4081
 	if l := vs.Len() - vs.NullN(); l > 0 {
 		a.count += int64(l)
 		if vs.NullN() == 0 {

--- a/stdlib/universe/sum.go
+++ b/stdlib/universe/sum.go
@@ -114,7 +114,6 @@ type SumIntAgg struct {
 }
 
 func (a *SumIntAgg) DoInt(vs *array.Int64) {
-	// https://issues.apache.org/jira/browse/ARROW-4081
 	if l := vs.Len() - vs.NullN(); l > 0 {
 		if vs.NullN() == 0 {
 			a.sum += math.Int64.Sum(vs)
@@ -145,7 +144,6 @@ type SumUIntAgg struct {
 }
 
 func (a *SumUIntAgg) DoUInt(vs *array.Uint64) {
-	// https://issues.apache.org/jira/browse/ARROW-4081
 	if l := vs.Len() - vs.NullN(); l > 0 {
 		if vs.NullN() == 0 {
 			a.sum += math.Uint64.Sum(vs)
@@ -176,7 +174,6 @@ type SumFloatAgg struct {
 }
 
 func (a *SumFloatAgg) DoFloat(vs *array.Float64) {
-	// https://issues.apache.org/jira/browse/ARROW-4081
 	if l := vs.Len() - vs.NullN(); l > 0 {
 		if vs.NullN() == 0 {
 			a.sum += math.Float64.Sum(vs)


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The string array data would not be preallocated which could lead to a
lot of allocations that lead to cruft for the garbage collector. This
fixes the most common helpers where we allocate string arrays to use the
new `ReserveData(int)` call to preallocate the buffer for the string
data.

Fixes #1209.