### PR TITLE
feat(values): add nullable value types

### DIFF
--- a/values/bool.go
+++ b/values/bool.go
@@ -1,0 +1,57 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// Bool represents a float value.
+type Bool struct {
+	Value bool
+	Null  bool
+}
+
+func (Bool) Type() semantic.Type {
+	return semantic.Bool
+}
+
+func (Bool) PolyType() semantic.PolyType {
+	return semantic.Bool
+}
+
+func (v Bool) Bool() bool {
+	return v.Value
+}
+
+func (v Bool) IsNull() bool {
+	return v.Null
+}
+
+func (Bool) Str() string            { panic(UnexpectedKind(semantic.String, semantic.Bool)) }
+func (Bool) Int() int64             { panic(UnexpectedKind(semantic.Int, semantic.Bool)) }
+func (Bool) UInt() uint64           { panic(UnexpectedKind(semantic.UInt, semantic.Bool)) }
+func (Bool) Float() float64         { panic(UnexpectedKind(semantic.Float, semantic.Bool)) }
+func (Bool) Time() Time             { panic(UnexpectedKind(semantic.Time, semantic.Bool)) }
+func (Bool) Duration() Duration     { panic(UnexpectedKind(semantic.Duration, semantic.Bool)) }
+func (Bool) Regexp() *regexp.Regexp { panic(UnexpectedKind(semantic.Regexp, semantic.Bool)) }
+func (Bool) Array() Array           { panic(UnexpectedKind(semantic.Array, semantic.Bool)) }
+func (Bool) Object() Object         { panic(UnexpectedKind(semantic.Object, semantic.Bool)) }
+func (Bool) Function() Function     { panic(UnexpectedKind(semantic.Function, semantic.Bool)) }
+
+func (v Bool) Equal(other Value) bool {
+	if v.Type() != other.Type() {
+		return false
+	} else if v.IsNull() || other.IsNull() {
+		return false
+	}
+	return v.Bool() == other.Bool()
+}
+
+func (v Bool) String() string {
+	if v.Null {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", v.Value)
+}

--- a/values/float.go
+++ b/values/float.go
@@ -1,0 +1,57 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// Float represents a float value.
+type Float struct {
+	Value float64
+	Null  bool
+}
+
+func (Float) Type() semantic.Type {
+	return semantic.Float
+}
+
+func (Float) PolyType() semantic.PolyType {
+	return semantic.Float
+}
+
+func (v Float) Float() float64 {
+	return v.Value
+}
+
+func (v Float) IsNull() bool {
+	return v.Null
+}
+
+func (Float) Str() string            { panic(UnexpectedKind(semantic.String, semantic.Float)) }
+func (Float) Int() int64             { panic(UnexpectedKind(semantic.Int, semantic.Float)) }
+func (Float) UInt() uint64           { panic(UnexpectedKind(semantic.UInt, semantic.Float)) }
+func (Float) Bool() bool             { panic(UnexpectedKind(semantic.Bool, semantic.Float)) }
+func (Float) Time() Time             { panic(UnexpectedKind(semantic.Time, semantic.Float)) }
+func (Float) Duration() Duration     { panic(UnexpectedKind(semantic.Duration, semantic.Float)) }
+func (Float) Regexp() *regexp.Regexp { panic(UnexpectedKind(semantic.Regexp, semantic.Float)) }
+func (Float) Array() Array           { panic(UnexpectedKind(semantic.Array, semantic.Float)) }
+func (Float) Object() Object         { panic(UnexpectedKind(semantic.Object, semantic.Float)) }
+func (Float) Function() Function     { panic(UnexpectedKind(semantic.Function, semantic.Float)) }
+
+func (v Float) Equal(other Value) bool {
+	if v.Type() != other.Type() {
+		return false
+	} else if v.IsNull() || other.IsNull() {
+		return false
+	}
+	return v.Float() == other.Float()
+}
+
+func (v Float) String() string {
+	if v.Null {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", v.Value)
+}

--- a/values/int.go
+++ b/values/int.go
@@ -1,0 +1,57 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// Int represents an int value.
+type Int struct {
+	Value int64
+	Null  bool
+}
+
+func (Int) Type() semantic.Type {
+	return semantic.Int
+}
+
+func (Int) PolyType() semantic.PolyType {
+	return semantic.Int
+}
+
+func (v Int) Int() int64 {
+	return v.Value
+}
+
+func (v Int) IsNull() bool {
+	return v.Null
+}
+
+func (Int) Str() string            { panic(UnexpectedKind(semantic.String, semantic.Int)) }
+func (Int) UInt() uint64           { panic(UnexpectedKind(semantic.UInt, semantic.Int)) }
+func (Int) Float() float64         { panic(UnexpectedKind(semantic.Float, semantic.Int)) }
+func (Int) Bool() bool             { panic(UnexpectedKind(semantic.Bool, semantic.Int)) }
+func (Int) Time() Time             { panic(UnexpectedKind(semantic.Time, semantic.Int)) }
+func (Int) Duration() Duration     { panic(UnexpectedKind(semantic.Duration, semantic.Int)) }
+func (Int) Regexp() *regexp.Regexp { panic(UnexpectedKind(semantic.Regexp, semantic.Int)) }
+func (Int) Array() Array           { panic(UnexpectedKind(semantic.Array, semantic.Int)) }
+func (Int) Object() Object         { panic(UnexpectedKind(semantic.Object, semantic.Int)) }
+func (Int) Function() Function     { panic(UnexpectedKind(semantic.Function, semantic.Int)) }
+
+func (v Int) Equal(other Value) bool {
+	if v.Type() != other.Type() {
+		return false
+	} else if v.IsNull() || other.IsNull() {
+		return false
+	}
+	return v.Int() == other.Int()
+}
+
+func (v Int) String() string {
+	if v.Null {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", v.Value)
+}

--- a/values/string.go
+++ b/values/string.go
@@ -1,0 +1,57 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// String represents a string value.
+type String struct {
+	Value string
+	Null  bool
+}
+
+func (String) Type() semantic.Type {
+	return semantic.String
+}
+
+func (String) PolyType() semantic.PolyType {
+	return semantic.String
+}
+
+func (v String) Str() string {
+	return v.Value
+}
+
+func (v String) IsNull() bool {
+	return v.Null
+}
+
+func (String) Int() int64             { panic(UnexpectedKind(semantic.Int, semantic.String)) }
+func (String) UInt() uint64           { panic(UnexpectedKind(semantic.UInt, semantic.String)) }
+func (String) Float() float64         { panic(UnexpectedKind(semantic.Float, semantic.String)) }
+func (String) Bool() bool             { panic(UnexpectedKind(semantic.Bool, semantic.String)) }
+func (String) Time() Time             { panic(UnexpectedKind(semantic.Time, semantic.String)) }
+func (String) Duration() Duration     { panic(UnexpectedKind(semantic.Duration, semantic.String)) }
+func (String) Regexp() *regexp.Regexp { panic(UnexpectedKind(semantic.Regexp, semantic.String)) }
+func (String) Array() Array           { panic(UnexpectedKind(semantic.Array, semantic.String)) }
+func (String) Object() Object         { panic(UnexpectedKind(semantic.Object, semantic.String)) }
+func (String) Function() Function     { panic(UnexpectedKind(semantic.Function, semantic.String)) }
+
+func (v String) Equal(other Value) bool {
+	if v.Type() != other.Type() {
+		return false
+	} else if v.IsNull() || other.IsNull() {
+		return false
+	}
+	return v.Str() == other.Str()
+}
+
+func (v String) String() string {
+	if v.Null {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", v.Value)
+}

--- a/values/uint.go
+++ b/values/uint.go
@@ -1,0 +1,57 @@
+package values
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// UInt represents a uint value.
+type UInt struct {
+	Value uint64
+	Null  bool
+}
+
+func (UInt) Type() semantic.Type {
+	return semantic.UInt
+}
+
+func (UInt) PolyType() semantic.PolyType {
+	return semantic.UInt
+}
+
+func (v UInt) UInt() uint64 {
+	return v.Value
+}
+
+func (v UInt) IsNull() bool {
+	return v.Null
+}
+
+func (UInt) Str() string            { panic(UnexpectedKind(semantic.String, semantic.UInt)) }
+func (UInt) Int() int64             { panic(UnexpectedKind(semantic.Int, semantic.UInt)) }
+func (UInt) Float() float64         { panic(UnexpectedKind(semantic.Float, semantic.UInt)) }
+func (UInt) Bool() bool             { panic(UnexpectedKind(semantic.Bool, semantic.UInt)) }
+func (UInt) Time() Time             { panic(UnexpectedKind(semantic.Time, semantic.UInt)) }
+func (UInt) Duration() Duration     { panic(UnexpectedKind(semantic.Duration, semantic.UInt)) }
+func (UInt) Regexp() *regexp.Regexp { panic(UnexpectedKind(semantic.Regexp, semantic.UInt)) }
+func (UInt) Array() Array           { panic(UnexpectedKind(semantic.Array, semantic.UInt)) }
+func (UInt) Object() Object         { panic(UnexpectedKind(semantic.Object, semantic.UInt)) }
+func (UInt) Function() Function     { panic(UnexpectedKind(semantic.Function, semantic.UInt)) }
+
+func (v UInt) Equal(other Value) bool {
+	if v.Type() != other.Type() {
+		return false
+	} else if v.IsNull() || other.IsNull() {
+		return false
+	}
+	return v.UInt() == other.UInt()
+}
+
+func (v UInt) String() string {
+	if v.Null {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%v", v.Value)
+}

--- a/values/values.go
+++ b/values/values.go
@@ -164,84 +164,84 @@ func New(v interface{}) Value {
 }
 
 func NewNull(t semantic.Type) Value {
-	return value{
-		t: t,
-		v: nil,
+	switch t {
+	case semantic.Float:
+		return Float{Null: true}
+	case semantic.Int:
+		return Int{Null: true}
+	case semantic.UInt:
+		return UInt{Null: true}
+	case semantic.String:
+		return String{Null: true}
+	case semantic.Bool:
+		return Bool{Null: true}
+	default:
+		return value{
+			t: t,
+			v: nil,
+		}
 	}
 }
 
 func NewFromString(t semantic.Type, s string) (Value, error) {
-	var err error
-	v := value{t: t}
 	switch t {
 	case semantic.String:
-		v.v = s
+		return String{Value: s}, nil
 	case semantic.Int:
-		v.v, err = strconv.ParseInt(s, 10, 64)
+		v, err := strconv.ParseInt(s, 10, 64)
 		if err != nil {
 			return nil, err
 		}
+		return Int{Value: v}, nil
 	case semantic.UInt:
-		v.v, err = strconv.ParseUint(s, 10, 64)
+		v, err := strconv.ParseUint(s, 10, 64)
 		if err != nil {
 			return nil, err
 		}
+		return UInt{Value: v}, nil
 	case semantic.Float:
-		v.v, err = strconv.ParseFloat(s, 64)
+		v, err := strconv.ParseFloat(s, 64)
 		if err != nil {
 			return nil, err
 		}
+		return Float{Value: v}, nil
 	case semantic.Bool:
-		v.v, err = strconv.ParseBool(s)
+		v, err := strconv.ParseBool(s)
 		if err != nil {
 			return nil, err
 		}
+		return Bool{Value: v}, nil
 	case semantic.Time:
-		v.v, err = ParseTime(s)
+		v, err := ParseTime(s)
 		if err != nil {
 			return nil, err
 		}
+		return value{t: t, v: v}, nil
 	case semantic.Duration:
-		v.v, err = ParseDuration(s)
+		v, err := ParseDuration(s)
 		if err != nil {
 			return nil, err
 		}
-
+		return value{t: t, v: v}, nil
 	default:
 		return nil, errors.New("invalid type for value stringer")
 	}
-	return v, nil
 }
 
 func NewString(v string) Value {
-	return value{
-		t: semantic.String,
-		v: v,
-	}
+	return String{Value: v}
 }
 func NewInt(v int64) Value {
-	return value{
-		t: semantic.Int,
-		v: v,
-	}
+	return Int{Value: v}
 }
 func NewUInt(v uint64) Value {
-	return value{
-		t: semantic.UInt,
-		v: v,
-	}
+	return UInt{Value: v}
 }
 func NewFloat(v float64) Value {
-	return value{
-		t: semantic.Float,
-		v: v,
-	}
+	return Float{Value: v}
 }
 func NewBool(v bool) Value {
-	return value{
-		t: semantic.Bool,
-		v: v,
-	}
+	return Bool{Value: v}
 }
 func NewTime(v Time) Value {
 	return value{


### PR DESCRIPTION
The `values` package has been modified to include a separate struct for
each type that has a `Value` and `Null` attribute so the typed
evaluators can use these instead of the values interface.

The inspiration for these types is taken from the `database/sql`
package.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
