### PR TITLE
fix(stdlib): use strings.Replace instead of strings.ReplaceAll for compatibility

### DIFF
--- a/stdlib/strings/compat.go
+++ b/stdlib/strings/compat.go
@@ -1,0 +1,13 @@
+package strings
+
+import "strings"
+
+// replaceAll implements strings.ReplaceAll for go 1.11 and
+// earlier. The function was added in go 1.12 and it is an
+// alias to calling strings.Replace with an argument of -1.
+//
+// This function may be removed when InfluxDB 1.x no longer
+// uses go 1.11 for its builds.
+func replaceAll(s string, old string, new string) string {
+	return strings.Replace(s, old, new, -1)
+}

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -438,7 +438,7 @@ func init() {
 	flux.RegisterPackageValue("strings", "replace",
 		generateReplace("replace", []string{stringArgV, stringArgT, stringArgU, integer}, strings.Replace))
 	flux.RegisterPackageValue("strings", "replaceAll",
-		generateReplaceAll("replaceAll", []string{stringArgV, stringArgT, stringArgU, integer}, strings.ReplaceAll))
+		generateReplaceAll("replaceAll", []string{stringArgV, stringArgT, stringArgU, integer}, replaceAll))
 	flux.RegisterPackageValue("strings", "split",
 		generateSplit("split", []string{stringArgV, stringArgT}, strings.Split))
 	flux.RegisterPackageValue("strings", "splitAfter",


### PR DESCRIPTION
The `strings.ReplaceAll` function was added in go 1.12 and InfluxDB 1.x
still uses go 1.11 for the moment so this changes the strings library to
use `strings.Replace` with `-1` as the final parameter which is the same
thing as the standard library.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written