### PR TITLE
fix(stdlib): read the table in assert empty to verify it is not empty

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -116,8 +116,11 @@ func CopyTable(t flux.Table) (flux.BufferedTable, error) {
 	}
 
 	if err := t.Do(func(cr flux.ColReader) error {
-		cr.Retain()
-		tbl.buffers = append(tbl.buffers, cr)
+		// If the column reader is empty, do not retain it.
+		if cr.Len() > 0 {
+			cr.Retain()
+			tbl.buffers = append(tbl.buffers, cr)
+		}
 		return nil
 	}); err != nil {
 		tbl.Done()

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -349,3 +349,41 @@ func TestCopyTable_Empty(t *testing.T) {
 		t.Fatal("expected copied table to be empty, but it wasn't")
 	}
 }
+
+// nonEmptyTable will always return false for empty.
+type nonEmptyTable struct {
+	flux.Table
+}
+
+func (t nonEmptyTable) Empty() bool {
+	return false
+}
+
+func TestCopyTable_EmptyNotEmpty(t *testing.T) {
+	in := nonEmptyTable{
+		Table: &executetest.Table{
+			GroupKey: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "t0", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("v0"),
+				},
+			),
+			ColMeta: []flux.ColMeta{
+				{Label: "t0", Type: flux.TString},
+				{Label: "_value", Type: flux.TFloat},
+			},
+		},
+	}
+
+	cpy, err := execute.CopyTable(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	defer cpy.Done()
+	if !cpy.Empty() {
+		t.Fatal("expected copied table to be empty, but it wasn't")
+	}
+}

--- a/result.go
+++ b/result.go
@@ -47,6 +47,8 @@ type Table interface {
 	Done()
 
 	// Empty returns whether the table contains no records.
+	// This is a hint and a table may still be empty even if this returns
+	// false.
 	Empty() bool
 }
 

--- a/stdlib/testing/assert_empty_test.go
+++ b/stdlib/testing/assert_empty_test.go
@@ -52,6 +52,24 @@ func TestAssertEmpty_Process(t *testing.T) {
 			}},
 			wantErr: errors.New("found 1 tables that were not empty"),
 		},
+		{
+			name: "empty but not empty",
+			data: []flux.Table{
+				nonEmptyTable{
+					Table: &executetest.Table{
+						KeyCols: []string{"t1"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_value", Type: flux.TFloat},
+							{Label: "t1", Type: flux.TString},
+							{Label: "t2", Type: flux.TString},
+						},
+						Data: [][]interface{}{},
+					},
+				},
+			},
+			want: []*executetest.Table(nil),
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -67,4 +85,13 @@ func TestAssertEmpty_Process(t *testing.T) {
 			)
 		})
 	}
+}
+
+// nonEmptyTable will always return false for empty.
+type nonEmptyTable struct {
+	flux.Table
+}
+
+func (t nonEmptyTable) Empty() bool {
+	return false
 }


### PR DESCRIPTION
Some table implementations don't know they are empty until `Do` has been
called. `assertEmpty` has been fixed so that it will not rely on
`Empty()` to return the correct value.

The table copy implementation has also been updated so it won't attempt
to retain buffers that have a length of zero for the same reason.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written