### PR TITLE
fix(execute): return the error from the context in the executor

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -297,7 +297,7 @@ func (es *executionState) do(ctx context.Context) {
 			select {
 			case <-t.Finished():
 			case <-ctx.Done():
-				es.abort(errors.New("context done"))
+				es.abort(ctx.Err())
 			case err := <-es.dispatcher.Err():
 				if err != nil {
 					es.abort(err)


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

When a query has had its context canceled, the query should abort with
the error contained within the context instead of swallowing the error
and returning `context done` as the error.