### PR TITLE
fix(stdlib): make "on" a required parameter to join()

### DIFF
--- a/stdlib/testing/testdata/join_agg.flux
+++ b/stdlib/testing/testdata/join_agg.flux
@@ -1,0 +1,52 @@
+package testdata_test
+ 
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,host,name
+,,0,2019-05-10T20:50:00Z,11930171,reads,diskio,ip-192-168-1-16.ec2.internal,disk0
+,,0,2019-05-10T20:50:10Z,11930171,reads,diskio,ip-192-168-1-16.ec2.internal,disk0
+,,1,2019-05-10T20:50:00Z,391,reads,diskio,ip-192-168-1-16.ec2.internal,disk2
+,,1,2019-05-10T20:50:10Z,391,reads,diskio,ip-192-168-1-16.ec2.internal,disk2
+,,2,2019-05-10T20:50:00Z,34399675,writes,diskio,ip-192-168-1-16.ec2.internal,disk0
+,,2,2019-05-10T20:50:10Z,34399831,writes,diskio,ip-192-168-1-16.ec2.internal,disk0
+,,3,2019-05-10T20:50:00Z,0,writes,diskio,ip-192-168-1-16.ec2.internal,disk2
+,,3,2019-05-10T20:50:10Z,0,writes,diskio,ip-192-168-1-16.ec2.internal,disk2
+"
+
+outData = "
+#datatype,string,long,string,long,long
+#group,false,false,true,false,false
+#default,_result,,,,
+,result,table,name,total_reads,total_writes
+,,0,disk0,23860342,68799506
+,,1,disk2,782,0
+"
+
+t_joinNoOn = (table=<-) => {
+    left = table
+		|> range(start: 2018-05-22T19:53:00Z)
+		|> filter(fn: (r) => r._field == "reads")
+        |> group(columns: ["name"])
+        |> keep(columns: ["name", "_value"])
+        |> sum()
+        |> rename(columns: {_value: "total_reads"})
+
+    right = table
+		|> range(start: 2018-05-22T19:53:00Z)
+		|> filter(fn: (r) => r._field == "writes")
+        |> group(columns: ["name"])
+        |> keep(columns: ["name", "_value"])
+        |> sum()
+        |> rename(columns: {_value: "total_writes"})
+
+    return join(tables: {left, right}, on: ["name"])
+}
+
+test _join = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_joinNoOn})

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -83,12 +83,12 @@ func (params *joinParams) Less(i, j int) bool {
 func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
 	spec := new(JoinOpSpec)
 
-	// On specifies the columns to join on. If 'on' is not present in the arguments
-	// to join, the default value will be set when the join tables are processed.
-	// Specifically when the schema of the output table is able to be constructed.
-	if array, ok, err := args.GetArray("on", semantic.String); err != nil {
+	// On specifies the columns to join on, and is required.
+	if array, err := args.GetRequiredArray("on", semantic.String); err != nil {
 		return nil, err
-	} else if ok {
+	} else if array.Len() == 0 {
+		return nil, errors.New("at least one column in 'on' column list is required")
+	} else {
 		spec.On, err = interpreter.ToStringArray(array)
 		if err != nil {
 			return nil, err
@@ -809,10 +809,6 @@ func (c *MergeJoinCache) buildPostJoinSchema() {
 				break
 			}
 		}
-	}
-
-	if len(c.on) == 0 {
-		c.on = shared
 	}
 
 	ncols := len(left) + len(right)

--- a/stdlib/universe/join_test.go
+++ b/stdlib/universe/join_test.go
@@ -153,6 +153,24 @@ func TestJoin_NewQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "no 'on' parameter",
+			Raw: `
+				a = from(bucket:"flux") |> range(start:-1h)
+				b = from(bucket:"flux") |> range(start:-1h)
+				join(tables:{a:a,b:b})
+			`,
+			WantErr: true,
+		},
+		{
+			Name: "zero-length on list",
+			Raw: `
+				a = from(bucket:"flux") |> range(start:-1h)
+				b = from(bucket:"flux") |> range(start:-1h)
+				join(tables:{a:a,b:b}, on: [])
+			`,
+			WantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -1336,55 +1354,6 @@ func TestMergeJoin_Process(t *testing.T) {
 						{execute.Time(2), 2.0, 20.1, "a", "a", "x", "y"},
 						{execute.Time(3), 3.0, 30.0, "a", "a", "x", "x"},
 						{execute.Time(3), 3.0, 30.1, "a", "a", "x", "y"},
-					},
-				},
-			},
-		},
-		{
-			name: "inner with default on parameter",
-			spec: &universe.MergeJoinProcedureSpec{
-				TableNames: tableNames,
-			},
-			data0: []*executetest.Table{
-				{
-					ColMeta: []flux.ColMeta{
-						{Label: "_time", Type: flux.TTime},
-						{Label: "_value", Type: flux.TFloat},
-						{Label: "a_tag", Type: flux.TString},
-					},
-					Data: [][]interface{}{
-						{execute.Time(1), 1.0, "a"},
-						{execute.Time(2), 2.0, "a"},
-						{execute.Time(3), 3.0, "a"},
-					},
-				},
-			},
-			data1: []*executetest.Table{
-				{
-					ColMeta: []flux.ColMeta{
-						{Label: "_time", Type: flux.TTime},
-						{Label: "_value", Type: flux.TFloat},
-						{Label: "b_tag", Type: flux.TString},
-					},
-					Data: [][]interface{}{
-						{execute.Time(1), 1.0, "b"},
-						{execute.Time(2), 2.0, "b"},
-						{execute.Time(3), 3.0, "b"},
-					},
-				},
-			},
-			want: []*executetest.Table{
-				{
-					ColMeta: []flux.ColMeta{
-						{Label: "_time", Type: flux.TTime},
-						{Label: "_value", Type: flux.TFloat},
-						{Label: "a_tag", Type: flux.TString},
-						{Label: "b_tag", Type: flux.TString},
-					},
-					Data: [][]interface{}{
-						{execute.Time(1), 1.0, "a", "b"},
-						{execute.Time(2), 2.0, "a", "b"},
-						{execute.Time(3), 3.0, "a", "b"},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes influxdata/idpe#3275.
BREAKING CHANGE: queries that made use of default "on" behavior will break.
However, this behavior was never described in the SPEC and had bugs.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
