### PR TITLE
test(universe): use multiple column readers to iterate over tables

### DIFF
--- a/stdlib/universe/last_test.go
+++ b/stdlib/universe/last_test.go
@@ -91,7 +91,9 @@ func TestLast_Process(t *testing.T) {
 			executetest.RowSelectorFuncTestHelper(
 				t,
 				new(universe.LastSelector),
-				tc.data,
+				&executetest.RowWiseTable{
+					Table: tc.data,
+				},
 				tc.want,
 			)
 		})

--- a/stdlib/universe/max_test.go
+++ b/stdlib/universe/max_test.go
@@ -145,7 +145,9 @@ func TestMax_Process(t *testing.T) {
 			executetest.RowSelectorFuncTestHelper(
 				t,
 				new(universe.MaxSelector),
-				tc.data,
+				&executetest.RowWiseTable{
+					Table: tc.data,
+				},
 				tc.want,
 			)
 		})

--- a/stdlib/universe/min_test.go
+++ b/stdlib/universe/min_test.go
@@ -145,7 +145,9 @@ func TestMin_Process(t *testing.T) {
 			executetest.RowSelectorFuncTestHelper(
 				t,
 				new(universe.MinSelector),
-				tc.data,
+				&executetest.RowWiseTable{
+					Table: tc.data,
+				},
 				tc.want,
 			)
 		})


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

This PR reverts a previous change (#1249) that converted the `last` function from a row selector to an index selector for performance reasons. Unfortunately the implementation was not correct when using multiple column readers to iterate over the rows of a table.

This PR refactors the tests for `last` to use multiple column readers when iterating over a table. It also does the same for the index selector functions `min` and `max` which previously only used a single column reader when reading a table.
