### PR TITLE
fix(execute): copy table will report if it is empty correctly

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -111,6 +111,10 @@ func CopyTable(t flux.Table) (flux.BufferedTable, error) {
 		key:     t.Key(),
 		colMeta: t.Cols(),
 	}
+	if t.Empty() {
+		return &tbl, nil
+	}
+
 	if err := t.Do(func(cr flux.ColReader) error {
 		cr.Retain()
 		tbl.buffers = append(tbl.buffers, cr)

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -322,3 +322,30 @@ func TestCopyTable(t *testing.T) {
 	// 	t.Errorf("memory leak -want/+got:\n\t- %d\n\t+ %d", want, got)
 	// }
 }
+
+func TestCopyTable_Empty(t *testing.T) {
+	in := &executetest.Table{
+		GroupKey: execute.NewGroupKey(
+			[]flux.ColMeta{
+				{Label: "t0", Type: flux.TString},
+			},
+			[]values.Value{
+				values.NewString("v0"),
+			},
+		),
+		ColMeta: []flux.ColMeta{
+			{Label: "t0", Type: flux.TString},
+			{Label: "_value", Type: flux.TFloat},
+		},
+	}
+
+	cpy, err := execute.CopyTable(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	defer cpy.Done()
+	if !cpy.Empty() {
+		t.Fatal("expected copied table to be empty, but it wasn't")
+	}
+}


### PR DESCRIPTION
Copying a table resulted in it retaining each of the column readers for
that table. It was possible for a table to be empty though and it would
still copy all of the column readers and report itself as not empty.

Now copy table will recognize when a table is empty and not attempt to
retain empty column readers.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written