### PR TITLE
feat(semantic): add nullable kind

### DIFF
--- a/semantic/constraints.go
+++ b/semantic/constraints.go
@@ -374,7 +374,12 @@ func (v ConstraintGenerator) typeof(n Node) (PolyType, error) {
 	case *Property:
 		return v.lookup(n.Value)
 	case *MemberExpression:
+		// Retrieve a new type variable for the property
+		// and add a nullable kind constraint to indicate
+		// that the variable can be null.
 		ptv := v.cs.f.Fresh()
+		v.cs.AddKindConst(ptv, NullableKind{T: ptv})
+
 		t, err := v.lookup(n.Object)
 		if err != nil {
 			return nil, err

--- a/values/values.go
+++ b/values/values.go
@@ -135,8 +135,13 @@ func (v value) String() string {
 	return fmt.Sprintf("%v", v.v)
 }
 
-// InvalidValue is a non nil value who's type is semantic.Invalid
-var InvalidValue = value{t: semantic.Invalid}
+var (
+	// InvalidValue is a non nil value who's type is semantic.Invalid
+	InvalidValue = value{t: semantic.Invalid}
+
+	// Null is an untyped nil value.
+	Null = value{t: semantic.Nil}
+)
 
 // New constructs a new Value by inferring the type from the interface. If the interface
 // does not translate to a valid Value type, then InvalidValue is returned.


### PR DESCRIPTION
The nullable kind is used for marking that a type variable may be null
in the semantic graph. This kind constraint is added to any values
retrieved using a `MemberExpression` because these are retrieved from
records and records can return null values if the key isn't present.

The nullable kind will unify with anything and it will discard itself if
it is unified with any other kind constraint. At that point, it is
determined that the type cannot be nullable anymore because the other
kind constraint says it cannot be.

If a type variable that is nullable never resolves itself to a concrete
type, it will determine itself to be the null type when used.

Fixes #1353.

- [x] docs/SPEC.md updated
- [x] Test cases written