### PR TITLE
fix(stdlib/map): remove mergeKey parameter from the map function

### DIFF
--- a/ast/errors.go
+++ b/ast/errors.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 // Check will inspect each node and annotate it with any AST errors.
@@ -91,7 +93,7 @@ func GetErrors(n Node) (errs []error) {
 	Walk(CreateVisitor(func(node Node) {
 		if nerrs := node.Errs(); len(nerrs) > 0 {
 			for _, err := range nerrs {
-				errs = append(errs, err)
+				errs = append(errs, errors.Wrapf(err, "loc %v", node.Location()))
 			}
 		}
 	}), n)

--- a/internal/cmd/builtin/cmd/generate.go
+++ b/internal/cmd/builtin/cmd/generate.go
@@ -118,7 +118,7 @@ func generate(cmd *cobra.Command, args []string) error {
 		}
 		if testPkg != nil {
 			if ast.Check(testPkg) > 0 {
-				return errors.Wrapf(ast.GetError(testPkg), "failed to parse package %q", testPkg.Package)
+				return errors.Wrapf(ast.GetError(testPkg), "failed to parse test package %q", testPkg.Package)
 			}
 			// Track go import path
 			importPath := path.Join(pkgName, dir)

--- a/stdlib/testing/testdata/filter_by_regex.flux
+++ b/stdlib/testing/testdata/filter_by_regex.flux
@@ -25,25 +25,22 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,dateTime:RFC3339,string,dateTime:RFC3339,long
-#group,false,false,true,true,false,false
-#default,0,,,,,
-,result,table,_start,_measurement,_time,io_time
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:26Z,15204688
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:36Z,15204894
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:46Z,15205102
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:56Z,15205226
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:06Z,15205499
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:16Z,15205755
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,true,true,false,false,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
 "
 
 t_filter_by_regex = (table=<-) =>
 table
   |> range(start: 2018-05-20T19:53:26Z)
   |> filter(fn: (r) => r["name"] =~ /.*0/)
-  |> group(columns: ["_measurement", "_start"])
-  |> map(fn: (r) => ({_time: r._time, io_time: r._value}))
-  |> yield(name:"0")
 
 test _filter_by_regex = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_by_regex})

--- a/stdlib/testing/testdata/filter_by_regex_compile.flux
+++ b/stdlib/testing/testdata/filter_by_regex_compile.flux
@@ -25,25 +25,22 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,dateTime:RFC3339,string,dateTime:RFC3339,long
-#group,false,false,true,true,false,false
-#default,0,,,,,
-,result,table,_start,_measurement,_time,io_time
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:26Z,15204688
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:36Z,15204894
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:46Z,15205102
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:56Z,15205226
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:06Z,15205499
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:16Z,15205755
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,true,true,false,false,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
 "
 
 t_filter_by_regex = (table=<-) =>
 table
   |> range(start: 2018-05-20T19:53:26Z)
   |> filter(fn: (r) => (r.name =~ regexp.compile(v: ".*0")))
-  |> group(columns: ["_measurement", "_start"])
-  |> map(fn: (r) => ({_time: r._time, io_time: r._value}))
-  |> yield(name:"0")
 
 test _filter_by_regex = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_by_regex})

--- a/stdlib/testing/testdata/filter_by_regex_match.flux
+++ b/stdlib/testing/testdata/filter_by_regex_match.flux
@@ -25,16 +25,16 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,dateTime:RFC3339,string,dateTime:RFC3339,long
-#group,false,false,true,true,false,false
-#default,0,,,,,
-,result,table,_start,_measurement,_time,io_time
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:26Z,15204688
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:36Z,15204894
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:46Z,15205102
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:56Z,15205226
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:06Z,15205499
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:16Z,15205755
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,true,true,false,false,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
 "
 
 re = regexp.compile(v: ".*0")
@@ -43,9 +43,6 @@ t_filter_by_regex = (table=<-) =>
 table
   |> range(start: 2018-05-20T19:53:26Z)
   |> filter(fn: (r) => (regexp.matchRegexpString(r: re, v: r.name)))
-  |> group(columns: ["_measurement", "_start"])
-  |> map(fn: (r) => ({_time: r._time, io_time: r._value}))
-  |> yield(name:"0")
 
 test _filter_by_regex = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_by_regex})

