### PR TITLE
refactor(stdlib/universe): convert last to index selector

### DIFF
--- a/stdlib/universe/last.go
+++ b/stdlib/universe/last.go
@@ -74,7 +74,7 @@ func (s *LastProcedureSpec) TriggerSpec() plan.TriggerSpec {
 }
 
 type LastSelector struct {
-	rows []execute.Row
+	selected bool
 }
 
 func createLastTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
@@ -82,63 +82,63 @@ func createLastTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
 	}
-	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(LastSelector), ps.SelectorConfig, a.Allocator())
+	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, new(LastSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil
 }
 
 func (s *LastSelector) reset() {
-	s.rows = nil
+	s.selected = false
 }
-func (s *LastSelector) NewBoolSelector() execute.DoBoolRowSelector {
+func (s *LastSelector) NewBoolSelector() execute.DoBoolIndexSelector {
 	s.reset()
 	return s
 }
 
-func (s *LastSelector) NewIntSelector() execute.DoIntRowSelector {
+func (s *LastSelector) NewIntSelector() execute.DoIntIndexSelector {
 	s.reset()
 	return s
 }
 
-func (s *LastSelector) NewUIntSelector() execute.DoUIntRowSelector {
+func (s *LastSelector) NewUIntSelector() execute.DoUIntIndexSelector {
 	s.reset()
 	return s
 }
 
-func (s *LastSelector) NewFloatSelector() execute.DoFloatRowSelector {
+func (s *LastSelector) NewFloatSelector() execute.DoFloatIndexSelector {
 	s.reset()
 	return s
 }
 
-func (s *LastSelector) NewStringSelector() execute.DoStringRowSelector {
+func (s *LastSelector) NewStringSelector() execute.DoStringIndexSelector {
 	s.reset()
 	return s
 }
 
-func (s *LastSelector) Rows() []execute.Row {
-	return s.rows
-}
-
-func (s *LastSelector) selectLast(vs array.Interface, cr flux.ColReader) {
-	for i := vs.Len() - 1; i >= 0; i-- {
-		if !vs.IsNull(i) {
-			s.rows = []execute.Row{execute.ReadRow(i, cr)}
-			return
+func (s *LastSelector) selectLast(vs array.Interface) []int {
+	if !s.selected {
+		sz := vs.Len()
+		for i := sz - 1; i >= 0; i-- {
+			if !vs.IsNull(i) {
+				s.selected = true
+				return []int{i}
+			}
 		}
 	}
+	return nil
 }
 
-func (s *LastSelector) DoBool(vs *array.Boolean, cr flux.ColReader) {
-	s.selectLast(vs, cr)
+func (s *LastSelector) DoBool(vs *array.Boolean) []int {
+	return s.selectLast(vs)
 }
-func (s *LastSelector) DoInt(vs *array.Int64, cr flux.ColReader) {
-	s.selectLast(vs, cr)
+func (s *LastSelector) DoInt(vs *array.Int64) []int {
+	return s.selectLast(vs)
 }
-func (s *LastSelector) DoUInt(vs *array.Uint64, cr flux.ColReader) {
-	s.selectLast(vs, cr)
+func (s *LastSelector) DoUInt(vs *array.Uint64) []int {
+	return s.selectLast(vs)
 }
-func (s *LastSelector) DoFloat(vs *array.Float64, cr flux.ColReader) {
-	s.selectLast(vs, cr)
+func (s *LastSelector) DoFloat(vs *array.Float64) []int {
+	return s.selectLast(vs)
 }
-func (s *LastSelector) DoString(vs *array.Binary, cr flux.ColReader) {
-	s.selectLast(vs, cr)
+func (s *LastSelector) DoString(vs *array.Binary) []int {
+	return s.selectLast(vs)
 }

--- a/stdlib/universe/last_test.go
+++ b/stdlib/universe/last_test.go
@@ -28,7 +28,7 @@ func TestLast_Process(t *testing.T) {
 	testCases := []struct {
 		name string
 		data *executetest.Table
-		want []execute.Row
+		want [][]int
 	}{
 		{
 			name: "last",
@@ -53,9 +53,7 @@ func TestLast_Process(t *testing.T) {
 					{execute.Time(90), 7.0, "a", "x"},
 				},
 			},
-			want: []execute.Row{{
-				Values: []interface{}{execute.Time(90), 7.0, "a", "x"},
-			}},
+			want: [][]int{{9}},
 		},
 		{
 			name: "with null",
@@ -80,15 +78,13 @@ func TestLast_Process(t *testing.T) {
 					{execute.Time(90), nil, "a", "x"},
 				},
 			},
-			want: []execute.Row{{
-				Values: []interface{}{execute.Time(80), 3.0, "a", "y"},
-			}},
+			want: [][]int{{8}},
 		},
 	}
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			executetest.RowSelectorFuncTestHelper(
+			executetest.IndexSelectorFuncTestHelper(
 				t,
 				new(universe.LastSelector),
 				tc.data,
@@ -99,5 +95,5 @@ func TestLast_Process(t *testing.T) {
 }
 
 func BenchmarkLast(b *testing.B) {
-	executetest.RowSelectorFuncBenchmarkHelper(b, new(universe.LastSelector), NormalTable)
+	executetest.IndexSelectorFuncBenchmarkHelper(b, new(universe.LastSelector), NormalTable)
 }


### PR DESCRIPTION
I was looking at the implementation of first and last, and I noticed
that first was an index selector while last was a row selector. It
seemed strange that they weren't a nearly identical implementation. Now
they are both index selectors, which improved the benchmarks for last:

```
name    old time/op    new time/op    delta
Last-4     395ns ± 6%     262ns ±13%  -33.61%  (p=0.000 n=8+8)

name    old alloc/op   new alloc/op   delta
Last-4      224B ± 0%      185B ± 0%  -17.41%  (p=0.000 n=8+8)

name    old allocs/op  new allocs/op  delta
Last-4      9.00 ± 0%      2.00 ± 0%  -77.78%  (p=0.000 n=8+8)
```