### PR TITLE
fix(lang): return compile time errors before program start

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -72,6 +72,9 @@ func Eval(semPkg *semantic.Package, opts ...ScopeMutator) ([]interpreter.SideEff
 // Apart from the side effects and the scope used by the interpreter, it returns the actual now time used during the
 // evaluation (in the case that a now option overrode the now passed in).
 func EvalWithNow(semPkg *semantic.Package, now time.Time) ([]interpreter.SideEffect, interpreter.Scope, time.Time, error) {
+	if now.IsZero() {
+		now = time.Now()
+	}
 	sideEffects, scope, err := Eval(semPkg, SetNow(now))
 	if err != nil {
 		return nil, nil, time.Time{}, err

--- a/compile_test.go
+++ b/compile_test.go
@@ -1,0 +1,96 @@
+package flux_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
+	"github.com/pkg/errors"
+)
+
+func mustGetSampleQuery() *semantic.Package {
+	q := `import g "generate"
+g.from(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:53:00Z, count: 10, fn: (n) => n)`
+	astPkg, err := flux.Parse(q)
+	if err != nil {
+		panic(errors.Wrap(err, "cannot compile simple query"))
+	}
+	semPkg, err := semantic.New(astPkg)
+	if err != nil {
+		panic(errors.Wrap(err, "cannot compile simple query"))
+	}
+	return semPkg
+}
+
+func Test_EvalWithNow(t *testing.T) {
+	now := time.Now()
+	tomorrow := now.Add(24 * time.Hour)
+	tcs := []struct {
+		name        string
+		paramNow    time.Time
+		optNow      time.Time
+		expectedNow time.Time
+	}{
+		{
+			name:        "no option set",
+			paramNow:    now,
+			expectedNow: now,
+		},
+		{
+			name:        "option set",
+			paramNow:    now,
+			optNow:      tomorrow,
+			expectedNow: tomorrow,
+		},
+		{
+			name:        "zero param with opt",
+			paramNow:    time.Time{},
+			optNow:      tomorrow,
+			expectedNow: tomorrow,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			q := mustGetSampleQuery()
+			if !tc.optNow.IsZero() {
+				nowOpt := &semantic.OptionStatement{
+					Assignment: &semantic.NativeVariableAssignment{
+						Identifier: &semantic.Identifier{
+							Name: "now",
+						},
+						Init: &semantic.FunctionExpression{
+							Block: &semantic.FunctionBlock{
+								Body: &semantic.DateTimeLiteral{
+									Value: tc.optNow,
+								},
+							},
+						},
+					},
+				}
+				q.Files[0].Body = append([]semantic.Statement{nowOpt}, q.Files[0].Body...)
+			}
+			_, _, gotNow, err := flux.EvalWithNow(q, tc.paramNow)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.expectedNow, gotNow); diff != "" {
+				t.Fatalf("got unexpected now time: -want/+got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_EvalWithNow_Zero(t *testing.T) {
+	now := time.Now()
+	q := mustGetSampleQuery()
+	_, _, gotNow, err := flux.EvalWithNow(q, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !now.Before(gotNow) {
+		t.Fatalf("query executed with wrong now: %v", gotNow)
+	}
+}

--- a/internal/spec/build.go
+++ b/internal/spec/build.go
@@ -41,6 +41,7 @@ func FromSemantic(semPkg *semantic.Package, now time.Time) (*flux.Spec, error) {
 	return FromSideEffects(sideEffects, now)
 }
 
+// FromSideEffects returns a spec from the side effects of evaluation.
 func FromSideEffects(sideEffects []interpreter.SideEffect, now time.Time) (*flux.Spec, error) {
 	spec, err := toSpec(sideEffects, now)
 	if err != nil {

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -1,7 +1,6 @@
 package plan_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -20,7 +19,7 @@ import (
 )
 
 func compile(fluxText string, now time.Time) (*flux.Spec, error) {
-	return spec.FromScript(context.Background(), fluxText, now)
+	return spec.FromScript(fluxText, now)
 }
 
 func TestPlan_LogicalPlanFromSpec(t *testing.T) {

--- a/plan/rules_test.go
+++ b/plan/rules_test.go
@@ -1,7 +1,6 @@
 package plan_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -19,7 +18,7 @@ func TestRuleRegistration(t *testing.T) {
 	plan.RegisterLogicalRules(&simpleRule)
 
 	now := time.Now().UTC()
-	fluxSpec, err := spec.FromScript(context.Background(), `from(bucket: "telegraf") |> range(start: -5m)`, now)
+	fluxSpec, err := spec.FromScript(`from(bucket: "telegraf") |> range(start: -5m)`, now)
 	if err != nil {
 		t.Fatalf("could not compile very simple Flux query: %v", err)
 	}

--- a/querytest/compile.go
+++ b/querytest/compile.go
@@ -35,7 +35,7 @@ func NewQueryTestHelper(t *testing.T, tc NewQueryTestCase) {
 	t.Helper()
 
 	now := time.Now().UTC()
-	got, err := spec.FromScript(context.Background(), tc.Raw, now)
+	got, err := spec.FromScript(tc.Raw, now)
 	if (err != nil) != tc.WantErr {
 		t.Errorf("error compiling spec error = %v, wantErr %v", err, tc.WantErr)
 		return

--- a/repl/compiler.go
+++ b/repl/compiler.go
@@ -23,7 +23,7 @@ func (c Compiler) Compile(ctx context.Context) (flux.Program, error) {
 		return nil, err
 	}
 
-	return &lang.Program{
+	return &lang.ReadyToStartProgram{
 		PlanSpec: ps,
 	}, err
 }

--- a/repl/compiler.go
+++ b/repl/compiler.go
@@ -23,7 +23,7 @@ func (c Compiler) Compile(ctx context.Context) (flux.Program, error) {
 		return nil, err
 	}
 
-	return &lang.ReadyToStartProgram{
+	return &lang.Program{
 		PlanSpec: ps,
 	}, err
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -134,7 +134,7 @@ func (r *REPL) executeLine(t string) error {
 		t = q
 	}
 
-	ses, scope, err := flux.Eval(t, func(ns interpreter.Scope) {
+	ses, scope, err := flux.EvalScript(t, func(ns interpreter.Scope) {
 		// copy values saved in the cached scope to the new interpreter's scope
 		r.scope.Range(func(k string, v values.Value) {
 			ns.Set(k, v)

--- a/stdlib/universe/table_fns_test.go
+++ b/stdlib/universe/table_fns_test.go
@@ -38,7 +38,7 @@ data = "#datatype,string,long,dateTime:RFC3339,double,string,string
 
 csv.from(csv: data)`
 
-	vs, _, err := flux.Eval(script)
+	vs, _, err := flux.EvalScript(script)
 	if err != nil {
 		panic(errors.Wrap(err, "cannot compile simple script to prepare test"))
 	}
@@ -118,7 +118,7 @@ func mustLookup(s interpreter.Scope, valueID string) values.Value {
 func evalOrFail(t *testing.T, script string, mutator flux.ScopeMutator) interpreter.Scope {
 	t.Helper()
 
-	_, s, err := flux.Eval(script, func(s interpreter.Scope) {
+	_, s, err := flux.EvalScript(script, func(s interpreter.Scope) {
 		if mutator != nil {
 			mutator(s)
 		}


### PR DESCRIPTION
Close #1292 

I caught the moment to refactor how spans are used in the compile -> eval -> execute path.  
I also updated the test for checking errors in the different phases.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
