### PR TITLE
fix(execute): do not call done after calling the function

### DIFF
--- a/execute/result.go
+++ b/execute/result.go
@@ -67,10 +67,7 @@ func (s *result) Do(f func(flux.Table) error) error {
 			if msg.err != nil {
 				return msg.err
 			}
-			if err := func() error {
-				defer msg.table.Done()
-				return f(msg.table)
-			}(); err != nil {
+			if err := f(msg.table); err != nil {
 				return err
 			}
 		}

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -197,7 +197,6 @@ func processMessage(t Transformation, m Message) (finished bool, err error) {
 	case ProcessMsg:
 		b := m.Table()
 		err = t.Process(m.SrcDatasetID(), b)
-		b.Done()
 	case UpdateWatermarkMsg:
 		err = t.UpdateWatermark(m.SrcDatasetID(), m.WatermarkTime())
 	case UpdateProcessingTimeMsg:


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

When `Process` is called, it is responsible for calling `Do` or `Done`.
The original idea was that the `Process` method would call `Do` and the
call to `Done` would be for safety, but implementations like the
consecutive transport and result violate that assumption.