### PR TITLE
tests(stdlib): fix the e2e benchmarks

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -305,11 +305,14 @@ func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Q
 		p.Now = time.Now()
 	}
 
+	astPkg := p.Ast
 	if p.opts.extern != nil {
-		p.Ast.Files = append([]*ast.File{p.opts.extern}, p.Ast.Files...)
+		// Duplicate the package so we can safely add the external files.
+		astPkg = astPkg.Copy().(*ast.Package)
+		astPkg.Files = append([]*ast.File{p.opts.extern}, astPkg.Files...)
 	}
 
-	s, err := spec.FromAST(ctx, p.Ast, p.Now)
+	s, err := spec.FromAST(ctx, astPkg, p.Now)
 	if err != nil {
 		return nil, errors.Wrap(err, "error in evaluating AST while starting program")
 	}

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -50,7 +50,6 @@ func BenchmarkFluxEndToEnd(b *testing.B) {
 
 func runEndToEnd(t *testing.T, pkgs []*ast.Package) {
 	for _, pkg := range pkgs {
-		pkg := pkg.Copy().(*ast.Package)
 		name := pkg.Files[0].Name
 		t.Run(name, func(t *testing.T) {
 			n := strings.TrimSuffix(name, ".flux")
@@ -64,7 +63,6 @@ func runEndToEnd(t *testing.T, pkgs []*ast.Package) {
 
 func benchEndToEnd(b *testing.B, pkgs []*ast.Package) {
 	for _, pkg := range pkgs {
-		pkg := pkg.Copy().(*ast.Package)
 		name := pkg.Files[0].Name
 		b.Run(name, func(b *testing.B) {
 			n := strings.TrimSuffix(name, ".flux")
@@ -81,6 +79,7 @@ func benchEndToEnd(b *testing.B, pkgs []*ast.Package) {
 }
 
 func testFlux(t testing.TB, pkg *ast.Package) {
+	pkg = pkg.Copy().(*ast.Package)
 	pkg.Files = append(pkg.Files, stdlib.TestingRunCalls(pkg))
 	c := lang.ASTCompiler{AST: pkg}
 


### PR DESCRIPTION
It needs to copy the package before adding the testing calls because
otherwise it adds the tests multiple times.

Ideally, this would be done before the benchmark, but a bit of
refactoring has to be done to separate that.

- [x] docs/SPEC.md updated
- [x] Test cases written