### PR TITLE
refactor: change the table interface

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -495,6 +495,8 @@ func (d *tableDecoder) Do(f func(flux.ColReader) error) error {
 	return nil
 }
 
+func (d *tableDecoder) Done() {}
+
 // advance reads the csv data until the end of the table or bufSize rows have been read.
 // Advance returns whether there is more data and any error.
 func (d *tableDecoder) advance(extraLine []string) (bool, error) {

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -70,8 +70,6 @@ func (t *Table) Empty() bool {
 	return len(t.Data) == 0
 }
 
-func (t *Table) RefCount(n int) {}
-
 func (t *Table) Cols() []flux.ColMeta {
 	return t.ColMeta
 }
@@ -166,6 +164,8 @@ func (t *Table) Do(f func(flux.ColReader) error) error {
 	return f(cr)
 }
 
+func (t *Table) Done() {}
+
 type ColReader struct {
 	key  flux.GroupKey
 	meta []flux.ColMeta
@@ -209,6 +209,18 @@ func (cr *ColReader) Strings(j int) *array.Binary {
 
 func (cr *ColReader) Times(j int) *array.Int64 {
 	return cr.cols[j].(*array.Int64)
+}
+
+func (cr *ColReader) Retain() {
+	for _, col := range cr.cols {
+		col.Retain()
+	}
+}
+
+func (cr *ColReader) Release() {
+	for _, col := range cr.cols {
+		col.Release()
+	}
 }
 
 // RowWiseTable is a flux Table implementation that

--- a/execute/table.go
+++ b/execute/table.go
@@ -1280,6 +1280,9 @@ func (t *ColListTable) RefCount(n int) {
 	}
 }
 
+func (t *ColListTable) Retain()  { t.RefCount(1) }
+func (t *ColListTable) Release() { t.RefCount(-1) }
+
 func (t *ColListTable) Key() flux.GroupKey {
 	return t.key
 }
@@ -1300,6 +1303,8 @@ func (t *ColListTable) Len() int {
 func (t *ColListTable) Do(f func(flux.ColReader) error) error {
 	return f(t)
 }
+
+func (t *ColListTable) Done() {}
 
 func (t *ColListTable) Bools(j int) *array.Boolean {
 	CheckColType(t.colMeta[j], flux.TBool)

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -68,7 +68,6 @@ func (t *consecutiveTransport) RetractTable(id DatasetID, key flux.GroupKey) err
 }
 
 func (t *consecutiveTransport) Process(id DatasetID, tbl flux.Table) error {
-	tbl.RefCount(1)
 	select {
 	case <-t.finished:
 		return t.err()
@@ -198,7 +197,7 @@ func processMessage(t Transformation, m Message) (finished bool, err error) {
 	case ProcessMsg:
 		b := m.Table()
 		err = t.Process(m.SrcDatasetID(), b)
-		b.RefCount(-1)
+		b.Done()
 	case UpdateWatermarkMsg:
 		err = t.UpdateWatermark(m.SrcDatasetID(), m.WatermarkTime())
 	case UpdateProcessingTimeMsg:

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -109,7 +109,6 @@ func tableFindCall(args values.Object) (values.Value, error) {
 				if tbl, err := execute.CopyTable(tbl, &memory.Allocator{}); err != nil {
 					return err
 				} else {
-					tbl.RefCount(1)
 					t = objects.NewTable(tbl)
 				}
 			}


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The table interface has been changed to make it more explicit about its
purpose. The `Do` call has been specified to work exactly once so that
interfaces can begin to implement this contract. The `Done` method has
been added to indicate that the table will not be processed or as a
no-op if it has already been processed. `RefCount` has been removed
because tables are streamed and `RefCount` can't actually be
implemented.

The `ColReader` interface has been modified to include a `Retain` and
`Release` methods that correspond to the arrow buffers themselves. This
is mostly as a convenience to keep the in buffer contents.