--- a/stdlib/testing/testdata/filter_by_tags.flux
+++ b/stdlib/testing/testdata/filter_by_tags.flux
@@ -24,25 +24,22 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,string,dateTime:RFC3339,long
-#group,false,false,true,false,false
-#default,0,,,,
-,result,table,_measurement,_time,io_time
-,,0,diskio,2018-05-22T19:53:26Z,15204688
-,,0,diskio,2018-05-22T19:53:36Z,15204894
-,,0,diskio,2018-05-22T19:53:46Z,15205102
-,,0,diskio,2018-05-22T19:53:56Z,15205226
-,,0,diskio,2018-05-22T19:54:06Z,15205499
-,,0,diskio,2018-05-22T19:54:16Z,15205755
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,dateTime:RFC3339,long
+#group,false,false,true,true,true,true,true,true,false,false
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_measurement,_field,host,name,_time,_value
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:53:26Z,15204688
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:53:36Z,15204894
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:53:46Z,15205102
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:53:56Z,15205226
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:54:06Z,15205499
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:54:16Z,15205755
 "
 
 t_filter_by_tags = (table=<-) =>
   table
   |> range(start: 2018-05-22T19:53:26Z)
   |> filter(fn: (r) => r["name"] == "disk0")
-  |> group(columns: ["_measurement"])
-  |> map(fn: (r) => ({_time: r._time, io_time: r._value}))
-  |> yield(name:"0")
 
 test _filter_by_tags = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_by_tags})

--- a/stdlib/testing/testdata/group.flux
+++ b/stdlib/testing/testdata/group.flux
@@ -24,24 +24,21 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,dateTime:RFC3339,string,string,dateTime:RFC3339,long
-#group,false,false,true,true,true,false,false
-#default,0,,,,,,
-,result,table,_start,_measurement,name,_time,max
-,,0,2018-05-22T19:53:26Z,diskio,disk0,2018-05-22T19:54:16Z,15205755
-,,1,2018-05-22T19:53:26Z,diskio,disk2,2018-05-22T19:53:26Z,648
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,dateTime:RFC3339,long
+#group,false,false,true,false,true,false,false,true,false,false
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_measurement,_field,host,name,_time,_value
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,2018-05-22T19:54:16Z,15205755
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk2,2018-05-22T19:53:26Z,648
 "
 
 t_group = (table=<-) =>
-	(table
+	table
 		|> range(start: 2018-05-22T19:53:26Z)
 		|> filter(fn: (r) =>
 			(r._measurement == "diskio" and r._field == "io_time"))
 		|> group(columns: ["_measurement", "_start", "name"])
 		|> max()
-		|> map(fn: (r) =>
-			({_time: r._time, max: r._value}))
-		|> yield(name: "0"))
 
 test _group = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_group})

--- a/stdlib/testing/testdata/map.flux
+++ b/stdlib/testing/testdata/map.flux
@@ -15,13 +15,13 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,string,string,string,double
-#group,false,false,true,true,true,false
-#default,_result,,,,,
-,result,table,_field,_measurement,host,newValue
-,,0,load1,system,host.local,100.0
-,,0,load1,system,host.local,101.0
-,,0,load1,system,host.local,102.0
+#datatype,string,long,double
+#group,false,false,false
+#default,_result,,
+,result,table,newValue
+,,0,100.0
+,,0,101.0
+,,0,102.0
 "
 
 t_map = (table=<-) =>

