### PR TITLE
feat(compiler): implement nulls in the compiler runtime

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -13,32 +13,11 @@ import (
 type Func interface {
 	Type() semantic.Type
 	Eval(input values.Object) (values.Value, error)
-	EvalString(input values.Object) (string, error)
-	EvalInt(input values.Object) (int64, error)
-	EvalUInt(input values.Object) (uint64, error)
-	EvalFloat(input values.Object) (float64, error)
-	EvalBool(input values.Object) (bool, error)
-	EvalTime(input values.Object) (values.Time, error)
-	EvalDuration(input values.Object) (values.Duration, error)
-	EvalRegexp(input values.Object) (*regexp.Regexp, error)
-	EvalArray(input values.Object) (values.Array, error)
-	EvalObject(input values.Object) (values.Object, error)
-	EvalFunction(input values.Object) (values.Function, error)
 }
 
 type Evaluator interface {
 	Type() semantic.Type
-	EvalString(scope Scope) (string, error)
-	EvalInt(scope Scope) (int64, error)
-	EvalUInt(scope Scope) (uint64, error)
-	EvalFloat(scope Scope) (float64, error)
-	EvalBool(scope Scope) (bool, error)
-	EvalTime(scope Scope) (values.Time, error)
-	EvalDuration(scope Scope) (values.Duration, error)
-	EvalRegexp(scope Scope) (*regexp.Regexp, error)
-	EvalArray(scope Scope) (values.Array, error)
-	EvalObject(scope Scope) (values.Object, error)
-	EvalFunction(scope Scope) (values.Function, error)
+	Eval(scope Scope) (values.Value, error)
 }
 
 type compiledFn struct {
@@ -54,17 +33,8 @@ func (c compiledFn) validate(input values.Object) error {
 		return errors.New("mismatched parameters and properties")
 	}
 	for k, v := range sig.Parameters {
-		if properties[k] != v {
-			// TODO(adam): we should have more thorough and specific type checking to make this work instead of just special casing objects.
-			if v.Nature() == semantic.Object && properties[k].Nature() == semantic.Object {
-				for f := range v.Properties() {
-					if _, ok := properties[k].Properties()[f]; !ok {
-						return fmt.Errorf("parameter %q has the wrong type, expected %v got %v", k, v, properties[k])
-					}
-				}
-			} else {
-				return fmt.Errorf("parameter %q has the wrong type, expected %v got %v", k, v, properties[k])
-			}
+		if !values.AssignableTo(properties[k], v) {
+			return fmt.Errorf("parameter %q has the wrong type, expected %v got %v", k, v, properties[k])
 		}
 	}
 	return nil
@@ -92,73 +62,6 @@ func (c compiledFn) Eval(input values.Object) (values.Value, error) {
 	return eval(c.root, c.inputScope)
 }
 
-func (c compiledFn) EvalString(input values.Object) (string, error) {
-	if err := c.buildScope(input); err != nil {
-		return "", err
-	}
-	return c.root.EvalString(c.inputScope)
-}
-func (c compiledFn) EvalBool(input values.Object) (bool, error) {
-	if err := c.buildScope(input); err != nil {
-		return false, err
-	}
-	return c.root.EvalBool(c.inputScope)
-}
-func (c compiledFn) EvalInt(input values.Object) (int64, error) {
-	if err := c.buildScope(input); err != nil {
-		return 0, err
-	}
-	return c.root.EvalInt(c.inputScope)
-}
-func (c compiledFn) EvalUInt(input values.Object) (uint64, error) {
-	if err := c.buildScope(input); err != nil {
-		return 0, err
-	}
-	return c.root.EvalUInt(c.inputScope)
-}
-func (c compiledFn) EvalFloat(input values.Object) (float64, error) {
-	if err := c.buildScope(input); err != nil {
-		return 0, err
-	}
-	return c.root.EvalFloat(c.inputScope)
-}
-func (c compiledFn) EvalTime(input values.Object) (values.Time, error) {
-	if err := c.buildScope(input); err != nil {
-		return 0, err
-	}
-	return c.root.EvalTime(c.inputScope)
-}
-func (c compiledFn) EvalDuration(input values.Object) (values.Duration, error) {
-	if err := c.buildScope(input); err != nil {
-		return 0, err
-	}
-	return c.root.EvalDuration(c.inputScope)
-}
-func (c compiledFn) EvalRegexp(input values.Object) (*regexp.Regexp, error) {
-	if err := c.buildScope(input); err != nil {
-		return nil, err
-	}
-	return c.root.EvalRegexp(c.inputScope)
-}
-func (c compiledFn) EvalArray(input values.Object) (values.Array, error) {
-	if err := c.buildScope(input); err != nil {
-		return nil, err
-	}
-	return c.root.EvalArray(c.inputScope)
-}
-func (c compiledFn) EvalObject(input values.Object) (values.Object, error) {
-	if err := c.buildScope(input); err != nil {
-		return nil, err
-	}
-	return c.root.EvalObject(c.inputScope)
-}
-func (c compiledFn) EvalFunction(input values.Object) (values.Function, error) {
-	if err := c.buildScope(input); err != nil {
-		return nil, err
-	}
-	return c.root.EvalFunction(c.inputScope)
-}
-
 type Scope map[string]values.Value
 
 func (s Scope) Type(name string) semantic.Type {
@@ -167,39 +70,12 @@ func (s Scope) Type(name string) semantic.Type {
 func (s Scope) Set(name string, v values.Value) {
 	s[name] = v
 }
-
-func (s Scope) GetString(name string) string {
-	return s[name].Str()
-}
-func (s Scope) GetInt(name string) int64 {
-	return s[name].Int()
-}
-func (s Scope) GetUInt(name string) uint64 {
-	return s[name].UInt()
-}
-func (s Scope) GetFloat(name string) float64 {
-	return s[name].Float()
-}
-func (s Scope) GetBool(name string) bool {
-	return s[name].Bool()
-}
-func (s Scope) GetTime(name string) values.Time {
-	return s[name].Time()
-}
-func (s Scope) GetDuration(name string) values.Duration {
-	return s[name].Duration()
-}
-func (s Scope) GetRegexp(name string) *regexp.Regexp {
-	return s[name].Regexp()
-}
-func (s Scope) GetArray(name string) values.Array {
-	return s[name].Array()
-}
-func (s Scope) GetObject(name string) values.Object {
-	return s[name].Object()
-}
-func (s Scope) GetFunction(name string) values.Function {
-	return s[name].Function()
+func (s Scope) Get(name string) values.Value {
+	v := s[name]
+	if v == nil {
+		panic("attempting to access non-existant value")
+	}
+	return v
 }
 
 func (s Scope) Copy() Scope {
@@ -211,70 +87,12 @@ func (s Scope) Copy() Scope {
 }
 
 func eval(e Evaluator, scope Scope) (values.Value, error) {
-	var v values.Value
-	var err error
-	switch e.Type().Nature() {
-	case semantic.String:
-		var v0 string
-		v0, err = e.EvalString(scope)
-		if err == nil {
-			v = values.NewString(v0)
-		}
-	case semantic.Int:
-		var v0 int64
-		v0, err = e.EvalInt(scope)
-		if err == nil {
-			v = values.NewInt(v0)
-		}
-	case semantic.UInt:
-		var v0 uint64
-		v0, err = e.EvalUInt(scope)
-		if err == nil {
-			v = values.NewUInt(v0)
-		}
-	case semantic.Float:
-		var v0 float64
-		v0, err = e.EvalFloat(scope)
-		if err == nil {
-			v = values.NewFloat(v0)
-		}
-	case semantic.Bool:
-		var v0 bool
-		v0, err = e.EvalBool(scope)
-		if err == nil {
-			v = values.NewBool(v0)
-		}
-	case semantic.Time:
-		var v0 values.Time
-		v0, err = e.EvalTime(scope)
-		if err == nil {
-			v = values.NewTime(v0)
-		}
-	case semantic.Duration:
-		var v0 values.Duration
-		v0, err = e.EvalDuration(scope)
-		if err == nil {
-			v = values.NewDuration(v0)
-		}
-	case semantic.Regexp:
-		var v0 *regexp.Regexp
-		v0, err = e.EvalRegexp(scope)
-		if err == nil {
-			v = values.NewRegexp(v0)
-		}
-	case semantic.Array:
-		v, err = e.EvalArray(scope)
-	case semantic.Object:
-		v, err = e.EvalObject(scope)
-	case semantic.Function:
-		v, err = e.EvalFunction(scope)
-	case semantic.Nil:
-		return nil, nil
-	default:
-		err = fmt.Errorf("eval: unknown type: %v", e.Type())
+	v, err := e.Eval(scope)
+	if err != nil {
+		return nil, err
 	}
-
-	return v, err
+	values.CheckKind(e.Type().Nature(), v.Type().Nature())
+	return v, nil
 }
 
 type blockEvaluator struct {
@@ -287,105 +105,16 @@ func (e *blockEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *blockEvaluator) eval(scope Scope) error {
+func (e *blockEvaluator) Eval(scope Scope) (values.Value, error) {
 	var err error
 	for _, b := range e.body {
 		e.value, err = eval(b, scope)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-
-	return nil
-}
-
-func (e *blockEvaluator) EvalString(scope Scope) (string, error) {
-	values.CheckKind(e.t.Nature(), semantic.String)
-	err := e.eval(scope)
-	if err != nil {
-		return "", err
-	}
-	return e.value.Str(), nil
-}
-func (e *blockEvaluator) EvalInt(scope Scope) (int64, error) {
-	values.CheckKind(e.t.Nature(), semantic.Int)
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.value.Int(), nil
-}
-func (e *blockEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	values.CheckKind(e.t.Nature(), semantic.UInt)
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.value.UInt(), nil
-}
-func (e *blockEvaluator) EvalFloat(scope Scope) (float64, error) {
-	values.CheckKind(e.t.Nature(), semantic.Float)
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.value.Float(), nil
-}
-func (e *blockEvaluator) EvalBool(scope Scope) (bool, error) {
-	values.CheckKind(e.t.Nature(), semantic.Bool)
-	err := e.eval(scope)
-	if err != nil {
-		return false, err
-	}
-	return e.value.Bool(), nil
-}
-func (e *blockEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	values.CheckKind(e.t.Nature(), semantic.Time)
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.value.Time(), nil
-}
-func (e *blockEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	values.CheckKind(e.t.Nature(), semantic.Duration)
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.value.Duration(), nil
-}
-func (e *blockEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	values.CheckKind(e.t.Nature(), semantic.Regexp)
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return e.value.Regexp(), nil
-}
-func (e *blockEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	values.CheckKind(e.t.Nature(), semantic.Object)
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return e.value.Array(), nil
-}
-func (e *blockEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	values.CheckKind(e.t.Nature(), semantic.Object)
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return e.value.Object(), nil
-}
-func (e *blockEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	values.CheckKind(e.t.Nature(), semantic.Object)
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return e.value.Function(), nil
+	values.CheckKind(e.value.Type().Nature(), e.Type().Nature())
+	return e.value, nil
 }
 
 type returnEvaluator struct {
@@ -402,95 +131,14 @@ func (e *declarationEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *declarationEvaluator) eval(scope Scope) error {
+func (e *declarationEvaluator) Eval(scope Scope) (values.Value, error) {
 	v, err := eval(e.init, scope)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	scope.Set(e.id, v)
-	return nil
-}
-
-func (e *declarationEvaluator) EvalString(scope Scope) (string, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return "", err
-	}
-	return scope.GetString(e.id), nil
-}
-func (e *declarationEvaluator) EvalInt(scope Scope) (int64, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return scope.GetInt(e.id), nil
-}
-func (e *declarationEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-
-	return scope.GetUInt(e.id), nil
-}
-func (e *declarationEvaluator) EvalFloat(scope Scope) (float64, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return 0.0, err
-	}
-
-	return scope.GetFloat(e.id), nil
-}
-func (e *declarationEvaluator) EvalBool(scope Scope) (bool, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return false, err
-	}
-	return scope.GetBool(e.id), nil
-}
-func (e *declarationEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return scope.GetTime(e.id), nil
-}
-func (e *declarationEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-
-	return scope.GetDuration(e.id), nil
-}
-func (e *declarationEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return scope.GetRegexp(e.id), nil
-}
-func (e *declarationEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return scope.GetArray(e.id), nil
-}
-func (e *declarationEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return scope.GetObject(e.id), nil
-}
-func (e *declarationEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return scope.GetFunction(e.id), nil
+	return v, nil
 }
 
 type objEvaluator struct {
@@ -503,41 +151,14 @@ func (e *objEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *objEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *objEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *objEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *objEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *objEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *objEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *objEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *objEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *objEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *objEvaluator) EvalObject(scope Scope) (values.Object, error) {
+func (e *objEvaluator) Eval(scope Scope) (values.Value, error) {
 	obj := values.NewObject()
 	if e.with != nil {
-		with, err := e.with.EvalObject(scope)
+		with, err := e.with.Eval(scope)
 		if err != nil {
 			return nil, err
 		}
-		with.Range(func(name string, v values.Value) {
+		with.Object().Range(func(name string, v values.Value) {
 			obj.Set(name, v)
 		})
 	}
@@ -552,9 +173,6 @@ func (e *objEvaluator) EvalObject(scope Scope) (values.Object, error) {
 
 	return obj, nil
 }
-func (e *objEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
-}
 
 type arrayEvaluator struct {
 	t     semantic.Type
@@ -565,31 +183,7 @@ func (e *arrayEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *arrayEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *arrayEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *arrayEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *arrayEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *arrayEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *arrayEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *arrayEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *arrayEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *arrayEvaluator) EvalArray(scope Scope) (values.Array, error) {
+func (e *arrayEvaluator) Eval(scope Scope) (values.Value, error) {
 	arr := values.NewArray(e.t.ElementType())
 	for _, ev := range e.array {
 		v, err := eval(ev, scope)
@@ -599,12 +193,6 @@ func (e *arrayEvaluator) EvalArray(scope Scope) (values.Array, error) {
 		arr.Append(v)
 	}
 	return arr, nil
-}
-func (e *arrayEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *arrayEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
 }
 
 type logicalEvaluator struct {
@@ -617,60 +205,31 @@ func (e *logicalEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *logicalEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *logicalEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *logicalEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *logicalEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *logicalEvaluator) EvalBool(scope Scope) (bool, error) {
-	l, err := e.left.EvalBool(scope)
+func (e *logicalEvaluator) Eval(scope Scope) (values.Value, error) {
+	l, err := e.left.Eval(scope)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
+	values.CheckKind(l.Type().Nature(), e.t.Nature())
 
 	switch e.operator {
 	case ast.AndOperator:
-		if !l {
-			return false, nil
+		if l.IsNull() || !l.Bool() {
+			return values.NewBool(false), nil
 		}
 	case ast.OrOperator:
-		if l {
-			return true, nil
+		if !l.IsNull() && l.Bool() {
+			return values.NewBool(true), nil
 		}
 	default:
 		panic(fmt.Errorf("unknown logical operator %v", e.operator))
 	}
 
-	r, err := e.right.EvalBool(scope)
+	r, err := e.right.Eval(scope)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	return r, nil
-}
-func (e *logicalEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *logicalEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *logicalEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *logicalEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *logicalEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *logicalEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
 }
 
 type conditionalEvaluator struct {
@@ -684,7 +243,7 @@ func (e *conditionalEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *conditionalEvaluator) eval(scope Scope) (values.Value, error) {
+func (e *conditionalEvaluator) Eval(scope Scope) (values.Value, error) {
 	t, err := eval(e.test, scope)
 	if err != nil {
 		return nil, err
@@ -697,84 +256,6 @@ func (e *conditionalEvaluator) eval(scope Scope) (values.Value, error) {
 	}
 }
 
-func (e *conditionalEvaluator) EvalString(scope Scope) (string, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return "", err
-	}
-	return v.Str(), nil
-}
-func (e *conditionalEvaluator) EvalInt(scope Scope) (int64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Int(), nil
-}
-func (e *conditionalEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.UInt(), nil
-}
-func (e *conditionalEvaluator) EvalFloat(scope Scope) (float64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0.0, err
-	}
-	return v.Float(), nil
-}
-func (e *conditionalEvaluator) EvalBool(scope Scope) (bool, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return false, err
-	}
-	return v.Bool(), nil
-}
-func (e *conditionalEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Time(), nil
-}
-func (e *conditionalEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Duration(), nil
-}
-func (e *conditionalEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Regexp(), nil
-}
-func (e *conditionalEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Array(), nil
-}
-func (e *conditionalEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Object(), nil
-}
-func (e *conditionalEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Function(), nil
-}
-
 type binaryEvaluator struct {
 	t           semantic.Type
 	left, right Evaluator
@@ -785,78 +266,16 @@ func (e *binaryEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *binaryEvaluator) eval(scope Scope) (values.Value, values.Value, error) {
+func (e *binaryEvaluator) Eval(scope Scope) (values.Value, error) {
 	l, err := eval(e.left, scope)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	r, err := eval(e.right, scope)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return l, r, nil
-}
-
-func (e *binaryEvaluator) EvalString(scope Scope) (string, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return "", err
-	}
-	return e.f(l, r).Str(), nil
-}
-func (e *binaryEvaluator) EvalInt(scope Scope) (int64, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.f(l, r).Int(), nil
-}
-func (e *binaryEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.f(l, r).UInt(), nil
-}
-func (e *binaryEvaluator) EvalFloat(scope Scope) (float64, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return 0.0, err
-	}
-	return e.f(l, r).Float(), nil
-}
-func (e *binaryEvaluator) EvalBool(scope Scope) (bool, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return false, err
-	}
-	return e.f(l, r).Bool(), nil
-}
-func (e *binaryEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.f(l, r).Time(), nil
-}
-func (e *binaryEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	l, r, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return e.f(l, r).Duration(), nil
-}
-func (e *binaryEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *binaryEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *binaryEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *binaryEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+	return e.f(l, r), nil
 }
 
 type unaryEvaluator struct {
@@ -869,87 +288,43 @@ func (e *unaryEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *unaryEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *unaryEvaluator) EvalInt(scope Scope) (int64, error) {
-	v, err := e.node.EvalInt(scope)
+func (e *unaryEvaluator) Eval(scope Scope) (values.Value, error) {
+	v, err := e.node.Eval(scope)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	var sign int64
+	values.CheckKind(v.Type().Nature(), e.t.Nature())
+
+	// If the value is null, return it immediately.
+	if v.IsNull() {
+		return v, nil
+	}
+
 	switch e.op {
 	case ast.AdditionOperator:
-		sign = 1
-	case ast.SubtractionOperator:
-		sign = -1
+		// Do nothing.
+		return v, nil
+	case ast.SubtractionOperator, ast.NotOperator:
+		// Fallthrough to below.
 	default:
-		return 0, fmt.Errorf("unknown unary operator: %s", e.op)
+		return nil, fmt.Errorf("unknown unary operator: %s", e.op)
 	}
-	return sign * v, nil
-}
-func (e *unaryEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *unaryEvaluator) EvalFloat(scope Scope) (float64, error) {
-	v, err := e.node.EvalFloat(scope)
-	if err != nil {
-		return 0, err
-	}
-	var sign float64
-	switch e.op {
-	case ast.AdditionOperator:
-		sign = 1.0
-	case ast.SubtractionOperator:
-		sign = -1.0
+
+	// The subtraction operator falls through to here.
+	switch e.t.Nature() {
+	case semantic.Int:
+		return values.NewInt(-v.Int()), nil
+	case semantic.Float:
+		return values.NewFloat(-v.Float()), nil
+	case semantic.Bool:
+		return values.NewBool(!v.Bool()), nil
+	case semantic.Duration:
+		return values.NewDuration(-v.Duration()), nil
+	case semantic.Nil:
+		return v, nil
 	default:
-		return 0.0, fmt.Errorf("unknown unary operator: %s", e.op)
+		panic(values.UnexpectedKind(e.t.Nature(), v.Type().Nature()))
 	}
-	return sign * v, nil
-}
-func (e *unaryEvaluator) EvalBool(scope Scope) (bool, error) {
-	v, err := eval(e.node, scope)
-	if err != nil {
-		return false, err
-	}
-	switch e.op {
-	case ast.NotOperator:
-		return !v.Bool(), nil
-	case ast.ExistsOperator:
-		return !v.IsNull(), nil
-	}
-	return false, fmt.Errorf("unknown unary logical operator: %s", e.op)
-}
-func (e *unaryEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *unaryEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	v, err := e.node.EvalDuration(scope)
-	if err != nil {
-		return 0, err
-	}
-	var sign int64
-	switch e.op {
-	case ast.AdditionOperator:
-		sign = 1
-	case ast.SubtractionOperator:
-		sign = -1
-	default:
-		return 0, fmt.Errorf("unknown unary logical operator: %s", e.op)
-	}
-	return values.Duration(sign * int64(v)), nil
-}
-func (e *unaryEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *unaryEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *unaryEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *unaryEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
 }
 
 type integerEvaluator struct {
@@ -961,38 +336,8 @@ func (e *integerEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *integerEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *integerEvaluator) EvalInt(scope Scope) (int64, error) {
-	return e.i, nil
-}
-func (e *integerEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	return uint64(e.i), nil
-}
-func (e *integerEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *integerEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *integerEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *integerEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *integerEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *integerEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *integerEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *integerEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *integerEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewInt(e.i), nil
 }
 
 type stringEvaluator struct {
@@ -1004,38 +349,8 @@ func (e *stringEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *stringEvaluator) EvalString(scope Scope) (string, error) {
-	return e.s, nil
-}
-func (e *stringEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *stringEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *stringEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *stringEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *stringEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *stringEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *stringEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *stringEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *stringEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *stringEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *stringEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewString(e.s), nil
 }
 
 type regexpEvaluator struct {
@@ -1047,38 +362,8 @@ func (e *regexpEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *regexpEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *regexpEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *regexpEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *regexpEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *regexpEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *regexpEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *regexpEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *regexpEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	return e.r, nil
-}
-func (e *regexpEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *regexpEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *regexpEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *regexpEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewRegexp(e.r), nil
 }
 
 type booleanEvaluator struct {
@@ -1090,38 +375,8 @@ func (e *booleanEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *booleanEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *booleanEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *booleanEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *booleanEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *booleanEvaluator) EvalBool(scope Scope) (bool, error) {
-	return e.b, nil
-}
-func (e *booleanEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *booleanEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *booleanEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *booleanEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *booleanEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *booleanEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *booleanEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewBool(e.b), nil
 }
 
 type floatEvaluator struct {
@@ -1133,38 +388,8 @@ func (e *floatEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *floatEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *floatEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *floatEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *floatEvaluator) EvalFloat(scope Scope) (float64, error) {
-	return e.f, nil
-}
-func (e *floatEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *floatEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *floatEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *floatEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *floatEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *floatEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *floatEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *floatEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewFloat(e.f), nil
 }
 
 type timeEvaluator struct {
@@ -1176,38 +401,8 @@ func (e *timeEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *timeEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *timeEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *timeEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *timeEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *timeEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *timeEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	return e.time, nil
-}
-func (e *timeEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *timeEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *timeEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *timeEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *timeEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *timeEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewTime(e.time), nil
 }
 
 type durationEvaluator struct {
@@ -1219,38 +414,8 @@ func (e *durationEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *durationEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *durationEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *durationEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *durationEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *durationEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *durationEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *durationEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	return e.duration, nil
-}
-func (e *durationEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *durationEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *durationEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *durationEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Function))
+func (e *durationEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.NewDuration(e.duration), nil
 }
 
 type identifierEvaluator struct {
@@ -1262,38 +427,10 @@ func (e *identifierEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *identifierEvaluator) EvalString(scope Scope) (string, error) {
-	return scope.GetString(e.name), nil
-}
-func (e *identifierEvaluator) EvalInt(scope Scope) (int64, error) {
-	return scope.GetInt(e.name), nil
-}
-func (e *identifierEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	return scope.GetUInt(e.name), nil
-}
-func (e *identifierEvaluator) EvalFloat(scope Scope) (float64, error) {
-	return scope.GetFloat(e.name), nil
-}
-func (e *identifierEvaluator) EvalBool(scope Scope) (bool, error) {
-	return scope.GetBool(e.name), nil
-}
-func (e *identifierEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	return scope.GetTime(e.name), nil
-}
-func (e *identifierEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	return scope.GetDuration(e.name), nil
-}
-func (e *identifierEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	return scope.GetRegexp(e.name), nil
-}
-func (e *identifierEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	return scope.GetArray(e.name), nil
-}
-func (e *identifierEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	return scope.GetObject(e.name), nil
-}
-func (e *identifierEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	return scope.GetFunction(e.name), nil
+func (e *identifierEvaluator) Eval(scope Scope) (values.Value, error) {
+	v := scope.Get(e.name)
+	values.CheckKind(v.Type().Nature(), e.t.Nature())
+	return v, nil
 }
 
 type valueEvaluator struct {
@@ -1304,38 +441,8 @@ func (e *valueEvaluator) Type() semantic.Type {
 	return e.value.Type()
 }
 
-func (e *valueEvaluator) EvalString(scope Scope) (string, error) {
-	return e.value.Str(), nil
-}
-func (e *valueEvaluator) EvalInt(scope Scope) (int64, error) {
-	return e.value.Int(), nil
-}
-func (e *valueEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	return e.value.UInt(), nil
-}
-func (e *valueEvaluator) EvalFloat(scope Scope) (float64, error) {
-	return e.value.Float(), nil
-}
-func (e *valueEvaluator) EvalBool(scope Scope) (bool, error) {
-	return e.value.Bool(), nil
-}
-func (e *valueEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	return e.value.Time(), nil
-}
-func (e *valueEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	return e.value.Duration(), nil
-}
-func (e *valueEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	return e.value.Regexp(), nil
-}
-func (e *valueEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	return e.value.Array(), nil
-}
-func (e *valueEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	return e.value.Object(), nil
-}
-func (e *valueEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	return e.value.Function(), nil
+func (e *valueEvaluator) Eval(scope Scope) (values.Value, error) {
+	return e.value, nil
 }
 
 type memberEvaluator struct {
@@ -1348,93 +455,14 @@ func (e *memberEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *memberEvaluator) EvalString(scope Scope) (string, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return "", err
-	}
-	v, _ := o.Get(e.property)
-	return v.Str(), nil
-}
-func (e *memberEvaluator) EvalInt(scope Scope) (int64, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return 0, err
-	}
-	v, _ := o.Get(e.property)
-	return v.Int(), nil
-}
-func (e *memberEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return 0, err
-	}
-	v, _ := o.Get(e.property)
-	return v.UInt(), nil
-}
-func (e *memberEvaluator) EvalFloat(scope Scope) (float64, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return 0.0, err
-	}
-	v, _ := o.Get(e.property)
-	return v.Float(), nil
-}
-func (e *memberEvaluator) EvalBool(scope Scope) (bool, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return false, err
-	}
-	v, _ := o.Get(e.property)
-	return v.Bool(), nil
-}
-func (e *memberEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return 0, err
-	}
-	v, _ := o.Get(e.property)
-	return v.Time(), nil
-}
-func (e *memberEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return 0, err
-	}
-	v, _ := o.Get(e.property)
-	return v.Duration(), nil
-}
-func (e *memberEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	o, err := e.object.EvalObject(scope)
+func (e *memberEvaluator) Eval(scope Scope) (values.Value, error) {
+	o, err := e.object.Eval(scope)
 	if err != nil {
 		return nil, err
 	}
-	v, _ := o.Get(e.property)
-	return v.Regexp(), nil
-}
-func (e *memberEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return nil, nil
-	}
-	v, _ := o.Get(e.property)
-	return v.Array(), nil
-}
-func (e *memberEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return nil, nil
-	}
-	v, _ := o.Get(e.property)
-	return v.Object(), nil
-}
-func (e *memberEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	o, err := e.object.EvalObject(scope)
-	if err != nil {
-		return nil, err
-	}
-	v, _ := o.Get(e.property)
-	return v.Function(), nil
+	v, _ := o.Object().Get(e.property)
+	values.CheckKind(v.Type().Nature(), e.t.Nature())
+	return v, nil
 }
 
 type arrayIndexEvaluator struct {
@@ -1447,94 +475,16 @@ func (e *arrayIndexEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *arrayIndexEvaluator) eval(scope Scope) (values.Value, error) {
-	a, err := e.array.EvalArray(scope)
+func (e *arrayIndexEvaluator) Eval(scope Scope) (values.Value, error) {
+	a, err := e.array.Eval(scope)
 	if err != nil {
 		return nil, err
 	}
-	i, err := e.index.EvalInt(scope)
+	i, err := e.index.Eval(scope)
 	if err != nil {
 		return nil, err
 	}
-	return a.Get(int(i)), nil
-}
-
-func (e *arrayIndexEvaluator) EvalString(scope Scope) (string, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return "", err
-	}
-	return v.Str(), nil
-}
-func (e *arrayIndexEvaluator) EvalInt(scope Scope) (int64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Int(), nil
-}
-func (e *arrayIndexEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.UInt(), nil
-}
-func (e *arrayIndexEvaluator) EvalFloat(scope Scope) (float64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0.0, err
-	}
-	return v.Float(), nil
-}
-func (e *arrayIndexEvaluator) EvalBool(scope Scope) (bool, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return false, err
-	}
-	return v.Bool(), nil
-}
-func (e *arrayIndexEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Time(), nil
-}
-func (e *arrayIndexEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Duration(), nil
-}
-func (e *arrayIndexEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Regexp(), nil
-}
-func (e *arrayIndexEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Array(), nil
-}
-func (e *arrayIndexEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Object(), nil
-}
-func (e *arrayIndexEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Function(), nil
+	return a.Array().Get(int(i.Int())), nil
 }
 
 type callEvaluator struct {
@@ -1547,94 +497,16 @@ func (e *callEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *callEvaluator) eval(scope Scope) (values.Value, error) {
-	args, err := e.args.EvalObject(scope)
+func (e *callEvaluator) Eval(scope Scope) (values.Value, error) {
+	args, err := e.args.Eval(scope)
 	if err != nil {
 		return nil, err
 	}
-	f, err := e.callee.EvalFunction(scope)
+	f, err := e.callee.Eval(scope)
 	if err != nil {
 		return nil, err
 	}
-	return f.Call(args)
-}
-
-func (e *callEvaluator) EvalString(scope Scope) (string, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return "", err
-	}
-	return v.Str(), nil
-}
-func (e *callEvaluator) EvalInt(scope Scope) (int64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Int(), nil
-}
-func (e *callEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.UInt(), nil
-}
-func (e *callEvaluator) EvalFloat(scope Scope) (float64, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0.0, err
-	}
-	return v.Float(), nil
-}
-func (e *callEvaluator) EvalBool(scope Scope) (bool, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return false, err
-	}
-	return v.Bool(), nil
-}
-func (e *callEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Time(), nil
-}
-func (e *callEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return 0, err
-	}
-	return v.Duration(), nil
-}
-func (e *callEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Regexp(), nil
-}
-func (e *callEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Array(), nil
-}
-func (e *callEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Object(), nil
-}
-func (e *callEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	v, err := e.eval(scope)
-	if err != nil {
-		return nil, err
-	}
-	return v.Function(), nil
+	return f.Function().Call(args.Object())
 }
 
 type functionEvaluator struct {
@@ -1647,37 +519,7 @@ func (e *functionEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *functionEvaluator) EvalString(scope Scope) (string, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.String))
-}
-func (e *functionEvaluator) EvalInt(scope Scope) (int64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Int))
-}
-func (e *functionEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.UInt))
-}
-func (e *functionEvaluator) EvalFloat(scope Scope) (float64, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Float))
-}
-func (e *functionEvaluator) EvalBool(scope Scope) (bool, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Bool))
-}
-func (e *functionEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Time))
-}
-func (e *functionEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Duration))
-}
-func (e *functionEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
-}
-func (e *functionEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Array))
-}
-func (e *functionEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	panic(values.UnexpectedKind(e.t.Nature(), semantic.Object))
-}
-func (e *functionEvaluator) EvalFunction(scope Scope) (values.Function, error) {
+func (e *functionEvaluator) Eval(scope Scope) (values.Value, error) {
 	return &functionValue{
 		t:      e.t,
 		body:   e.body,
@@ -1699,16 +541,29 @@ type functionParam struct {
 	Type    semantic.Type
 }
 
-func (f *functionValue) Type() semantic.Type {
-	return f.t
-}
-func (f *functionValue) PolyType() semantic.PolyType {
-	return f.t.PolyType()
-}
-
-func (f *functionValue) IsNull() bool {
+func (f *functionValue) HasSideEffect() bool {
 	return false
 }
+
+func (f *functionValue) Call(args values.Object) (values.Value, error) {
+	scope := f.scope.Copy()
+	for _, p := range f.params {
+		a, ok := args.Get(p.Key)
+		if !ok && p.Default != nil {
+			v, err := eval(p.Default, f.scope)
+			if err != nil {
+				return nil, err
+			}
+			a = v
+		}
+		scope.Set(p.Key, a)
+	}
+	return eval(f.body, scope)
+}
+
+func (f *functionValue) Type() semantic.Type         { return f.t }
+func (f *functionValue) PolyType() semantic.PolyType { return f.t.PolyType() }
+func (f *functionValue) IsNull() bool                { return false }
 func (f *functionValue) Str() string {
 	panic(values.UnexpectedKind(semantic.Function, semantic.String))
 }
@@ -1749,73 +604,13 @@ func (f *functionValue) Equal(rhs values.Value) bool {
 	v, ok := rhs.(*functionValue)
 	return ok && (f == v)
 }
-func (f *functionValue) HasSideEffect() bool {
-	return false
-}
 
-func (f *functionValue) Call(args values.Object) (values.Value, error) {
-	scope := f.scope.Copy()
-	for _, p := range f.params {
-		a, ok := args.Get(p.Key)
-		if !ok && p.Default != nil {
-			v, err := eval(p.Default, f.scope)
-			if err != nil {
-				return nil, err
-			}
-			a = v
-		}
-		scope.Set(p.Key, a)
-	}
-	return eval(f.body, scope)
-}
-
-type noopEvaluator struct {
-}
+type noopEvaluator struct{}
 
 func (noopEvaluator) Type() semantic.Type {
 	return semantic.Nil
 }
 
-func (noopEvaluator) EvalString(scope Scope) (string, error) {
-	return "", nil
-}
-
-func (noopEvaluator) EvalInt(scope Scope) (int64, error) {
-	return 0, nil
-}
-
-func (noopEvaluator) EvalUInt(scope Scope) (uint64, error) {
-	return 0, nil
-}
-
-func (noopEvaluator) EvalFloat(scope Scope) (float64, error) {
-	return 0.0, nil
-}
-
-func (noopEvaluator) EvalBool(scope Scope) (bool, error) {
-	return false, nil
-}
-
-func (noopEvaluator) EvalTime(scope Scope) (values.Time, error) {
-	return 0, nil
-}
-
-func (noopEvaluator) EvalDuration(scope Scope) (values.Duration, error) {
-	return 0, nil
-}
-
-func (noopEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
-	return nil, nil
-}
-
-func (noopEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	return nil, nil
-}
-
-func (noopEvaluator) EvalObject(scope Scope) (values.Object, error) {
-	return nil, nil
-}
-
-func (noopEvaluator) EvalFunction(scope Scope) (values.Function, error) {
-	return nil, nil
+func (noopEvaluator) Eval(scope Scope) (values.Value, error) {
+	return values.Null, nil
 }

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -590,7 +590,7 @@ func (e *arrayEvaluator) EvalRegexp(scope Scope) (*regexp.Regexp, error) {
 	panic(values.UnexpectedKind(e.t.Nature(), semantic.Regexp))
 }
 func (e *arrayEvaluator) EvalArray(scope Scope) (values.Array, error) {
-	arr := values.NewArray(e.t)
+	arr := values.NewArray(e.t.ElementType())
 	for _, ev := range e.array {
 		v, err := eval(ev, scope)
 		if err != nil {

--- a/stdlib/generate/from.go
+++ b/stdlib/generate/from.go
@@ -209,11 +209,11 @@ func (s *GeneratorSource) Decode() (flux.Table, error) {
 		b.AppendTime(timeIdx, values.ConvertTime(s.Start.Add(time.Duration(i)*deltaT)))
 		in := values.NewObject()
 		in.Set("n", values.NewInt(int64(i)))
-		v, err := s.Fn.EvalInt(in)
+		v, err := s.Fn.Eval(in)
 		if err != nil {
 			return nil, err
 		}
-		if err := b.AppendInt(valueIdx, v); err != nil {
+		if err := b.AppendValue(valueIdx, v); err != nil {
 			return nil, err
 		}
 	}

--- a/values/binary_test.go
+++ b/values/binary_test.go
@@ -6,7 +6,16 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
+)
+
+var (
+	intNullValue    = (*int64)(nil)
+	uintNullValue   = (*uint64)(nil)
+	floatNullValue  = (*float64)(nil)
+	stringNullValue = (*string)(nil)
+	timeNullValue   = (*values.Time)(nil)
 )
 
 func TestBinaryOperator(t *testing.T) {
@@ -17,297 +26,502 @@ func TestBinaryOperator(t *testing.T) {
 	}{
 		// int + int
 		{lhs: int64(6), op: "+", rhs: int64(4), want: int64(10)},
+		{lhs: int64(6), op: "+", rhs: intNullValue, want: nil},
 		// uint + uint
 		{lhs: uint64(6), op: "+", rhs: uint64(4), want: uint64(10)},
+		{lhs: uint64(6), op: "+", rhs: uintNullValue, want: nil},
 		// float + float
 		{lhs: 4.5, op: "+", rhs: 8.2, want: 12.7},
+		{lhs: 4.5, op: "+", rhs: floatNullValue, want: nil},
+		// string + string
+		{lhs: "a", op: "+", rhs: "b", want: "ab"},
+		{lhs: "a", op: "+", rhs: stringNullValue, want: nil},
+		// null + null
+		{lhs: nil, op: "+", rhs: nil, want: nil},
 		// int - int
 		{lhs: int64(6), op: "-", rhs: int64(4), want: int64(2)},
+		{lhs: int64(6), op: "-", rhs: intNullValue, want: nil},
 		// uint - uint
 		{lhs: uint64(6), op: "-", rhs: uint64(4), want: uint64(2)},
+		{lhs: uint64(6), op: "-", rhs: uintNullValue, want: nil},
 		// float - float
 		{lhs: 4.5, op: "-", rhs: 8.0, want: -3.5},
+		{lhs: 4.5, op: "-", rhs: floatNullValue, want: nil},
+		// null - null
+		{lhs: nil, op: "-", rhs: nil, want: nil},
 		// int * int
 		{lhs: int64(6), op: "*", rhs: int64(4), want: int64(24)},
+		{lhs: int64(6), op: "*", rhs: intNullValue, want: nil},
 		// uint * uint
 		{lhs: uint64(6), op: "*", rhs: uint64(4), want: uint64(24)},
+		{lhs: uint64(6), op: "*", rhs: uintNullValue, want: nil},
 		// float * float
 		{lhs: 4.5, op: "*", rhs: 8.2, want: 36.9},
+		{lhs: 4.5, op: "*", rhs: floatNullValue, want: nil},
+		// null * null
+		{lhs: nil, op: "*", rhs: nil, want: nil},
 		// int / int
 		{lhs: int64(6), op: "/", rhs: int64(4), want: int64(1)},
+		{lhs: int64(6), op: "/", rhs: intNullValue, want: nil},
 		// uint / uint
 		{lhs: uint64(6), op: "/", rhs: uint64(4), want: uint64(1)},
+		{lhs: uint64(6), op: "/", rhs: uintNullValue, want: nil},
 		// float / float
 		{lhs: 5.0, op: "/", rhs: 2.0, want: 2.5},
+		{lhs: 4.5, op: "/", rhs: floatNullValue, want: nil},
+		// null / null
+		{lhs: nil, op: "/", rhs: nil, want: nil},
 		// int <= int
 		{lhs: int64(6), op: "<=", rhs: int64(4), want: false},
 		{lhs: int64(4), op: "<=", rhs: int64(4), want: true},
 		{lhs: int64(4), op: "<=", rhs: int64(6), want: true},
+		{lhs: int64(6), op: "<=", rhs: intNullValue, want: nil},
 		// int <= uint
 		{lhs: int64(6), op: "<=", rhs: uint64(4), want: false},
 		{lhs: int64(4), op: "<=", rhs: uint64(4), want: true},
 		{lhs: int64(4), op: "<=", rhs: uint64(6), want: true},
+		{lhs: int64(6), op: "<=", rhs: uintNullValue, want: nil},
 		// int <= float
 		{lhs: int64(8), op: "<=", rhs: 6.7, want: false},
 		{lhs: int64(6), op: "<=", rhs: 6.0, want: true},
 		{lhs: int64(4), op: "<=", rhs: 6.7, want: true},
+		{lhs: int64(8), op: "<=", rhs: floatNullValue, want: nil},
+		// int <= null
+		{lhs: int64(8), op: "<=", rhs: nil, want: nil},
 		// uint <= int
 		{lhs: uint64(6), op: "<=", rhs: int64(4), want: false},
 		{lhs: uint64(4), op: "<=", rhs: int64(4), want: true},
 		{lhs: uint64(4), op: "<=", rhs: int64(6), want: true},
+		{lhs: uint64(6), op: "<=", rhs: intNullValue, want: nil},
 		// uint <= uint
 		{lhs: uint64(6), op: "<=", rhs: uint64(4), want: false},
 		{lhs: uint64(4), op: "<=", rhs: uint64(4), want: true},
 		{lhs: uint64(4), op: "<=", rhs: uint64(6), want: true},
+		{lhs: uint64(6), op: "<=", rhs: uintNullValue, want: nil},
 		// uint <= float
 		{lhs: uint64(8), op: "<=", rhs: 6.7, want: false},
 		{lhs: uint64(6), op: "<=", rhs: 6.0, want: true},
 		{lhs: uint64(4), op: "<=", rhs: 6.7, want: true},
+		{lhs: uint64(8), op: "<=", rhs: floatNullValue, want: nil},
+		// uint <= null
+		{lhs: uint64(8), op: "<=", rhs: nil, want: nil},
 		// float <= int
 		{lhs: 6.7, op: "<=", rhs: int64(4), want: false},
 		{lhs: 6.0, op: "<=", rhs: int64(6), want: true},
 		{lhs: 6.7, op: "<=", rhs: int64(8), want: true},
+		{lhs: 6.7, op: "<=", rhs: intNullValue, want: nil},
 		// float <= uint
 		{lhs: 6.7, op: "<=", rhs: uint64(4), want: false},
 		{lhs: 6.0, op: "<=", rhs: uint64(6), want: true},
 		{lhs: 6.7, op: "<=", rhs: uint64(8), want: true},
+		{lhs: 6.7, op: "<=", rhs: uintNullValue, want: nil},
 		// float <= float
 		{lhs: 8.2, op: "<=", rhs: 4.5, want: false},
 		{lhs: 4.5, op: "<=", rhs: 4.5, want: true},
 		{lhs: 4.5, op: "<=", rhs: 8.2, want: true},
+		{lhs: 8.2, op: "<=", rhs: floatNullValue, want: nil},
+		// float <= null
+		{lhs: 6.7, op: "<=", rhs: nil, want: nil},
 		// string <= string
 		{lhs: "", op: "<=", rhs: "x", want: true},
 		{lhs: "x", op: "<=", rhs: "", want: false},
 		{lhs: "x", op: "<=", rhs: "x", want: true},
 		{lhs: "x", op: "<=", rhs: "a", want: false},
 		{lhs: "x", op: "<=", rhs: "abc", want: false},
+		{lhs: "x", op: "<=", rhs: stringNullValue, want: nil},
+		// string <= null
+		{lhs: "x", op: "<=", rhs: nil, want: nil},
 		// time <= time
 		{lhs: values.Time(0), op: "<=", rhs: values.Time(1), want: true},
 		{lhs: values.Time(0), op: "<=", rhs: values.Time(0), want: true},
 		{lhs: values.Time(1), op: "<=", rhs: values.Time(0), want: false},
+		{lhs: values.Time(0), op: "<=", rhs: nil, want: nil},
+		// time <= null
+		{lhs: values.Time(0), op: "<=", rhs: nil, want: nil},
+		// null <= int
+		{lhs: nil, op: "<=", rhs: int64(8), want: nil},
+		// null <= uint
+		{lhs: nil, op: "<=", rhs: uint64(8), want: nil},
+		// null <= float
+		{lhs: nil, op: "<=", rhs: 6.7, want: nil},
+		// null <= string
+		{lhs: nil, op: "<=", rhs: "x", want: nil},
+		// null <= time
+		{lhs: nil, op: "<=", rhs: values.Time(0), want: nil},
+		// null <= null
+		{lhs: nil, op: "<=", rhs: nil, want: nil},
 		// int < int
 		{lhs: int64(6), op: "<", rhs: int64(4), want: false},
 		{lhs: int64(4), op: "<", rhs: int64(4), want: false},
 		{lhs: int64(4), op: "<", rhs: int64(6), want: true},
+		{lhs: int64(6), op: "<", rhs: intNullValue, want: nil},
 		// int < uint
 		{lhs: int64(6), op: "<", rhs: uint64(4), want: false},
 		{lhs: int64(4), op: "<", rhs: uint64(4), want: false},
 		{lhs: int64(4), op: "<", rhs: uint64(6), want: true},
+		{lhs: int64(6), op: "<", rhs: uintNullValue, want: nil},
 		// int < float
 		{lhs: int64(8), op: "<", rhs: 6.7, want: false},
 		{lhs: int64(6), op: "<", rhs: 6.0, want: false},
 		{lhs: int64(4), op: "<", rhs: 6.7, want: true},
+		{lhs: int64(8), op: "<", rhs: floatNullValue, want: nil},
+		// int < null
+		{lhs: int64(8), op: "<", rhs: nil, want: nil},
 		// uint < int
 		{lhs: uint64(6), op: "<", rhs: int64(4), want: false},
 		{lhs: uint64(4), op: "<", rhs: int64(4), want: false},
 		{lhs: uint64(4), op: "<", rhs: int64(6), want: true},
+		{lhs: uint64(6), op: "<", rhs: intNullValue, want: nil},
 		// uint < uint
 		{lhs: uint64(6), op: "<", rhs: uint64(4), want: false},
 		{lhs: uint64(4), op: "<", rhs: uint64(4), want: false},
 		{lhs: uint64(4), op: "<", rhs: uint64(6), want: true},
+		{lhs: uint64(6), op: "<", rhs: uintNullValue, want: nil},
 		// uint < float
 		{lhs: uint64(8), op: "<", rhs: 6.7, want: false},
 		{lhs: uint64(6), op: "<", rhs: 6.0, want: false},
 		{lhs: uint64(4), op: "<", rhs: 6.7, want: true},
+		{lhs: uint64(8), op: "<", rhs: floatNullValue, want: nil},
+		// uint < null
+		{lhs: uint64(8), op: "<", rhs: nil, want: nil},
 		// float < int
 		{lhs: 6.7, op: "<", rhs: int64(4), want: false},
 		{lhs: 6.0, op: "<", rhs: int64(6), want: false},
 		{lhs: 6.7, op: "<", rhs: int64(8), want: true},
+		{lhs: 6.7, op: "<", rhs: intNullValue, want: nil},
 		// float < uint
 		{lhs: 6.7, op: "<", rhs: uint64(4), want: false},
 		{lhs: 6.0, op: "<", rhs: uint64(6), want: false},
 		{lhs: 6.7, op: "<", rhs: uint64(8), want: true},
+		{lhs: 6.7, op: "<", rhs: uintNullValue, want: nil},
 		// float < float
 		{lhs: 8.2, op: "<", rhs: 4.5, want: false},
 		{lhs: 4.5, op: "<", rhs: 4.5, want: false},
 		{lhs: 4.5, op: "<", rhs: 8.2, want: true},
+		{lhs: 8.2, op: "<", rhs: floatNullValue, want: nil},
+		// float < null
+		{lhs: 8.2, op: "<", rhs: nil, want: nil},
 		// string < string
 		{lhs: "", op: "<", rhs: "x", want: true},
 		{lhs: "x", op: "<", rhs: "", want: false},
 		{lhs: "x", op: "<", rhs: "x", want: false},
 		{lhs: "x", op: "<", rhs: "a", want: false},
 		{lhs: "x", op: "<", rhs: "abc", want: false},
+		{lhs: "x", op: "<", rhs: stringNullValue, want: nil},
+		// string < null
+		{lhs: "x", op: "<", rhs: nil, want: nil},
 		// time < time
 		{lhs: values.Time(0), op: "<", rhs: values.Time(1), want: true},
 		{lhs: values.Time(0), op: "<", rhs: values.Time(0), want: false},
 		{lhs: values.Time(1), op: "<", rhs: values.Time(0), want: false},
+		{lhs: values.Time(0), op: "<", rhs: timeNullValue, want: nil},
+		// time < null
+		{lhs: values.Time(0), op: "<", rhs: nil, want: nil},
+		// null < int
+		{lhs: nil, op: "<", rhs: int64(8), want: nil},
+		// null < uint
+		{lhs: nil, op: "<", rhs: uint64(8), want: nil},
+		// null < float
+		{lhs: nil, op: "<", rhs: 6.7, want: nil},
+		// null < string
+		{lhs: nil, op: "<", rhs: "x", want: nil},
+		// null < time
+		{lhs: nil, op: "<", rhs: values.Time(0), want: nil},
+		// null < null
+		{lhs: nil, op: "<", rhs: nil, want: nil},
 		// int >= int
 		{lhs: int64(6), op: ">=", rhs: int64(4), want: true},
 		{lhs: int64(4), op: ">=", rhs: int64(4), want: true},
 		{lhs: int64(4), op: ">=", rhs: int64(6), want: false},
+		{lhs: int64(6), op: ">=", rhs: intNullValue, want: nil},
 		// int >= uint
 		{lhs: int64(6), op: ">=", rhs: uint64(4), want: true},
 		{lhs: int64(4), op: ">=", rhs: uint64(4), want: true},
 		{lhs: int64(4), op: ">=", rhs: uint64(6), want: false},
+		{lhs: int64(6), op: ">=", rhs: uintNullValue, want: nil},
 		// int >= float
 		{lhs: int64(8), op: ">=", rhs: 6.7, want: true},
 		{lhs: int64(6), op: ">=", rhs: 6.0, want: true},
 		{lhs: int64(4), op: ">=", rhs: 6.7, want: false},
+		{lhs: int64(8), op: ">=", rhs: floatNullValue, want: nil},
+		// int <= null
+		{lhs: int64(8), op: ">=", rhs: nil, want: nil},
 		// uint >= int
 		{lhs: uint64(6), op: ">=", rhs: int64(4), want: true},
 		{lhs: uint64(4), op: ">=", rhs: int64(4), want: true},
 		{lhs: uint64(4), op: ">=", rhs: int64(6), want: false},
+		{lhs: uint64(6), op: ">=", rhs: intNullValue, want: nil},
 		// uint >= uint
 		{lhs: uint64(6), op: ">=", rhs: uint64(4), want: true},
 		{lhs: uint64(4), op: ">=", rhs: uint64(4), want: true},
 		{lhs: uint64(4), op: ">=", rhs: uint64(6), want: false},
+		{lhs: uint64(6), op: ">=", rhs: uintNullValue, want: nil},
 		// uint >= float
 		{lhs: uint64(8), op: ">=", rhs: 6.7, want: true},
 		{lhs: uint64(6), op: ">=", rhs: 6.0, want: true},
 		{lhs: uint64(4), op: ">=", rhs: 6.7, want: false},
+		{lhs: uint64(8), op: ">=", rhs: floatNullValue, want: nil},
+		// uint <= null
+		{lhs: uint64(8), op: ">=", rhs: nil, want: nil},
 		// float >= int
 		{lhs: 6.7, op: ">=", rhs: int64(4), want: true},
 		{lhs: 6.0, op: ">=", rhs: int64(6), want: true},
 		{lhs: 6.7, op: ">=", rhs: int64(8), want: false},
+		{lhs: 6.7, op: ">=", rhs: intNullValue, want: nil},
 		// float >= uint
 		{lhs: 6.7, op: ">=", rhs: uint64(4), want: true},
 		{lhs: 6.0, op: ">=", rhs: uint64(6), want: true},
 		{lhs: 6.7, op: ">=", rhs: uint64(8), want: false},
+		{lhs: 6.7, op: ">=", rhs: uintNullValue, want: nil},
 		// float >= float
 		{lhs: 8.2, op: ">=", rhs: 4.5, want: true},
 		{lhs: 4.5, op: ">=", rhs: 4.5, want: true},
 		{lhs: 4.5, op: ">=", rhs: 8.2, want: false},
+		{lhs: 8.2, op: ">=", rhs: floatNullValue, want: nil},
+		// float <= null
+		{lhs: 6.7, op: ">=", rhs: nil, want: nil},
 		// string >= string
 		{lhs: "", op: ">=", rhs: "x", want: false},
 		{lhs: "x", op: ">=", rhs: "", want: true},
 		{lhs: "x", op: ">=", rhs: "x", want: true},
 		{lhs: "x", op: ">=", rhs: "a", want: true},
 		{lhs: "x", op: ">=", rhs: "abc", want: true},
+		{lhs: "x", op: ">=", rhs: stringNullValue, want: nil},
+		// string <= null
+		{lhs: "x", op: ">=", rhs: nil, want: nil},
 		// time >= time
 		{lhs: values.Time(0), op: ">=", rhs: values.Time(1), want: false},
 		{lhs: values.Time(0), op: ">=", rhs: values.Time(0), want: true},
 		{lhs: values.Time(1), op: ">=", rhs: values.Time(0), want: true},
+		{lhs: values.Time(0), op: ">=", rhs: nil, want: nil},
+		// time <= null
+		{lhs: values.Time(0), op: ">=", rhs: nil, want: nil},
+		// null <= int
+		{lhs: nil, op: ">=", rhs: int64(8), want: nil},
+		// null <= uint
+		{lhs: nil, op: ">=", rhs: uint64(8), want: nil},
+		// null <= float
+		{lhs: nil, op: ">=", rhs: 6.7, want: nil},
+		// null <= string
+		{lhs: nil, op: ">=", rhs: "x", want: nil},
+		// null <= time
+		{lhs: nil, op: ">=", rhs: values.Time(0), want: nil},
+		// null <= null
+		{lhs: nil, op: ">=", rhs: nil, want: nil},
 		// int > int
 		{lhs: int64(6), op: ">", rhs: int64(4), want: true},
 		{lhs: int64(4), op: ">", rhs: int64(4), want: false},
 		{lhs: int64(4), op: ">", rhs: int64(6), want: false},
+		{lhs: int64(6), op: ">", rhs: intNullValue, want: nil},
 		// int > uint
 		{lhs: int64(6), op: ">", rhs: uint64(4), want: true},
 		{lhs: int64(4), op: ">", rhs: uint64(4), want: false},
 		{lhs: int64(4), op: ">", rhs: uint64(6), want: false},
+		{lhs: int64(6), op: ">", rhs: uintNullValue, want: nil},
 		// int > float
 		{lhs: int64(8), op: ">", rhs: 6.7, want: true},
 		{lhs: int64(6), op: ">", rhs: 6.0, want: false},
 		{lhs: int64(4), op: ">", rhs: 6.7, want: false},
+		{lhs: int64(8), op: ">", rhs: floatNullValue, want: nil},
+		// int < null
+		{lhs: int64(8), op: ">", rhs: nil, want: nil},
 		// uint > int
 		{lhs: uint64(6), op: ">", rhs: int64(4), want: true},
 		{lhs: uint64(4), op: ">", rhs: int64(4), want: false},
 		{lhs: uint64(4), op: ">", rhs: int64(6), want: false},
+		{lhs: uint64(6), op: ">", rhs: intNullValue, want: nil},
 		// uint > uint
 		{lhs: uint64(6), op: ">", rhs: uint64(4), want: true},
 		{lhs: uint64(4), op: ">", rhs: uint64(4), want: false},
 		{lhs: uint64(4), op: ">", rhs: uint64(6), want: false},
+		{lhs: uint64(6), op: ">", rhs: uintNullValue, want: nil},
 		// uint > float
 		{lhs: uint64(8), op: ">", rhs: 6.7, want: true},
 		{lhs: uint64(6), op: ">", rhs: 6.0, want: false},
 		{lhs: uint64(4), op: ">", rhs: 6.7, want: false},
+		{lhs: uint64(8), op: ">", rhs: floatNullValue, want: nil},
+		// uint < null
+		{lhs: uint64(8), op: ">", rhs: nil, want: nil},
 		// float > int
 		{lhs: 6.7, op: ">", rhs: int64(4), want: true},
 		{lhs: 6.0, op: ">", rhs: int64(6), want: false},
 		{lhs: 6.7, op: ">", rhs: int64(8), want: false},
+		{lhs: 6.7, op: ">", rhs: intNullValue, want: nil},
 		// float > uint
 		{lhs: 6.7, op: ">", rhs: uint64(4), want: true},
 		{lhs: 6.0, op: ">", rhs: uint64(6), want: false},
 		{lhs: 6.7, op: ">", rhs: uint64(8), want: false},
+		{lhs: 6.7, op: ">", rhs: uintNullValue, want: nil},
 		// float > float
 		{lhs: 8.2, op: ">", rhs: 4.5, want: true},
 		{lhs: 4.5, op: ">", rhs: 8.2, want: false},
 		{lhs: 4.5, op: ">", rhs: 4.5, want: false},
+		{lhs: 8.2, op: ">", rhs: floatNullValue, want: nil},
 		// string > string
 		{lhs: "", op: ">", rhs: "x", want: false},
 		{lhs: "x", op: ">", rhs: "", want: true},
 		{lhs: "x", op: ">", rhs: "x", want: false},
 		{lhs: "x", op: ">", rhs: "a", want: true},
 		{lhs: "x", op: ">", rhs: "abc", want: true},
+		{lhs: "x", op: ">", rhs: stringNullValue, want: nil},
 		// time > time
 		{lhs: values.Time(0), op: ">", rhs: values.Time(1), want: false},
 		{lhs: values.Time(0), op: ">", rhs: values.Time(0), want: false},
 		{lhs: values.Time(1), op: ">", rhs: values.Time(0), want: true},
+		{lhs: values.Time(0), op: ">", rhs: timeNullValue, want: nil},
+		// time < null
+		{lhs: values.Time(0), op: ">", rhs: nil, want: nil},
+		// null < int
+		{lhs: nil, op: ">", rhs: int64(8), want: nil},
+		// null < uint
+		{lhs: nil, op: ">", rhs: uint64(8), want: nil},
+		// null < float
+		{lhs: nil, op: ">", rhs: 6.7, want: nil},
+		// null < string
+		{lhs: nil, op: ">", rhs: "x", want: nil},
+		// null < time
+		{lhs: nil, op: ">", rhs: values.Time(0), want: nil},
+		// null < null
+		{lhs: nil, op: ">", rhs: nil, want: nil},
 		// int == int
 		{lhs: int64(4), op: "==", rhs: int64(4), want: true},
 		{lhs: int64(6), op: "==", rhs: int64(4), want: false},
+		{lhs: int64(4), op: "==", rhs: intNullValue, want: nil},
 		// int == uint
 		{lhs: int64(4), op: "==", rhs: uint64(4), want: true},
 		{lhs: int64(6), op: "==", rhs: uint64(4), want: false},
+		{lhs: int64(4), op: "==", rhs: uintNullValue, want: nil},
 		// int == float
 		{lhs: int64(4), op: "==", rhs: float64(4), want: true},
 		{lhs: int64(6), op: "==", rhs: float64(4), want: false},
+		{lhs: int64(4), op: "==", rhs: floatNullValue, want: nil},
+		// int == null
+		{lhs: int64(4), op: "==", rhs: nil, want: nil},
 		// uint == int
 		{lhs: uint64(4), op: "==", rhs: int64(4), want: true},
 		{lhs: uint64(6), op: "==", rhs: int64(4), want: false},
+		{lhs: uint64(4), op: "==", rhs: intNullValue, want: nil},
 		// uint == uint
 		{lhs: uint64(4), op: "==", rhs: uint64(4), want: true},
 		{lhs: uint64(6), op: "==", rhs: uint64(4), want: false},
+		{lhs: uint64(4), op: "==", rhs: uintNullValue, want: nil},
 		// uint == float
 		{lhs: uint64(4), op: "==", rhs: float64(4), want: true},
 		{lhs: uint64(6), op: "==", rhs: float64(4), want: false},
+		{lhs: uint64(4), op: "==", rhs: floatNullValue, want: nil},
+		// uint == null
+		{lhs: uint64(4), op: "==", rhs: nil, want: nil},
 		// float == int
 		{lhs: float64(4), op: "==", rhs: int64(4), want: true},
 		{lhs: float64(6), op: "==", rhs: int64(4), want: false},
+		{lhs: float64(4), op: "==", rhs: intNullValue, want: nil},
 		// float == uint
 		{lhs: float64(4), op: "==", rhs: uint64(4), want: true},
 		{lhs: float64(6), op: "==", rhs: uint64(4), want: false},
+		{lhs: float64(4), op: "==", rhs: uintNullValue, want: nil},
 		// float == float
 		{lhs: float64(4), op: "==", rhs: float64(4), want: true},
 		{lhs: float64(6), op: "==", rhs: float64(4), want: false},
+		{lhs: float64(4), op: "==", rhs: floatNullValue, want: nil},
+		// float == null
+		{lhs: float64(4), op: "==", rhs: nil, want: nil},
 		// string == string
 		{lhs: "a", op: "==", rhs: "a", want: true},
 		{lhs: "a", op: "==", rhs: "b", want: false},
+		{lhs: "a", op: "==", rhs: stringNullValue, want: nil},
+		// string == null
+		{lhs: "a", op: "==", rhs: nil, want: nil},
 		// time == time
 		{lhs: values.Time(0), op: "==", rhs: values.Time(1), want: false},
 		{lhs: values.Time(0), op: "==", rhs: values.Time(0), want: true},
 		{lhs: values.Time(1), op: "==", rhs: values.Time(0), want: false},
+		{lhs: values.Time(0), op: "==", rhs: timeNullValue, want: nil},
+		// time == null
+		{lhs: values.Time(0), op: "==", rhs: nil, want: nil},
+		// null == int
+		{lhs: nil, op: "==", rhs: int64(4), want: nil},
+		// null == uint
+		{lhs: nil, op: "==", rhs: uint64(4), want: nil},
+		// null == float
+		{lhs: nil, op: "==", rhs: float64(4), want: nil},
+		// null == string
+		{lhs: nil, op: "==", rhs: "a", want: nil},
+		// null == time
+		{lhs: nil, op: "==", rhs: values.Time(0), want: nil},
 		// int != int
 		{lhs: int64(4), op: "!=", rhs: int64(4), want: false},
 		{lhs: int64(6), op: "!=", rhs: int64(4), want: true},
+		{lhs: int64(4), op: "!=", rhs: intNullValue, want: nil},
 		// int != uint
 		{lhs: int64(4), op: "!=", rhs: uint64(4), want: false},
 		{lhs: int64(6), op: "!=", rhs: uint64(4), want: true},
+		{lhs: int64(4), op: "!=", rhs: uintNullValue, want: nil},
 		// int != float
 		{lhs: int64(4), op: "!=", rhs: float64(4), want: false},
 		{lhs: int64(6), op: "!=", rhs: float64(4), want: true},
+		{lhs: int64(4), op: "!=", rhs: uintNullValue, want: nil},
+		// int != null
+		{lhs: int64(4), op: "!=", rhs: nil, want: nil},
 		// uint != int
 		{lhs: uint64(4), op: "!=", rhs: int64(4), want: false},
 		{lhs: uint64(6), op: "!=", rhs: int64(4), want: true},
+		{lhs: uint64(4), op: "!=", rhs: intNullValue, want: nil},
 		// uint != uint
 		{lhs: uint64(4), op: "!=", rhs: uint64(4), want: false},
 		{lhs: uint64(6), op: "!=", rhs: uint64(4), want: true},
+		{lhs: uint64(4), op: "!=", rhs: uintNullValue, want: nil},
 		// uint != float
 		{lhs: uint64(4), op: "!=", rhs: float64(4), want: false},
 		{lhs: uint64(6), op: "!=", rhs: float64(4), want: true},
+		{lhs: uint64(4), op: "!=", rhs: floatNullValue, want: nil},
+		// uint != null
+		{lhs: uint64(4), op: "!=", rhs: nil, want: nil},
 		// float != int
 		{lhs: float64(4), op: "!=", rhs: int64(4), want: false},
 		{lhs: float64(6), op: "!=", rhs: int64(4), want: true},
+		{lhs: float64(4), op: "!=", rhs: intNullValue, want: nil},
 		// float != uint
 		{lhs: float64(4), op: "!=", rhs: uint64(4), want: false},
 		{lhs: float64(6), op: "!=", rhs: uint64(4), want: true},
+		{lhs: float64(4), op: "!=", rhs: uintNullValue, want: nil},
 		// float != float
 		{lhs: float64(4), op: "!=", rhs: float64(4), want: false},
 		{lhs: float64(6), op: "!=", rhs: float64(4), want: true},
+		{lhs: float64(4), op: "!=", rhs: floatNullValue, want: nil},
 		// string != string
 		{lhs: "a", op: "!=", rhs: "a", want: false},
 		{lhs: "a", op: "!=", rhs: "b", want: true},
+		{lhs: "a", op: "!=", rhs: stringNullValue, want: nil},
+		// string == null
+		{lhs: "a", op: "!=", rhs: nil, want: nil},
 		// time != time
 		{lhs: values.Time(0), op: "!=", rhs: values.Time(1), want: true},
 		{lhs: values.Time(0), op: "!=", rhs: values.Time(0), want: false},
 		{lhs: values.Time(1), op: "!=", rhs: values.Time(0), want: true},
+		{lhs: values.Time(0), op: "!=", rhs: timeNullValue, want: nil},
+		// time != null
+		{lhs: values.Time(0), op: "!=", rhs: nil, want: nil},
+		// null != int
+		{lhs: nil, op: "!=", rhs: int64(4), want: nil},
+		// null != uint
+		{lhs: nil, op: "!=", rhs: uint64(4), want: nil},
+		// null != float
+		{lhs: nil, op: "!=", rhs: float64(4), want: nil},
+		// null != string
+		{lhs: nil, op: "!=", rhs: "a", want: nil},
+		// null != time
+		{lhs: nil, op: "!=", rhs: values.Time(0), want: nil},
 		// string =~ regex
 		{lhs: "abc", op: "=~", rhs: regexp.MustCompile(`.+`), want: true},
 		{lhs: "abc", op: "=~", rhs: regexp.MustCompile(`b{2}`), want: false},
-		// regex =~ string
-		{lhs: regexp.MustCompile(`.+`), op: "=~", rhs: "abc", want: true},
-		{lhs: regexp.MustCompile(`b{2}`), op: "=~", rhs: "abc", want: false},
+		{lhs: stringNullValue, op: "=~", rhs: regexp.MustCompile(`.*`), want: nil},
 		// string !~ regex
 		{lhs: "abc", op: "!~", rhs: regexp.MustCompile(`.+`), want: false},
 		{lhs: "abc", op: "!~", rhs: regexp.MustCompile(`b{2}`), want: true},
-		// regex !~ string
-		{lhs: regexp.MustCompile(`.+`), op: "!~", rhs: "abc", want: false},
-		{lhs: regexp.MustCompile(`b{2}`), op: "!~", rhs: "abc", want: true},
-		// string + string
-		{lhs: "a", op: "+", rhs: "b", want: "ab"},
+		{lhs: stringNullValue, op: "!~", rhs: regexp.MustCompile(`.*`), want: nil},
 	} {
 		t.Run(fmt.Sprintf("%v %s %v", tt.lhs, tt.op, tt.rhs), func(t *testing.T) {
-			left, right := values.New(tt.lhs), values.New(tt.rhs)
+			left, right := Value(tt.lhs), Value(tt.rhs)
 			fn, err := values.LookupBinaryFunction(values.BinaryFuncSignature{
 				Operator: ast.OperatorLookup(tt.op),
 				Left:     left.Type(),
@@ -317,9 +531,68 @@ func TestBinaryOperator(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if want, got := values.New(tt.want), fn(left, right); !want.Equal(got) {
+			if want, got := Value(tt.want), fn(left, right); !ValueEqual(want, got) {
 				t.Fatalf("unexpected value -want/+got\n\t- %s\n\t+ %s", want, got)
 			}
 		})
 	}
+}
+
+// Value converts an interface into a value.
+//
+// If the interface is a pointer to a basic type that is null,
+// it will create a null with the type of the pointer.
+//
+// Otherwise, it will use values.New to create the value.
+func Value(v interface{}) values.Value {
+	switch v := v.(type) {
+	case *int64:
+		if v == nil {
+			return values.NewNull(semantic.Int)
+		}
+		return values.NewInt(*v)
+	case *uint64:
+		if v == nil {
+			return values.NewNull(semantic.UInt)
+		}
+		return values.NewUInt(*v)
+	case *float64:
+		if v == nil {
+			return values.NewNull(semantic.Float)
+		}
+		return values.NewFloat(*v)
+	case *string:
+		if v == nil {
+			return values.NewNull(semantic.String)
+		}
+		return values.NewString(*v)
+	case *bool:
+		if v == nil {
+			return values.NewNull(semantic.Bool)
+		}
+		return values.NewBool(*v)
+	case *values.Time:
+		if v == nil {
+			return values.NewNull(semantic.Time)
+		}
+		return values.NewTime(*v)
+	case *values.Duration:
+		if v == nil {
+			return values.NewNull(semantic.Duration)
+		}
+		return values.NewDuration(*v)
+	}
+	return values.New(v)
+}
+
+// ValueEqual compares two values and considers two null
+// values to be equal to each other.
+//
+// The standard equality operator does not consider null
+// to be equal to null.
+func ValueEqual(l, r values.Value) bool {
+	if l.IsNull() && r.IsNull() {
+		return true
+	}
+	return l.Equal(r)
 }

--- a/values/object.go
+++ b/values/object.go
@@ -110,7 +110,7 @@ func (o *object) Get(name string) (Value, bool) {
 			return o.values[i], true
 		}
 	}
-	return nil, false
+	return Null, false
 }
 func (o *object) Len() int {
 	return len(o.values)


### PR DESCRIPTION
BREAKING CHANGE: This updates the compiler function so there is only one
`Eval` function instead of one for each type. This may break code that
called these other methods.

- [ ] docs/SPEC.md updated
- [ ] Test cases written

Fixes #1329.