### PR TITLE
fix(interpreter|repl): make repl output every side effect of the line…

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"context"
-	"io/ioutil"
-	"os"
+	"fmt"
 
 	_ "github.com/influxdata/flux/builtin"
-	"github.com/influxdata/flux/csv"
-	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/repl"
 	"github.com/spf13/cobra"
 )
 
@@ -25,34 +22,14 @@ func init() {
 }
 
 func execute(cmd *cobra.Command, args []string) error {
-	scriptSource := args[0]
-
-	var script string
-	if scriptSource[0] == '@' {
-		scriptBytes, err := ioutil.ReadFile(scriptSource[1:])
-		if err != nil {
-			return err
-		}
-		script = string(scriptBytes)
-	} else {
-		script = scriptSource
-	}
-
-	c := lang.FluxCompiler{
-		Query: script,
-	}
-
-	querier, err := NewQuerier()
+	q, err := NewQuerier()
 	if err != nil {
 		return err
 	}
-	result, err := querier.Query(context.Background(), c)
-	if err != nil {
-		return err
+	r := repl.New(q)
+	if err := r.Input(args[0]); err != nil {
+		return fmt.Errorf("failed to execute query: %v", err)
 	}
-	defer result.Release()
 
-	encoder := csv.NewMultiResultEncoder(csv.DefaultEncoderConfig())
-	_, err = encoder.Encode(os.Stdout, result)
-	return err
+	return nil
 }

--- a/compile.go
+++ b/compile.go
@@ -34,7 +34,7 @@ func Parse(flux string) (*ast.Package, error) {
 }
 
 // Eval accepts a Flux script and evaluates it to produce a set of side effects (as a slice of values) and a scope.
-func Eval(flux string, opts ...ScopeMutator) ([]values.Value, interpreter.Scope, error) {
+func Eval(flux string, opts ...ScopeMutator) ([]interpreter.SideEffect, interpreter.Scope, error) {
 	astPkg, err := Parse(flux)
 	if err != nil {
 		return nil, nil, err
@@ -43,7 +43,7 @@ func Eval(flux string, opts ...ScopeMutator) ([]values.Value, interpreter.Scope,
 }
 
 // EvalAST accepts a Flux AST and evaluates it to produce a set of side effects (as a slice of values) and a scope.
-func EvalAST(astPkg *ast.Package, opts ...ScopeMutator) ([]values.Value, interpreter.Scope, error) {
+func EvalAST(astPkg *ast.Package, opts ...ScopeMutator) ([]interpreter.SideEffect, interpreter.Scope, error) {
 	semPkg, err := semantic.New(astPkg)
 	if err != nil {
 		return nil, nil, err

--- a/internal/spec/build.go
+++ b/internal/spec/build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	"github.com/opentracing/opentracing-go"
@@ -122,7 +123,7 @@ func (i *ider) ID(t *flux.TableObject) flux.OperationID {
 	return tableID
 }
 
-func toSpec(functionCalls []values.Value, now time.Time) (*flux.Spec, error) {
+func toSpec(functionCalls []interpreter.SideEffect, now time.Time) (*flux.Spec, error) {
 	ider := &ider{
 		id:     0,
 		lookup: make(map[*flux.TableObject]flux.OperationID),
@@ -133,7 +134,7 @@ func toSpec(functionCalls []values.Value, now time.Time) (*flux.Spec, error) {
 	objs := make([]*flux.TableObject, 0, len(functionCalls))
 
 	for _, call := range functionCalls {
-		if op, ok := call.(*flux.TableObject); ok {
+		if op, ok := call.Value.(*flux.TableObject); ok {
 			dup := false
 			for _, tableObject := range objs {
 				if op.Equal(tableObject) {

--- a/interpreter/interptest/eval.go
+++ b/interpreter/interptest/eval.go
@@ -5,10 +5,9 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
-	"github.com/influxdata/flux/values"
 )
 
-func Eval(itrp *interpreter.Interpreter, scope interpreter.Scope, importer interpreter.Importer, src string) ([]values.Value, error) {
+func Eval(itrp *interpreter.Interpreter, scope interpreter.Scope, importer interpreter.Importer, src string) ([]interpreter.SideEffect, error) {
 	pkg := parser.ParseSource(src)
 	if ast.Check(pkg) > 0 {
 		return nil, ast.GetError(pkg)

--- a/interpreter/package.go
+++ b/interpreter/package.go
@@ -12,7 +12,7 @@ import (
 type Package struct {
 	name        string
 	object      values.Object
-	sideEffects []values.Value
+	sideEffects []SideEffect
 }
 
 func NewPackageWithValues(name string, obj values.Object) *Package {
@@ -32,7 +32,7 @@ func (p *Package) Copy() *Package {
 	p.object.Range(func(k string, v values.Value) {
 		object.Set(k, v)
 	})
-	sideEffects := make([]values.Value, len(p.sideEffects))
+	sideEffects := make([]SideEffect, len(p.sideEffects))
 	copy(sideEffects, p.sideEffects)
 	return &Package{
 		name:        p.name,
@@ -43,7 +43,7 @@ func (p *Package) Copy() *Package {
 func (p *Package) Name() string {
 	return p.name
 }
-func (p *Package) SideEffects() []values.Value {
+func (p *Package) SideEffects() []SideEffect {
 	return p.sideEffects
 }
 func (p *Package) Type() semantic.Type {

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -14,6 +14,7 @@ import (
 	fcsv "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/mock"
@@ -404,10 +405,10 @@ func getTablesFromResultOrFail(t *testing.T, result flux.Result) []*executetest.
 	return tables
 }
 
-func getTableObjects(vs []values.Value) []*flux.TableObject {
+func getTableObjects(vs []interpreter.SideEffect) []*flux.TableObject {
 	tos := make([]*flux.TableObject, 0)
 	for _, v := range vs {
-		if to, ok := v.(*flux.TableObject); ok {
+		if to, ok := v.Value.(*flux.TableObject); ok {
 			tos = append(tos, to)
 			tos = append(tos, getTableObjectsFromArray(to.Parents)...)
 		}


### PR DESCRIPTION
… under evaluation

This partially solves #1234, in that it solves the issue of not getting some piece of results.  
It doesn't fix the issue of empty tables returned, though. I couldn't reproduce that in Flux, so it could be caused by InfluxDB.

This also updates `flux execute` to use the REPL.

The REPL can pass multiple lines at once to the interpreter (for example, when loading a file). This makes it limiting to only consume `scope.Return()`, because the script under evaluation could produce multiple side effects. I updated the interpreter to return `Eval`-local side effects (as opposed to every possible side effects occurred in multiple calls to `Eval`), and updated the data structure that contains a side effectsto contain also the `semantic.Node` that generated it. In this way, the REPL can filter out which side effect to display on standard out.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