--- a/stdlib/testing/testdata/map_with_obj.flux
+++ b/stdlib/testing/testdata/map_with_obj.flux
@@ -15,13 +15,13 @@ inData = "
 ,,0,2018-05-22T19:53:46Z,102,load1,system,host.local
 "
 outData = "
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long,long,long,long,string,dateTime:RFC3339,long
-#group,false,false,true,true,true,true,true,false,false,false,false,false,false,false
-#default,got,,,,,,,,,,,,,
-,result,table,_start,_stop,_field,_measurement,host,array,boolAdd,floatAdd,intAdd,string,time,uintAdd
-,,0,1947-11-13T00:00:00Z,2030-01-01T00:00:00Z,load1,system,host.local,101,101,101,99,1,2018-05-22T19:53:26Z,101
-,,0,1947-11-13T00:00:00Z,2030-01-01T00:00:00Z,load1,system,host.local,102,102,102,100,1,2018-05-22T19:53:26Z,102
-,,0,1947-11-13T00:00:00Z,2030-01-01T00:00:00Z,load1,system,host.local,103,103,103,101,1,2018-05-22T19:53:26Z,103
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,dateTime:RFC3339,long,long,long,long,long,string,dateTime:RFC3339,long
+#group,false,false,true,true,true,true,true,false,false,false,false,false,false,false,false,false
+#default,got,,,,,,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,host,_time,_value,array,boolAdd,floatAdd,intAdd,string,time,uintAdd
+,,0,1947-11-13T00:00:00Z,2030-01-01T00:00:00Z,load1,system,host.local,2018-05-22T19:53:26Z,100,101,101,101,99,1,2018-05-22T19:53:26Z,101
+,,0,1947-11-13T00:00:00Z,2030-01-01T00:00:00Z,load1,system,host.local,2018-05-22T19:53:36Z,101,102,102,102,100,1,2018-05-22T19:53:26Z,102
+,,0,1947-11-13T00:00:00Z,2030-01-01T00:00:00Z,load1,system,host.local,2018-05-22T19:53:46Z,102,103,103,103,101,1,2018-05-22T19:53:26Z,103
 "
 obj = {
 	b: true,
@@ -37,7 +37,7 @@ t_map = (table=<-) =>
 	(table
 		|> range(start: obj.r)
 		|> map(fn: (r) =>
-			({
+			({r with
 				boolAdd: int(v: obj.b) + r._value,
 				intAdd: obj.i + r._value,
 				floatAdd: int(v: obj.d) + r._value,

--- a/stdlib/testing/testdata/regexp_replaceAllString.flux
+++ b/stdlib/testing/testdata/regexp_replaceAllString.flux
@@ -25,16 +25,16 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,dateTime:RFC3339,string,dateTime:RFC3339,long,string
-#group,false,false,true,true,false,false,false
-#default,0,,,,,,
-,result,table,_start,_measurement,_time,io_time,name
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:26Z,15204688,disk9
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:36Z,15204894,disk9
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:46Z,15205102,disk9
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:53:56Z,15205226,disk9
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:06Z,15205499,disk9
-,,0,2018-05-20T19:53:26Z,diskio,2018-05-22T19:54:16Z,15205755,disk9
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,dateTime:RFC3339,long,string
+#group,false,false,true,true,true,true,true,false,false,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_measurement,_field,host,_time,_value,name
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,2018-05-22T19:53:26Z,15204688,disk9
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,2018-05-22T19:53:36Z,15204894,disk9
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,2018-05-22T19:53:46Z,15205102,disk9
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,2018-05-22T19:53:56Z,15205226,disk9
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,2018-05-22T19:54:06Z,15205499,disk9
+,,0,2018-05-20T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,2018-05-22T19:54:16Z,15205755,disk9
 "
 
 re = regexp.compile(v: ".*0")
@@ -43,10 +43,8 @@ t_filter_by_regex = (table=<-) =>
 table
   |> range(start: 2018-05-20T19:53:26Z)
   |> filter(fn: (r) => r["name"] =~ /.*0/)
-  |> group(columns: ["_measurement", "_start"])
   |> map(fn: (r) =>
-                ({name: regexp.replaceAllString(r: re, v: r.name, t: "disk9"), _time: r._time, io_time: r._value}))
-  |> yield(name:"0")
+                ({r with name: regexp.replaceAllString(r: re, v: r.name, t: "disk9")}))
 
 test _filter_by_regex = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_by_regex})

--- a/stdlib/testing/testdata/simple_max.flux
+++ b/stdlib/testing/testdata/simple_max.flux
@@ -14,19 +14,16 @@ inData = "
 "
 
 outData = "
-#datatype,string,long,dateTime:RFC3339,string,dateTime:RFC3339,double
-#group,false,false,true,true,false,false
-#default,_result,,,,,
-,result,table,_start,_measurement,_time,max
-,,0,2018-04-17T00:00:00Z,m1,2018-04-17T00:00:01Z,43
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,dateTime:RFC3339,double
+#group,false,false,true,true,true,true,false,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_measurement,_field,_time,_value
+,,0,2018-04-17T00:00:00Z,2030-01-01T00:00:00Z,m1,f1,2018-04-17T00:00:01Z,43
 "
 simple_max = (table=<-) =>
-	(table
+	table
 		|> range(start: 2018-04-17T00:00:00Z)
-		|> group(columns: ["_measurement", "_start"])
 		|> max(column: "_value")
-		|> map(fn: (r) =>
-			({_time: r._time, max: r._value})))
 
 test _simple_max = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: simple_max})

--- a/stdlib/testing/testdata/string_trimLeft.flux
+++ b/stdlib/testing/testdata/string_trimLeft.flux
@@ -34,7 +34,7 @@ t_string_trimLeft = (table=<-) =>
 	(table
 		|> range(start: 2018-05-22T19:53:26Z)
 		|> map(fn: (r) =>
-        			({_value: strings.trimLeft(v: r._value, cutset: " "), _time: r._time})))
+        			({r with _value: strings.trimLeft(v: r._value, cutset: " ")})))
 
 test _string_trimLeft = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_string_trimLeft})

