### PR TITLE
fix(stdlib/universe): an error when joining could result in two calls to finish

### DIFF
--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -29,6 +29,9 @@ type Table struct {
 	// Data is a list of rows, i.e. Data[row][col]
 	// Each row must be a list with length equal to len(ColMeta)
 	Data [][]interface{}
+	// Err contains the error that should be returned
+	// by this table when calling Do.
+	Err error
 }
 
 // Normalize ensures all fields of the table are set correctly.
@@ -79,6 +82,10 @@ func (t *Table) Key() flux.GroupKey {
 }
 
 func (t *Table) Do(f func(flux.ColReader) error) error {
+	if t.Err != nil {
+		return t.Err
+	}
+
 	cols := make([]array.Interface, len(t.ColMeta))
 	for j, col := range t.ColMeta {
 		switch col.Type {


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

When an error occurred in one of the two datasets that compromised a
join, this error would cause `Finish()` to be called even when there
were more tables to process. This meant that the second call to
`Finish()` would cause a panic in some implementations because
`Finish()` is only supposed to be called a maximum of once.

The test for join never called `Finish()` as part of the test so that
has been added to ensure the correct functionality.

Along with that, an error when processing the table would be discarded
except in the case where a join was happening on a null group key. So
many possible errors were never even detected.