### PR TITLE
feat(interpreter): nulls work in table and row functions

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -13,27 +13,7 @@ import (
 	"github.com/influxdata/flux/values"
 )
 
-var CmpOptions []cmp.Option
-
-func init() {
-	CmpOptions = append(semantictest.CmpOptions, cmp.Comparer(ValueEqual))
-}
-
-func ValueEqual(x, y values.Value) bool {
-	if x == values.Null && y == values.Null {
-		return true
-	}
-
-	switch k := x.Type().Nature(); k {
-	case semantic.Object:
-		if x.Type() != y.Type() {
-			return false
-		}
-		return cmp.Equal(x.Object(), y.Object(), CmpOptions...)
-	default:
-		return x.Equal(y)
-	}
-}
+var CmpOptions = semantictest.CmpOptions
 
 func TestCompilationCache(t *testing.T) {
 	add := &semantic.FunctionExpression{
@@ -1045,6 +1025,34 @@ func TestCompileAndEval(t *testing.T) {
 					"a": values.NewInt(4),
 					// "b": values.Null,
 				}),
+			}),
+			want: values.Null,
+		},
+		{
+			name: "two null values are not equal",
+			// fn = (a, b) => a == b
+			fn: &semantic.FunctionExpression{
+				Block: &semantic.FunctionBlock{
+					Parameters: &semantic.FunctionParameters{
+						List: []*semantic.FunctionParameter{
+							{Key: &semantic.Identifier{Name: "a"}},
+							{Key: &semantic.Identifier{Name: "b"}},
+						},
+					},
+					Body: &semantic.BinaryExpression{
+						Operator: ast.EqualOperator,
+						Left:     &semantic.IdentifierExpression{Name: "a"},
+						Right:    &semantic.IdentifierExpression{Name: "b"},
+					},
+				},
+			},
+			inType: semantic.NewObjectType(map[string]semantic.Type{
+				"a": semantic.Int,
+				"b": semantic.Int,
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"a": values.Null,
+				"b": values.Null,
 			}),
 			want: values.Null,
 		},

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -1,7 +1,6 @@
 package execute
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/influxdata/flux"
@@ -11,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type rowFn struct {
+type dynamicFn struct {
 	compilationCache *compiler.CompilationCache
 	inRecord         values.Object
 
@@ -24,32 +23,23 @@ type rowFn struct {
 	references []string
 }
 
-func newRowFn(fn *semantic.FunctionExpression) (rowFn, error) {
-	//if fn.Block.Parameters != nil && len(fn.Block.Parameters.List) != 1 {
-	//	return rowFn{}, errors.New("function should only have a single parameter")
-	//}
+func newDynamicFn(fn *semantic.FunctionExpression) dynamicFn {
 	scope := flux.BuiltIns()
-	return rowFn{
+	return dynamicFn{
 		compilationCache: compiler.NewCompilationCache(fn, scope),
 		inRecord:         values.NewObject(),
 		recordName:       fn.Block.Parameters.List[0].Key.Name,
 		references:       findColReferences(fn),
 		recordCols:       make(map[string]int),
-	}, nil
+	}
 }
 
-func (f *rowFn) prepare(cols []flux.ColMeta, extraTypes map[string]semantic.Type) error {
+func (f *dynamicFn) prepare(cols []flux.ColMeta, extraTypes map[string]semantic.Type) error {
 	// Prepare types and recordCols
 	propertyTypes := make(map[string]semantic.Type, len(f.references))
 	for j, c := range cols {
 		propertyTypes[c.Label] = ConvertToKind(c.Type)
 		f.recordCols[c.Label] = j
-	}
-
-	for _, r := range f.references {
-		if _, ok := f.recordCols[r]; !ok {
-			return fmt.Errorf("function references unknown column %q", r)
-		}
 	}
 
 	f.record = NewRecord(semantic.NewObjectType(propertyTypes))
@@ -116,12 +106,62 @@ func ConvertFromKind(k semantic.Nature) flux.ColType {
 	}
 }
 
-func (f *rowFn) eval(row int, cr flux.ColReader, extraParams map[string]values.Value) (values.Value, error) {
-	// TODO(affo) will remove this once null support for lambdas is provided
-	if f.anyNilReferenceInRow(row, cr) {
-		return nil, errors.New("null reference used in row function: skipping evaluation until null support is provided")
-	}
+type tableFn struct {
+	dynamicFn
+}
 
+func newTableFn(fn *semantic.FunctionExpression) tableFn {
+	return tableFn{
+		dynamicFn: newDynamicFn(fn),
+	}
+}
+
+func (f *tableFn) eval(tbl flux.Table) (values.Value, error) {
+	for r, col := range f.recordCols {
+		f.record.Set(r, tbl.Key().Value(col))
+	}
+	f.inRecord.Set(f.recordName, f.record)
+	return f.preparedFn.Eval(f.inRecord)
+}
+
+type TablePredicateFn struct {
+	tableFn
+}
+
+func NewTablePredicateFn(fn *semantic.FunctionExpression) (*TablePredicateFn, error) {
+	t := newTableFn(fn)
+	return &TablePredicateFn{tableFn: t}, nil
+}
+
+func (f *TablePredicateFn) Prepare(tbl flux.Table) error {
+	if err := f.tableFn.prepare(tbl.Key().Cols(), nil); err != nil {
+		return err
+	}
+	if f.preparedFn.Type() != semantic.Bool {
+		return errors.New("table predicate function does not evaluate to a boolean")
+	}
+	return nil
+}
+
+func (f *TablePredicateFn) Eval(tbl flux.Table) (bool, error) {
+	v, err := f.tableFn.eval(tbl)
+	if err != nil {
+		return false, err
+	}
+	return !v.IsNull() && v.Bool(), nil
+}
+
+type rowFn struct {
+	dynamicFn
+}
+
+func newRowFn(fn *semantic.FunctionExpression) (rowFn, error) {
+	return rowFn{
+		dynamicFn: newDynamicFn(fn),
+	}, nil
+}
+
+func (f *rowFn) eval(row int, cr flux.ColReader, extraParams map[string]values.Value) (values.Value, error) {
 	for r, col := range f.recordCols {
 		f.record.Set(r, ValueForRow(cr, row, col))
 	}
@@ -131,46 +171,6 @@ func (f *rowFn) eval(row int, cr flux.ColReader, extraParams map[string]values.V
 	}
 
 	return f.preparedFn.Eval(f.inRecord)
-}
-
-func (f *rowFn) anyNilReferenceInRow(i int, cr flux.ColReader) bool {
-	for _, ref := range f.references {
-		j := ColIdx(ref, cr.Cols())
-		if j < 0 {
-			continue
-		}
-
-		switch cr.Cols()[j].Type {
-		case flux.TBool:
-			if cr.Bools(j).IsNull(i) {
-				return true
-			}
-		case flux.TInt:
-			if cr.Ints(j).IsNull(i) {
-				return true
-			}
-		case flux.TUInt:
-			if cr.UInts(j).IsNull(i) {
-				return true
-			}
-		case flux.TFloat:
-			if cr.Floats(j).IsNull(i) {
-				return true
-			}
-		case flux.TString:
-			if cr.Strings(j).IsNull(i) {
-				return true
-			}
-		case flux.TTime:
-			if cr.Times(j).IsNull(i) {
-				return true
-			}
-		default:
-			PanicUnknownType(cr.Cols()[j].Type)
-		}
-	}
-
-	return false
 }
 
 type RowPredicateFn struct {
@@ -188,8 +188,7 @@ func NewRowPredicateFn(fn *semantic.FunctionExpression) (*RowPredicateFn, error)
 }
 
 func (f *RowPredicateFn) Prepare(cols []flux.ColMeta) error {
-	err := f.rowFn.prepare(cols, nil)
-	if err != nil {
+	if err := f.rowFn.prepare(cols, nil); err != nil {
 		return err
 	}
 	if f.preparedFn.Type() != semantic.Bool {
@@ -203,7 +202,7 @@ func (f *RowPredicateFn) Eval(row int, cr flux.ColReader) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return v.Bool(), nil
+	return !v.IsNull() && v.Bool(), nil
 }
 
 type RowMapFn struct {
@@ -224,7 +223,7 @@ func NewRowMapFn(fn *semantic.FunctionExpression) (*RowMapFn, error) {
 }
 
 func (f *RowMapFn) Prepare(cols []flux.ColMeta) error {
-	err := f.rowFn.prepare(cols, nil)
+	err := f.dynamicFn.prepare(cols, nil)
 	if err != nil {
 		return err
 	}
@@ -408,7 +407,10 @@ func (r *Record) Set(name string, v values.Value) {
 }
 func (r *Record) Get(name string) (values.Value, bool) {
 	v, ok := r.values[name]
-	return v, ok
+	if !ok {
+		return values.Null, false
+	}
+	return v, true
 }
 func (r *Record) Len() int {
 	return len(r.values)

--- a/execute/row_fn_test.go
+++ b/execute/row_fn_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/semantic/semantictest"
 	"github.com/influxdata/flux/values"
 )
+
+var CmpOptions = semantictest.CmpOptions
 
 func createRecord(row []interface{}) (*execute.Record, error) {
 	if len(row) == 0 {
@@ -147,10 +150,10 @@ func TestRowMapFn_Eval(t *testing.T) {
 			want: [][]interface{}{
 				{"_value", -2.0},
 				{"_value", -1.0},
-				{},
-				{},
+				{"_value", nil},
+				{"_value", nil},
 				{"_value", 2.0},
-				{},
+				{"_value", nil},
 			},
 		},
 	}
@@ -197,8 +200,8 @@ func TestRowMapFn_Eval(t *testing.T) {
 				return nil
 			})
 
-			if !cmp.Equal(want, got) {
-				t.Errorf("unexpected result -want/+got\n%s", cmp.Diff(want, got))
+			if !cmp.Equal(want, got, CmpOptions...) {
+				t.Errorf("unexpected result -want/+got\n%s", cmp.Diff(want, got, CmpOptions...))
 			}
 		})
 	}
@@ -272,7 +275,10 @@ func TestRowPredicateFn_Eval(t *testing.T) {
 			want: []bool{
 				false,
 				false,
+				false,
+				false,
 				true,
+				false,
 			},
 		},
 	}
@@ -303,8 +309,8 @@ func TestRowPredicateFn_Eval(t *testing.T) {
 				return nil
 			})
 
-			if !cmp.Equal(tc.want, got) {
-				t.Errorf("unexpected result -want/+got\n%s", cmp.Diff(tc.want, got))
+			if !cmp.Equal(tc.want, got, CmpOptions...) {
+				t.Errorf("unexpected result -want/+got\n%s", cmp.Diff(tc.want, got, CmpOptions...))
 			}
 		})
 	}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -254,10 +254,7 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope Scope) (va
 		if typ := obj.Type().Nature(); typ != semantic.Object {
 			return nil, fmt.Errorf("cannot access property %q on value of type %s", e.Property, typ)
 		}
-		v, ok := obj.Object().Get(e.Property)
-		if !ok {
-			return nil, fmt.Errorf("object has no property %q", e.Property)
-		}
+		v, _ := obj.Object().Get(e.Property)
 		if pkg, ok := v.(*Package); ok {
 			// If the property of a member expression represents a package, then the object itself must be a package.
 			return nil, fmt.Errorf("cannot access imported package %q of imported package %q", pkg.Name(), obj.(*Package).Name())
@@ -313,10 +310,22 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope Scope) (va
 			return nil, err
 		}
 
+		ltyp := itrp.typeof(e.Left, l.Type())
+		rtyp := itrp.typeof(e.Right, r.Type())
+		// TODO(jsternberg): This next section needs to be removed
+		// since type inference should give the correct type.
+		if ltyp == semantic.Nil && l.Type() != semantic.Nil {
+			// There's a weird bug in type inference where it
+			// determines the type is null even when it's not.
+			ltyp = l.Type()
+		}
+		if rtyp == semantic.Nil && r.Type() != semantic.Nil {
+			rtyp = r.Type()
+		}
 		bf, err := values.LookupBinaryFunction(values.BinaryFuncSignature{
 			Operator: e.Operator,
-			Left:     l.Type(),
-			Right:    r.Type(),
+			Left:     ltyp,
+			Right:    rtyp,
 		})
 		if err != nil {
 			return nil, err
@@ -556,6 +565,15 @@ func (itrp *Interpreter) doArguments(args *semantic.ObjectExpression, scope Scop
 	return obj, nil
 }
 
+// typeof returns the typeof a node or returns the default
+// if there is no registered type.
+func (itrp *Interpreter) typeof(n semantic.Node, def semantic.Type) semantic.Type {
+	if typ, ok := itrp.types[n]; ok {
+		return typ
+	}
+	return def
+}
+
 // Value represents any value that can be the result of evaluating any expression.
 type Value interface {
 	// Type reports the type of value
@@ -658,6 +676,13 @@ func (f function) Call(argsObj values.Object) (values.Value, error) {
 	return v, nil
 }
 func (f function) doCall(args Arguments) (values.Value, error) {
+	if f.itrp == nil {
+		f.itrp = &Interpreter{
+			types:     f.types,
+			polyTypes: f.polyTypes,
+		}
+	}
+
 	blockScope := f.scope.Nest(nil)
 	if f.e.Block.Parameters != nil {
 	PARAMETERS:

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -227,6 +227,9 @@ func TestEval(t *testing.T) {
             x == 5 or fail()
 			`,
 		},
+		// TODO(jsternberg): This test seems to not
+		// infer the type constraints correctly for m.a,
+		// but it doesn't fail.
 		{
 			name: "return map from func",
 			query: `
@@ -743,10 +746,11 @@ func TestInterpreter_MultiPhaseInterpretation(t *testing.T) {
 				t.Fatal("expected to error during program evaluation")
 			}
 
-			if tc.want != nil && !cmp.Equal(tc.want, getSideEffectsValues(sideEffects), semantictest.CmpOptions...) {
-				t.Fatalf("unexpected side effect values -want/+got: \n%s", cmp.Diff(tc.want, sideEffects, semantictest.CmpOptions...))
+			if tc.want != nil {
+				if want, got := tc.want, getSideEffectsValues(sideEffects); !cmp.Equal(want, got, semantictest.CmpOptions...) {
+					t.Fatalf("unexpected side effect values -want/+got: \n%s", cmp.Diff(want, got, semantictest.CmpOptions...))
+				}
 			}
-
 		})
 	}
 }

--- a/semantic/semantictest/cmp.go
+++ b/semantic/semantictest/cmp.go
@@ -1,15 +1,18 @@
 package semantictest
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
 )
 
 var CmpOptions = []cmp.Option{
 	cmp.Comparer(func(x, y *regexp.Regexp) bool { return x.String() == y.String() }),
+	cmp.Transformer("Value", TransformValue),
 
 	cmpopts.IgnoreUnexported(semantic.ArrayExpression{}),
 	cmpopts.IgnoreUnexported(semantic.Package{}),
@@ -50,4 +53,76 @@ var CmpOptions = []cmp.Option{
 	cmpopts.IgnoreUnexported(semantic.RegexpLiteral{}),
 	cmpopts.IgnoreUnexported(semantic.StringLiteral{}),
 	cmpopts.IgnoreUnexported(semantic.UnsignedIntegerLiteral{}),
+}
+
+func TransformValue(v values.Value) map[string]interface{} {
+	if v.IsNull() {
+		return map[string]interface{}{
+			"type":  v.Type(),
+			"value": nil,
+		}
+	}
+
+	switch v.Type().Nature() {
+	case semantic.Int:
+		return map[string]interface{}{
+			"type":  semantic.Int.String(),
+			"value": v.Int(),
+		}
+	case semantic.UInt:
+		return map[string]interface{}{
+			"type":  semantic.UInt.String(),
+			"value": v.UInt(),
+		}
+	case semantic.Float:
+		return map[string]interface{}{
+			"type":  semantic.Float.String(),
+			"value": v.Float(),
+		}
+	case semantic.String:
+		return map[string]interface{}{
+			"type":  semantic.String.String(),
+			"value": v.Str(),
+		}
+	case semantic.Bool:
+		return map[string]interface{}{
+			"type":  semantic.Bool.String(),
+			"value": v.Bool(),
+		}
+	case semantic.Time:
+		return map[string]interface{}{
+			"type":  semantic.Time.String(),
+			"value": v.Time(),
+		}
+	case semantic.Duration:
+		return map[string]interface{}{
+			"type":  semantic.Duration.String(),
+			"value": v.Duration(),
+		}
+	case semantic.Regexp:
+		return map[string]interface{}{
+			"type":  semantic.Regexp.String(),
+			"value": v.Regexp(),
+		}
+	case semantic.Array:
+		elements := make([]map[string]interface{}, v.Array().Len())
+		for i := range elements {
+			elements[i] = TransformValue(v.Array().Get(i))
+		}
+		return map[string]interface{}{
+			"type":     semantic.Array.String(),
+			"elements": elements,
+		}
+	case semantic.Object:
+		elements := make(map[string]interface{})
+		v.Object().Range(func(name string, v values.Value) {
+			elements[name] = TransformValue(v)
+		})
+		return map[string]interface{}{
+			"type":     semantic.Object.String(),
+			"elements": elements,
+		}
+	default:
+		panic(fmt.Errorf("unexpected value type %v", v.Type()))
+	}
 }

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -64,9 +64,19 @@ func tableFindCall(args values.Object) (values.Value, error) {
 		to = v.(*flux.TableObject)
 	}
 
-	fn, err := arguments.GetRequiredFunction(tableFindFunctionArg)
-	if err != nil {
+	var fn *execute.TablePredicateFn
+	if call, err := arguments.GetRequiredFunction(tableFindFunctionArg); err != nil {
 		return nil, fmt.Errorf("missing argument: %s", tableFindFunctionArg)
+	} else {
+		predicate, err := interpreter.ResolveFunction(call)
+		if err != nil {
+			return nil, err
+		}
+
+		fn, err = execute.NewTablePredicateFn(predicate)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	c := lang.TableObjectCompiler{
@@ -88,31 +98,31 @@ func tableFindCall(args values.Object) (values.Value, error) {
 	var found bool
 	for res := range q.Results() {
 		if err := res.Tables().Do(func(tbl flux.Table) error {
+			defer tbl.Done()
 			if found {
 				// the result is filled, you can skip other tables
 				return nil
 			}
-			gk := objectFromGroupKey(tbl.Key())
-			pass, err := fn.Call(values.NewObjectWithValues(map[string]values.Value{tableFindFunctionGroupKeyArg: gk}))
+
+			if err := fn.Prepare(tbl); err != nil {
+				return err
+			}
+
+			var err error
+			found, err = fn.Eval(tbl)
 			if err != nil {
 				return errors.Wrap(err, "failed to evaluate group key predicate function")
 			}
-			found = pass.Bool()
+
 			if found {
-				// We need to copy the table in memory and increase its refCount in order to make
-				// subsequent calls to getRecord/Column idempotent. If we don't do it, then it would be
-				// consumed by calls to `Do`, and subsequent calls to getRecord/Column would find
-				// an empty table.
-				// TODO(jsternberg): Tables can only be consumed once so the implementation of a table
-				// must use a buffered table and copy it when it is used. This is not done yet so the
-				// result of retrieving the table can only be consumed once.
-				// The table must also be copied into a buffer because once the table goes out of the
-				// current scope it is discarded by the processing system.
-				if tbl, err := execute.CopyTable(tbl); err != nil {
+				t, err = objects.NewTable(tbl)
+				if err != nil {
 					return err
-				} else {
-					t = objects.NewTable(tbl)
 				}
+			} else {
+				// TODO(jsternberg): Remove the Do call when Done
+				// is implemented for all table types.
+				_ = tbl.Do(func(flux.ColReader) error { return nil })
 			}
 			return nil
 		}); err != nil {
@@ -123,14 +133,6 @@ func tableFindCall(args values.Object) (values.Value, error) {
 		return nil, fmt.Errorf("no table found")
 	}
 	return t, nil
-}
-
-func objectFromGroupKey(gk flux.GroupKey) values.Object {
-	vsMap := make(map[string]values.Value, len(gk.Cols()))
-	for j, c := range gk.Cols() {
-		vsMap[c.Label] = gk.Value(j)
-	}
-	return values.NewObjectWithValues(vsMap)
 }
 
 func NewGetColumnFunction() values.Value {
@@ -156,7 +158,7 @@ func getColumnCall(args values.Object) (values.Value, error) {
 	} else if v.Type() != objects.TableMonoType {
 		return nil, fmt.Errorf("unexpected type for %s: want %v, got %v", getColumnTableArg, objects.TableMonoType, v.Type())
 	} else {
-		tbl = v.(*objects.Table).Table
+		tbl = v.(*objects.Table).Table()
 	}
 
 	col, err := arguments.GetRequiredString(getColumnColumnArg)
@@ -251,7 +253,7 @@ func getRecordCall(args values.Object) (values.Value, error) {
 	} else if v.Type() != objects.TableMonoType {
 		return nil, fmt.Errorf("unexpected type for %s: want %v, got %v", getRecordTableArg, objects.TableMonoType, v.Type())
 	} else {
-		tbl = v.(*objects.Table).Table
+		tbl = v.(*objects.Table).Table()
 	}
 
 	rowIdx, err := arguments.GetRequiredInt(getRecordIndexArg)

--- a/stdlib/universe/table_fns_test.go
+++ b/stdlib/universe/table_fns_test.go
@@ -131,105 +131,55 @@ func evalOrFail(t *testing.T, script string, mutator flux.ScopeMutator) interpre
 
 func TestTableFind_Call(t *testing.T) {
 	testCases := []struct {
-		name    string
-		want    flux.Table
-		fn      func(key values.Object) (values.Value, error)
+		name string
+		want flux.Table
+		fn   string
+		// fn      func(key values.Object) (values.Value, error)
 		wantErr error
 	}{
 		{
 			name: "exactly one match 1", // first table
 			want: tables[0],
-			fn: func(key values.Object) (values.Value, error) {
-				user, ok := key.Get("user")
-				if !ok {
-					return nil, fmt.Errorf("property not found: user")
-				}
-				m, ok := key.Get("_measurement")
-				if !ok {
-					return nil, fmt.Errorf("property not found: _measurement")
-				}
-				return values.New(user.Str() == "user1" && m.Str() == "CPU"), nil
-			},
+			fn:   `f = (key) => key.user == "user1" and key._measurement == "CPU"`,
 		},
 		{
 			name: "exactly one match 2", // second table
 			want: tables[1],
-			fn: func(key values.Object) (values.Value, error) {
-				user, ok := key.Get("user")
-				if !ok {
-					return nil, fmt.Errorf("property not found: user")
-				}
-				return values.New(user.Str() == "user2"), nil
-			},
+			fn:   `f = (key) => key.user == "user2"`,
 		},
 		{
 			name: "exactly one match 3", // third table
 			want: tables[2],
-			fn: func(key values.Object) (values.Value, error) {
-				user, ok := key.Get("user")
-				if !ok {
-					return nil, fmt.Errorf("property not found: user")
-				}
-				m, ok := key.Get("_measurement")
-				if !ok {
-					return nil, fmt.Errorf("property not found: _measurement")
-				}
-				return values.New(user.Str() == "user1" && m.Str() == "RAM"), nil
-			},
+			fn:   `f = (key) => key.user == "user1" and key._measurement == "RAM"`,
 		},
 		{
 			name: "multiple match", // first and third
 			want: tables[0],
-			fn: func(key values.Object) (values.Value, error) {
-				user, ok := key.Get("user")
-				if !ok {
-					return nil, fmt.Errorf("property not found: user")
-				}
-				return values.New(user.Str() == "user1"), nil
-			},
+			fn:   `f = (key) => key.user == "user1"`,
 		},
 		{
 			name:    "no match",
 			wantErr: fmt.Errorf("no table found"),
-			fn: func(key values.Object) (values.Value, error) {
-				idk, ok := key.Get("user")
-				if !ok {
-					return nil, fmt.Errorf("property not found: user")
-				}
-				return values.New(idk.Str() == "no-user"), nil
-			},
-		},
-		{
-			name:    "wrong property",
-			wantErr: fmt.Errorf("failed to evaluate group key predicate function: property not found: idk"),
-			fn: func(key values.Object) (values.Value, error) {
-				idk, ok := key.Get("idk")
-				if !ok {
-					return nil, fmt.Errorf("property not found: idk")
-				}
-				return values.New(idk.Str() == "idk"), nil
-			},
+			fn:      `f = (key) => key.user == "no-user"`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			_, scope, err := flux.Eval(tc.fn)
+			if err != nil {
+				t.Fatalf("error compiling function: %v", err)
+			}
+
+			fn, ok := scope.Lookup("f")
+			if !ok {
+				t.Fatal("must define a function to the f variable")
+			}
+
 			f := universe.NewTableFindFunction()
 			res, err := f.Function().Call(values.NewObjectWithValues(map[string]values.Value{
 				"tables": to,
-				"fn": values.NewFunction("",
-					semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
-						Parameters: map[string]semantic.PolyType{"key": semantic.Tvar(1)},
-						Return:     semantic.Bool,
-					}),
-					func(args values.Object) (values.Value, error) {
-						key, ok := args.Object().Get("key")
-						if !ok {
-							return nil, fmt.Errorf("property not found: key")
-						}
-						return tc.fn(key.Object())
-					},
-					false),
+				"fn":     fn,
 			}))
 			if err != nil {
 				if tc.wantErr != nil {
@@ -241,7 +191,7 @@ func TestTableFind_Call(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got, err := executetest.ConvertTable(res.(*objects.Table).Table)
+			got, err := executetest.ConvertTable(res.(*objects.Table).Table())
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
- [x] docs/SPEC.md updated
- [x] Test cases written

The interpreter has been updated for the work on nulls. The row and
table functions now work with nulls.

Unfortunately, some potential issues were found. It seems type inference
doesn't resolve some types for the interpreter correctly specifically
related to functions so certain type constraints don't get identified.
This causes them to erroneously be marked as null types rather than
their appropriate type and so there's currently a hack included to make
it work while still allowing us to evaluate null types in the interim.