--- a/stdlib/testing/testdata/string_trimRight.flux
+++ b/stdlib/testing/testdata/string_trimRight.flux
@@ -34,7 +34,7 @@ t_string_trimRight = (table=<-) =>
 	(table
 		|> range(start: 2018-05-22T19:53:26Z)
 		|> map(fn: (r) =>
-        			({_value: strings.trimRight(v: r._value, cutset: " "), _time: r._time})))
+        			({r with _value: strings.trimRight(v: r._value, cutset: " ")})))
 
 test _string_trimRight = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_string_trimRight})

--- a/stdlib/testing/testdata/strings_joinStr.flux
+++ b/stdlib/testing/testdata/strings_joinStr.flux
@@ -34,7 +34,7 @@ t_string_joinStr = (table=<-) =>
 	(table
 		|> range(start: 2018-05-22T19:53:26Z)
 		|> map(fn: (r) =>
-        			({_value: strings.joinStr(arr: [r._value, "PLUS"], v: ""), _time: r._time})))
+        			({r with _value: strings.joinStr(arr: [r._value, "PLUS"], v: "")})))
 
 test _string_joinStr = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_string_joinStr})

--- a/stdlib/testing/testdata/strings_length.flux
+++ b/stdlib/testing/testdata/strings_length.flux
@@ -34,7 +34,7 @@ t_string_len = (table=<-) =>
 	(table
 		|> range(start: 2018-05-22T19:53:26Z)
 		|> map(fn: (r) =>
-        			({_value: r._value, _time: r._time, len: strings.strlen(v: r._value)})))
+        			({r with len: strings.strlen(v: r._value)})))
 
 test _string_len = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_string_len})

--- a/stdlib/testing/testdata/strings_substring.flux
+++ b/stdlib/testing/testdata/strings_substring.flux
@@ -34,7 +34,7 @@ t_string_sub = (table=<-) =>
 	(table
 		|> range(start: 2018-05-22T19:53:26Z)
 		|> map(fn: (r) =>
-        			({_value: r._value, _time: r._time, sub: strings.substring(v: r._value, start: strings.strlen(v: r._value)-1, end: strings.strlen(v: r._value))})))
+        			({r with sub: strings.substring(v: r._value, start: strings.strlen(v: r._value)-1, end: strings.strlen(v: r._value))})))
 
 test _string_sub = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_string_sub})

--- a/stdlib/testing/testdata/totime.flux
+++ b/stdlib/testing/testdata/totime.flux
@@ -18,15 +18,15 @@ inData = "
 
 // NOTE: This test will fail with differences in the last two rows when time zone support arrives.
 outData = "
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,dateTime:RFC3339
-#group,false,false,true,true,true,true,false
-#default,want,,,,,,
-,result,table,_start,_stop,_field,_measurement,_value
-,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,k,m,2018-05-22T19:53:26Z
-,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,k,m,2018-05-22T19:53:26.033Z
-,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,k,m,2018-05-22T19:53:26.033066Z
-,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,k,m,2018-05-22T19:00:00Z
-,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,k,m,2018-05-22T19:00:00Z
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,dateTime:RFC3339
+#group,false,false,true,true,false,true,true,false
+#default,want,,,,,,,
+,result,table,_start,_stop,_time,_field,_measurement,_value
+,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,k,m,2018-05-22T19:53:26Z
+,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,2018-05-22T19:53:27Z,k,m,2018-05-22T19:53:26.033Z
+,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,2018-05-22T19:53:28Z,k,m,2018-05-22T19:53:26.033066Z
+,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,2018-05-22T19:53:29Z,k,m,2018-05-22T19:00:00Z
+,,0,2018-05-22T19:52:00Z,2030-01-01T00:00:00Z,2018-05-22T19:53:30Z,k,m,2018-05-22T19:00:00Z
 "
 
 t_toTime = (table=<-) => table

