### PR TITLE
feat: add enriched error interface to flux

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -1,0 +1,229 @@
+/*
+ * This file has been modified for use in flux, but the original
+ * is part of the grpc-go project.
+ *
+ * The original can be located here: https://github.com/grpc/grpc-go/blob/master/codes/codes.go
+ *
+ * Copyright 2014 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package codes defines the error codes used by flux.
+package codes
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Code uint32
+
+const (
+	// OK is returned on success.
+	OK Code = 0
+
+	// Canceled indicates the operation was canceled (typically by the caller).
+	Canceled Code = 1
+
+	// Unknown error. An example of where this error may be returned is
+	// if a Status value received from another address space belongs to
+	// an error-space that is not known in this address space. Also
+	// errors raised by APIs that do not return enough error information
+	// may be converted to this error.
+	Unknown Code = 2
+
+	// Invalid indicates the client made an invalid request.
+	// Note that this differs from FailedPrecondition. It indicates arguments
+	// that are missing or problematic regardless of the state of the system
+	// (e.g., a missing or invalid argument, a script error, etc).
+	Invalid Code = 3
+
+	// DeadlineExceeded means operation expired before completion.
+	// For operations that change the state of the system, this error may be
+	// returned even if the operation has completed successfully. For
+	// example, a successful response from a server could have been delayed
+	// long enough for the deadline to expire.
+	DeadlineExceeded Code = 4
+
+	// NotFound means some requested entity (e.g., bucket or database) was
+	// not found.
+	NotFound Code = 5
+
+	// AlreadyExists means an attempt to create an entity failed because one
+	// already exists.
+	AlreadyExists Code = 6
+
+	// PermissionDenied indicates the caller does not have permission to
+	// execute the specified operation. It must not be used for rejections
+	// caused by exhausting some resource (use ResourceExhausted
+	// instead for those errors). It must not be
+	// used if the caller cannot be identified (use Unauthenticated
+	// instead for those errors).
+	PermissionDenied Code = 7
+
+	// ResourceExhausted indicates some resource has been exhausted, perhaps
+	// a per-user quota, or perhaps the the memory allocation limit has been
+	// reached.
+	ResourceExhausted Code = 8
+
+	// FailedPrecondition indicates operation was rejected because the
+	// system is not in a state required for the operation's execution.
+	// For example, directory to be deleted may be non-empty, an rmdir
+	// operation is applied to a non-directory, etc.
+	//
+	// A litmus test that may help a service implementor in deciding
+	// between FailedPrecondition, Aborted, and Unavailable:
+	//  (a) Use Unavailable if the client can retry just the failing call.
+	//  (b) Use Aborted if the client should retry at a higher-level
+	//      (e.g., restarting a read-modify-write sequence).
+	//  (c) Use FailedPrecondition if the client should not retry until
+	//      the system state has been explicitly fixed. E.g., if an "rmdir"
+	//      fails because the directory is non-empty, FailedPrecondition
+	//      should be returned since the client should not retry unless
+	//      they have first fixed up the directory by deleting files from it.
+	//  (d) Use FailedPrecondition if the client performs conditional
+	//      REST Get/Update/Delete on a resource and the resource on the
+	//      server does not match the condition. E.g., conflicting
+	//      read-modify-write on the same resource.
+	FailedPrecondition Code = 9
+
+	// Aborted indicates the operation was aborted, typically due to a
+	// concurrency issue like sequencer check failures, transaction aborts,
+	// etc.
+	//
+	// See litmus test above for deciding between FailedPrecondition,
+	// Aborted, and Unavailable.
+	Aborted Code = 10
+
+	// OutOfRange means operation was attempted past the valid range.
+	// E.g., accessing a row or column outside of the table dimensions.
+	//
+	// Unlike Invalid, this error indicates a problem that may
+	// be fixed if the system state changes. For example, a 32-bit file
+	// system will generate Invalid if asked to read at an
+	// offset that is not in the range [0,2^32-1], but it will generate
+	// OutOfRange if asked to read from an offset past the current
+	// file size.
+	OutOfRange Code = 11
+
+	// Unimplemented indicates operation is not implemented or not
+	// supported/enabled in this service.
+	Unimplemented Code = 12
+
+	// Internal errors. Means some invariants expected by underlying
+	// system has been broken. If you see one of these errors,
+	// something is very broken.
+	//
+	// This should not be used when wrapping unidentified errors from
+	// other services. Unknown should be used instead when wrapping
+	// external errors.
+	Internal Code = 13
+
+	// Unavailable indicates the service is currently unavailable.
+	// This is a most likely a transient condition and may be corrected
+	// by retrying with a backoff. Note that it is not always safe to retry
+	// non-idempotent operations.
+	//
+	// See litmus test above for deciding between FailedPrecondition,
+	// Aborted, and Unavailable.
+	Unavailable Code = 14
+
+	// Unauthenticated indicates the request does not have valid
+	// authentication credentials for the operation.
+	Unauthenticated Code = 15
+)
+
+func (c Code) MarshalText() ([]byte, error) {
+	s := c.String()
+	return []byte(s), nil
+}
+
+var strToCode = map[string]Code{
+	"ok":                  OK,
+	"canceled":            Canceled,
+	"unknown":             Unknown,
+	"invalid":             Invalid,
+	"deadline exceeded":   DeadlineExceeded,
+	"not found":           NotFound,
+	"already exists":      AlreadyExists,
+	"permission denied":   PermissionDenied,
+	"resource exhausted":  ResourceExhausted,
+	"failed precondition": FailedPrecondition,
+	"aborted":             Aborted,
+	"out of range":        OutOfRange,
+	"unimplemented":       Unimplemented,
+	"internal":            Internal,
+	"unavailable":         Unavailable,
+	"unauthenticated":     Unauthenticated,
+}
+
+func (c *Code) UnmarshalText(text []byte) error {
+	code, ok := strToCode[string(text)]
+	if ok {
+		*c = code
+		return nil
+	}
+
+	s := string(text)
+	if strings.HasPrefix(s, "code(") && strings.HasSuffix(s, ")") {
+		n, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return err
+		}
+		*c = Code(n)
+		return nil
+	}
+	return fmt.Errorf("unknown code: %s", text)
+}
+
+func (c Code) String() string {
+	switch c {
+	case OK:
+		return "ok"
+	case Canceled:
+		return "canceled"
+	case Unknown:
+		return "unknown"
+	case Invalid:
+		return "invalid"
+	case DeadlineExceeded:
+		return "deadline exceeded"
+	case NotFound:
+		return "not found"
+	case AlreadyExists:
+		return "already exists"
+	case PermissionDenied:
+		return "permission denied"
+	case ResourceExhausted:
+		return "resource exhausted"
+	case FailedPrecondition:
+		return "failed precondition"
+	case Aborted:
+		return "aborted"
+	case OutOfRange:
+		return "out of range"
+	case Unimplemented:
+		return "unimplemented"
+	case Internal:
+		return "internal"
+	case Unavailable:
+		return "unavailable"
+	case Unauthenticated:
+		return "unauthenticated"
+	default:
+		return "code(" + strconv.FormatInt(int64(c), 10) + ")"
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package flux
+
+import "github.com/influxdata/flux/internal/errors"
+
+type Error = errors.Error

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,72 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/influxdata/flux/codes"
+)
+
+// Error is the error struct of flux.
+type Error struct {
+	// Code is the code of the error as defined in the codes package.
+	// This describes the type and category of the error. It is required.
+	Code codes.Code
+
+	// Msg contains a human-readable description and additional information
+	// about the error itself. This is optional.
+	Msg string
+
+	// Err contains the error that was the cause of this error.
+	// This is optional.
+	Err error
+}
+
+// Error implement the error interface by outputting the Code and Err.
+func (e *Error) Error() string {
+	if e.Msg != "" && e.Err != nil {
+		var b strings.Builder
+		b.WriteString(e.Msg)
+		b.WriteString(": ")
+		b.WriteString(e.Err.Error())
+		return b.String()
+	} else if e.Msg != "" {
+		return e.Msg
+	} else if e.Err != nil {
+		return e.Err.Error()
+	}
+	return e.Code.String()
+}
+
+// Unwrap will return the wrapped error.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+func New(code codes.Code, msg ...interface{}) error {
+	return Wrap(nil, code, msg...)
+}
+
+func Newf(code codes.Code, fmtStr string, args ...interface{}) error {
+	return Wrapf(nil, code, fmtStr, args...)
+}
+
+func Wrap(err error, code codes.Code, msg ...interface{}) error {
+	var s string
+	if len(msg) > 0 {
+		s = fmt.Sprint(msg...)
+	}
+	return &Error{
+		Code: code,
+		Msg:  s,
+		Err:  err,
+	}
+}
+
+func Wrapf(err error, code codes.Code, format string, a ...interface{}) error {
+	return &Error{
+		Code: code,
+		Msg:  fmt.Sprintf(format, a...),
+		Err:  err,
+	}
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,125 @@
+package errors_test
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+func TestErrorString(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "normal message",
+			err:  errors.New(codes.Invalid, "expected message"),
+			want: "expected message",
+		},
+		{
+			name: "wrapped error",
+			err:  errors.Wrap(stderrors.New("wrapped error"), codes.Invalid, "expected message"),
+			want: "expected message: wrapped error",
+		},
+		{
+			name: "wrapped error with no message",
+			err:  errors.Wrap(stderrors.New("wrapped error"), codes.Invalid),
+			want: "wrapped error",
+		},
+		{
+			name: "code only",
+			err:  errors.New(codes.NotFound),
+			want: "not found",
+		},
+		{
+			name: "formatted message",
+			err:  errors.Newf(codes.Invalid, "formatted message %q", "string"),
+			want: `formatted message "string"`,
+		},
+		{
+			name: "wrapped error with formatted message",
+			err:  errors.Wrapf(stderrors.New("wrapped error"), codes.Invalid, "formatted message %q", "string"),
+			want: `formatted message "string": wrapped error`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := tt.err.Error(), tt.want; got != want {
+				t.Errorf("unexpected error message -want/+got:\n\t- %s\n\t+ %s", want, got)
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want *flux.Error
+	}{
+		{
+			name: "code only",
+			err:  errors.New(codes.NotFound),
+			want: &flux.Error{
+				Code: codes.NotFound,
+			},
+		},
+		{
+			name: "code and message",
+			err:  errors.New(codes.NotFound, "source is missing"),
+			want: &flux.Error{
+				Code: codes.NotFound,
+				Msg:  "source is missing",
+			},
+		},
+		{
+			name: "code and formatted message",
+			err:  errors.Newf(codes.Invalid, "number must be greater than zero, was %d", -1),
+			want: &flux.Error{
+				Code: codes.Invalid,
+				Msg:  "number must be greater than zero, was -1",
+			},
+		},
+		{
+			name: "code, message, and wrapped error",
+			err:  errors.Wrap(stderrors.New("expected error"), codes.Unknown, "unknown error from external system"),
+			want: &flux.Error{
+				Code: codes.Unknown,
+				Msg:  "unknown error from external system",
+				Err:  stderrors.New("expected error"),
+			},
+		},
+		{
+			name: "code, formatted message, and wrapped error",
+			err:  errors.Wrapf(stderrors.New("expected error"), codes.Unknown, "unknown error from %q", "influxdb"),
+			want: &flux.Error{
+				Code: codes.Unknown,
+				Msg:  `unknown error from "influxdb"`,
+				Err:  stderrors.New("expected error"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, want := tt.err.(*flux.Error), tt.want
+			if got.Code != want.Code {
+				t.Errorf("unexpected error code -want/+got:\n\t- %v\n\t+ %v", got.Code, want.Code)
+			}
+			if got.Msg != want.Msg {
+				t.Errorf("unexpected error message -want/+got:\n\t- %v\n\t+ %v", got.Msg, want.Msg)
+			}
+			if got, want := errorString(got.Err), errorString(want.Err); got != want {
+				t.Errorf("unexpected error message -want/+got:\n\t- %v\n\t+ %v", got, want)
+			}
+		})
+	}
+}
+
+func errorString(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return "<nil>"
+}

--- a/internal/errors/unwrap_test.go
+++ b/internal/errors/unwrap_test.go
@@ -1,0 +1,35 @@
+// +build go1.13
+
+package errors_test
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/memory"
+)
+
+func TestUnwrap(t *testing.T) {
+	err := errors.Wrap(memory.LimitExceededError{
+		Limit:     1024,
+		Allocated: 896,
+		Wanted:    1152,
+	}, codes.ResourceExhausted)
+
+	var limitExceededErr memory.LimitExceededError
+	if stderrors.As(err, &limitExceededErr) {
+		if got, want := limitExceededErr.Limit, int64(1024); got != want {
+			t.Errorf("unexpected wrapped error's memory limit -want/+got\n\t- %d\n\t+ %d", got, want)
+		}
+		if got, want := limitExceededErr.Allocated, int64(896); got != want {
+			t.Errorf("unexpected wrapped error's memory allocated -want/+got\n\t- %d\n\t+ %d", got, want)
+		}
+		if got, want := limitExceededErr.Wanted, int64(1152); got != want {
+			t.Errorf("unexpected wrapped error's memory wanted -want/+got\n\t- %d\n\t+ %d", got, want)
+		}
+	} else {
+		t.Error("expected unwrapping error to work")
+	}
+}

--- a/semantic/solve.go
+++ b/semantic/solve.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/influxdata/flux/ast"
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // SolveConstraints solves the type inference problem defined by the constraints.
@@ -69,7 +70,7 @@ func (sol *Solution) solve() error {
 		r := subst.ApplyType(tc.r)
 		s, err := unifyTypes(kinds, l, r)
 		if err != nil {
-			return errors.Wrapf(err, "type error %v", tc.loc)
+			return errors.Wrapf(err, codes.Invalid, "type error %v", tc.loc)
 		}
 		subst.Merge(s)
 	}
@@ -199,7 +200,7 @@ func (s *Solution) PolyTypeOf(n Node) (PolyType, error) {
 
 func (s *Solution) AddConstraint(l, r PolyType) error {
 	if l == nil || r == nil {
-		return errors.New("cannot add type constraint on nil types")
+		return errors.New(codes.Invalid, "cannot add type constraint on nil types")
 	}
 	s.kinds = nil
 	s.cs.AddTypeConst(l, r, ast.SourceLocation{})


### PR DESCRIPTION
We need a common way of categorizing and understanding errors returned
from InfluxDB. We model the errors based on the same concepts that
InfluxDB uses, but we create our own error codes that are modeled on the
grpc error codes.

Each native flux error will have a code that represents the category or
type of error and a message that gives detailed and human-readable
output about the error.

The errors library is included as an internal library and the error
struct itself is exposed using a type alias in the top level package.
This allows the errors to be used by packages that cannot depend on the
top level package (like semantic), but still have the error type be
exposed.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written

Related to #1364.