--- a/stdlib/testing/testdata/window.flux
+++ b/stdlib/testing/testdata/window.flux
@@ -26,8 +26,8 @@ inData = "
 outData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,dateTime:RFC3339,double
 #group,false,false,true,true,true,false,false
-#default,0,,,,,,
-,result,table,_start,_stop,_measurement,_time,mean
+#default,_result,,,,,,
+,result,table,_start,_stop,_measurement,_time,_value
 ,,0,2018-05-22T19:53:00Z,2018-05-22T19:55:00Z,diskio,2018-05-22T19:53:26Z,7602668
 ,,0,2018-05-22T19:53:00Z,2018-05-22T19:55:00Z,diskio,2018-05-22T19:53:36Z,7602771
 ,,0,2018-05-22T19:53:00Z,2018-05-22T19:55:00Z,diskio,2018-05-22T19:53:46Z,7602875
@@ -37,16 +37,13 @@ outData = "
 "
 
 t_window = (table=<-) =>
-	(table
+	table
 		|> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
 		|> group(columns: ["_measurement"])
 		|> window(every: 1s)
 		|> mean()
 		|> duplicate(column: "_start", as: "_time")
 		|> window(every: inf)
-		|> map(fn: (r) =>
-			({_time: r._time, mean: r._value}))
-		|> yield(name: "0"))
 
 test _window = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_window})

--- a/stdlib/testing/testdata/window_offset.flux
+++ b/stdlib/testing/testdata/window_offset.flux
@@ -26,8 +26,8 @@ inData = "
 outData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,dateTime:RFC3339,double
 #group,false,false,true,true,true,false,false
-#default,0,,,,,,
-,result,table,_start,_stop,_measurement,_time,mean
+#default,_result,,,,,,
+,result,table,_start,_stop,_measurement,_time,_value
 ,,0,2018-05-22T19:53:00Z,2018-05-22T19:55:00Z,diskio,2018-05-22T19:53:26Z,7602668
 ,,0,2018-05-22T19:53:00Z,2018-05-22T19:55:00Z,diskio,2018-05-22T19:53:36Z,7602771
 ,,0,2018-05-22T19:53:00Z,2018-05-22T19:55:00Z,diskio,2018-05-22T19:53:46Z,7602875
@@ -37,16 +37,13 @@ outData = "
 "
 
 t_window_offset = (table=<-) =>
-	(table
+	table
 		|> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
 		|> group(columns: ["_measurement"])
 		|> window(every: 1s, offset: 2s)
 		|> mean()
 		|> duplicate(column: "_start", as: "_time")
 		|> window(every: inf)
-		|> map(fn: (r) =>
-			({_time: r._time, mean: r._value}))
-		|> yield(name: "0"))
 
 test _window_offset = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_window_offset})

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -238,10 +238,10 @@ lowestCurrent = (n, column="_value", groupColumns=[], tables=<-) =>
                 _sortLimit: bottom,
             )
 
-toString = (tables=<-) => tables |> map(fn:(r) => string(v:r._value))
-toInt = (tables=<-) => tables |> map(fn:(r) => int(v:r._value))
-toUInt = (tables=<-) => tables |> map(fn:(r) => uint(v:r._value))
-toFloat = (tables=<-) => tables |> map(fn:(r) => float(v:r._value))
-toBool = (tables=<-) => tables |> map(fn:(r) => bool(v:r._value))
-toTime = (tables=<-) => tables |> map(fn:(r) => time(v:r._value))
-toDuration = (tables=<-) => tables |> map(fn:(r) => duration(v:r._value))
+toString   = (tables=<-) => tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))
+toInt      = (tables=<-) => tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))
+toUInt     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: uint(v:r._value)}))
+toFloat    = (tables=<-) => tables |> map(fn:(r) => ({r with _value: float(v:r._value)}))
+toBool     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: bool(v:r._value)}))
+toTime     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: time(v:r._value)}))
+toDuration = (tables=<-) => tables |> map(fn:(r) => ({r with _value: duration(v:r._value)}))


### PR DESCRIPTION
BREAKING CHANGE: The removal of the mergeKey parameter is a breaking
change. Users will either need to use the `with` operator to preserve
columns or explicitly list all columns they wish to preserve through the
map function.
Several other test cases that used map have been simplified to remove
their use of the map function as we want the test cases to focus on
testing the function they are designed to test.


### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
