### PR TITLE
feat(stdlib/universe): added go movingAverage

### DIFF
--- a/stdlib/testing/testdata/moving_average.flux
+++ b/stdlib/testing/testdata/moving_average.flux
@@ -18,23 +18,18 @@ inData = "
 "
 
 outData = "
-#group,false,false,true,true,true,true,true,true,true,true,false,false
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,dateTime:RFC3339
-#default,_result,,,,,,,,,,,
-,result,table,_start,_stop,_field,_measurement,device,fstype,host,path,_value,_time
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,30,2018-05-22T00:00:10Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,30,2018-05-22T00:00:20Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,30,2018-05-22T00:00:30Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,33.333333333333336,2018-05-22T00:00:40Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,36.666666666666664,2018-05-22T00:00:50Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40,2018-05-22T00:01:00Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40,2018-05-22T00:01:00Z
-,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40,2018-05-22T00:01:00Z
+#group,false,false,false,false,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string,string
+#default,_result,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,path
+,,0,2018-05-22T00:00:20Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:30Z,33.333333333333336,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:40Z,36.666666666666664,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:50Z,40,used_percent,disk,disk1s1,apfs,host.local,/
 "
 moving_average = (table=<-) =>
 	(table
-		|> range(start: 2018-05-22T00:00:00Z, stop: 2018-05-22T00:01:00Z)
-		|> movingAverage(every: 10s, period: 30s))
+		|> movingAverage(n:3))
 
 test _moving_average = () =>
 	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: moving_average})

--- a/stdlib/testing/testdata/timed_moving_average.flux
+++ b/stdlib/testing/testdata/timed_moving_average.flux
@@ -1,0 +1,41 @@
+package testdata_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string,string
+#group,false,false,false,false,true,true,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,path
+,,0,2018-05-22T00:00:00Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:10Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:20Z,30,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:30Z,40,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:40Z,40,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T00:00:50Z,40,used_percent,disk,disk1s1,apfs,host.local,/
+"
+
+outData = "
+#group,false,false,true,true,true,true,true,true,true,true,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,dateTime:RFC3339
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,device,fstype,host,path,_value,_time
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,30,2018-05-22T00:00:10Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,30,2018-05-22T00:00:20Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,30,2018-05-22T00:00:30Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,33.333333333333336,2018-05-22T00:00:40Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,36.666666666666664,2018-05-22T00:00:50Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40,2018-05-22T00:01:00Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40,2018-05-22T00:01:00Z
+,,0,2018-05-22T00:00:00Z,2018-05-22T00:01:00Z,used_percent,disk,disk1s1,apfs,host.local,/,40,2018-05-22T00:01:00Z
+"
+timed_moving_average = (table=<-) =>
+	(table
+		|> range(start: 2018-05-22T00:00:00Z, stop: 2018-05-22T00:01:00Z)
+		|> timedMovingAverage(every: 10s, period: 30s))
+
+test _timed_moving_average = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: timed_moving_average})
+

--- a/stdlib/universe/flux_gen.go
+++ b/stdlib/universe/flux_gen.go
@@ -22,10 +22,10 @@ var pkgAST = &ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 89,
-					Line:   259,
+					Line:   260,
 				},
 				File:   "universe.flux",
-				Source: "package universe\n\nimport \"system\"\n\n// now is a function option whose default behaviour is to return the current system time\noption now = system.time\n\n// Booleans\nbuiltin true\nbuiltin false\n\n// Transformation functions\nbuiltin columns\nbuiltin count\nbuiltin covariance\nbuiltin cumulativeSum\nbuiltin derivative\nbuiltin difference\nbuiltin distinct\nbuiltin drop\nbuiltin duplicate\nbuiltin elapsed\nbuiltin fill\nbuiltin filter\nbuiltin first\nbuiltin group\nbuiltin histogram\nbuiltin histogramQuantile\nbuiltin integral\nbuiltin join\nbuiltin keep\nbuiltin keyValues\nbuiltin keys\nbuiltin last\nbuiltin limit\nbuiltin map\nbuiltin max\nbuiltin mean\nbuiltin min\nbuiltin mode\nbuiltin quantile\nbuiltin pivot\nbuiltin range\nbuiltin reduce\nbuiltin rename\nbuiltin sample\nbuiltin set\nbuiltin timeShift\nbuiltin skew\nbuiltin spread\nbuiltin sort\nbuiltin stateTracking\nbuiltin stddev\nbuiltin sum\nbuiltin union\nbuiltin unique\nbuiltin window\nbuiltin yield\n\n// stream/table index functions\nbuiltin tableFind\nbuiltin getColumn\nbuiltin getRecord\n\n// type conversion functions\nbuiltin bool\nbuiltin duration\nbuiltin float\nbuiltin int\nbuiltin string\nbuiltin time\nbuiltin uint\n\n// contains function\nbuiltin contains\n\n// other builtins\nbuiltin inf\nbuiltin length // length function for arrays\nbuiltin linearBins\nbuiltin logarithmicBins\nbuiltin sleep // sleep is the identity function with the side effect of delaying execution by a specified duration.\n\n// covariance function with automatic join\ncov = (x,y,on,pearsonr=false) =>\n    join(\n        tables:{x:x, y:y},\n        on:on,\n    )\n    |> covariance(pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"])\n\npearsonr = (x,y,on) => cov(x:x, y:y, on:on, pearsonr:true)\n\n// AggregateWindow applies an aggregate function to fixed windows of time.\n// The procedure is to window the data, perform an aggregate operation,\n// and then undo the windowing to produce an output table for every input table.\naggregateWindow = (every, fn, column=\"_value\", timeSrc=\"_stop\",timeDst=\"_time\", createEmpty=true, tables=<-) =>\n    tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)\n        |> duplicate(column:timeSrc,as:timeDst)\n        |> window(every:inf, timeColumn:timeDst)\n\n// Increase returns the total non-negative difference between values in a table.\n// A main usage case is tracking changes in counter values which may wrap over time when they hit\n// a threshold or are reset. In the case of a wrap/reset,\n// we can assume that the absolute delta between two points will be at least their non-negative difference.\nincrease = (tables=<-, columns=[\"_value\"]) =>\n    tables\n        |> difference(nonNegative: true, columns:columns)\n        |> cumulativeSum(columns: columns)\n\n// median returns the 50th percentile.\nmedian = (method=\"estimate_tdigest\", compression=0.0, column=\"_value\", tables=<-) =>\n    tables\n        |> quantile(q:0.5, method: method, compression: compression, column: column)\n\n// stateCount computes the number of consecutive records in a given state.\n// The state is defined via the function fn. For each consecutive point for\n// which the expression evaluates as true, the state count will be incremented\n// When a point evaluates as false, the state count is reset.\n//\n// The state count will be added as an additional column to each record. If the\n// expression evaluates as false, the value will be -1. If the expression\n// generates an error during evaluation, the point is discarded, and does not\n// affect the state count.\nstateCount = (fn, column=\"stateCount\", tables=<-) =>\n    tables\n        |> stateTracking(countColumn:column, fn:fn)\n\n// stateDuration computes the duration of a given state.\n// The state is defined via the function fn. For each consecutive point for\n// which the expression evaluates as true, the state duration will be\n// incremented by the duration between points. When a point evaluates as false,\n// the state duration is reset.\n//\n// The state duration will be added as an additional column to each record. If the\n// expression evaluates as false, the value will be -1. If the expression\n// generates an error during evaluation, the point is discarded, and does not\n// affect the state duration.\n//\n// Note that as the first point in the given state has no previous point, its\n// state duration will be 0.\n//\n// The duration is represented as an integer in the units specified.\nstateDuration = (fn, column=\"stateDuration\", timeColumn=\"_time\", unit=1s, tables=<-) =>\n    tables\n        |> stateTracking(durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit)\n\n// _sortLimit is a helper function, which sorts and limits a table.\n_sortLimit = (n, desc, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> sort(columns:columns, desc:desc)\n        |> limit(n:n)\n\n// top sorts a table by columns and keeps only the top n records.\ntop = (n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:true)\n\n// top sorts a table by columns and keeps only the bottom n records.\nbottom = (n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:false)\n\n// _highestOrLowest is a helper function, which reduces all groups into a single group by specific tags and a reducer function,\n// then it selects the highest or lowest records based on the column and the _sortLimit function.\n// The default reducer assumes no reducing needs to be performed.\n_highestOrLowest = (n, _sortLimit, reducer, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> group(columns:groupColumns)\n        |> reducer()\n        |> group(columns:[])\n        |> _sortLimit(n:n, columns:[column])\n\n// highestMax returns the top N records from all groups using the maximum of each group.\nhighestMax = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top,\n            )\n\n// highestAverage returns the top N records from all groups using the average of each group.\nhighestAverage = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top,\n            )\n\n// highestCurrent returns the top N records from all groups using the last value of each group.\nhighestCurrent = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top,\n            )\n\n// lowestMin returns the bottom N records from all groups using the minimum of each group.\nlowestMin = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom,\n            )\n\n// lowestAverage returns the bottom N records from all groups using the average of each group.\nlowestAverage = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom,\n            )\n\n// lowestCurrent returns the bottom N records from all groups using the last value of each group.\nlowestCurrent = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom,\n            )\n\n// movingAverage constructs a simple moving average over windows of 'period' duration\n// eg: A 5 year moving average would be called as such:\n//    movingAverage(1y, 5y)\n movingAverage = (every, period, column=\"_value\", tables=<-) =>\n     tables\n         |> window(every: every, period: period)\n         |> mean(column:column)\n         |> duplicate(column: \"_stop\", as: \"_time\")\n         |> window(every: inf)\n\ntoString   = (tables=<-) => tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))\ntoInt      = (tables=<-) => tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))\ntoUInt     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: uint(v:r._value)}))\ntoFloat    = (tables=<-) => tables |> map(fn:(r) => ({r with _value: float(v:r._value)}))\ntoBool     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: bool(v:r._value)}))\ntoTime     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: time(v:r._value)}))",
+				Source: "package universe\n\nimport \"system\"\n\n// now is a function option whose default behaviour is to return the current system time\noption now = system.time\n\n// Booleans\nbuiltin true\nbuiltin false\n\n// Transformation functions\nbuiltin columns\nbuiltin count\nbuiltin covariance\nbuiltin cumulativeSum\nbuiltin derivative\nbuiltin difference\nbuiltin distinct\nbuiltin drop\nbuiltin duplicate\nbuiltin elapsed\nbuiltin fill\nbuiltin filter\nbuiltin first\nbuiltin group\nbuiltin histogram\nbuiltin histogramQuantile\nbuiltin integral\nbuiltin join\nbuiltin keep\nbuiltin keyValues\nbuiltin keys\nbuiltin last\nbuiltin limit\nbuiltin map\nbuiltin max\nbuiltin mean\nbuiltin min\nbuiltin mode\nbuiltin movingAverage\nbuiltin quantile\nbuiltin pivot\nbuiltin range\nbuiltin reduce\nbuiltin rename\nbuiltin sample\nbuiltin set\nbuiltin timeShift\nbuiltin skew\nbuiltin spread\nbuiltin sort\nbuiltin stateTracking\nbuiltin stddev\nbuiltin sum\nbuiltin union\nbuiltin unique\nbuiltin window\nbuiltin yield\n\n// stream/table index functions\nbuiltin tableFind\nbuiltin getColumn\nbuiltin getRecord\n\n// type conversion functions\nbuiltin bool\nbuiltin duration\nbuiltin float\nbuiltin int\nbuiltin string\nbuiltin time\nbuiltin uint\n\n// contains function\nbuiltin contains\n\n// other builtins\nbuiltin inf\nbuiltin length // length function for arrays\nbuiltin linearBins\nbuiltin logarithmicBins\nbuiltin sleep // sleep is the identity function with the side effect of delaying execution by a specified duration.\n\n// covariance function with automatic join\ncov = (x,y,on,pearsonr=false) =>\n    join(\n        tables:{x:x, y:y},\n        on:on,\n    )\n    |> covariance(pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"])\n\npearsonr = (x,y,on) => cov(x:x, y:y, on:on, pearsonr:true)\n\n// AggregateWindow applies an aggregate function to fixed windows of time.\n// The procedure is to window the data, perform an aggregate operation,\n// and then undo the windowing to produce an output table for every input table.\naggregateWindow = (every, fn, column=\"_value\", timeSrc=\"_stop\",timeDst=\"_time\", createEmpty=true, tables=<-) =>\n    tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)\n        |> duplicate(column:timeSrc,as:timeDst)\n        |> window(every:inf, timeColumn:timeDst)\n\n// Increase returns the total non-negative difference between values in a table.\n// A main usage case is tracking changes in counter values which may wrap over time when they hit\n// a threshold or are reset. In the case of a wrap/reset,\n// we can assume that the absolute delta between two points will be at least their non-negative difference.\nincrease = (tables=<-, columns=[\"_value\"]) =>\n    tables\n        |> difference(nonNegative: true, columns:columns)\n        |> cumulativeSum(columns: columns)\n\n// median returns the 50th percentile.\nmedian = (method=\"estimate_tdigest\", compression=0.0, column=\"_value\", tables=<-) =>\n    tables\n        |> quantile(q:0.5, method: method, compression: compression, column: column)\n\n// stateCount computes the number of consecutive records in a given state.\n// The state is defined via the function fn. For each consecutive point for\n// which the expression evaluates as true, the state count will be incremented\n// When a point evaluates as false, the state count is reset.\n//\n// The state count will be added as an additional column to each record. If the\n// expression evaluates as false, the value will be -1. If the expression\n// generates an error during evaluation, the point is discarded, and does not\n// affect the state count.\nstateCount = (fn, column=\"stateCount\", tables=<-) =>\n    tables\n        |> stateTracking(countColumn:column, fn:fn)\n\n// stateDuration computes the duration of a given state.\n// The state is defined via the function fn. For each consecutive point for\n// which the expression evaluates as true, the state duration will be\n// incremented by the duration between points. When a point evaluates as false,\n// the state duration is reset.\n//\n// The state duration will be added as an additional column to each record. If the\n// expression evaluates as false, the value will be -1. If the expression\n// generates an error during evaluation, the point is discarded, and does not\n// affect the state duration.\n//\n// Note that as the first point in the given state has no previous point, its\n// state duration will be 0.\n//\n// The duration is represented as an integer in the units specified.\nstateDuration = (fn, column=\"stateDuration\", timeColumn=\"_time\", unit=1s, tables=<-) =>\n    tables\n        |> stateTracking(durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit)\n\n// _sortLimit is a helper function, which sorts and limits a table.\n_sortLimit = (n, desc, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> sort(columns:columns, desc:desc)\n        |> limit(n:n)\n\n// top sorts a table by columns and keeps only the top n records.\ntop = (n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:true)\n\n// top sorts a table by columns and keeps only the bottom n records.\nbottom = (n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:false)\n\n// _highestOrLowest is a helper function, which reduces all groups into a single group by specific tags and a reducer function,\n// then it selects the highest or lowest records based on the column and the _sortLimit function.\n// The default reducer assumes no reducing needs to be performed.\n_highestOrLowest = (n, _sortLimit, reducer, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> group(columns:groupColumns)\n        |> reducer()\n        |> group(columns:[])\n        |> _sortLimit(n:n, columns:[column])\n\n// highestMax returns the top N records from all groups using the maximum of each group.\nhighestMax = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top,\n            )\n\n// highestAverage returns the top N records from all groups using the average of each group.\nhighestAverage = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top,\n            )\n\n// highestCurrent returns the top N records from all groups using the last value of each group.\nhighestCurrent = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top,\n            )\n\n// lowestMin returns the bottom N records from all groups using the minimum of each group.\nlowestMin = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom,\n            )\n\n// lowestAverage returns the bottom N records from all groups using the average of each group.\nlowestAverage = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom,\n            )\n\n// lowestCurrent returns the bottom N records from all groups using the last value of each group.\nlowestCurrent = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom,\n            )\n\n// timedMovingAverage constructs a simple moving average over windows of 'period' duration\n// eg: A 5 year moving average would be called as such:\n//    movingAverage(1y, 5y)\ntimedMovingAverage = (every, period, column=\"_value\", tables=<-) =>\n    tables\n        |> window(every: every, period: period)\n        |> mean(column:column)\n        |> duplicate(column: \"_stop\", as: \"_time\")\n        |> window(every: inf)\n\ntoString   = (tables=<-) => tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))\ntoInt      = (tables=<-) => tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))\ntoUInt     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: uint(v:r._value)}))\ntoFloat    = (tables=<-) => tables |> map(fn:(r) => ({r with _value: float(v:r._value)}))\ntoBool     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: bool(v:r._value)}))\ntoTime     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: time(v:r._value)}))",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -1161,11 +1161,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 17,
+						Column: 22,
 						Line:   41,
 					},
 					File:   "universe.flux",
-					Source: "builtin quantile",
+					Source: "builtin movingAverage",
 					Start: ast.Position{
 						Column: 1,
 						Line:   41,
@@ -1177,14 +1177,48 @@ var pkgAST = &ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 17,
+							Column: 22,
 							Line:   41,
+						},
+						File:   "universe.flux",
+						Source: "movingAverage",
+						Start: ast.Position{
+							Column: 9,
+							Line:   41,
+						},
+					},
+				},
+				Name: "movingAverage",
+			},
+		}, &ast.BuiltinStatement{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   42,
+					},
+					File:   "universe.flux",
+					Source: "builtin quantile",
+					Start: ast.Position{
+						Column: 1,
+						Line:   42,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   42,
 						},
 						File:   "universe.flux",
 						Source: "quantile",
 						Start: ast.Position{
 							Column: 9,
-							Line:   41,
+							Line:   42,
 						},
 					},
 				},
@@ -1196,13 +1230,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   42,
+						Line:   43,
 					},
 					File:   "universe.flux",
 					Source: "builtin pivot",
 					Start: ast.Position{
 						Column: 1,
-						Line:   42,
+						Line:   43,
 					},
 				},
 			},
@@ -1212,13 +1246,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   42,
+							Line:   43,
 						},
 						File:   "universe.flux",
 						Source: "pivot",
 						Start: ast.Position{
 							Column: 9,
-							Line:   42,
+							Line:   43,
 						},
 					},
 				},
@@ -1230,13 +1264,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   43,
+						Line:   44,
 					},
 					File:   "universe.flux",
 					Source: "builtin range",
 					Start: ast.Position{
 						Column: 1,
-						Line:   43,
+						Line:   44,
 					},
 				},
 			},
@@ -1246,13 +1280,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   43,
+							Line:   44,
 						},
 						File:   "universe.flux",
 						Source: "range",
 						Start: ast.Position{
 							Column: 9,
-							Line:   43,
+							Line:   44,
 						},
 					},
 				},
@@ -1264,13 +1298,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   44,
+						Line:   45,
 					},
 					File:   "universe.flux",
 					Source: "builtin reduce",
 					Start: ast.Position{
 						Column: 1,
-						Line:   44,
+						Line:   45,
 					},
 				},
 			},
@@ -1280,13 +1314,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   44,
+							Line:   45,
 						},
 						File:   "universe.flux",
 						Source: "reduce",
 						Start: ast.Position{
 							Column: 9,
-							Line:   44,
+							Line:   45,
 						},
 					},
 				},
@@ -1298,13 +1332,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   45,
+						Line:   46,
 					},
 					File:   "universe.flux",
 					Source: "builtin rename",
 					Start: ast.Position{
 						Column: 1,
-						Line:   45,
+						Line:   46,
 					},
 				},
 			},
@@ -1314,13 +1348,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   45,
+							Line:   46,
 						},
 						File:   "universe.flux",
 						Source: "rename",
 						Start: ast.Position{
 							Column: 9,
-							Line:   45,
+							Line:   46,
 						},
 					},
 				},
@@ -1332,13 +1366,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   46,
+						Line:   47,
 					},
 					File:   "universe.flux",
 					Source: "builtin sample",
 					Start: ast.Position{
 						Column: 1,
-						Line:   46,
+						Line:   47,
 					},
 				},
 			},
@@ -1348,13 +1382,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   46,
+							Line:   47,
 						},
 						File:   "universe.flux",
 						Source: "sample",
 						Start: ast.Position{
 							Column: 9,
-							Line:   46,
+							Line:   47,
 						},
 					},
 				},
@@ -1366,13 +1400,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 12,
-						Line:   47,
+						Line:   48,
 					},
 					File:   "universe.flux",
 					Source: "builtin set",
 					Start: ast.Position{
 						Column: 1,
-						Line:   47,
+						Line:   48,
 					},
 				},
 			},
@@ -1382,13 +1416,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 12,
-							Line:   47,
+							Line:   48,
 						},
 						File:   "universe.flux",
 						Source: "set",
 						Start: ast.Position{
 							Column: 9,
-							Line:   47,
+							Line:   48,
 						},
 					},
 				},
@@ -1400,13 +1434,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 18,
-						Line:   48,
+						Line:   49,
 					},
 					File:   "universe.flux",
 					Source: "builtin timeShift",
 					Start: ast.Position{
 						Column: 1,
-						Line:   48,
+						Line:   49,
 					},
 				},
 			},
@@ -1416,13 +1450,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 18,
-							Line:   48,
+							Line:   49,
 						},
 						File:   "universe.flux",
 						Source: "timeShift",
 						Start: ast.Position{
 							Column: 9,
-							Line:   48,
+							Line:   49,
 						},
 					},
 				},
@@ -1434,13 +1468,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 13,
-						Line:   49,
+						Line:   50,
 					},
 					File:   "universe.flux",
 					Source: "builtin skew",
 					Start: ast.Position{
 						Column: 1,
-						Line:   49,
+						Line:   50,
 					},
 				},
 			},
@@ -1450,13 +1484,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   49,
+							Line:   50,
 						},
 						File:   "universe.flux",
 						Source: "skew",
 						Start: ast.Position{
 							Column: 9,
-							Line:   49,
+							Line:   50,
 						},
 					},
 				},
@@ -1468,13 +1502,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   50,
+						Line:   51,
 					},
 					File:   "universe.flux",
 					Source: "builtin spread",
 					Start: ast.Position{
 						Column: 1,
-						Line:   50,
+						Line:   51,
 					},
 				},
 			},
@@ -1484,13 +1518,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   50,
+							Line:   51,
 						},
 						File:   "universe.flux",
 						Source: "spread",
 						Start: ast.Position{
 							Column: 9,
-							Line:   50,
+							Line:   51,
 						},
 					},
 				},
@@ -1502,13 +1536,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 13,
-						Line:   51,
+						Line:   52,
 					},
 					File:   "universe.flux",
 					Source: "builtin sort",
 					Start: ast.Position{
 						Column: 1,
-						Line:   51,
+						Line:   52,
 					},
 				},
 			},
@@ -1518,13 +1552,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   51,
+							Line:   52,
 						},
 						File:   "universe.flux",
 						Source: "sort",
 						Start: ast.Position{
 							Column: 9,
-							Line:   51,
+							Line:   52,
 						},
 					},
 				},
@@ -1536,13 +1570,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 22,
-						Line:   52,
+						Line:   53,
 					},
 					File:   "universe.flux",
 					Source: "builtin stateTracking",
 					Start: ast.Position{
 						Column: 1,
-						Line:   52,
+						Line:   53,
 					},
 				},
 			},
@@ -1552,13 +1586,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 22,
-							Line:   52,
+							Line:   53,
 						},
 						File:   "universe.flux",
 						Source: "stateTracking",
 						Start: ast.Position{
 							Column: 9,
-							Line:   52,
+							Line:   53,
 						},
 					},
 				},
@@ -1570,13 +1604,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   53,
+						Line:   54,
 					},
 					File:   "universe.flux",
 					Source: "builtin stddev",
 					Start: ast.Position{
 						Column: 1,
-						Line:   53,
+						Line:   54,
 					},
 				},
 			},
@@ -1586,13 +1620,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   53,
+							Line:   54,
 						},
 						File:   "universe.flux",
 						Source: "stddev",
 						Start: ast.Position{
 							Column: 9,
-							Line:   53,
+							Line:   54,
 						},
 					},
 				},
@@ -1604,13 +1638,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 12,
-						Line:   54,
+						Line:   55,
 					},
 					File:   "universe.flux",
 					Source: "builtin sum",
 					Start: ast.Position{
 						Column: 1,
-						Line:   54,
+						Line:   55,
 					},
 				},
 			},
@@ -1620,13 +1654,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 12,
-							Line:   54,
+							Line:   55,
 						},
 						File:   "universe.flux",
 						Source: "sum",
 						Start: ast.Position{
 							Column: 9,
-							Line:   54,
+							Line:   55,
 						},
 					},
 				},
@@ -1638,13 +1672,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   55,
+						Line:   56,
 					},
 					File:   "universe.flux",
 					Source: "builtin union",
 					Start: ast.Position{
 						Column: 1,
-						Line:   55,
+						Line:   56,
 					},
 				},
 			},
@@ -1654,13 +1688,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   55,
+							Line:   56,
 						},
 						File:   "universe.flux",
 						Source: "union",
 						Start: ast.Position{
 							Column: 9,
-							Line:   55,
+							Line:   56,
 						},
 					},
 				},
@@ -1672,13 +1706,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   56,
+						Line:   57,
 					},
 					File:   "universe.flux",
 					Source: "builtin unique",
 					Start: ast.Position{
 						Column: 1,
-						Line:   56,
+						Line:   57,
 					},
 				},
 			},
@@ -1688,13 +1722,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   56,
+							Line:   57,
 						},
 						File:   "universe.flux",
 						Source: "unique",
 						Start: ast.Position{
 							Column: 9,
-							Line:   56,
+							Line:   57,
 						},
 					},
 				},
@@ -1706,13 +1740,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   57,
+						Line:   58,
 					},
 					File:   "universe.flux",
 					Source: "builtin window",
 					Start: ast.Position{
 						Column: 1,
-						Line:   57,
+						Line:   58,
 					},
 				},
 			},
@@ -1722,13 +1756,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   57,
+							Line:   58,
 						},
 						File:   "universe.flux",
 						Source: "window",
 						Start: ast.Position{
 							Column: 9,
-							Line:   57,
+							Line:   58,
 						},
 					},
 				},
@@ -1740,13 +1774,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   58,
+						Line:   59,
 					},
 					File:   "universe.flux",
 					Source: "builtin yield",
 					Start: ast.Position{
 						Column: 1,
-						Line:   58,
+						Line:   59,
 					},
 				},
 			},
@@ -1756,13 +1790,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   58,
+							Line:   59,
 						},
 						File:   "universe.flux",
 						Source: "yield",
 						Start: ast.Position{
 							Column: 9,
-							Line:   58,
+							Line:   59,
 						},
 					},
 				},
@@ -1774,13 +1808,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 18,
-						Line:   61,
+						Line:   62,
 					},
 					File:   "universe.flux",
 					Source: "builtin tableFind",
 					Start: ast.Position{
 						Column: 1,
-						Line:   61,
+						Line:   62,
 					},
 				},
 			},
@@ -1790,13 +1824,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 18,
-							Line:   61,
+							Line:   62,
 						},
 						File:   "universe.flux",
 						Source: "tableFind",
 						Start: ast.Position{
 							Column: 9,
-							Line:   61,
+							Line:   62,
 						},
 					},
 				},
@@ -1808,13 +1842,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 18,
-						Line:   62,
+						Line:   63,
 					},
 					File:   "universe.flux",
 					Source: "builtin getColumn",
 					Start: ast.Position{
 						Column: 1,
-						Line:   62,
+						Line:   63,
 					},
 				},
 			},
@@ -1824,13 +1858,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 18,
-							Line:   62,
+							Line:   63,
 						},
 						File:   "universe.flux",
 						Source: "getColumn",
 						Start: ast.Position{
 							Column: 9,
-							Line:   62,
+							Line:   63,
 						},
 					},
 				},
@@ -1842,13 +1876,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 18,
-						Line:   63,
+						Line:   64,
 					},
 					File:   "universe.flux",
 					Source: "builtin getRecord",
 					Start: ast.Position{
 						Column: 1,
-						Line:   63,
+						Line:   64,
 					},
 				},
 			},
@@ -1858,13 +1892,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 18,
-							Line:   63,
+							Line:   64,
 						},
 						File:   "universe.flux",
 						Source: "getRecord",
 						Start: ast.Position{
 							Column: 9,
-							Line:   63,
+							Line:   64,
 						},
 					},
 				},
@@ -1876,13 +1910,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 13,
-						Line:   66,
+						Line:   67,
 					},
 					File:   "universe.flux",
 					Source: "builtin bool",
 					Start: ast.Position{
 						Column: 1,
-						Line:   66,
+						Line:   67,
 					},
 				},
 			},
@@ -1892,13 +1926,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   66,
+							Line:   67,
 						},
 						File:   "universe.flux",
 						Source: "bool",
 						Start: ast.Position{
 							Column: 9,
-							Line:   66,
+							Line:   67,
 						},
 					},
 				},
@@ -1910,13 +1944,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 17,
-						Line:   67,
+						Line:   68,
 					},
 					File:   "universe.flux",
 					Source: "builtin duration",
 					Start: ast.Position{
 						Column: 1,
-						Line:   67,
+						Line:   68,
 					},
 				},
 			},
@@ -1926,13 +1960,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 17,
-							Line:   67,
+							Line:   68,
 						},
 						File:   "universe.flux",
 						Source: "duration",
 						Start: ast.Position{
 							Column: 9,
-							Line:   67,
+							Line:   68,
 						},
 					},
 				},
@@ -1944,13 +1978,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   68,
+						Line:   69,
 					},
 					File:   "universe.flux",
 					Source: "builtin float",
 					Start: ast.Position{
 						Column: 1,
-						Line:   68,
+						Line:   69,
 					},
 				},
 			},
@@ -1960,13 +1994,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   68,
+							Line:   69,
 						},
 						File:   "universe.flux",
 						Source: "float",
 						Start: ast.Position{
 							Column: 9,
-							Line:   68,
+							Line:   69,
 						},
 					},
 				},
@@ -1978,13 +2012,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 12,
-						Line:   69,
+						Line:   70,
 					},
 					File:   "universe.flux",
 					Source: "builtin int",
 					Start: ast.Position{
 						Column: 1,
-						Line:   69,
+						Line:   70,
 					},
 				},
 			},
@@ -1994,13 +2028,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 12,
-							Line:   69,
+							Line:   70,
 						},
 						File:   "universe.flux",
 						Source: "int",
 						Start: ast.Position{
 							Column: 9,
-							Line:   69,
+							Line:   70,
 						},
 					},
 				},
@@ -2012,13 +2046,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   70,
+						Line:   71,
 					},
 					File:   "universe.flux",
 					Source: "builtin string",
 					Start: ast.Position{
 						Column: 1,
-						Line:   70,
+						Line:   71,
 					},
 				},
 			},
@@ -2028,13 +2062,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   70,
+							Line:   71,
 						},
 						File:   "universe.flux",
 						Source: "string",
 						Start: ast.Position{
 							Column: 9,
-							Line:   70,
+							Line:   71,
 						},
 					},
 				},
@@ -2046,13 +2080,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 13,
-						Line:   71,
+						Line:   72,
 					},
 					File:   "universe.flux",
 					Source: "builtin time",
 					Start: ast.Position{
 						Column: 1,
-						Line:   71,
+						Line:   72,
 					},
 				},
 			},
@@ -2062,13 +2096,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   71,
+							Line:   72,
 						},
 						File:   "universe.flux",
 						Source: "time",
 						Start: ast.Position{
 							Column: 9,
-							Line:   71,
+							Line:   72,
 						},
 					},
 				},
@@ -2080,13 +2114,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 13,
-						Line:   72,
+						Line:   73,
 					},
 					File:   "universe.flux",
 					Source: "builtin uint",
 					Start: ast.Position{
 						Column: 1,
-						Line:   72,
+						Line:   73,
 					},
 				},
 			},
@@ -2096,13 +2130,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   72,
+							Line:   73,
 						},
 						File:   "universe.flux",
 						Source: "uint",
 						Start: ast.Position{
 							Column: 9,
-							Line:   72,
+							Line:   73,
 						},
 					},
 				},
@@ -2114,13 +2148,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 17,
-						Line:   75,
+						Line:   76,
 					},
 					File:   "universe.flux",
 					Source: "builtin contains",
 					Start: ast.Position{
 						Column: 1,
-						Line:   75,
+						Line:   76,
 					},
 				},
 			},
@@ -2130,13 +2164,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 17,
-							Line:   75,
+							Line:   76,
 						},
 						File:   "universe.flux",
 						Source: "contains",
 						Start: ast.Position{
 							Column: 9,
-							Line:   75,
+							Line:   76,
 						},
 					},
 				},
@@ -2148,13 +2182,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 12,
-						Line:   78,
+						Line:   79,
 					},
 					File:   "universe.flux",
 					Source: "builtin inf",
 					Start: ast.Position{
 						Column: 1,
-						Line:   78,
+						Line:   79,
 					},
 				},
 			},
@@ -2164,13 +2198,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 12,
-							Line:   78,
+							Line:   79,
 						},
 						File:   "universe.flux",
 						Source: "inf",
 						Start: ast.Position{
 							Column: 9,
-							Line:   78,
+							Line:   79,
 						},
 					},
 				},
@@ -2182,13 +2216,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   79,
+						Line:   80,
 					},
 					File:   "universe.flux",
 					Source: "builtin length",
 					Start: ast.Position{
 						Column: 1,
-						Line:   79,
+						Line:   80,
 					},
 				},
 			},
@@ -2198,13 +2232,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   79,
+							Line:   80,
 						},
 						File:   "universe.flux",
 						Source: "length",
 						Start: ast.Position{
 							Column: 9,
-							Line:   79,
+							Line:   80,
 						},
 					},
 				},
@@ -2216,13 +2250,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 19,
-						Line:   80,
+						Line:   81,
 					},
 					File:   "universe.flux",
 					Source: "builtin linearBins",
 					Start: ast.Position{
 						Column: 1,
-						Line:   80,
+						Line:   81,
 					},
 				},
 			},
@@ -2232,13 +2266,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 19,
-							Line:   80,
+							Line:   81,
 						},
 						File:   "universe.flux",
 						Source: "linearBins",
 						Start: ast.Position{
 							Column: 9,
-							Line:   80,
+							Line:   81,
 						},
 					},
 				},
@@ -2250,13 +2284,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 24,
-						Line:   81,
+						Line:   82,
 					},
 					File:   "universe.flux",
 					Source: "builtin logarithmicBins",
 					Start: ast.Position{
 						Column: 1,
-						Line:   81,
+						Line:   82,
 					},
 				},
 			},
@@ -2266,13 +2300,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 24,
-							Line:   81,
+							Line:   82,
 						},
 						File:   "universe.flux",
 						Source: "logarithmicBins",
 						Start: ast.Position{
 							Column: 9,
-							Line:   81,
+							Line:   82,
 						},
 					},
 				},
@@ -2284,13 +2318,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   82,
+						Line:   83,
 					},
 					File:   "universe.flux",
 					Source: "builtin sleep",
 					Start: ast.Position{
 						Column: 1,
-						Line:   82,
+						Line:   83,
 					},
 				},
 			},
@@ -2300,13 +2334,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   82,
+							Line:   83,
 						},
 						File:   "universe.flux",
 						Source: "sleep",
 						Start: ast.Position{
 							Column: 9,
-							Line:   82,
+							Line:   83,
 						},
 					},
 				},
@@ -2318,13 +2352,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 70,
-						Line:   90,
+						Line:   91,
 					},
 					File:   "universe.flux",
 					Source: "cov = (x,y,on,pearsonr=false) =>\n    join(\n        tables:{x:x, y:y},\n        on:on,\n    )\n    |> covariance(pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"])",
 					Start: ast.Position{
 						Column: 1,
-						Line:   85,
+						Line:   86,
 					},
 				},
 			},
@@ -2334,13 +2368,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 4,
-							Line:   85,
+							Line:   86,
 						},
 						File:   "universe.flux",
 						Source: "cov",
 						Start: ast.Position{
 							Column: 1,
-							Line:   85,
+							Line:   86,
 						},
 					},
 				},
@@ -2352,13 +2386,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 70,
-							Line:   90,
+							Line:   91,
 						},
 						File:   "universe.flux",
 						Source: "(x,y,on,pearsonr=false) =>\n    join(\n        tables:{x:x, y:y},\n        on:on,\n    )\n    |> covariance(pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"])",
 						Start: ast.Position{
 							Column: 7,
-							Line:   85,
+							Line:   86,
 						},
 					},
 				},
@@ -2370,13 +2404,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 14,
-										Line:   88,
+										Line:   89,
 									},
 									File:   "universe.flux",
 									Source: "tables:{x:x, y:y},\n        on:on",
 									Start: ast.Position{
 										Column: 9,
-										Line:   87,
+										Line:   88,
 									},
 								},
 							},
@@ -2386,13 +2420,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 26,
-											Line:   87,
+											Line:   88,
 										},
 										File:   "universe.flux",
 										Source: "tables:{x:x, y:y}",
 										Start: ast.Position{
 											Column: 9,
-											Line:   87,
+											Line:   88,
 										},
 									},
 								},
@@ -2402,13 +2436,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 15,
-												Line:   87,
+												Line:   88,
 											},
 											File:   "universe.flux",
 											Source: "tables",
 											Start: ast.Position{
 												Column: 9,
-												Line:   87,
+												Line:   88,
 											},
 										},
 									},
@@ -2420,13 +2454,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 26,
-												Line:   87,
+												Line:   88,
 											},
 											File:   "universe.flux",
 											Source: "{x:x, y:y}",
 											Start: ast.Position{
 												Column: 16,
-												Line:   87,
+												Line:   88,
 											},
 										},
 									},
@@ -2436,13 +2470,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 20,
-													Line:   87,
+													Line:   88,
 												},
 												File:   "universe.flux",
 												Source: "x:x",
 												Start: ast.Position{
 													Column: 17,
-													Line:   87,
+													Line:   88,
 												},
 											},
 										},
@@ -2452,13 +2486,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 18,
-														Line:   87,
+														Line:   88,
 													},
 													File:   "universe.flux",
 													Source: "x",
 													Start: ast.Position{
 														Column: 17,
-														Line:   87,
+														Line:   88,
 													},
 												},
 											},
@@ -2470,13 +2504,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 20,
-														Line:   87,
+														Line:   88,
 													},
 													File:   "universe.flux",
 													Source: "x",
 													Start: ast.Position{
 														Column: 19,
-														Line:   87,
+														Line:   88,
 													},
 												},
 											},
@@ -2488,13 +2522,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 25,
-													Line:   87,
+													Line:   88,
 												},
 												File:   "universe.flux",
 												Source: "y:y",
 												Start: ast.Position{
 													Column: 22,
-													Line:   87,
+													Line:   88,
 												},
 											},
 										},
@@ -2504,13 +2538,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 23,
-														Line:   87,
+														Line:   88,
 													},
 													File:   "universe.flux",
 													Source: "y",
 													Start: ast.Position{
 														Column: 22,
-														Line:   87,
+														Line:   88,
 													},
 												},
 											},
@@ -2522,13 +2556,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 25,
-														Line:   87,
+														Line:   88,
 													},
 													File:   "universe.flux",
 													Source: "y",
 													Start: ast.Position{
 														Column: 24,
-														Line:   87,
+														Line:   88,
 													},
 												},
 											},
@@ -2543,13 +2577,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 14,
-											Line:   88,
+											Line:   89,
 										},
 										File:   "universe.flux",
 										Source: "on:on",
 										Start: ast.Position{
 											Column: 9,
-											Line:   88,
+											Line:   89,
 										},
 									},
 								},
@@ -2559,13 +2593,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 11,
-												Line:   88,
+												Line:   89,
 											},
 											File:   "universe.flux",
 											Source: "on",
 											Start: ast.Position{
 												Column: 9,
-												Line:   88,
+												Line:   89,
 											},
 										},
 									},
@@ -2577,13 +2611,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 14,
-												Line:   88,
+												Line:   89,
 											},
 											File:   "universe.flux",
 											Source: "on",
 											Start: ast.Position{
 												Column: 12,
-												Line:   88,
+												Line:   89,
 											},
 										},
 									},
@@ -2597,13 +2631,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   89,
+									Line:   90,
 								},
 								File:   "universe.flux",
 								Source: "join(\n        tables:{x:x, y:y},\n        on:on,\n    )",
 								Start: ast.Position{
 									Column: 5,
-									Line:   86,
+									Line:   87,
 								},
 							},
 						},
@@ -2613,13 +2647,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 9,
-										Line:   86,
+										Line:   87,
 									},
 									File:   "universe.flux",
 									Source: "join",
 									Start: ast.Position{
 										Column: 5,
-										Line:   86,
+										Line:   87,
 									},
 								},
 							},
@@ -2631,13 +2665,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 70,
-								Line:   90,
+								Line:   91,
 							},
 							File:   "universe.flux",
 							Source: "join(\n        tables:{x:x, y:y},\n        on:on,\n    )\n    |> covariance(pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"])",
 							Start: ast.Position{
 								Column: 5,
-								Line:   86,
+								Line:   87,
 							},
 						},
 					},
@@ -2648,13 +2682,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 69,
-										Line:   90,
+										Line:   91,
 									},
 									File:   "universe.flux",
 									Source: "pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"]",
 									Start: ast.Position{
 										Column: 19,
-										Line:   90,
+										Line:   91,
 									},
 								},
 							},
@@ -2664,13 +2698,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 36,
-											Line:   90,
+											Line:   91,
 										},
 										File:   "universe.flux",
 										Source: "pearsonr:pearsonr",
 										Start: ast.Position{
 											Column: 19,
-											Line:   90,
+											Line:   91,
 										},
 									},
 								},
@@ -2680,13 +2714,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   90,
+												Line:   91,
 											},
 											File:   "universe.flux",
 											Source: "pearsonr",
 											Start: ast.Position{
 												Column: 19,
-												Line:   90,
+												Line:   91,
 											},
 										},
 									},
@@ -2698,13 +2732,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 36,
-												Line:   90,
+												Line:   91,
 											},
 											File:   "universe.flux",
 											Source: "pearsonr",
 											Start: ast.Position{
 												Column: 28,
-												Line:   90,
+												Line:   91,
 											},
 										},
 									},
@@ -2716,13 +2750,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 69,
-											Line:   90,
+											Line:   91,
 										},
 										File:   "universe.flux",
 										Source: "columns:[\"_value_x\",\"_value_y\"]",
 										Start: ast.Position{
 											Column: 38,
-											Line:   90,
+											Line:   91,
 										},
 									},
 								},
@@ -2732,13 +2766,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   90,
+												Line:   91,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 38,
-												Line:   90,
+												Line:   91,
 											},
 										},
 									},
@@ -2750,13 +2784,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 69,
-												Line:   90,
+												Line:   91,
 											},
 											File:   "universe.flux",
 											Source: "[\"_value_x\",\"_value_y\"]",
 											Start: ast.Position{
 												Column: 46,
-												Line:   90,
+												Line:   91,
 											},
 										},
 									},
@@ -2766,13 +2800,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 57,
-													Line:   90,
+													Line:   91,
 												},
 												File:   "universe.flux",
 												Source: "\"_value_x\"",
 												Start: ast.Position{
 													Column: 47,
-													Line:   90,
+													Line:   91,
 												},
 											},
 										},
@@ -2783,13 +2817,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 68,
-													Line:   90,
+													Line:   91,
 												},
 												File:   "universe.flux",
 												Source: "\"_value_y\"",
 												Start: ast.Position{
 													Column: 58,
-													Line:   90,
+													Line:   91,
 												},
 											},
 										},
@@ -2804,13 +2838,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 70,
-									Line:   90,
+									Line:   91,
 								},
 								File:   "universe.flux",
 								Source: "covariance(pearsonr:pearsonr, columns:[\"_value_x\",\"_value_y\"])",
 								Start: ast.Position{
 									Column: 8,
-									Line:   90,
+									Line:   91,
 								},
 							},
 						},
@@ -2820,13 +2854,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 18,
-										Line:   90,
+										Line:   91,
 									},
 									File:   "universe.flux",
 									Source: "covariance",
 									Start: ast.Position{
 										Column: 8,
-										Line:   90,
+										Line:   91,
 									},
 								},
 							},
@@ -2840,13 +2874,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 9,
-								Line:   85,
+								Line:   86,
 							},
 							File:   "universe.flux",
 							Source: "x",
 							Start: ast.Position{
 								Column: 8,
-								Line:   85,
+								Line:   86,
 							},
 						},
 					},
@@ -2856,13 +2890,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 9,
-									Line:   85,
+									Line:   86,
 								},
 								File:   "universe.flux",
 								Source: "x",
 								Start: ast.Position{
 									Column: 8,
-									Line:   85,
+									Line:   86,
 								},
 							},
 						},
@@ -2875,13 +2909,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 11,
-								Line:   85,
+								Line:   86,
 							},
 							File:   "universe.flux",
 							Source: "y",
 							Start: ast.Position{
 								Column: 10,
-								Line:   85,
+								Line:   86,
 							},
 						},
 					},
@@ -2891,13 +2925,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   85,
+									Line:   86,
 								},
 								File:   "universe.flux",
 								Source: "y",
 								Start: ast.Position{
 									Column: 10,
-									Line:   85,
+									Line:   86,
 								},
 							},
 						},
@@ -2910,13 +2944,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   85,
+								Line:   86,
 							},
 							File:   "universe.flux",
 							Source: "on",
 							Start: ast.Position{
 								Column: 12,
-								Line:   85,
+								Line:   86,
 							},
 						},
 					},
@@ -2926,13 +2960,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   85,
+									Line:   86,
 								},
 								File:   "universe.flux",
 								Source: "on",
 								Start: ast.Position{
 									Column: 12,
-									Line:   85,
+									Line:   86,
 								},
 							},
 						},
@@ -2945,13 +2979,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 29,
-								Line:   85,
+								Line:   86,
 							},
 							File:   "universe.flux",
 							Source: "pearsonr=false",
 							Start: ast.Position{
 								Column: 15,
-								Line:   85,
+								Line:   86,
 							},
 						},
 					},
@@ -2961,13 +2995,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 23,
-									Line:   85,
+									Line:   86,
 								},
 								File:   "universe.flux",
 								Source: "pearsonr",
 								Start: ast.Position{
 									Column: 15,
-									Line:   85,
+									Line:   86,
 								},
 							},
 						},
@@ -2979,13 +3013,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   85,
+									Line:   86,
 								},
 								File:   "universe.flux",
 								Source: "false",
 								Start: ast.Position{
 									Column: 24,
-									Line:   85,
+									Line:   86,
 								},
 							},
 						},
@@ -2999,13 +3033,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 59,
-						Line:   92,
+						Line:   93,
 					},
 					File:   "universe.flux",
 					Source: "pearsonr = (x,y,on) => cov(x:x, y:y, on:on, pearsonr:true)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   92,
+						Line:   93,
 					},
 				},
 			},
@@ -3015,13 +3049,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 9,
-							Line:   92,
+							Line:   93,
 						},
 						File:   "universe.flux",
 						Source: "pearsonr",
 						Start: ast.Position{
 							Column: 1,
-							Line:   92,
+							Line:   93,
 						},
 					},
 				},
@@ -3033,13 +3067,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 59,
-							Line:   92,
+							Line:   93,
 						},
 						File:   "universe.flux",
 						Source: "(x,y,on) => cov(x:x, y:y, on:on, pearsonr:true)",
 						Start: ast.Position{
 							Column: 12,
-							Line:   92,
+							Line:   93,
 						},
 					},
 				},
@@ -3050,13 +3084,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 58,
-									Line:   92,
+									Line:   93,
 								},
 								File:   "universe.flux",
 								Source: "x:x, y:y, on:on, pearsonr:true",
 								Start: ast.Position{
 									Column: 28,
-									Line:   92,
+									Line:   93,
 								},
 							},
 						},
@@ -3066,13 +3100,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 31,
-										Line:   92,
+										Line:   93,
 									},
 									File:   "universe.flux",
 									Source: "x:x",
 									Start: ast.Position{
 										Column: 28,
-										Line:   92,
+										Line:   93,
 									},
 								},
 							},
@@ -3082,13 +3116,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "x",
 										Start: ast.Position{
 											Column: 28,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3100,13 +3134,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 31,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "x",
 										Start: ast.Position{
 											Column: 30,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3118,13 +3152,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 36,
-										Line:   92,
+										Line:   93,
 									},
 									File:   "universe.flux",
 									Source: "y:y",
 									Start: ast.Position{
 										Column: 33,
-										Line:   92,
+										Line:   93,
 									},
 								},
 							},
@@ -3134,13 +3168,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 34,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "y",
 										Start: ast.Position{
 											Column: 33,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3152,13 +3186,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 36,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "y",
 										Start: ast.Position{
 											Column: 35,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3170,13 +3204,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 43,
-										Line:   92,
+										Line:   93,
 									},
 									File:   "universe.flux",
 									Source: "on:on",
 									Start: ast.Position{
 										Column: 38,
-										Line:   92,
+										Line:   93,
 									},
 								},
 							},
@@ -3186,13 +3220,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 40,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "on",
 										Start: ast.Position{
 											Column: 38,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3204,13 +3238,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 43,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "on",
 										Start: ast.Position{
 											Column: 41,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3222,13 +3256,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 58,
-										Line:   92,
+										Line:   93,
 									},
 									File:   "universe.flux",
 									Source: "pearsonr:true",
 									Start: ast.Position{
 										Column: 45,
-										Line:   92,
+										Line:   93,
 									},
 								},
 							},
@@ -3238,13 +3272,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 53,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "pearsonr",
 										Start: ast.Position{
 											Column: 45,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3256,13 +3290,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 58,
-											Line:   92,
+											Line:   93,
 										},
 										File:   "universe.flux",
 										Source: "true",
 										Start: ast.Position{
 											Column: 54,
-											Line:   92,
+											Line:   93,
 										},
 									},
 								},
@@ -3276,13 +3310,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 59,
-								Line:   92,
+								Line:   93,
 							},
 							File:   "universe.flux",
 							Source: "cov(x:x, y:y, on:on, pearsonr:true)",
 							Start: ast.Position{
 								Column: 24,
-								Line:   92,
+								Line:   93,
 							},
 						},
 					},
@@ -3292,13 +3326,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 27,
-									Line:   92,
+									Line:   93,
 								},
 								File:   "universe.flux",
 								Source: "cov",
 								Start: ast.Position{
 									Column: 24,
-									Line:   92,
+									Line:   93,
 								},
 							},
 						},
@@ -3311,13 +3345,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   92,
+								Line:   93,
 							},
 							File:   "universe.flux",
 							Source: "x",
 							Start: ast.Position{
 								Column: 13,
-								Line:   92,
+								Line:   93,
 							},
 						},
 					},
@@ -3327,13 +3361,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   92,
+									Line:   93,
 								},
 								File:   "universe.flux",
 								Source: "x",
 								Start: ast.Position{
 									Column: 13,
-									Line:   92,
+									Line:   93,
 								},
 							},
 						},
@@ -3346,13 +3380,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 16,
-								Line:   92,
+								Line:   93,
 							},
 							File:   "universe.flux",
 							Source: "y",
 							Start: ast.Position{
 								Column: 15,
-								Line:   92,
+								Line:   93,
 							},
 						},
 					},
@@ -3362,13 +3396,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 16,
-									Line:   92,
+									Line:   93,
 								},
 								File:   "universe.flux",
 								Source: "y",
 								Start: ast.Position{
 									Column: 15,
-									Line:   92,
+									Line:   93,
 								},
 							},
 						},
@@ -3381,13 +3415,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 19,
-								Line:   92,
+								Line:   93,
 							},
 							File:   "universe.flux",
 							Source: "on",
 							Start: ast.Position{
 								Column: 17,
-								Line:   92,
+								Line:   93,
 							},
 						},
 					},
@@ -3397,13 +3431,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 19,
-									Line:   92,
+									Line:   93,
 								},
 								File:   "universe.flux",
 								Source: "on",
 								Start: ast.Position{
 									Column: 17,
-									Line:   92,
+									Line:   93,
 								},
 							},
 						},
@@ -3418,13 +3452,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 49,
-						Line:   102,
+						Line:   103,
 					},
 					File:   "universe.flux",
 					Source: "aggregateWindow = (every, fn, column=\"_value\", timeSrc=\"_stop\",timeDst=\"_time\", createEmpty=true, tables=<-) =>\n    tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)\n        |> duplicate(column:timeSrc,as:timeDst)\n        |> window(every:inf, timeColumn:timeDst)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   97,
+						Line:   98,
 					},
 				},
 			},
@@ -3434,13 +3468,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 16,
-							Line:   97,
+							Line:   98,
 						},
 						File:   "universe.flux",
 						Source: "aggregateWindow",
 						Start: ast.Position{
 							Column: 1,
-							Line:   97,
+							Line:   98,
 						},
 					},
 				},
@@ -3452,13 +3486,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 49,
-							Line:   102,
+							Line:   103,
 						},
 						File:   "universe.flux",
 						Source: "(every, fn, column=\"_value\", timeSrc=\"_stop\",timeDst=\"_time\", createEmpty=true, tables=<-) =>\n    tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)\n        |> duplicate(column:timeSrc,as:timeDst)\n        |> window(every:inf, timeColumn:timeDst)",
 						Start: ast.Position{
 							Column: 19,
-							Line:   97,
+							Line:   98,
 						},
 					},
 				},
@@ -3472,13 +3506,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 11,
-												Line:   98,
+												Line:   99,
 											},
 											File:   "universe.flux",
 											Source: "tables",
 											Start: ast.Position{
 												Column: 5,
-												Line:   98,
+												Line:   99,
 											},
 										},
 									},
@@ -3489,13 +3523,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 57,
-											Line:   99,
+											Line:   100,
 										},
 										File:   "universe.flux",
 										Source: "tables\n        |> window(every:every, createEmpty: createEmpty)",
 										Start: ast.Position{
 											Column: 5,
-											Line:   98,
+											Line:   99,
 										},
 									},
 								},
@@ -3506,13 +3540,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 56,
-													Line:   99,
+													Line:   100,
 												},
 												File:   "universe.flux",
 												Source: "every:every, createEmpty: createEmpty",
 												Start: ast.Position{
 													Column: 19,
-													Line:   99,
+													Line:   100,
 												},
 											},
 										},
@@ -3522,13 +3556,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 30,
-														Line:   99,
+														Line:   100,
 													},
 													File:   "universe.flux",
 													Source: "every:every",
 													Start: ast.Position{
 														Column: 19,
-														Line:   99,
+														Line:   100,
 													},
 												},
 											},
@@ -3538,13 +3572,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 24,
-															Line:   99,
+															Line:   100,
 														},
 														File:   "universe.flux",
 														Source: "every",
 														Start: ast.Position{
 															Column: 19,
-															Line:   99,
+															Line:   100,
 														},
 													},
 												},
@@ -3556,13 +3590,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 30,
-															Line:   99,
+															Line:   100,
 														},
 														File:   "universe.flux",
 														Source: "every",
 														Start: ast.Position{
 															Column: 25,
-															Line:   99,
+															Line:   100,
 														},
 													},
 												},
@@ -3574,13 +3608,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   99,
+														Line:   100,
 													},
 													File:   "universe.flux",
 													Source: "createEmpty: createEmpty",
 													Start: ast.Position{
 														Column: 32,
-														Line:   99,
+														Line:   100,
 													},
 												},
 											},
@@ -3590,13 +3624,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 43,
-															Line:   99,
+															Line:   100,
 														},
 														File:   "universe.flux",
 														Source: "createEmpty",
 														Start: ast.Position{
 															Column: 32,
-															Line:   99,
+															Line:   100,
 														},
 													},
 												},
@@ -3608,13 +3642,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 56,
-															Line:   99,
+															Line:   100,
 														},
 														File:   "universe.flux",
 														Source: "createEmpty",
 														Start: ast.Position{
 															Column: 45,
-															Line:   99,
+															Line:   100,
 														},
 													},
 												},
@@ -3628,13 +3662,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 57,
-												Line:   99,
+												Line:   100,
 											},
 											File:   "universe.flux",
 											Source: "window(every:every, createEmpty: createEmpty)",
 											Start: ast.Position{
 												Column: 12,
-												Line:   99,
+												Line:   100,
 											},
 										},
 									},
@@ -3644,13 +3678,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 18,
-													Line:   99,
+													Line:   100,
 												},
 												File:   "universe.flux",
 												Source: "window",
 												Start: ast.Position{
 													Column: 12,
-													Line:   99,
+													Line:   100,
 												},
 											},
 										},
@@ -3663,13 +3697,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 29,
-										Line:   100,
+										Line:   101,
 									},
 									File:   "universe.flux",
 									Source: "tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)",
 									Start: ast.Position{
 										Column: 5,
-										Line:   98,
+										Line:   99,
 									},
 								},
 							},
@@ -3680,13 +3714,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 28,
-												Line:   100,
+												Line:   101,
 											},
 											File:   "universe.flux",
 											Source: "column:column",
 											Start: ast.Position{
 												Column: 15,
-												Line:   100,
+												Line:   101,
 											},
 										},
 									},
@@ -3696,13 +3730,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 28,
-													Line:   100,
+													Line:   101,
 												},
 												File:   "universe.flux",
 												Source: "column:column",
 												Start: ast.Position{
 													Column: 15,
-													Line:   100,
+													Line:   101,
 												},
 											},
 										},
@@ -3712,13 +3746,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 21,
-														Line:   100,
+														Line:   101,
 													},
 													File:   "universe.flux",
 													Source: "column",
 													Start: ast.Position{
 														Column: 15,
-														Line:   100,
+														Line:   101,
 													},
 												},
 											},
@@ -3730,13 +3764,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 28,
-														Line:   100,
+														Line:   101,
 													},
 													File:   "universe.flux",
 													Source: "column",
 													Start: ast.Position{
 														Column: 22,
-														Line:   100,
+														Line:   101,
 													},
 												},
 											},
@@ -3750,13 +3784,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   100,
+											Line:   101,
 										},
 										File:   "universe.flux",
 										Source: "fn(column:column)",
 										Start: ast.Position{
 											Column: 12,
-											Line:   100,
+											Line:   101,
 										},
 									},
 								},
@@ -3766,13 +3800,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 14,
-												Line:   100,
+												Line:   101,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 12,
-												Line:   100,
+												Line:   101,
 											},
 										},
 									},
@@ -3785,13 +3819,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 48,
-									Line:   101,
+									Line:   102,
 								},
 								File:   "universe.flux",
 								Source: "tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)\n        |> duplicate(column:timeSrc,as:timeDst)",
 								Start: ast.Position{
 									Column: 5,
-									Line:   98,
+									Line:   99,
 								},
 							},
 						},
@@ -3802,13 +3836,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 47,
-											Line:   101,
+											Line:   102,
 										},
 										File:   "universe.flux",
 										Source: "column:timeSrc,as:timeDst",
 										Start: ast.Position{
 											Column: 22,
-											Line:   101,
+											Line:   102,
 										},
 									},
 								},
@@ -3818,13 +3852,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 36,
-												Line:   101,
+												Line:   102,
 											},
 											File:   "universe.flux",
 											Source: "column:timeSrc",
 											Start: ast.Position{
 												Column: 22,
-												Line:   101,
+												Line:   102,
 											},
 										},
 									},
@@ -3834,13 +3868,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 28,
-													Line:   101,
+													Line:   102,
 												},
 												File:   "universe.flux",
 												Source: "column",
 												Start: ast.Position{
 													Column: 22,
-													Line:   101,
+													Line:   102,
 												},
 											},
 										},
@@ -3852,13 +3886,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   101,
+													Line:   102,
 												},
 												File:   "universe.flux",
 												Source: "timeSrc",
 												Start: ast.Position{
 													Column: 29,
-													Line:   101,
+													Line:   102,
 												},
 											},
 										},
@@ -3870,13 +3904,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 47,
-												Line:   101,
+												Line:   102,
 											},
 											File:   "universe.flux",
 											Source: "as:timeDst",
 											Start: ast.Position{
 												Column: 37,
-												Line:   101,
+												Line:   102,
 											},
 										},
 									},
@@ -3886,13 +3920,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 39,
-													Line:   101,
+													Line:   102,
 												},
 												File:   "universe.flux",
 												Source: "as",
 												Start: ast.Position{
 													Column: 37,
-													Line:   101,
+													Line:   102,
 												},
 											},
 										},
@@ -3904,13 +3938,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 47,
-													Line:   101,
+													Line:   102,
 												},
 												File:   "universe.flux",
 												Source: "timeDst",
 												Start: ast.Position{
 													Column: 40,
-													Line:   101,
+													Line:   102,
 												},
 											},
 										},
@@ -3924,13 +3958,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 48,
-										Line:   101,
+										Line:   102,
 									},
 									File:   "universe.flux",
 									Source: "duplicate(column:timeSrc,as:timeDst)",
 									Start: ast.Position{
 										Column: 12,
-										Line:   101,
+										Line:   102,
 									},
 								},
 							},
@@ -3940,13 +3974,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   101,
+											Line:   102,
 										},
 										File:   "universe.flux",
 										Source: "duplicate",
 										Start: ast.Position{
 											Column: 12,
-											Line:   101,
+											Line:   102,
 										},
 									},
 								},
@@ -3959,13 +3993,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 49,
-								Line:   102,
+								Line:   103,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> window(every:every, createEmpty: createEmpty)\n        |> fn(column:column)\n        |> duplicate(column:timeSrc,as:timeDst)\n        |> window(every:inf, timeColumn:timeDst)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   98,
+								Line:   99,
 							},
 						},
 					},
@@ -3976,13 +4010,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 48,
-										Line:   102,
+										Line:   103,
 									},
 									File:   "universe.flux",
 									Source: "every:inf, timeColumn:timeDst",
 									Start: ast.Position{
 										Column: 19,
-										Line:   102,
+										Line:   103,
 									},
 								},
 							},
@@ -3992,13 +4026,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 28,
-											Line:   102,
+											Line:   103,
 										},
 										File:   "universe.flux",
 										Source: "every:inf",
 										Start: ast.Position{
 											Column: 19,
-											Line:   102,
+											Line:   103,
 										},
 									},
 								},
@@ -4008,13 +4042,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   102,
+												Line:   103,
 											},
 											File:   "universe.flux",
 											Source: "every",
 											Start: ast.Position{
 												Column: 19,
-												Line:   102,
+												Line:   103,
 											},
 										},
 									},
@@ -4026,13 +4060,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 28,
-												Line:   102,
+												Line:   103,
 											},
 											File:   "universe.flux",
 											Source: "inf",
 											Start: ast.Position{
 												Column: 25,
-												Line:   102,
+												Line:   103,
 											},
 										},
 									},
@@ -4044,13 +4078,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 48,
-											Line:   102,
+											Line:   103,
 										},
 										File:   "universe.flux",
 										Source: "timeColumn:timeDst",
 										Start: ast.Position{
 											Column: 30,
-											Line:   102,
+											Line:   103,
 										},
 									},
 								},
@@ -4060,13 +4094,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 40,
-												Line:   102,
+												Line:   103,
 											},
 											File:   "universe.flux",
 											Source: "timeColumn",
 											Start: ast.Position{
 												Column: 30,
-												Line:   102,
+												Line:   103,
 											},
 										},
 									},
@@ -4078,13 +4112,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 48,
-												Line:   102,
+												Line:   103,
 											},
 											File:   "universe.flux",
 											Source: "timeDst",
 											Start: ast.Position{
 												Column: 41,
-												Line:   102,
+												Line:   103,
 											},
 										},
 									},
@@ -4098,13 +4132,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 49,
-									Line:   102,
+									Line:   103,
 								},
 								File:   "universe.flux",
 								Source: "window(every:inf, timeColumn:timeDst)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   102,
+									Line:   103,
 								},
 							},
 						},
@@ -4114,13 +4148,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 18,
-										Line:   102,
+										Line:   103,
 									},
 									File:   "universe.flux",
 									Source: "window",
 									Start: ast.Position{
 										Column: 12,
-										Line:   102,
+										Line:   103,
 									},
 								},
 							},
@@ -4134,13 +4168,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 25,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "every",
 							Start: ast.Position{
 								Column: 20,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4150,13 +4184,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 25,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "every",
 								Start: ast.Position{
 									Column: 20,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4169,13 +4203,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 29,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "fn",
 							Start: ast.Position{
 								Column: 27,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4185,13 +4219,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "fn",
 								Start: ast.Position{
 									Column: 27,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4204,13 +4238,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 46,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 31,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4220,13 +4254,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 37,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 31,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4238,13 +4272,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 46,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 38,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4256,13 +4290,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 63,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "timeSrc=\"_stop\"",
 							Start: ast.Position{
 								Column: 48,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4272,13 +4306,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 55,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "timeSrc",
 								Start: ast.Position{
 									Column: 48,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4290,13 +4324,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 63,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "\"_stop\"",
 								Start: ast.Position{
 									Column: 56,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4308,13 +4342,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 79,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "timeDst=\"_time\"",
 							Start: ast.Position{
 								Column: 64,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4324,13 +4358,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 71,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "timeDst",
 								Start: ast.Position{
 									Column: 64,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4342,13 +4376,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 79,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "\"_time\"",
 								Start: ast.Position{
 									Column: 72,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4360,13 +4394,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 97,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "createEmpty=true",
 							Start: ast.Position{
 								Column: 81,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4376,13 +4410,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 92,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "createEmpty",
 								Start: ast.Position{
 									Column: 81,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4394,13 +4428,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 97,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "true",
 								Start: ast.Position{
 									Column: 93,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4412,13 +4446,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 108,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 99,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					},
@@ -4428,13 +4462,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 105,
-									Line:   97,
+									Line:   98,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 99,
-									Line:   97,
+									Line:   98,
 								},
 							},
 						},
@@ -4445,13 +4479,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 108,
-								Line:   97,
+								Line:   98,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 106,
-								Line:   97,
+								Line:   98,
 							},
 						},
 					}},
@@ -4463,13 +4497,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 43,
-						Line:   111,
+						Line:   112,
 					},
 					File:   "universe.flux",
 					Source: "increase = (tables=<-, columns=[\"_value\"]) =>\n    tables\n        |> difference(nonNegative: true, columns:columns)\n        |> cumulativeSum(columns: columns)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   108,
+						Line:   109,
 					},
 				},
 			},
@@ -4479,13 +4513,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 9,
-							Line:   108,
+							Line:   109,
 						},
 						File:   "universe.flux",
 						Source: "increase",
 						Start: ast.Position{
 							Column: 1,
-							Line:   108,
+							Line:   109,
 						},
 					},
 				},
@@ -4497,13 +4531,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 43,
-							Line:   111,
+							Line:   112,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-, columns=[\"_value\"]) =>\n    tables\n        |> difference(nonNegative: true, columns:columns)\n        |> cumulativeSum(columns: columns)",
 						Start: ast.Position{
 							Column: 12,
-							Line:   108,
+							Line:   109,
 						},
 					},
 				},
@@ -4515,13 +4549,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 11,
-										Line:   109,
+										Line:   110,
 									},
 									File:   "universe.flux",
 									Source: "tables",
 									Start: ast.Position{
 										Column: 5,
-										Line:   109,
+										Line:   110,
 									},
 								},
 							},
@@ -4532,13 +4566,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 58,
-									Line:   110,
+									Line:   111,
 								},
 								File:   "universe.flux",
 								Source: "tables\n        |> difference(nonNegative: true, columns:columns)",
 								Start: ast.Position{
 									Column: 5,
-									Line:   109,
+									Line:   110,
 								},
 							},
 						},
@@ -4549,13 +4583,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 57,
-											Line:   110,
+											Line:   111,
 										},
 										File:   "universe.flux",
 										Source: "nonNegative: true, columns:columns",
 										Start: ast.Position{
 											Column: 23,
-											Line:   110,
+											Line:   111,
 										},
 									},
 								},
@@ -4565,13 +4599,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 40,
-												Line:   110,
+												Line:   111,
 											},
 											File:   "universe.flux",
 											Source: "nonNegative: true",
 											Start: ast.Position{
 												Column: 23,
-												Line:   110,
+												Line:   111,
 											},
 										},
 									},
@@ -4581,13 +4615,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 34,
-													Line:   110,
+													Line:   111,
 												},
 												File:   "universe.flux",
 												Source: "nonNegative",
 												Start: ast.Position{
 													Column: 23,
-													Line:   110,
+													Line:   111,
 												},
 											},
 										},
@@ -4599,13 +4633,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 40,
-													Line:   110,
+													Line:   111,
 												},
 												File:   "universe.flux",
 												Source: "true",
 												Start: ast.Position{
 													Column: 36,
-													Line:   110,
+													Line:   111,
 												},
 											},
 										},
@@ -4617,13 +4651,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 57,
-												Line:   110,
+												Line:   111,
 											},
 											File:   "universe.flux",
 											Source: "columns:columns",
 											Start: ast.Position{
 												Column: 42,
-												Line:   110,
+												Line:   111,
 											},
 										},
 									},
@@ -4633,13 +4667,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 49,
-													Line:   110,
+													Line:   111,
 												},
 												File:   "universe.flux",
 												Source: "columns",
 												Start: ast.Position{
 													Column: 42,
-													Line:   110,
+													Line:   111,
 												},
 											},
 										},
@@ -4651,13 +4685,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 57,
-													Line:   110,
+													Line:   111,
 												},
 												File:   "universe.flux",
 												Source: "columns",
 												Start: ast.Position{
 													Column: 50,
-													Line:   110,
+													Line:   111,
 												},
 											},
 										},
@@ -4671,13 +4705,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 58,
-										Line:   110,
+										Line:   111,
 									},
 									File:   "universe.flux",
 									Source: "difference(nonNegative: true, columns:columns)",
 									Start: ast.Position{
 										Column: 12,
-										Line:   110,
+										Line:   111,
 									},
 								},
 							},
@@ -4687,13 +4721,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 22,
-											Line:   110,
+											Line:   111,
 										},
 										File:   "universe.flux",
 										Source: "difference",
 										Start: ast.Position{
 											Column: 12,
-											Line:   110,
+											Line:   111,
 										},
 									},
 								},
@@ -4706,13 +4740,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 43,
-								Line:   111,
+								Line:   112,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> difference(nonNegative: true, columns:columns)\n        |> cumulativeSum(columns: columns)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   109,
+								Line:   110,
 							},
 						},
 					},
@@ -4723,13 +4757,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   111,
+										Line:   112,
 									},
 									File:   "universe.flux",
 									Source: "columns: columns",
 									Start: ast.Position{
 										Column: 26,
-										Line:   111,
+										Line:   112,
 									},
 								},
 							},
@@ -4739,13 +4773,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   111,
+											Line:   112,
 										},
 										File:   "universe.flux",
 										Source: "columns: columns",
 										Start: ast.Position{
 											Column: 26,
-											Line:   111,
+											Line:   112,
 										},
 									},
 								},
@@ -4755,13 +4789,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 33,
-												Line:   111,
+												Line:   112,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 26,
-												Line:   111,
+												Line:   112,
 											},
 										},
 									},
@@ -4773,13 +4807,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   111,
+												Line:   112,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 35,
-												Line:   111,
+												Line:   112,
 											},
 										},
 									},
@@ -4793,13 +4827,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 43,
-									Line:   111,
+									Line:   112,
 								},
 								File:   "universe.flux",
 								Source: "cumulativeSum(columns: columns)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   111,
+									Line:   112,
 								},
 							},
 						},
@@ -4809,13 +4843,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 25,
-										Line:   111,
+										Line:   112,
 									},
 									File:   "universe.flux",
 									Source: "cumulativeSum",
 									Start: ast.Position{
 										Column: 12,
-										Line:   111,
+										Line:   112,
 									},
 								},
 							},
@@ -4829,13 +4863,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 22,
-								Line:   108,
+								Line:   109,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 13,
-								Line:   108,
+								Line:   109,
 							},
 						},
 					},
@@ -4845,13 +4879,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 19,
-									Line:   108,
+									Line:   109,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 13,
-									Line:   108,
+									Line:   109,
 								},
 							},
 						},
@@ -4862,13 +4896,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 22,
-								Line:   108,
+								Line:   109,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 20,
-								Line:   108,
+								Line:   109,
 							},
 						},
 					}},
@@ -4878,13 +4912,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 42,
-								Line:   108,
+								Line:   109,
 							},
 							File:   "universe.flux",
 							Source: "columns=[\"_value\"]",
 							Start: ast.Position{
 								Column: 24,
-								Line:   108,
+								Line:   109,
 							},
 						},
 					},
@@ -4894,13 +4928,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 31,
-									Line:   108,
+									Line:   109,
 								},
 								File:   "universe.flux",
 								Source: "columns",
 								Start: ast.Position{
 									Column: 24,
-									Line:   108,
+									Line:   109,
 								},
 							},
 						},
@@ -4912,13 +4946,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 42,
-									Line:   108,
+									Line:   109,
 								},
 								File:   "universe.flux",
 								Source: "[\"_value\"]",
 								Start: ast.Position{
 									Column: 32,
-									Line:   108,
+									Line:   109,
 								},
 							},
 						},
@@ -4928,13 +4962,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 41,
-										Line:   108,
+										Line:   109,
 									},
 									File:   "universe.flux",
 									Source: "\"_value\"",
 									Start: ast.Position{
 										Column: 33,
-										Line:   108,
+										Line:   109,
 									},
 								},
 							},
@@ -4949,13 +4983,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 85,
-						Line:   116,
+						Line:   117,
 					},
 					File:   "universe.flux",
 					Source: "median = (method=\"estimate_tdigest\", compression=0.0, column=\"_value\", tables=<-) =>\n    tables\n        |> quantile(q:0.5, method: method, compression: compression, column: column)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   114,
+						Line:   115,
 					},
 				},
 			},
@@ -4965,13 +4999,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   114,
+							Line:   115,
 						},
 						File:   "universe.flux",
 						Source: "median",
 						Start: ast.Position{
 							Column: 1,
-							Line:   114,
+							Line:   115,
 						},
 					},
 				},
@@ -4983,13 +5017,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 85,
-							Line:   116,
+							Line:   117,
 						},
 						File:   "universe.flux",
 						Source: "(method=\"estimate_tdigest\", compression=0.0, column=\"_value\", tables=<-) =>\n    tables\n        |> quantile(q:0.5, method: method, compression: compression, column: column)",
 						Start: ast.Position{
 							Column: 10,
-							Line:   114,
+							Line:   115,
 						},
 					},
 				},
@@ -5000,13 +5034,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   115,
+									Line:   116,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   115,
+									Line:   116,
 								},
 							},
 						},
@@ -5017,13 +5051,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 85,
-								Line:   116,
+								Line:   117,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> quantile(q:0.5, method: method, compression: compression, column: column)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   115,
+								Line:   116,
 							},
 						},
 					},
@@ -5034,13 +5068,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 84,
-										Line:   116,
+										Line:   117,
 									},
 									File:   "universe.flux",
 									Source: "q:0.5, method: method, compression: compression, column: column",
 									Start: ast.Position{
 										Column: 21,
-										Line:   116,
+										Line:   117,
 									},
 								},
 							},
@@ -5050,13 +5084,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 26,
-											Line:   116,
+											Line:   117,
 										},
 										File:   "universe.flux",
 										Source: "q:0.5",
 										Start: ast.Position{
 											Column: 21,
-											Line:   116,
+											Line:   117,
 										},
 									},
 								},
@@ -5066,13 +5100,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 22,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "q",
 											Start: ast.Position{
 												Column: 21,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5084,13 +5118,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 26,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "0.5",
 											Start: ast.Position{
 												Column: 23,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5102,13 +5136,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   116,
+											Line:   117,
 										},
 										File:   "universe.flux",
 										Source: "method: method",
 										Start: ast.Position{
 											Column: 28,
-											Line:   116,
+											Line:   117,
 										},
 									},
 								},
@@ -5118,13 +5152,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 34,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "method",
 											Start: ast.Position{
 												Column: 28,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5136,13 +5170,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "method",
 											Start: ast.Position{
 												Column: 36,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5154,13 +5188,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 68,
-											Line:   116,
+											Line:   117,
 										},
 										File:   "universe.flux",
 										Source: "compression: compression",
 										Start: ast.Position{
 											Column: 44,
-											Line:   116,
+											Line:   117,
 										},
 									},
 								},
@@ -5170,13 +5204,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 55,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "compression",
 											Start: ast.Position{
 												Column: 44,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5188,13 +5222,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 68,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "compression",
 											Start: ast.Position{
 												Column: 57,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5206,13 +5240,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 84,
-											Line:   116,
+											Line:   117,
 										},
 										File:   "universe.flux",
 										Source: "column: column",
 										Start: ast.Position{
 											Column: 70,
-											Line:   116,
+											Line:   117,
 										},
 									},
 								},
@@ -5222,13 +5256,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 76,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 70,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5240,13 +5274,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 84,
-												Line:   116,
+												Line:   117,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 78,
-												Line:   116,
+												Line:   117,
 											},
 										},
 									},
@@ -5260,13 +5294,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 85,
-									Line:   116,
+									Line:   117,
 								},
 								File:   "universe.flux",
 								Source: "quantile(q:0.5, method: method, compression: compression, column: column)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   116,
+									Line:   117,
 								},
 							},
 						},
@@ -5276,13 +5310,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 20,
-										Line:   116,
+										Line:   117,
 									},
 									File:   "universe.flux",
 									Source: "quantile",
 									Start: ast.Position{
 										Column: 12,
-										Line:   116,
+										Line:   117,
 									},
 								},
 							},
@@ -5296,13 +5330,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 36,
-								Line:   114,
+								Line:   115,
 							},
 							File:   "universe.flux",
 							Source: "method=\"estimate_tdigest\"",
 							Start: ast.Position{
 								Column: 11,
-								Line:   114,
+								Line:   115,
 							},
 						},
 					},
@@ -5312,13 +5346,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 17,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "method",
 								Start: ast.Position{
 									Column: 11,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5330,13 +5364,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 36,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "\"estimate_tdigest\"",
 								Start: ast.Position{
 									Column: 18,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5348,13 +5382,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 53,
-								Line:   114,
+								Line:   115,
 							},
 							File:   "universe.flux",
 							Source: "compression=0.0",
 							Start: ast.Position{
 								Column: 38,
-								Line:   114,
+								Line:   115,
 							},
 						},
 					},
@@ -5364,13 +5398,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 49,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "compression",
 								Start: ast.Position{
 									Column: 38,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5382,13 +5416,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 53,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "0.0",
 								Start: ast.Position{
 									Column: 50,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5400,13 +5434,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 70,
-								Line:   114,
+								Line:   115,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 55,
-								Line:   114,
+								Line:   115,
 							},
 						},
 					},
@@ -5416,13 +5450,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 61,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 55,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5434,13 +5468,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 70,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 62,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5452,13 +5486,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 81,
-								Line:   114,
+								Line:   115,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 72,
-								Line:   114,
+								Line:   115,
 							},
 						},
 					},
@@ -5468,13 +5502,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 78,
-									Line:   114,
+									Line:   115,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 72,
-									Line:   114,
+									Line:   115,
 								},
 							},
 						},
@@ -5485,13 +5519,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 81,
-								Line:   114,
+								Line:   115,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 79,
-								Line:   114,
+								Line:   115,
 							},
 						},
 					}},
@@ -5503,13 +5537,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 52,
-						Line:   129,
+						Line:   130,
 					},
 					File:   "universe.flux",
 					Source: "stateCount = (fn, column=\"stateCount\", tables=<-) =>\n    tables\n        |> stateTracking(countColumn:column, fn:fn)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   127,
+						Line:   128,
 					},
 				},
 			},
@@ -5519,13 +5553,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 11,
-							Line:   127,
+							Line:   128,
 						},
 						File:   "universe.flux",
 						Source: "stateCount",
 						Start: ast.Position{
 							Column: 1,
-							Line:   127,
+							Line:   128,
 						},
 					},
 				},
@@ -5537,13 +5571,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 52,
-							Line:   129,
+							Line:   130,
 						},
 						File:   "universe.flux",
 						Source: "(fn, column=\"stateCount\", tables=<-) =>\n    tables\n        |> stateTracking(countColumn:column, fn:fn)",
 						Start: ast.Position{
 							Column: 14,
-							Line:   127,
+							Line:   128,
 						},
 					},
 				},
@@ -5554,13 +5588,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   128,
+									Line:   129,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   128,
+									Line:   129,
 								},
 							},
 						},
@@ -5571,13 +5605,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 52,
-								Line:   129,
+								Line:   130,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> stateTracking(countColumn:column, fn:fn)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   128,
+								Line:   129,
 							},
 						},
 					},
@@ -5588,13 +5622,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 51,
-										Line:   129,
+										Line:   130,
 									},
 									File:   "universe.flux",
 									Source: "countColumn:column, fn:fn",
 									Start: ast.Position{
 										Column: 26,
-										Line:   129,
+										Line:   130,
 									},
 								},
 							},
@@ -5604,13 +5638,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 44,
-											Line:   129,
+											Line:   130,
 										},
 										File:   "universe.flux",
 										Source: "countColumn:column",
 										Start: ast.Position{
 											Column: 26,
-											Line:   129,
+											Line:   130,
 										},
 									},
 								},
@@ -5620,13 +5654,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 37,
-												Line:   129,
+												Line:   130,
 											},
 											File:   "universe.flux",
 											Source: "countColumn",
 											Start: ast.Position{
 												Column: 26,
-												Line:   129,
+												Line:   130,
 											},
 										},
 									},
@@ -5638,13 +5672,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 44,
-												Line:   129,
+												Line:   130,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 38,
-												Line:   129,
+												Line:   130,
 											},
 										},
 									},
@@ -5656,13 +5690,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 51,
-											Line:   129,
+											Line:   130,
 										},
 										File:   "universe.flux",
 										Source: "fn:fn",
 										Start: ast.Position{
 											Column: 46,
-											Line:   129,
+											Line:   130,
 										},
 									},
 								},
@@ -5672,13 +5706,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 48,
-												Line:   129,
+												Line:   130,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 46,
-												Line:   129,
+												Line:   130,
 											},
 										},
 									},
@@ -5690,13 +5724,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 51,
-												Line:   129,
+												Line:   130,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 49,
-												Line:   129,
+												Line:   130,
 											},
 										},
 									},
@@ -5710,13 +5744,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 52,
-									Line:   129,
+									Line:   130,
 								},
 								File:   "universe.flux",
 								Source: "stateTracking(countColumn:column, fn:fn)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   129,
+									Line:   130,
 								},
 							},
 						},
@@ -5726,13 +5760,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 25,
-										Line:   129,
+										Line:   130,
 									},
 									File:   "universe.flux",
 									Source: "stateTracking",
 									Start: ast.Position{
 										Column: 12,
-										Line:   129,
+										Line:   130,
 									},
 								},
 							},
@@ -5746,13 +5780,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 17,
-								Line:   127,
+								Line:   128,
 							},
 							File:   "universe.flux",
 							Source: "fn",
 							Start: ast.Position{
 								Column: 15,
-								Line:   127,
+								Line:   128,
 							},
 						},
 					},
@@ -5762,13 +5796,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 17,
-									Line:   127,
+									Line:   128,
 								},
 								File:   "universe.flux",
 								Source: "fn",
 								Start: ast.Position{
 									Column: 15,
-									Line:   127,
+									Line:   128,
 								},
 							},
 						},
@@ -5781,13 +5815,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 38,
-								Line:   127,
+								Line:   128,
 							},
 							File:   "universe.flux",
 							Source: "column=\"stateCount\"",
 							Start: ast.Position{
 								Column: 19,
-								Line:   127,
+								Line:   128,
 							},
 						},
 					},
@@ -5797,13 +5831,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 25,
-									Line:   127,
+									Line:   128,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 19,
-									Line:   127,
+									Line:   128,
 								},
 							},
 						},
@@ -5815,13 +5849,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 38,
-									Line:   127,
+									Line:   128,
 								},
 								File:   "universe.flux",
 								Source: "\"stateCount\"",
 								Start: ast.Position{
 									Column: 26,
-									Line:   127,
+									Line:   128,
 								},
 							},
 						},
@@ -5833,13 +5867,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 49,
-								Line:   127,
+								Line:   128,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 40,
-								Line:   127,
+								Line:   128,
 							},
 						},
 					},
@@ -5849,13 +5883,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 46,
-									Line:   127,
+									Line:   128,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 40,
-									Line:   127,
+									Line:   128,
 								},
 							},
 						},
@@ -5866,13 +5900,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 49,
-								Line:   127,
+								Line:   128,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 47,
-								Line:   127,
+								Line:   128,
 							},
 						},
 					}},
@@ -5884,13 +5918,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 97,
-						Line:   148,
+						Line:   149,
 					},
 					File:   "universe.flux",
 					Source: "stateDuration = (fn, column=\"stateDuration\", timeColumn=\"_time\", unit=1s, tables=<-) =>\n    tables\n        |> stateTracking(durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   146,
+						Line:   147,
 					},
 				},
 			},
@@ -5900,13 +5934,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   146,
+							Line:   147,
 						},
 						File:   "universe.flux",
 						Source: "stateDuration",
 						Start: ast.Position{
 							Column: 1,
-							Line:   146,
+							Line:   147,
 						},
 					},
 				},
@@ -5918,13 +5952,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 97,
-							Line:   148,
+							Line:   149,
 						},
 						File:   "universe.flux",
 						Source: "(fn, column=\"stateDuration\", timeColumn=\"_time\", unit=1s, tables=<-) =>\n    tables\n        |> stateTracking(durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit)",
 						Start: ast.Position{
 							Column: 17,
-							Line:   146,
+							Line:   147,
 						},
 					},
 				},
@@ -5935,13 +5969,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   147,
+									Line:   148,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   147,
+									Line:   148,
 								},
 							},
 						},
@@ -5952,13 +5986,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 97,
-								Line:   148,
+								Line:   149,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> stateTracking(durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   147,
+								Line:   148,
 							},
 						},
 					},
@@ -5969,13 +6003,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 96,
-										Line:   148,
+										Line:   149,
 									},
 									File:   "universe.flux",
 									Source: "durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit",
 									Start: ast.Position{
 										Column: 26,
-										Line:   148,
+										Line:   149,
 									},
 								},
 							},
@@ -5985,13 +6019,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 47,
-											Line:   148,
+											Line:   149,
 										},
 										File:   "universe.flux",
 										Source: "durationColumn:column",
 										Start: ast.Position{
 											Column: 26,
-											Line:   148,
+											Line:   149,
 										},
 									},
 								},
@@ -6001,13 +6035,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 40,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "durationColumn",
 											Start: ast.Position{
 												Column: 26,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6019,13 +6053,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 47,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 41,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6037,13 +6071,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 70,
-											Line:   148,
+											Line:   149,
 										},
 										File:   "universe.flux",
 										Source: "timeColumn:timeColumn",
 										Start: ast.Position{
 											Column: 49,
-											Line:   148,
+											Line:   149,
 										},
 									},
 								},
@@ -6053,13 +6087,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 59,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "timeColumn",
 											Start: ast.Position{
 												Column: 49,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6071,13 +6105,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 70,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "timeColumn",
 											Start: ast.Position{
 												Column: 60,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6089,13 +6123,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 77,
-											Line:   148,
+											Line:   149,
 										},
 										File:   "universe.flux",
 										Source: "fn:fn",
 										Start: ast.Position{
 											Column: 72,
-											Line:   148,
+											Line:   149,
 										},
 									},
 								},
@@ -6105,13 +6139,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 74,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 72,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6123,13 +6157,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 77,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 75,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6141,13 +6175,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 96,
-											Line:   148,
+											Line:   149,
 										},
 										File:   "universe.flux",
 										Source: "durationUnit:unit",
 										Start: ast.Position{
 											Column: 79,
-											Line:   148,
+											Line:   149,
 										},
 									},
 								},
@@ -6157,13 +6191,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 91,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "durationUnit",
 											Start: ast.Position{
 												Column: 79,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6175,13 +6209,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 96,
-												Line:   148,
+												Line:   149,
 											},
 											File:   "universe.flux",
 											Source: "unit",
 											Start: ast.Position{
 												Column: 92,
-												Line:   148,
+												Line:   149,
 											},
 										},
 									},
@@ -6195,13 +6229,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 97,
-									Line:   148,
+									Line:   149,
 								},
 								File:   "universe.flux",
 								Source: "stateTracking(durationColumn:column, timeColumn:timeColumn, fn:fn, durationUnit:unit)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   148,
+									Line:   149,
 								},
 							},
 						},
@@ -6211,13 +6245,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 25,
-										Line:   148,
+										Line:   149,
 									},
 									File:   "universe.flux",
 									Source: "stateTracking",
 									Start: ast.Position{
 										Column: 12,
-										Line:   148,
+										Line:   149,
 									},
 								},
 							},
@@ -6231,13 +6265,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 20,
-								Line:   146,
+								Line:   147,
 							},
 							File:   "universe.flux",
 							Source: "fn",
 							Start: ast.Position{
 								Column: 18,
-								Line:   146,
+								Line:   147,
 							},
 						},
 					},
@@ -6247,13 +6281,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 20,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "fn",
 								Start: ast.Position{
 									Column: 18,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6266,13 +6300,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 44,
-								Line:   146,
+								Line:   147,
 							},
 							File:   "universe.flux",
 							Source: "column=\"stateDuration\"",
 							Start: ast.Position{
 								Column: 22,
-								Line:   146,
+								Line:   147,
 							},
 						},
 					},
@@ -6282,13 +6316,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 28,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 22,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6300,13 +6334,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 44,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "\"stateDuration\"",
 								Start: ast.Position{
 									Column: 29,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6318,13 +6352,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 64,
-								Line:   146,
+								Line:   147,
 							},
 							File:   "universe.flux",
 							Source: "timeColumn=\"_time\"",
 							Start: ast.Position{
 								Column: 46,
-								Line:   146,
+								Line:   147,
 							},
 						},
 					},
@@ -6334,13 +6368,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 56,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "timeColumn",
 								Start: ast.Position{
 									Column: 46,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6352,13 +6386,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 64,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "\"_time\"",
 								Start: ast.Position{
 									Column: 57,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6370,13 +6404,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 73,
-								Line:   146,
+								Line:   147,
 							},
 							File:   "universe.flux",
 							Source: "unit=1s",
 							Start: ast.Position{
 								Column: 66,
-								Line:   146,
+								Line:   147,
 							},
 						},
 					},
@@ -6386,13 +6420,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 70,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "unit",
 								Start: ast.Position{
 									Column: 66,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6404,13 +6438,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 73,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "1s",
 								Start: ast.Position{
 									Column: 71,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6425,13 +6459,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 84,
-								Line:   146,
+								Line:   147,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 75,
-								Line:   146,
+								Line:   147,
 							},
 						},
 					},
@@ -6441,13 +6475,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 81,
-									Line:   146,
+									Line:   147,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 75,
-									Line:   146,
+									Line:   147,
 								},
 							},
 						},
@@ -6458,13 +6492,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 84,
-								Line:   146,
+								Line:   147,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 82,
-								Line:   146,
+								Line:   147,
 							},
 						},
 					}},
@@ -6476,13 +6510,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 22,
-						Line:   154,
+						Line:   155,
 					},
 					File:   "universe.flux",
 					Source: "_sortLimit = (n, desc, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> sort(columns:columns, desc:desc)\n        |> limit(n:n)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   151,
+						Line:   152,
 					},
 				},
 			},
@@ -6492,13 +6526,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 11,
-							Line:   151,
+							Line:   152,
 						},
 						File:   "universe.flux",
 						Source: "_sortLimit",
 						Start: ast.Position{
 							Column: 1,
-							Line:   151,
+							Line:   152,
 						},
 					},
 				},
@@ -6510,13 +6544,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 22,
-							Line:   154,
+							Line:   155,
 						},
 						File:   "universe.flux",
 						Source: "(n, desc, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> sort(columns:columns, desc:desc)\n        |> limit(n:n)",
 						Start: ast.Position{
 							Column: 14,
-							Line:   151,
+							Line:   152,
 						},
 					},
 				},
@@ -6528,13 +6562,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 11,
-										Line:   152,
+										Line:   153,
 									},
 									File:   "universe.flux",
 									Source: "tables",
 									Start: ast.Position{
 										Column: 5,
-										Line:   152,
+										Line:   153,
 									},
 								},
 							},
@@ -6545,13 +6579,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 44,
-									Line:   153,
+									Line:   154,
 								},
 								File:   "universe.flux",
 								Source: "tables\n        |> sort(columns:columns, desc:desc)",
 								Start: ast.Position{
 									Column: 5,
-									Line:   152,
+									Line:   153,
 								},
 							},
 						},
@@ -6562,13 +6596,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 43,
-											Line:   153,
+											Line:   154,
 										},
 										File:   "universe.flux",
 										Source: "columns:columns, desc:desc",
 										Start: ast.Position{
 											Column: 17,
-											Line:   153,
+											Line:   154,
 										},
 									},
 								},
@@ -6578,13 +6612,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 32,
-												Line:   153,
+												Line:   154,
 											},
 											File:   "universe.flux",
 											Source: "columns:columns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   153,
+												Line:   154,
 											},
 										},
 									},
@@ -6594,13 +6628,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 24,
-													Line:   153,
+													Line:   154,
 												},
 												File:   "universe.flux",
 												Source: "columns",
 												Start: ast.Position{
 													Column: 17,
-													Line:   153,
+													Line:   154,
 												},
 											},
 										},
@@ -6612,13 +6646,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 32,
-													Line:   153,
+													Line:   154,
 												},
 												File:   "universe.flux",
 												Source: "columns",
 												Start: ast.Position{
 													Column: 25,
-													Line:   153,
+													Line:   154,
 												},
 											},
 										},
@@ -6630,13 +6664,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 43,
-												Line:   153,
+												Line:   154,
 											},
 											File:   "universe.flux",
 											Source: "desc:desc",
 											Start: ast.Position{
 												Column: 34,
-												Line:   153,
+												Line:   154,
 											},
 										},
 									},
@@ -6646,13 +6680,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 38,
-													Line:   153,
+													Line:   154,
 												},
 												File:   "universe.flux",
 												Source: "desc",
 												Start: ast.Position{
 													Column: 34,
-													Line:   153,
+													Line:   154,
 												},
 											},
 										},
@@ -6664,13 +6698,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 43,
-													Line:   153,
+													Line:   154,
 												},
 												File:   "universe.flux",
 												Source: "desc",
 												Start: ast.Position{
 													Column: 39,
-													Line:   153,
+													Line:   154,
 												},
 											},
 										},
@@ -6684,13 +6718,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 44,
-										Line:   153,
+										Line:   154,
 									},
 									File:   "universe.flux",
 									Source: "sort(columns:columns, desc:desc)",
 									Start: ast.Position{
 										Column: 12,
-										Line:   153,
+										Line:   154,
 									},
 								},
 							},
@@ -6700,13 +6734,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 16,
-											Line:   153,
+											Line:   154,
 										},
 										File:   "universe.flux",
 										Source: "sort",
 										Start: ast.Position{
 											Column: 12,
-											Line:   153,
+											Line:   154,
 										},
 									},
 								},
@@ -6719,13 +6753,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 22,
-								Line:   154,
+								Line:   155,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> sort(columns:columns, desc:desc)\n        |> limit(n:n)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   152,
+								Line:   153,
 							},
 						},
 					},
@@ -6736,13 +6770,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 21,
-										Line:   154,
+										Line:   155,
 									},
 									File:   "universe.flux",
 									Source: "n:n",
 									Start: ast.Position{
 										Column: 18,
-										Line:   154,
+										Line:   155,
 									},
 								},
 							},
@@ -6752,13 +6786,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   154,
+											Line:   155,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 18,
-											Line:   154,
+											Line:   155,
 										},
 									},
 								},
@@ -6768,13 +6802,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 19,
-												Line:   154,
+												Line:   155,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 18,
-												Line:   154,
+												Line:   155,
 											},
 										},
 									},
@@ -6786,13 +6820,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 21,
-												Line:   154,
+												Line:   155,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 20,
-												Line:   154,
+												Line:   155,
 											},
 										},
 									},
@@ -6806,13 +6840,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 22,
-									Line:   154,
+									Line:   155,
 								},
 								File:   "universe.flux",
 								Source: "limit(n:n)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   154,
+									Line:   155,
 								},
 							},
 						},
@@ -6822,13 +6856,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 17,
-										Line:   154,
+										Line:   155,
 									},
 									File:   "universe.flux",
 									Source: "limit",
 									Start: ast.Position{
 										Column: 12,
-										Line:   154,
+										Line:   155,
 									},
 								},
 							},
@@ -6842,13 +6876,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 16,
-								Line:   151,
+								Line:   152,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 15,
-								Line:   151,
+								Line:   152,
 							},
 						},
 					},
@@ -6858,13 +6892,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 16,
-									Line:   151,
+									Line:   152,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 15,
-									Line:   151,
+									Line:   152,
 								},
 							},
 						},
@@ -6877,13 +6911,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 22,
-								Line:   151,
+								Line:   152,
 							},
 							File:   "universe.flux",
 							Source: "desc",
 							Start: ast.Position{
 								Column: 18,
-								Line:   151,
+								Line:   152,
 							},
 						},
 					},
@@ -6893,13 +6927,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 22,
-									Line:   151,
+									Line:   152,
 								},
 								File:   "universe.flux",
 								Source: "desc",
 								Start: ast.Position{
 									Column: 18,
-									Line:   151,
+									Line:   152,
 								},
 							},
 						},
@@ -6912,13 +6946,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 42,
-								Line:   151,
+								Line:   152,
 							},
 							File:   "universe.flux",
 							Source: "columns=[\"_value\"]",
 							Start: ast.Position{
 								Column: 24,
-								Line:   151,
+								Line:   152,
 							},
 						},
 					},
@@ -6928,13 +6962,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 31,
-									Line:   151,
+									Line:   152,
 								},
 								File:   "universe.flux",
 								Source: "columns",
 								Start: ast.Position{
 									Column: 24,
-									Line:   151,
+									Line:   152,
 								},
 							},
 						},
@@ -6946,13 +6980,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 42,
-									Line:   151,
+									Line:   152,
 								},
 								File:   "universe.flux",
 								Source: "[\"_value\"]",
 								Start: ast.Position{
 									Column: 32,
-									Line:   151,
+									Line:   152,
 								},
 							},
 						},
@@ -6962,13 +6996,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 41,
-										Line:   151,
+										Line:   152,
 									},
 									File:   "universe.flux",
 									Source: "\"_value\"",
 									Start: ast.Position{
 										Column: 33,
-										Line:   151,
+										Line:   152,
 									},
 								},
 							},
@@ -6981,13 +7015,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 53,
-								Line:   151,
+								Line:   152,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 44,
-								Line:   151,
+								Line:   152,
 							},
 						},
 					},
@@ -6997,13 +7031,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 50,
-									Line:   151,
+									Line:   152,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 44,
-									Line:   151,
+									Line:   152,
 								},
 							},
 						},
@@ -7014,13 +7048,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 53,
-								Line:   151,
+								Line:   152,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 51,
-								Line:   151,
+								Line:   152,
 							},
 						},
 					}},
@@ -7032,13 +7066,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 55,
-						Line:   159,
+						Line:   160,
 					},
 					File:   "universe.flux",
 					Source: "top = (n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:true)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   157,
+						Line:   158,
 					},
 				},
 			},
@@ -7048,13 +7082,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 4,
-							Line:   157,
+							Line:   158,
 						},
 						File:   "universe.flux",
 						Source: "top",
 						Start: ast.Position{
 							Column: 1,
-							Line:   157,
+							Line:   158,
 						},
 					},
 				},
@@ -7066,13 +7100,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 55,
-							Line:   159,
+							Line:   160,
 						},
 						File:   "universe.flux",
 						Source: "(n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:true)",
 						Start: ast.Position{
 							Column: 7,
-							Line:   157,
+							Line:   158,
 						},
 					},
 				},
@@ -7083,13 +7117,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   158,
+									Line:   159,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   158,
+									Line:   159,
 								},
 							},
 						},
@@ -7100,13 +7134,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 55,
-								Line:   159,
+								Line:   160,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _sortLimit(n:n, columns:columns, desc:true)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   158,
+								Line:   159,
 							},
 						},
 					},
@@ -7117,13 +7151,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 54,
-										Line:   159,
+										Line:   160,
 									},
 									File:   "universe.flux",
 									Source: "n:n, columns:columns, desc:true",
 									Start: ast.Position{
 										Column: 23,
-										Line:   159,
+										Line:   160,
 									},
 								},
 							},
@@ -7133,13 +7167,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 26,
-											Line:   159,
+											Line:   160,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 23,
-											Line:   159,
+											Line:   160,
 										},
 									},
 								},
@@ -7149,13 +7183,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   159,
+												Line:   160,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 23,
-												Line:   159,
+												Line:   160,
 											},
 										},
 									},
@@ -7167,13 +7201,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 26,
-												Line:   159,
+												Line:   160,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 25,
-												Line:   159,
+												Line:   160,
 											},
 										},
 									},
@@ -7185,13 +7219,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 43,
-											Line:   159,
+											Line:   160,
 										},
 										File:   "universe.flux",
 										Source: "columns:columns",
 										Start: ast.Position{
 											Column: 28,
-											Line:   159,
+											Line:   160,
 										},
 									},
 								},
@@ -7201,13 +7235,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 35,
-												Line:   159,
+												Line:   160,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 28,
-												Line:   159,
+												Line:   160,
 											},
 										},
 									},
@@ -7219,13 +7253,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 43,
-												Line:   159,
+												Line:   160,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 36,
-												Line:   159,
+												Line:   160,
 											},
 										},
 									},
@@ -7237,13 +7271,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 54,
-											Line:   159,
+											Line:   160,
 										},
 										File:   "universe.flux",
 										Source: "desc:true",
 										Start: ast.Position{
 											Column: 45,
-											Line:   159,
+											Line:   160,
 										},
 									},
 								},
@@ -7253,13 +7287,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 49,
-												Line:   159,
+												Line:   160,
 											},
 											File:   "universe.flux",
 											Source: "desc",
 											Start: ast.Position{
 												Column: 45,
-												Line:   159,
+												Line:   160,
 											},
 										},
 									},
@@ -7271,13 +7305,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 54,
-												Line:   159,
+												Line:   160,
 											},
 											File:   "universe.flux",
 											Source: "true",
 											Start: ast.Position{
 												Column: 50,
-												Line:   159,
+												Line:   160,
 											},
 										},
 									},
@@ -7291,13 +7325,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 55,
-									Line:   159,
+									Line:   160,
 								},
 								File:   "universe.flux",
 								Source: "_sortLimit(n:n, columns:columns, desc:true)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   159,
+									Line:   160,
 								},
 							},
 						},
@@ -7307,13 +7341,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 22,
-										Line:   159,
+										Line:   160,
 									},
 									File:   "universe.flux",
 									Source: "_sortLimit",
 									Start: ast.Position{
 										Column: 12,
-										Line:   159,
+										Line:   160,
 									},
 								},
 							},
@@ -7327,13 +7361,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 9,
-								Line:   157,
+								Line:   158,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 8,
-								Line:   157,
+								Line:   158,
 							},
 						},
 					},
@@ -7343,13 +7377,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 9,
-									Line:   157,
+									Line:   158,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 8,
-									Line:   157,
+									Line:   158,
 								},
 							},
 						},
@@ -7362,13 +7396,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 29,
-								Line:   157,
+								Line:   158,
 							},
 							File:   "universe.flux",
 							Source: "columns=[\"_value\"]",
 							Start: ast.Position{
 								Column: 11,
-								Line:   157,
+								Line:   158,
 							},
 						},
 					},
@@ -7378,13 +7412,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 18,
-									Line:   157,
+									Line:   158,
 								},
 								File:   "universe.flux",
 								Source: "columns",
 								Start: ast.Position{
 									Column: 11,
-									Line:   157,
+									Line:   158,
 								},
 							},
 						},
@@ -7396,13 +7430,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   157,
+									Line:   158,
 								},
 								File:   "universe.flux",
 								Source: "[\"_value\"]",
 								Start: ast.Position{
 									Column: 19,
-									Line:   157,
+									Line:   158,
 								},
 							},
 						},
@@ -7412,13 +7446,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   157,
+										Line:   158,
 									},
 									File:   "universe.flux",
 									Source: "\"_value\"",
 									Start: ast.Position{
 										Column: 20,
-										Line:   157,
+										Line:   158,
 									},
 								},
 							},
@@ -7431,13 +7465,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 40,
-								Line:   157,
+								Line:   158,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 31,
-								Line:   157,
+								Line:   158,
 							},
 						},
 					},
@@ -7447,13 +7481,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 37,
-									Line:   157,
+									Line:   158,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 31,
-									Line:   157,
+									Line:   158,
 								},
 							},
 						},
@@ -7464,13 +7498,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 40,
-								Line:   157,
+								Line:   158,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 38,
-								Line:   157,
+								Line:   158,
 							},
 						},
 					}},
@@ -7482,13 +7516,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 56,
-						Line:   164,
+						Line:   165,
 					},
 					File:   "universe.flux",
 					Source: "bottom = (n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:false)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   162,
+						Line:   163,
 					},
 				},
 			},
@@ -7498,13 +7532,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   162,
+							Line:   163,
 						},
 						File:   "universe.flux",
 						Source: "bottom",
 						Start: ast.Position{
 							Column: 1,
-							Line:   162,
+							Line:   163,
 						},
 					},
 				},
@@ -7516,13 +7550,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 56,
-							Line:   164,
+							Line:   165,
 						},
 						File:   "universe.flux",
 						Source: "(n, columns=[\"_value\"], tables=<-) =>\n    tables\n        |> _sortLimit(n:n, columns:columns, desc:false)",
 						Start: ast.Position{
 							Column: 10,
-							Line:   162,
+							Line:   163,
 						},
 					},
 				},
@@ -7533,13 +7567,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   163,
+									Line:   164,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   163,
+									Line:   164,
 								},
 							},
 						},
@@ -7550,13 +7584,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 56,
-								Line:   164,
+								Line:   165,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _sortLimit(n:n, columns:columns, desc:false)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   163,
+								Line:   164,
 							},
 						},
 					},
@@ -7567,13 +7601,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 55,
-										Line:   164,
+										Line:   165,
 									},
 									File:   "universe.flux",
 									Source: "n:n, columns:columns, desc:false",
 									Start: ast.Position{
 										Column: 23,
-										Line:   164,
+										Line:   165,
 									},
 								},
 							},
@@ -7583,13 +7617,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 26,
-											Line:   164,
+											Line:   165,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 23,
-											Line:   164,
+											Line:   165,
 										},
 									},
 								},
@@ -7599,13 +7633,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   164,
+												Line:   165,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 23,
-												Line:   164,
+												Line:   165,
 											},
 										},
 									},
@@ -7617,13 +7651,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 26,
-												Line:   164,
+												Line:   165,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 25,
-												Line:   164,
+												Line:   165,
 											},
 										},
 									},
@@ -7635,13 +7669,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 43,
-											Line:   164,
+											Line:   165,
 										},
 										File:   "universe.flux",
 										Source: "columns:columns",
 										Start: ast.Position{
 											Column: 28,
-											Line:   164,
+											Line:   165,
 										},
 									},
 								},
@@ -7651,13 +7685,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 35,
-												Line:   164,
+												Line:   165,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 28,
-												Line:   164,
+												Line:   165,
 											},
 										},
 									},
@@ -7669,13 +7703,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 43,
-												Line:   164,
+												Line:   165,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 36,
-												Line:   164,
+												Line:   165,
 											},
 										},
 									},
@@ -7687,13 +7721,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 55,
-											Line:   164,
+											Line:   165,
 										},
 										File:   "universe.flux",
 										Source: "desc:false",
 										Start: ast.Position{
 											Column: 45,
-											Line:   164,
+											Line:   165,
 										},
 									},
 								},
@@ -7703,13 +7737,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 49,
-												Line:   164,
+												Line:   165,
 											},
 											File:   "universe.flux",
 											Source: "desc",
 											Start: ast.Position{
 												Column: 45,
-												Line:   164,
+												Line:   165,
 											},
 										},
 									},
@@ -7721,13 +7755,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 55,
-												Line:   164,
+												Line:   165,
 											},
 											File:   "universe.flux",
 											Source: "false",
 											Start: ast.Position{
 												Column: 50,
-												Line:   164,
+												Line:   165,
 											},
 										},
 									},
@@ -7741,13 +7775,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 56,
-									Line:   164,
+									Line:   165,
 								},
 								File:   "universe.flux",
 								Source: "_sortLimit(n:n, columns:columns, desc:false)",
 								Start: ast.Position{
 									Column: 12,
-									Line:   164,
+									Line:   165,
 								},
 							},
 						},
@@ -7757,13 +7791,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 22,
-										Line:   164,
+										Line:   165,
 									},
 									File:   "universe.flux",
 									Source: "_sortLimit",
 									Start: ast.Position{
 										Column: 12,
-										Line:   164,
+										Line:   165,
 									},
 								},
 							},
@@ -7777,13 +7811,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 12,
-								Line:   162,
+								Line:   163,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 11,
-								Line:   162,
+								Line:   163,
 							},
 						},
 					},
@@ -7793,13 +7827,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 12,
-									Line:   162,
+									Line:   163,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 11,
-									Line:   162,
+									Line:   163,
 								},
 							},
 						},
@@ -7812,13 +7846,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 32,
-								Line:   162,
+								Line:   163,
 							},
 							File:   "universe.flux",
 							Source: "columns=[\"_value\"]",
 							Start: ast.Position{
 								Column: 14,
-								Line:   162,
+								Line:   163,
 							},
 						},
 					},
@@ -7828,13 +7862,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   162,
+									Line:   163,
 								},
 								File:   "universe.flux",
 								Source: "columns",
 								Start: ast.Position{
 									Column: 14,
-									Line:   162,
+									Line:   163,
 								},
 							},
 						},
@@ -7846,13 +7880,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 32,
-									Line:   162,
+									Line:   163,
 								},
 								File:   "universe.flux",
 								Source: "[\"_value\"]",
 								Start: ast.Position{
 									Column: 22,
-									Line:   162,
+									Line:   163,
 								},
 							},
 						},
@@ -7862,13 +7896,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 31,
-										Line:   162,
+										Line:   163,
 									},
 									File:   "universe.flux",
 									Source: "\"_value\"",
 									Start: ast.Position{
 										Column: 23,
-										Line:   162,
+										Line:   163,
 									},
 								},
 							},
@@ -7881,13 +7915,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 43,
-								Line:   162,
+								Line:   163,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 34,
-								Line:   162,
+								Line:   163,
 							},
 						},
 					},
@@ -7897,13 +7931,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 40,
-									Line:   162,
+									Line:   163,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 34,
-									Line:   162,
+									Line:   163,
 								},
 							},
 						},
@@ -7914,13 +7948,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 43,
-								Line:   162,
+								Line:   163,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 41,
-								Line:   162,
+								Line:   163,
 							},
 						},
 					}},
@@ -7932,13 +7966,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 45,
-						Line:   174,
+						Line:   175,
 					},
 					File:   "universe.flux",
 					Source: "_highestOrLowest = (n, _sortLimit, reducer, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> group(columns:groupColumns)\n        |> reducer()\n        |> group(columns:[])\n        |> _sortLimit(n:n, columns:[column])",
 					Start: ast.Position{
 						Column: 1,
-						Line:   169,
+						Line:   170,
 					},
 				},
 			},
@@ -7948,13 +7982,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 17,
-							Line:   169,
+							Line:   170,
 						},
 						File:   "universe.flux",
 						Source: "_highestOrLowest",
 						Start: ast.Position{
 							Column: 1,
-							Line:   169,
+							Line:   170,
 						},
 					},
 				},
@@ -7966,13 +8000,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 45,
-							Line:   174,
+							Line:   175,
 						},
 						File:   "universe.flux",
 						Source: "(n, _sortLimit, reducer, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> group(columns:groupColumns)\n        |> reducer()\n        |> group(columns:[])\n        |> _sortLimit(n:n, columns:[column])",
 						Start: ast.Position{
 							Column: 20,
-							Line:   169,
+							Line:   170,
 						},
 					},
 				},
@@ -7986,13 +8020,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 11,
-												Line:   170,
+												Line:   171,
 											},
 											File:   "universe.flux",
 											Source: "tables",
 											Start: ast.Position{
 												Column: 5,
-												Line:   170,
+												Line:   171,
 											},
 										},
 									},
@@ -8003,13 +8037,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 39,
-											Line:   171,
+											Line:   172,
 										},
 										File:   "universe.flux",
 										Source: "tables\n        |> group(columns:groupColumns)",
 										Start: ast.Position{
 											Column: 5,
-											Line:   170,
+											Line:   171,
 										},
 									},
 								},
@@ -8020,13 +8054,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 38,
-													Line:   171,
+													Line:   172,
 												},
 												File:   "universe.flux",
 												Source: "columns:groupColumns",
 												Start: ast.Position{
 													Column: 18,
-													Line:   171,
+													Line:   172,
 												},
 											},
 										},
@@ -8036,13 +8070,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 38,
-														Line:   171,
+														Line:   172,
 													},
 													File:   "universe.flux",
 													Source: "columns:groupColumns",
 													Start: ast.Position{
 														Column: 18,
-														Line:   171,
+														Line:   172,
 													},
 												},
 											},
@@ -8052,13 +8086,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 25,
-															Line:   171,
+															Line:   172,
 														},
 														File:   "universe.flux",
 														Source: "columns",
 														Start: ast.Position{
 															Column: 18,
-															Line:   171,
+															Line:   172,
 														},
 													},
 												},
@@ -8070,13 +8104,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 38,
-															Line:   171,
+															Line:   172,
 														},
 														File:   "universe.flux",
 														Source: "groupColumns",
 														Start: ast.Position{
 															Column: 26,
-															Line:   171,
+															Line:   172,
 														},
 													},
 												},
@@ -8090,13 +8124,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 39,
-												Line:   171,
+												Line:   172,
 											},
 											File:   "universe.flux",
 											Source: "group(columns:groupColumns)",
 											Start: ast.Position{
 												Column: 12,
-												Line:   171,
+												Line:   172,
 											},
 										},
 									},
@@ -8106,13 +8140,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 17,
-													Line:   171,
+													Line:   172,
 												},
 												File:   "universe.flux",
 												Source: "group",
 												Start: ast.Position{
 													Column: 12,
-													Line:   171,
+													Line:   172,
 												},
 											},
 										},
@@ -8125,13 +8159,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 21,
-										Line:   172,
+										Line:   173,
 									},
 									File:   "universe.flux",
 									Source: "tables\n        |> group(columns:groupColumns)\n        |> reducer()",
 									Start: ast.Position{
 										Column: 5,
-										Line:   170,
+										Line:   171,
 									},
 								},
 							},
@@ -8142,13 +8176,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   172,
+											Line:   173,
 										},
 										File:   "universe.flux",
 										Source: "reducer()",
 										Start: ast.Position{
 											Column: 12,
-											Line:   172,
+											Line:   173,
 										},
 									},
 								},
@@ -8158,13 +8192,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 19,
-												Line:   172,
+												Line:   173,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 12,
-												Line:   172,
+												Line:   173,
 											},
 										},
 									},
@@ -8177,13 +8211,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   173,
+									Line:   174,
 								},
 								File:   "universe.flux",
 								Source: "tables\n        |> group(columns:groupColumns)\n        |> reducer()\n        |> group(columns:[])",
 								Start: ast.Position{
 									Column: 5,
-									Line:   170,
+									Line:   171,
 								},
 							},
 						},
@@ -8194,13 +8228,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 28,
-											Line:   173,
+											Line:   174,
 										},
 										File:   "universe.flux",
 										Source: "columns:[]",
 										Start: ast.Position{
 											Column: 18,
-											Line:   173,
+											Line:   174,
 										},
 									},
 								},
@@ -8210,13 +8244,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 28,
-												Line:   173,
+												Line:   174,
 											},
 											File:   "universe.flux",
 											Source: "columns:[]",
 											Start: ast.Position{
 												Column: 18,
-												Line:   173,
+												Line:   174,
 											},
 										},
 									},
@@ -8226,13 +8260,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 25,
-													Line:   173,
+													Line:   174,
 												},
 												File:   "universe.flux",
 												Source: "columns",
 												Start: ast.Position{
 													Column: 18,
-													Line:   173,
+													Line:   174,
 												},
 											},
 										},
@@ -8244,13 +8278,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 28,
-													Line:   173,
+													Line:   174,
 												},
 												File:   "universe.flux",
 												Source: "[]",
 												Start: ast.Position{
 													Column: 26,
-													Line:   173,
+													Line:   174,
 												},
 											},
 										},
@@ -8264,13 +8298,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 29,
-										Line:   173,
+										Line:   174,
 									},
 									File:   "universe.flux",
 									Source: "group(columns:[])",
 									Start: ast.Position{
 										Column: 12,
-										Line:   173,
+										Line:   174,
 									},
 								},
 							},
@@ -8280,13 +8314,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 17,
-											Line:   173,
+											Line:   174,
 										},
 										File:   "universe.flux",
 										Source: "group",
 										Start: ast.Position{
 											Column: 12,
-											Line:   173,
+											Line:   174,
 										},
 									},
 								},
@@ -8299,13 +8333,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 45,
-								Line:   174,
+								Line:   175,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> group(columns:groupColumns)\n        |> reducer()\n        |> group(columns:[])\n        |> _sortLimit(n:n, columns:[column])",
 							Start: ast.Position{
 								Column: 5,
-								Line:   170,
+								Line:   171,
 							},
 						},
 					},
@@ -8316,13 +8350,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 44,
-										Line:   174,
+										Line:   175,
 									},
 									File:   "universe.flux",
 									Source: "n:n, columns:[column]",
 									Start: ast.Position{
 										Column: 23,
-										Line:   174,
+										Line:   175,
 									},
 								},
 							},
@@ -8332,13 +8366,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 26,
-											Line:   174,
+											Line:   175,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 23,
-											Line:   174,
+											Line:   175,
 										},
 									},
 								},
@@ -8348,13 +8382,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   174,
+												Line:   175,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 23,
-												Line:   174,
+												Line:   175,
 											},
 										},
 									},
@@ -8366,13 +8400,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 26,
-												Line:   174,
+												Line:   175,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 25,
-												Line:   174,
+												Line:   175,
 											},
 										},
 									},
@@ -8384,13 +8418,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 44,
-											Line:   174,
+											Line:   175,
 										},
 										File:   "universe.flux",
 										Source: "columns:[column]",
 										Start: ast.Position{
 											Column: 28,
-											Line:   174,
+											Line:   175,
 										},
 									},
 								},
@@ -8400,13 +8434,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 35,
-												Line:   174,
+												Line:   175,
 											},
 											File:   "universe.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 28,
-												Line:   174,
+												Line:   175,
 											},
 										},
 									},
@@ -8418,13 +8452,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 44,
-												Line:   174,
+												Line:   175,
 											},
 											File:   "universe.flux",
 											Source: "[column]",
 											Start: ast.Position{
 												Column: 36,
-												Line:   174,
+												Line:   175,
 											},
 										},
 									},
@@ -8434,13 +8468,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 43,
-													Line:   174,
+													Line:   175,
 												},
 												File:   "universe.flux",
 												Source: "column",
 												Start: ast.Position{
 													Column: 37,
-													Line:   174,
+													Line:   175,
 												},
 											},
 										},
@@ -8455,13 +8489,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 45,
-									Line:   174,
+									Line:   175,
 								},
 								File:   "universe.flux",
 								Source: "_sortLimit(n:n, columns:[column])",
 								Start: ast.Position{
 									Column: 12,
-									Line:   174,
+									Line:   175,
 								},
 							},
 						},
@@ -8471,13 +8505,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 22,
-										Line:   174,
+										Line:   175,
 									},
 									File:   "universe.flux",
 									Source: "_sortLimit",
 									Start: ast.Position{
 										Column: 12,
-										Line:   174,
+										Line:   175,
 									},
 								},
 							},
@@ -8491,13 +8525,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 22,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 21,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					},
@@ -8507,13 +8541,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 22,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 21,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8526,13 +8560,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 34,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "_sortLimit",
 							Start: ast.Position{
 								Column: 24,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					},
@@ -8542,13 +8576,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 34,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "_sortLimit",
 								Start: ast.Position{
 									Column: 24,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8561,13 +8595,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 43,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "reducer",
 							Start: ast.Position{
 								Column: 36,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					},
@@ -8577,13 +8611,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 43,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "reducer",
 								Start: ast.Position{
 									Column: 36,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8596,13 +8630,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 60,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 45,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					},
@@ -8612,13 +8646,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 51,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 45,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8630,13 +8664,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 60,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 52,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8648,13 +8682,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 77,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 62,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					},
@@ -8664,13 +8698,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 74,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 62,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8682,13 +8716,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 77,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 75,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8700,13 +8734,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 88,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 79,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					},
@@ -8716,13 +8750,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 85,
-									Line:   169,
+									Line:   170,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 79,
-									Line:   169,
+									Line:   170,
 								},
 							},
 						},
@@ -8733,13 +8767,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 88,
-								Line:   169,
+								Line:   170,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 86,
-								Line:   169,
+								Line:   170,
 							},
 						},
 					}},
@@ -8751,13 +8785,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   186,
+						Line:   187,
 					},
 					File:   "universe.flux",
 					Source: "highestMax = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top,\n            )",
 					Start: ast.Position{
 						Column: 1,
-						Line:   177,
+						Line:   178,
 					},
 				},
 			},
@@ -8767,13 +8801,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 11,
-							Line:   177,
+							Line:   178,
 						},
 						File:   "universe.flux",
 						Source: "highestMax",
 						Start: ast.Position{
 							Column: 1,
-							Line:   177,
+							Line:   178,
 						},
 					},
 				},
@@ -8785,13 +8819,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   186,
+							Line:   187,
 						},
 						File:   "universe.flux",
 						Source: "(n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top,\n            )",
 						Start: ast.Position{
 							Column: 14,
-							Line:   177,
+							Line:   178,
 						},
 					},
 				},
@@ -8802,13 +8836,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   178,
+									Line:   179,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   178,
+									Line:   179,
 								},
 							},
 						},
@@ -8819,13 +8853,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   186,
+								Line:   187,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top,\n            )",
 							Start: ast.Position{
 								Column: 5,
-								Line:   178,
+								Line:   179,
 							},
 						},
 					},
@@ -8836,13 +8870,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 32,
-										Line:   185,
+										Line:   186,
 									},
 									File:   "universe.flux",
 									Source: "n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top",
 									Start: ast.Position{
 										Column: 17,
-										Line:   180,
+										Line:   181,
 									},
 								},
 							},
@@ -8852,13 +8886,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 20,
-											Line:   180,
+											Line:   181,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 17,
-											Line:   180,
+											Line:   181,
 										},
 									},
 								},
@@ -8868,13 +8902,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 18,
-												Line:   180,
+												Line:   181,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 17,
-												Line:   180,
+												Line:   181,
 											},
 										},
 									},
@@ -8886,13 +8920,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   180,
+												Line:   181,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 19,
-												Line:   180,
+												Line:   181,
 											},
 										},
 									},
@@ -8904,13 +8938,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   181,
+											Line:   182,
 										},
 										File:   "universe.flux",
 										Source: "column:column",
 										Start: ast.Position{
 											Column: 17,
-											Line:   181,
+											Line:   182,
 										},
 									},
 								},
@@ -8920,13 +8954,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   181,
+												Line:   182,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 17,
-												Line:   181,
+												Line:   182,
 											},
 										},
 									},
@@ -8938,13 +8972,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   181,
+												Line:   182,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 24,
-												Line:   181,
+												Line:   182,
 											},
 										},
 									},
@@ -8956,13 +8990,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   182,
+											Line:   183,
 										},
 										File:   "universe.flux",
 										Source: "groupColumns:groupColumns",
 										Start: ast.Position{
 											Column: 17,
-											Line:   182,
+											Line:   183,
 										},
 									},
 								},
@@ -8972,13 +9006,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   182,
+												Line:   183,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   182,
+												Line:   183,
 											},
 										},
 									},
@@ -8990,13 +9024,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   182,
+												Line:   183,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 30,
-												Line:   182,
+												Line:   183,
 											},
 										},
 									},
@@ -9008,13 +9042,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 69,
-											Line:   184,
+											Line:   185,
 										},
 										File:   "universe.flux",
 										Source: "reducer: (tables=<-) => tables |> max(column:column)",
 										Start: ast.Position{
 											Column: 17,
-											Line:   184,
+											Line:   185,
 										},
 									},
 								},
@@ -9024,13 +9058,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   184,
+												Line:   185,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 17,
-												Line:   184,
+												Line:   185,
 											},
 										},
 									},
@@ -9042,13 +9076,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 69,
-												Line:   184,
+												Line:   185,
 											},
 											File:   "universe.flux",
 											Source: "(tables=<-) => tables |> max(column:column)",
 											Start: ast.Position{
 												Column: 26,
-												Line:   184,
+												Line:   185,
 											},
 										},
 									},
@@ -9059,13 +9093,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 47,
-														Line:   184,
+														Line:   185,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 41,
-														Line:   184,
+														Line:   185,
 													},
 												},
 											},
@@ -9076,13 +9110,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 69,
-													Line:   184,
+													Line:   185,
 												},
 												File:   "universe.flux",
 												Source: "tables |> max(column:column)",
 												Start: ast.Position{
 													Column: 41,
-													Line:   184,
+													Line:   185,
 												},
 											},
 										},
@@ -9093,13 +9127,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   184,
+															Line:   185,
 														},
 														File:   "universe.flux",
 														Source: "column:column",
 														Start: ast.Position{
 															Column: 55,
-															Line:   184,
+															Line:   185,
 														},
 													},
 												},
@@ -9109,13 +9143,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 68,
-																Line:   184,
+																Line:   185,
 															},
 															File:   "universe.flux",
 															Source: "column:column",
 															Start: ast.Position{
 																Column: 55,
-																Line:   184,
+																Line:   185,
 															},
 														},
 													},
@@ -9125,13 +9159,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 61,
-																	Line:   184,
+																	Line:   185,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 55,
-																	Line:   184,
+																	Line:   185,
 																},
 															},
 														},
@@ -9143,13 +9177,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 68,
-																	Line:   184,
+																	Line:   185,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 62,
-																	Line:   184,
+																	Line:   185,
 																},
 															},
 														},
@@ -9163,13 +9197,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 69,
-														Line:   184,
+														Line:   185,
 													},
 													File:   "universe.flux",
 													Source: "max(column:column)",
 													Start: ast.Position{
 														Column: 51,
-														Line:   184,
+														Line:   185,
 													},
 												},
 											},
@@ -9179,13 +9213,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 54,
-															Line:   184,
+															Line:   185,
 														},
 														File:   "universe.flux",
 														Source: "max",
 														Start: ast.Position{
 															Column: 51,
-															Line:   184,
+															Line:   185,
 														},
 													},
 												},
@@ -9199,13 +9233,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   184,
+													Line:   185,
 												},
 												File:   "universe.flux",
 												Source: "tables=<-",
 												Start: ast.Position{
 													Column: 27,
-													Line:   184,
+													Line:   185,
 												},
 											},
 										},
@@ -9215,13 +9249,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   184,
+														Line:   185,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 27,
-														Line:   184,
+														Line:   185,
 													},
 												},
 											},
@@ -9232,13 +9266,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   184,
+													Line:   185,
 												},
 												File:   "universe.flux",
 												Source: "<-",
 												Start: ast.Position{
 													Column: 34,
-													Line:   184,
+													Line:   185,
 												},
 											},
 										}},
@@ -9250,13 +9284,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 32,
-											Line:   185,
+											Line:   186,
 										},
 										File:   "universe.flux",
 										Source: "_sortLimit: top",
 										Start: ast.Position{
 											Column: 17,
-											Line:   185,
+											Line:   186,
 										},
 									},
 								},
@@ -9266,13 +9300,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   185,
+												Line:   186,
 											},
 											File:   "universe.flux",
 											Source: "_sortLimit",
 											Start: ast.Position{
 												Column: 17,
-												Line:   185,
+												Line:   186,
 											},
 										},
 									},
@@ -9284,13 +9318,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 32,
-												Line:   185,
+												Line:   186,
 											},
 											File:   "universe.flux",
 											Source: "top",
 											Start: ast.Position{
 												Column: 29,
-												Line:   185,
+												Line:   186,
 											},
 										},
 									},
@@ -9304,13 +9338,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   186,
+									Line:   187,
 								},
 								File:   "universe.flux",
 								Source: "_highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> max(column:column),\n                _sortLimit: top,\n            )",
 								Start: ast.Position{
 									Column: 12,
-									Line:   179,
+									Line:   180,
 								},
 							},
 						},
@@ -9320,13 +9354,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   179,
+										Line:   180,
 									},
 									File:   "universe.flux",
 									Source: "_highestOrLowest",
 									Start: ast.Position{
 										Column: 12,
-										Line:   179,
+										Line:   180,
 									},
 								},
 							},
@@ -9340,13 +9374,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 16,
-								Line:   177,
+								Line:   178,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 15,
-								Line:   177,
+								Line:   178,
 							},
 						},
 					},
@@ -9356,13 +9390,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 16,
-									Line:   177,
+									Line:   178,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 15,
-									Line:   177,
+									Line:   178,
 								},
 							},
 						},
@@ -9375,13 +9409,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 33,
-								Line:   177,
+								Line:   178,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 18,
-								Line:   177,
+								Line:   178,
 							},
 						},
 					},
@@ -9391,13 +9425,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 24,
-									Line:   177,
+									Line:   178,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 18,
-									Line:   177,
+									Line:   178,
 								},
 							},
 						},
@@ -9409,13 +9443,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 33,
-									Line:   177,
+									Line:   178,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 25,
-									Line:   177,
+									Line:   178,
 								},
 							},
 						},
@@ -9427,13 +9461,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 50,
-								Line:   177,
+								Line:   178,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 35,
-								Line:   177,
+								Line:   178,
 							},
 						},
 					},
@@ -9443,13 +9477,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 47,
-									Line:   177,
+									Line:   178,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 35,
-									Line:   177,
+									Line:   178,
 								},
 							},
 						},
@@ -9461,13 +9495,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 50,
-									Line:   177,
+									Line:   178,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 48,
-									Line:   177,
+									Line:   178,
 								},
 							},
 						},
@@ -9479,13 +9513,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 61,
-								Line:   177,
+								Line:   178,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 52,
-								Line:   177,
+								Line:   178,
 							},
 						},
 					},
@@ -9495,13 +9529,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 58,
-									Line:   177,
+									Line:   178,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 52,
-									Line:   177,
+									Line:   178,
 								},
 							},
 						},
@@ -9512,13 +9546,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 61,
-								Line:   177,
+								Line:   178,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 59,
-								Line:   177,
+								Line:   178,
 							},
 						},
 					}},
@@ -9530,13 +9564,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   197,
+						Line:   198,
 					},
 					File:   "universe.flux",
 					Source: "highestAverage = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top,\n            )",
 					Start: ast.Position{
 						Column: 1,
-						Line:   189,
+						Line:   190,
 					},
 				},
 			},
@@ -9546,13 +9580,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   189,
+							Line:   190,
 						},
 						File:   "universe.flux",
 						Source: "highestAverage",
 						Start: ast.Position{
 							Column: 1,
-							Line:   189,
+							Line:   190,
 						},
 					},
 				},
@@ -9564,13 +9598,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   197,
+							Line:   198,
 						},
 						File:   "universe.flux",
 						Source: "(n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top,\n            )",
 						Start: ast.Position{
 							Column: 18,
-							Line:   189,
+							Line:   190,
 						},
 					},
 				},
@@ -9581,13 +9615,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   190,
+									Line:   191,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   190,
+									Line:   191,
 								},
 							},
 						},
@@ -9598,13 +9632,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   197,
+								Line:   198,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top,\n            )",
 							Start: ast.Position{
 								Column: 5,
-								Line:   190,
+								Line:   191,
 							},
 						},
 					},
@@ -9615,13 +9649,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 32,
-										Line:   196,
+										Line:   197,
 									},
 									File:   "universe.flux",
 									Source: "n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top",
 									Start: ast.Position{
 										Column: 17,
-										Line:   192,
+										Line:   193,
 									},
 								},
 							},
@@ -9631,13 +9665,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 20,
-											Line:   192,
+											Line:   193,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 17,
-											Line:   192,
+											Line:   193,
 										},
 									},
 								},
@@ -9647,13 +9681,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 18,
-												Line:   192,
+												Line:   193,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 17,
-												Line:   192,
+												Line:   193,
 											},
 										},
 									},
@@ -9665,13 +9699,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   192,
+												Line:   193,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 19,
-												Line:   192,
+												Line:   193,
 											},
 										},
 									},
@@ -9683,13 +9717,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   193,
+											Line:   194,
 										},
 										File:   "universe.flux",
 										Source: "column:column",
 										Start: ast.Position{
 											Column: 17,
-											Line:   193,
+											Line:   194,
 										},
 									},
 								},
@@ -9699,13 +9733,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   193,
+												Line:   194,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 17,
-												Line:   193,
+												Line:   194,
 											},
 										},
 									},
@@ -9717,13 +9751,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   193,
+												Line:   194,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 24,
-												Line:   193,
+												Line:   194,
 											},
 										},
 									},
@@ -9735,13 +9769,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   194,
+											Line:   195,
 										},
 										File:   "universe.flux",
 										Source: "groupColumns:groupColumns",
 										Start: ast.Position{
 											Column: 17,
-											Line:   194,
+											Line:   195,
 										},
 									},
 								},
@@ -9751,13 +9785,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   194,
+												Line:   195,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   194,
+												Line:   195,
 											},
 										},
 									},
@@ -9769,13 +9803,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   194,
+												Line:   195,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 30,
-												Line:   194,
+												Line:   195,
 											},
 										},
 									},
@@ -9787,13 +9821,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 70,
-											Line:   195,
+											Line:   196,
 										},
 										File:   "universe.flux",
 										Source: "reducer: (tables=<-) => tables |> mean(column:column)",
 										Start: ast.Position{
 											Column: 17,
-											Line:   195,
+											Line:   196,
 										},
 									},
 								},
@@ -9803,13 +9837,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   195,
+												Line:   196,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 17,
-												Line:   195,
+												Line:   196,
 											},
 										},
 									},
@@ -9821,13 +9855,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 70,
-												Line:   195,
+												Line:   196,
 											},
 											File:   "universe.flux",
 											Source: "(tables=<-) => tables |> mean(column:column)",
 											Start: ast.Position{
 												Column: 26,
-												Line:   195,
+												Line:   196,
 											},
 										},
 									},
@@ -9838,13 +9872,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 47,
-														Line:   195,
+														Line:   196,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 41,
-														Line:   195,
+														Line:   196,
 													},
 												},
 											},
@@ -9855,13 +9889,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 70,
-													Line:   195,
+													Line:   196,
 												},
 												File:   "universe.flux",
 												Source: "tables |> mean(column:column)",
 												Start: ast.Position{
 													Column: 41,
-													Line:   195,
+													Line:   196,
 												},
 											},
 										},
@@ -9872,13 +9906,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 69,
-															Line:   195,
+															Line:   196,
 														},
 														File:   "universe.flux",
 														Source: "column:column",
 														Start: ast.Position{
 															Column: 56,
-															Line:   195,
+															Line:   196,
 														},
 													},
 												},
@@ -9888,13 +9922,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 69,
-																Line:   195,
+																Line:   196,
 															},
 															File:   "universe.flux",
 															Source: "column:column",
 															Start: ast.Position{
 																Column: 56,
-																Line:   195,
+																Line:   196,
 															},
 														},
 													},
@@ -9904,13 +9938,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 62,
-																	Line:   195,
+																	Line:   196,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 56,
-																	Line:   195,
+																	Line:   196,
 																},
 															},
 														},
@@ -9922,13 +9956,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 69,
-																	Line:   195,
+																	Line:   196,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 63,
-																	Line:   195,
+																	Line:   196,
 																},
 															},
 														},
@@ -9942,13 +9976,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 70,
-														Line:   195,
+														Line:   196,
 													},
 													File:   "universe.flux",
 													Source: "mean(column:column)",
 													Start: ast.Position{
 														Column: 51,
-														Line:   195,
+														Line:   196,
 													},
 												},
 											},
@@ -9958,13 +9992,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 55,
-															Line:   195,
+															Line:   196,
 														},
 														File:   "universe.flux",
 														Source: "mean",
 														Start: ast.Position{
 															Column: 51,
-															Line:   195,
+															Line:   196,
 														},
 													},
 												},
@@ -9978,13 +10012,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   195,
+													Line:   196,
 												},
 												File:   "universe.flux",
 												Source: "tables=<-",
 												Start: ast.Position{
 													Column: 27,
-													Line:   195,
+													Line:   196,
 												},
 											},
 										},
@@ -9994,13 +10028,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   195,
+														Line:   196,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 27,
-														Line:   195,
+														Line:   196,
 													},
 												},
 											},
@@ -10011,13 +10045,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   195,
+													Line:   196,
 												},
 												File:   "universe.flux",
 												Source: "<-",
 												Start: ast.Position{
 													Column: 34,
-													Line:   195,
+													Line:   196,
 												},
 											},
 										}},
@@ -10029,13 +10063,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 32,
-											Line:   196,
+											Line:   197,
 										},
 										File:   "universe.flux",
 										Source: "_sortLimit: top",
 										Start: ast.Position{
 											Column: 17,
-											Line:   196,
+											Line:   197,
 										},
 									},
 								},
@@ -10045,13 +10079,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   196,
+												Line:   197,
 											},
 											File:   "universe.flux",
 											Source: "_sortLimit",
 											Start: ast.Position{
 												Column: 17,
-												Line:   196,
+												Line:   197,
 											},
 										},
 									},
@@ -10063,13 +10097,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 32,
-												Line:   196,
+												Line:   197,
 											},
 											File:   "universe.flux",
 											Source: "top",
 											Start: ast.Position{
 												Column: 29,
-												Line:   196,
+												Line:   197,
 											},
 										},
 									},
@@ -10083,13 +10117,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   197,
+									Line:   198,
 								},
 								File:   "universe.flux",
 								Source: "_highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: top,\n            )",
 								Start: ast.Position{
 									Column: 12,
-									Line:   191,
+									Line:   192,
 								},
 							},
 						},
@@ -10099,13 +10133,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   191,
+										Line:   192,
 									},
 									File:   "universe.flux",
 									Source: "_highestOrLowest",
 									Start: ast.Position{
 										Column: 12,
-										Line:   191,
+										Line:   192,
 									},
 								},
 							},
@@ -10119,13 +10153,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 20,
-								Line:   189,
+								Line:   190,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 19,
-								Line:   189,
+								Line:   190,
 							},
 						},
 					},
@@ -10135,13 +10169,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 20,
-									Line:   189,
+									Line:   190,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 19,
-									Line:   189,
+									Line:   190,
 								},
 							},
 						},
@@ -10154,13 +10188,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 37,
-								Line:   189,
+								Line:   190,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 22,
-								Line:   189,
+								Line:   190,
 							},
 						},
 					},
@@ -10170,13 +10204,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 28,
-									Line:   189,
+									Line:   190,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 22,
-									Line:   189,
+									Line:   190,
 								},
 							},
 						},
@@ -10188,13 +10222,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 37,
-									Line:   189,
+									Line:   190,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 29,
-									Line:   189,
+									Line:   190,
 								},
 							},
 						},
@@ -10206,13 +10240,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 54,
-								Line:   189,
+								Line:   190,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 39,
-								Line:   189,
+								Line:   190,
 							},
 						},
 					},
@@ -10222,13 +10256,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 51,
-									Line:   189,
+									Line:   190,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 39,
-									Line:   189,
+									Line:   190,
 								},
 							},
 						},
@@ -10240,13 +10274,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 54,
-									Line:   189,
+									Line:   190,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 52,
-									Line:   189,
+									Line:   190,
 								},
 							},
 						},
@@ -10258,13 +10292,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 65,
-								Line:   189,
+								Line:   190,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 56,
-								Line:   189,
+								Line:   190,
 							},
 						},
 					},
@@ -10274,13 +10308,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 62,
-									Line:   189,
+									Line:   190,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 56,
-									Line:   189,
+									Line:   190,
 								},
 							},
 						},
@@ -10291,13 +10325,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 65,
-								Line:   189,
+								Line:   190,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 63,
-								Line:   189,
+								Line:   190,
 							},
 						},
 					}},
@@ -10309,13 +10343,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   208,
+						Line:   209,
 					},
 					File:   "universe.flux",
 					Source: "highestCurrent = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top,\n            )",
 					Start: ast.Position{
 						Column: 1,
-						Line:   200,
+						Line:   201,
 					},
 				},
 			},
@@ -10325,13 +10359,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   200,
+							Line:   201,
 						},
 						File:   "universe.flux",
 						Source: "highestCurrent",
 						Start: ast.Position{
 							Column: 1,
-							Line:   200,
+							Line:   201,
 						},
 					},
 				},
@@ -10343,13 +10377,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   208,
+							Line:   209,
 						},
 						File:   "universe.flux",
 						Source: "(n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top,\n            )",
 						Start: ast.Position{
 							Column: 18,
-							Line:   200,
+							Line:   201,
 						},
 					},
 				},
@@ -10360,13 +10394,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   201,
+									Line:   202,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   201,
+									Line:   202,
 								},
 							},
 						},
@@ -10377,13 +10411,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   208,
+								Line:   209,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top,\n            )",
 							Start: ast.Position{
 								Column: 5,
-								Line:   201,
+								Line:   202,
 							},
 						},
 					},
@@ -10394,13 +10428,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 32,
-										Line:   207,
+										Line:   208,
 									},
 									File:   "universe.flux",
 									Source: "n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top",
 									Start: ast.Position{
 										Column: 17,
-										Line:   203,
+										Line:   204,
 									},
 								},
 							},
@@ -10410,13 +10444,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 20,
-											Line:   203,
+											Line:   204,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 17,
-											Line:   203,
+											Line:   204,
 										},
 									},
 								},
@@ -10426,13 +10460,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 18,
-												Line:   203,
+												Line:   204,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 17,
-												Line:   203,
+												Line:   204,
 											},
 										},
 									},
@@ -10444,13 +10478,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   203,
+												Line:   204,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 19,
-												Line:   203,
+												Line:   204,
 											},
 										},
 									},
@@ -10462,13 +10496,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   204,
+											Line:   205,
 										},
 										File:   "universe.flux",
 										Source: "column:column",
 										Start: ast.Position{
 											Column: 17,
-											Line:   204,
+											Line:   205,
 										},
 									},
 								},
@@ -10478,13 +10512,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   204,
+												Line:   205,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 17,
-												Line:   204,
+												Line:   205,
 											},
 										},
 									},
@@ -10496,13 +10530,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   204,
+												Line:   205,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 24,
-												Line:   204,
+												Line:   205,
 											},
 										},
 									},
@@ -10514,13 +10548,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   205,
+											Line:   206,
 										},
 										File:   "universe.flux",
 										Source: "groupColumns:groupColumns",
 										Start: ast.Position{
 											Column: 17,
-											Line:   205,
+											Line:   206,
 										},
 									},
 								},
@@ -10530,13 +10564,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   205,
+												Line:   206,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   205,
+												Line:   206,
 											},
 										},
 									},
@@ -10548,13 +10582,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   205,
+												Line:   206,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 30,
-												Line:   205,
+												Line:   206,
 											},
 										},
 									},
@@ -10566,13 +10600,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 70,
-											Line:   206,
+											Line:   207,
 										},
 										File:   "universe.flux",
 										Source: "reducer: (tables=<-) => tables |> last(column:column)",
 										Start: ast.Position{
 											Column: 17,
-											Line:   206,
+											Line:   207,
 										},
 									},
 								},
@@ -10582,13 +10616,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   206,
+												Line:   207,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 17,
-												Line:   206,
+												Line:   207,
 											},
 										},
 									},
@@ -10600,13 +10634,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 70,
-												Line:   206,
+												Line:   207,
 											},
 											File:   "universe.flux",
 											Source: "(tables=<-) => tables |> last(column:column)",
 											Start: ast.Position{
 												Column: 26,
-												Line:   206,
+												Line:   207,
 											},
 										},
 									},
@@ -10617,13 +10651,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 47,
-														Line:   206,
+														Line:   207,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 41,
-														Line:   206,
+														Line:   207,
 													},
 												},
 											},
@@ -10634,13 +10668,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 70,
-													Line:   206,
+													Line:   207,
 												},
 												File:   "universe.flux",
 												Source: "tables |> last(column:column)",
 												Start: ast.Position{
 													Column: 41,
-													Line:   206,
+													Line:   207,
 												},
 											},
 										},
@@ -10651,13 +10685,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 69,
-															Line:   206,
+															Line:   207,
 														},
 														File:   "universe.flux",
 														Source: "column:column",
 														Start: ast.Position{
 															Column: 56,
-															Line:   206,
+															Line:   207,
 														},
 													},
 												},
@@ -10667,13 +10701,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 69,
-																Line:   206,
+																Line:   207,
 															},
 															File:   "universe.flux",
 															Source: "column:column",
 															Start: ast.Position{
 																Column: 56,
-																Line:   206,
+																Line:   207,
 															},
 														},
 													},
@@ -10683,13 +10717,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 62,
-																	Line:   206,
+																	Line:   207,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 56,
-																	Line:   206,
+																	Line:   207,
 																},
 															},
 														},
@@ -10701,13 +10735,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 69,
-																	Line:   206,
+																	Line:   207,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 63,
-																	Line:   206,
+																	Line:   207,
 																},
 															},
 														},
@@ -10721,13 +10755,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 70,
-														Line:   206,
+														Line:   207,
 													},
 													File:   "universe.flux",
 													Source: "last(column:column)",
 													Start: ast.Position{
 														Column: 51,
-														Line:   206,
+														Line:   207,
 													},
 												},
 											},
@@ -10737,13 +10771,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 55,
-															Line:   206,
+															Line:   207,
 														},
 														File:   "universe.flux",
 														Source: "last",
 														Start: ast.Position{
 															Column: 51,
-															Line:   206,
+															Line:   207,
 														},
 													},
 												},
@@ -10757,13 +10791,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   206,
+													Line:   207,
 												},
 												File:   "universe.flux",
 												Source: "tables=<-",
 												Start: ast.Position{
 													Column: 27,
-													Line:   206,
+													Line:   207,
 												},
 											},
 										},
@@ -10773,13 +10807,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   206,
+														Line:   207,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 27,
-														Line:   206,
+														Line:   207,
 													},
 												},
 											},
@@ -10790,13 +10824,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   206,
+													Line:   207,
 												},
 												File:   "universe.flux",
 												Source: "<-",
 												Start: ast.Position{
 													Column: 34,
-													Line:   206,
+													Line:   207,
 												},
 											},
 										}},
@@ -10808,13 +10842,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 32,
-											Line:   207,
+											Line:   208,
 										},
 										File:   "universe.flux",
 										Source: "_sortLimit: top",
 										Start: ast.Position{
 											Column: 17,
-											Line:   207,
+											Line:   208,
 										},
 									},
 								},
@@ -10824,13 +10858,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   207,
+												Line:   208,
 											},
 											File:   "universe.flux",
 											Source: "_sortLimit",
 											Start: ast.Position{
 												Column: 17,
-												Line:   207,
+												Line:   208,
 											},
 										},
 									},
@@ -10842,13 +10876,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 32,
-												Line:   207,
+												Line:   208,
 											},
 											File:   "universe.flux",
 											Source: "top",
 											Start: ast.Position{
 												Column: 29,
-												Line:   207,
+												Line:   208,
 											},
 										},
 									},
@@ -10862,13 +10896,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   208,
+									Line:   209,
 								},
 								File:   "universe.flux",
 								Source: "_highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: top,\n            )",
 								Start: ast.Position{
 									Column: 12,
-									Line:   202,
+									Line:   203,
 								},
 							},
 						},
@@ -10878,13 +10912,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   202,
+										Line:   203,
 									},
 									File:   "universe.flux",
 									Source: "_highestOrLowest",
 									Start: ast.Position{
 										Column: 12,
-										Line:   202,
+										Line:   203,
 									},
 								},
 							},
@@ -10898,13 +10932,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 20,
-								Line:   200,
+								Line:   201,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 19,
-								Line:   200,
+								Line:   201,
 							},
 						},
 					},
@@ -10914,13 +10948,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 20,
-									Line:   200,
+									Line:   201,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 19,
-									Line:   200,
+									Line:   201,
 								},
 							},
 						},
@@ -10933,13 +10967,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 37,
-								Line:   200,
+								Line:   201,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 22,
-								Line:   200,
+								Line:   201,
 							},
 						},
 					},
@@ -10949,13 +10983,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 28,
-									Line:   200,
+									Line:   201,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 22,
-									Line:   200,
+									Line:   201,
 								},
 							},
 						},
@@ -10967,13 +11001,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 37,
-									Line:   200,
+									Line:   201,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 29,
-									Line:   200,
+									Line:   201,
 								},
 							},
 						},
@@ -10985,13 +11019,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 54,
-								Line:   200,
+								Line:   201,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 39,
-								Line:   200,
+								Line:   201,
 							},
 						},
 					},
@@ -11001,13 +11035,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 51,
-									Line:   200,
+									Line:   201,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 39,
-									Line:   200,
+									Line:   201,
 								},
 							},
 						},
@@ -11019,13 +11053,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 54,
-									Line:   200,
+									Line:   201,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 52,
-									Line:   200,
+									Line:   201,
 								},
 							},
 						},
@@ -11037,13 +11071,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 65,
-								Line:   200,
+								Line:   201,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 56,
-								Line:   200,
+								Line:   201,
 							},
 						},
 					},
@@ -11053,13 +11087,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 62,
-									Line:   200,
+									Line:   201,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 56,
-									Line:   200,
+									Line:   201,
 								},
 							},
 						},
@@ -11070,13 +11104,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 65,
-								Line:   200,
+								Line:   201,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 63,
-								Line:   200,
+								Line:   201,
 							},
 						},
 					}},
@@ -11088,13 +11122,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   220,
+						Line:   221,
 					},
 					File:   "universe.flux",
 					Source: "lowestMin = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom,\n            )",
 					Start: ast.Position{
 						Column: 1,
-						Line:   211,
+						Line:   212,
 					},
 				},
 			},
@@ -11104,13 +11138,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 10,
-							Line:   211,
+							Line:   212,
 						},
 						File:   "universe.flux",
 						Source: "lowestMin",
 						Start: ast.Position{
 							Column: 1,
-							Line:   211,
+							Line:   212,
 						},
 					},
 				},
@@ -11122,13 +11156,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   220,
+							Line:   221,
 						},
 						File:   "universe.flux",
 						Source: "(n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom,\n            )",
 						Start: ast.Position{
 							Column: 13,
-							Line:   211,
+							Line:   212,
 						},
 					},
 				},
@@ -11139,13 +11173,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   212,
+									Line:   213,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   212,
+									Line:   213,
 								},
 							},
 						},
@@ -11156,13 +11190,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   220,
+								Line:   221,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom,\n            )",
 							Start: ast.Position{
 								Column: 5,
-								Line:   212,
+								Line:   213,
 							},
 						},
 					},
@@ -11173,13 +11207,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 35,
-										Line:   219,
+										Line:   220,
 									},
 									File:   "universe.flux",
 									Source: "n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom",
 									Start: ast.Position{
 										Column: 17,
-										Line:   214,
+										Line:   215,
 									},
 								},
 							},
@@ -11189,13 +11223,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 20,
-											Line:   214,
+											Line:   215,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 17,
-											Line:   214,
+											Line:   215,
 										},
 									},
 								},
@@ -11205,13 +11239,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 18,
-												Line:   214,
+												Line:   215,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 17,
-												Line:   214,
+												Line:   215,
 											},
 										},
 									},
@@ -11223,13 +11257,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   214,
+												Line:   215,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 19,
-												Line:   214,
+												Line:   215,
 											},
 										},
 									},
@@ -11241,13 +11275,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   215,
+											Line:   216,
 										},
 										File:   "universe.flux",
 										Source: "column:column",
 										Start: ast.Position{
 											Column: 17,
-											Line:   215,
+											Line:   216,
 										},
 									},
 								},
@@ -11257,13 +11291,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   215,
+												Line:   216,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 17,
-												Line:   215,
+												Line:   216,
 											},
 										},
 									},
@@ -11275,13 +11309,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   215,
+												Line:   216,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 24,
-												Line:   215,
+												Line:   216,
 											},
 										},
 									},
@@ -11293,13 +11327,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   216,
+											Line:   217,
 										},
 										File:   "universe.flux",
 										Source: "groupColumns:groupColumns",
 										Start: ast.Position{
 											Column: 17,
-											Line:   216,
+											Line:   217,
 										},
 									},
 								},
@@ -11309,13 +11343,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   216,
+												Line:   217,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   216,
+												Line:   217,
 											},
 										},
 									},
@@ -11327,13 +11361,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   216,
+												Line:   217,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 30,
-												Line:   216,
+												Line:   217,
 											},
 										},
 									},
@@ -11345,13 +11379,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 69,
-											Line:   218,
+											Line:   219,
 										},
 										File:   "universe.flux",
 										Source: "reducer: (tables=<-) => tables |> min(column:column)",
 										Start: ast.Position{
 											Column: 17,
-											Line:   218,
+											Line:   219,
 										},
 									},
 								},
@@ -11361,13 +11395,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   218,
+												Line:   219,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 17,
-												Line:   218,
+												Line:   219,
 											},
 										},
 									},
@@ -11379,13 +11413,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 69,
-												Line:   218,
+												Line:   219,
 											},
 											File:   "universe.flux",
 											Source: "(tables=<-) => tables |> min(column:column)",
 											Start: ast.Position{
 												Column: 26,
-												Line:   218,
+												Line:   219,
 											},
 										},
 									},
@@ -11396,13 +11430,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 47,
-														Line:   218,
+														Line:   219,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 41,
-														Line:   218,
+														Line:   219,
 													},
 												},
 											},
@@ -11413,13 +11447,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 69,
-													Line:   218,
+													Line:   219,
 												},
 												File:   "universe.flux",
 												Source: "tables |> min(column:column)",
 												Start: ast.Position{
 													Column: 41,
-													Line:   218,
+													Line:   219,
 												},
 											},
 										},
@@ -11430,13 +11464,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   218,
+															Line:   219,
 														},
 														File:   "universe.flux",
 														Source: "column:column",
 														Start: ast.Position{
 															Column: 55,
-															Line:   218,
+															Line:   219,
 														},
 													},
 												},
@@ -11446,13 +11480,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 68,
-																Line:   218,
+																Line:   219,
 															},
 															File:   "universe.flux",
 															Source: "column:column",
 															Start: ast.Position{
 																Column: 55,
-																Line:   218,
+																Line:   219,
 															},
 														},
 													},
@@ -11462,13 +11496,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 61,
-																	Line:   218,
+																	Line:   219,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 55,
-																	Line:   218,
+																	Line:   219,
 																},
 															},
 														},
@@ -11480,13 +11514,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 68,
-																	Line:   218,
+																	Line:   219,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 62,
-																	Line:   218,
+																	Line:   219,
 																},
 															},
 														},
@@ -11500,13 +11534,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 69,
-														Line:   218,
+														Line:   219,
 													},
 													File:   "universe.flux",
 													Source: "min(column:column)",
 													Start: ast.Position{
 														Column: 51,
-														Line:   218,
+														Line:   219,
 													},
 												},
 											},
@@ -11516,13 +11550,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 54,
-															Line:   218,
+															Line:   219,
 														},
 														File:   "universe.flux",
 														Source: "min",
 														Start: ast.Position{
 															Column: 51,
-															Line:   218,
+															Line:   219,
 														},
 													},
 												},
@@ -11536,13 +11570,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   218,
+													Line:   219,
 												},
 												File:   "universe.flux",
 												Source: "tables=<-",
 												Start: ast.Position{
 													Column: 27,
-													Line:   218,
+													Line:   219,
 												},
 											},
 										},
@@ -11552,13 +11586,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   218,
+														Line:   219,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 27,
-														Line:   218,
+														Line:   219,
 													},
 												},
 											},
@@ -11569,13 +11603,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   218,
+													Line:   219,
 												},
 												File:   "universe.flux",
 												Source: "<-",
 												Start: ast.Position{
 													Column: 34,
-													Line:   218,
+													Line:   219,
 												},
 											},
 										}},
@@ -11587,13 +11621,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 35,
-											Line:   219,
+											Line:   220,
 										},
 										File:   "universe.flux",
 										Source: "_sortLimit: bottom",
 										Start: ast.Position{
 											Column: 17,
-											Line:   219,
+											Line:   220,
 										},
 									},
 								},
@@ -11603,13 +11637,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   219,
+												Line:   220,
 											},
 											File:   "universe.flux",
 											Source: "_sortLimit",
 											Start: ast.Position{
 												Column: 17,
-												Line:   219,
+												Line:   220,
 											},
 										},
 									},
@@ -11621,13 +11655,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 35,
-												Line:   219,
+												Line:   220,
 											},
 											File:   "universe.flux",
 											Source: "bottom",
 											Start: ast.Position{
 												Column: 29,
-												Line:   219,
+												Line:   220,
 											},
 										},
 									},
@@ -11641,13 +11675,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   220,
+									Line:   221,
 								},
 								File:   "universe.flux",
 								Source: "_highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                // TODO(nathanielc): Once max/min support selecting based on multiple columns change this to pass all columns.\n                reducer: (tables=<-) => tables |> min(column:column),\n                _sortLimit: bottom,\n            )",
 								Start: ast.Position{
 									Column: 12,
-									Line:   213,
+									Line:   214,
 								},
 							},
 						},
@@ -11657,13 +11691,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   213,
+										Line:   214,
 									},
 									File:   "universe.flux",
 									Source: "_highestOrLowest",
 									Start: ast.Position{
 										Column: 12,
-										Line:   213,
+										Line:   214,
 									},
 								},
 							},
@@ -11677,13 +11711,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 15,
-								Line:   211,
+								Line:   212,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 14,
-								Line:   211,
+								Line:   212,
 							},
 						},
 					},
@@ -11693,13 +11727,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 15,
-									Line:   211,
+									Line:   212,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 14,
-									Line:   211,
+									Line:   212,
 								},
 							},
 						},
@@ -11712,13 +11746,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 32,
-								Line:   211,
+								Line:   212,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 17,
-								Line:   211,
+								Line:   212,
 							},
 						},
 					},
@@ -11728,13 +11762,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 23,
-									Line:   211,
+									Line:   212,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 17,
-									Line:   211,
+									Line:   212,
 								},
 							},
 						},
@@ -11746,13 +11780,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 32,
-									Line:   211,
+									Line:   212,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 24,
-									Line:   211,
+									Line:   212,
 								},
 							},
 						},
@@ -11764,13 +11798,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 49,
-								Line:   211,
+								Line:   212,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 34,
-								Line:   211,
+								Line:   212,
 							},
 						},
 					},
@@ -11780,13 +11814,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 46,
-									Line:   211,
+									Line:   212,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 34,
-									Line:   211,
+									Line:   212,
 								},
 							},
 						},
@@ -11798,13 +11832,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 49,
-									Line:   211,
+									Line:   212,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 47,
-									Line:   211,
+									Line:   212,
 								},
 							},
 						},
@@ -11816,13 +11850,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 60,
-								Line:   211,
+								Line:   212,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 51,
-								Line:   211,
+								Line:   212,
 							},
 						},
 					},
@@ -11832,13 +11866,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 57,
-									Line:   211,
+									Line:   212,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 51,
-									Line:   211,
+									Line:   212,
 								},
 							},
 						},
@@ -11849,13 +11883,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 60,
-								Line:   211,
+								Line:   212,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 58,
-								Line:   211,
+								Line:   212,
 							},
 						},
 					}},
@@ -11867,13 +11901,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   231,
+						Line:   232,
 					},
 					File:   "universe.flux",
 					Source: "lowestAverage = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom,\n            )",
 					Start: ast.Position{
 						Column: 1,
-						Line:   223,
+						Line:   224,
 					},
 				},
 			},
@@ -11883,13 +11917,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   223,
+							Line:   224,
 						},
 						File:   "universe.flux",
 						Source: "lowestAverage",
 						Start: ast.Position{
 							Column: 1,
-							Line:   223,
+							Line:   224,
 						},
 					},
 				},
@@ -11901,13 +11935,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   231,
+							Line:   232,
 						},
 						File:   "universe.flux",
 						Source: "(n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom,\n            )",
 						Start: ast.Position{
 							Column: 17,
-							Line:   223,
+							Line:   224,
 						},
 					},
 				},
@@ -11918,13 +11952,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   224,
+									Line:   225,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   224,
+									Line:   225,
 								},
 							},
 						},
@@ -11935,13 +11969,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   231,
+								Line:   232,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom,\n            )",
 							Start: ast.Position{
 								Column: 5,
-								Line:   224,
+								Line:   225,
 							},
 						},
 					},
@@ -11952,13 +11986,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 35,
-										Line:   230,
+										Line:   231,
 									},
 									File:   "universe.flux",
 									Source: "n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom",
 									Start: ast.Position{
 										Column: 17,
-										Line:   226,
+										Line:   227,
 									},
 								},
 							},
@@ -11968,13 +12002,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 20,
-											Line:   226,
+											Line:   227,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 17,
-											Line:   226,
+											Line:   227,
 										},
 									},
 								},
@@ -11984,13 +12018,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 18,
-												Line:   226,
+												Line:   227,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 17,
-												Line:   226,
+												Line:   227,
 											},
 										},
 									},
@@ -12002,13 +12036,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   226,
+												Line:   227,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 19,
-												Line:   226,
+												Line:   227,
 											},
 										},
 									},
@@ -12020,13 +12054,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   227,
+											Line:   228,
 										},
 										File:   "universe.flux",
 										Source: "column:column",
 										Start: ast.Position{
 											Column: 17,
-											Line:   227,
+											Line:   228,
 										},
 									},
 								},
@@ -12036,13 +12070,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   227,
+												Line:   228,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 17,
-												Line:   227,
+												Line:   228,
 											},
 										},
 									},
@@ -12054,13 +12088,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   227,
+												Line:   228,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 24,
-												Line:   227,
+												Line:   228,
 											},
 										},
 									},
@@ -12072,13 +12106,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   228,
+											Line:   229,
 										},
 										File:   "universe.flux",
 										Source: "groupColumns:groupColumns",
 										Start: ast.Position{
 											Column: 17,
-											Line:   228,
+											Line:   229,
 										},
 									},
 								},
@@ -12088,13 +12122,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   228,
+												Line:   229,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   228,
+												Line:   229,
 											},
 										},
 									},
@@ -12106,13 +12140,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   228,
+												Line:   229,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 30,
-												Line:   228,
+												Line:   229,
 											},
 										},
 									},
@@ -12124,13 +12158,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 70,
-											Line:   229,
+											Line:   230,
 										},
 										File:   "universe.flux",
 										Source: "reducer: (tables=<-) => tables |> mean(column:column)",
 										Start: ast.Position{
 											Column: 17,
-											Line:   229,
+											Line:   230,
 										},
 									},
 								},
@@ -12140,13 +12174,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   229,
+												Line:   230,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 17,
-												Line:   229,
+												Line:   230,
 											},
 										},
 									},
@@ -12158,13 +12192,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 70,
-												Line:   229,
+												Line:   230,
 											},
 											File:   "universe.flux",
 											Source: "(tables=<-) => tables |> mean(column:column)",
 											Start: ast.Position{
 												Column: 26,
-												Line:   229,
+												Line:   230,
 											},
 										},
 									},
@@ -12175,13 +12209,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 47,
-														Line:   229,
+														Line:   230,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 41,
-														Line:   229,
+														Line:   230,
 													},
 												},
 											},
@@ -12192,13 +12226,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 70,
-													Line:   229,
+													Line:   230,
 												},
 												File:   "universe.flux",
 												Source: "tables |> mean(column:column)",
 												Start: ast.Position{
 													Column: 41,
-													Line:   229,
+													Line:   230,
 												},
 											},
 										},
@@ -12209,13 +12243,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 69,
-															Line:   229,
+															Line:   230,
 														},
 														File:   "universe.flux",
 														Source: "column:column",
 														Start: ast.Position{
 															Column: 56,
-															Line:   229,
+															Line:   230,
 														},
 													},
 												},
@@ -12225,13 +12259,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 69,
-																Line:   229,
+																Line:   230,
 															},
 															File:   "universe.flux",
 															Source: "column:column",
 															Start: ast.Position{
 																Column: 56,
-																Line:   229,
+																Line:   230,
 															},
 														},
 													},
@@ -12241,13 +12275,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 62,
-																	Line:   229,
+																	Line:   230,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 56,
-																	Line:   229,
+																	Line:   230,
 																},
 															},
 														},
@@ -12259,13 +12293,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 69,
-																	Line:   229,
+																	Line:   230,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 63,
-																	Line:   229,
+																	Line:   230,
 																},
 															},
 														},
@@ -12279,13 +12313,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 70,
-														Line:   229,
+														Line:   230,
 													},
 													File:   "universe.flux",
 													Source: "mean(column:column)",
 													Start: ast.Position{
 														Column: 51,
-														Line:   229,
+														Line:   230,
 													},
 												},
 											},
@@ -12295,13 +12329,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 55,
-															Line:   229,
+															Line:   230,
 														},
 														File:   "universe.flux",
 														Source: "mean",
 														Start: ast.Position{
 															Column: 51,
-															Line:   229,
+															Line:   230,
 														},
 													},
 												},
@@ -12315,13 +12349,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   229,
+													Line:   230,
 												},
 												File:   "universe.flux",
 												Source: "tables=<-",
 												Start: ast.Position{
 													Column: 27,
-													Line:   229,
+													Line:   230,
 												},
 											},
 										},
@@ -12331,13 +12365,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   229,
+														Line:   230,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 27,
-														Line:   229,
+														Line:   230,
 													},
 												},
 											},
@@ -12348,13 +12382,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   229,
+													Line:   230,
 												},
 												File:   "universe.flux",
 												Source: "<-",
 												Start: ast.Position{
 													Column: 34,
-													Line:   229,
+													Line:   230,
 												},
 											},
 										}},
@@ -12366,13 +12400,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 35,
-											Line:   230,
+											Line:   231,
 										},
 										File:   "universe.flux",
 										Source: "_sortLimit: bottom",
 										Start: ast.Position{
 											Column: 17,
-											Line:   230,
+											Line:   231,
 										},
 									},
 								},
@@ -12382,13 +12416,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   230,
+												Line:   231,
 											},
 											File:   "universe.flux",
 											Source: "_sortLimit",
 											Start: ast.Position{
 												Column: 17,
-												Line:   230,
+												Line:   231,
 											},
 										},
 									},
@@ -12400,13 +12434,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 35,
-												Line:   230,
+												Line:   231,
 											},
 											File:   "universe.flux",
 											Source: "bottom",
 											Start: ast.Position{
 												Column: 29,
-												Line:   230,
+												Line:   231,
 											},
 										},
 									},
@@ -12420,13 +12454,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   231,
+									Line:   232,
 								},
 								File:   "universe.flux",
 								Source: "_highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> mean(column:column),\n                _sortLimit: bottom,\n            )",
 								Start: ast.Position{
 									Column: 12,
-									Line:   225,
+									Line:   226,
 								},
 							},
 						},
@@ -12436,13 +12470,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   225,
+										Line:   226,
 									},
 									File:   "universe.flux",
 									Source: "_highestOrLowest",
 									Start: ast.Position{
 										Column: 12,
-										Line:   225,
+										Line:   226,
 									},
 								},
 							},
@@ -12456,13 +12490,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 19,
-								Line:   223,
+								Line:   224,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 18,
-								Line:   223,
+								Line:   224,
 							},
 						},
 					},
@@ -12472,13 +12506,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 19,
-									Line:   223,
+									Line:   224,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 18,
-									Line:   223,
+									Line:   224,
 								},
 							},
 						},
@@ -12491,13 +12525,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 36,
-								Line:   223,
+								Line:   224,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 21,
-								Line:   223,
+								Line:   224,
 							},
 						},
 					},
@@ -12507,13 +12541,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 27,
-									Line:   223,
+									Line:   224,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 21,
-									Line:   223,
+									Line:   224,
 								},
 							},
 						},
@@ -12525,13 +12559,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 36,
-									Line:   223,
+									Line:   224,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 28,
-									Line:   223,
+									Line:   224,
 								},
 							},
 						},
@@ -12543,13 +12577,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 53,
-								Line:   223,
+								Line:   224,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 38,
-								Line:   223,
+								Line:   224,
 							},
 						},
 					},
@@ -12559,13 +12593,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 50,
-									Line:   223,
+									Line:   224,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 38,
-									Line:   223,
+									Line:   224,
 								},
 							},
 						},
@@ -12577,13 +12611,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 53,
-									Line:   223,
+									Line:   224,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 51,
-									Line:   223,
+									Line:   224,
 								},
 							},
 						},
@@ -12595,13 +12629,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 64,
-								Line:   223,
+								Line:   224,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 55,
-								Line:   223,
+								Line:   224,
 							},
 						},
 					},
@@ -12611,13 +12645,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 61,
-									Line:   223,
+									Line:   224,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 55,
-									Line:   223,
+									Line:   224,
 								},
 							},
 						},
@@ -12628,13 +12662,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 64,
-								Line:   223,
+								Line:   224,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 62,
-								Line:   223,
+								Line:   224,
 							},
 						},
 					}},
@@ -12646,13 +12680,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 14,
-						Line:   242,
+						Line:   243,
 					},
 					File:   "universe.flux",
 					Source: "lowestCurrent = (n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom,\n            )",
 					Start: ast.Position{
 						Column: 1,
-						Line:   234,
+						Line:   235,
 					},
 				},
 			},
@@ -12662,13 +12696,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   234,
+							Line:   235,
 						},
 						File:   "universe.flux",
 						Source: "lowestCurrent",
 						Start: ast.Position{
 							Column: 1,
-							Line:   234,
+							Line:   235,
 						},
 					},
 				},
@@ -12680,13 +12714,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 14,
-							Line:   242,
+							Line:   243,
 						},
 						File:   "universe.flux",
 						Source: "(n, column=\"_value\", groupColumns=[], tables=<-) =>\n    tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom,\n            )",
 						Start: ast.Position{
 							Column: 17,
-							Line:   234,
+							Line:   235,
 						},
 					},
 				},
@@ -12697,13 +12731,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   235,
+									Line:   236,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 5,
-									Line:   235,
+									Line:   236,
 								},
 							},
 						},
@@ -12714,13 +12748,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 14,
-								Line:   242,
+								Line:   243,
 							},
 							File:   "universe.flux",
 							Source: "tables\n        |> _highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom,\n            )",
 							Start: ast.Position{
 								Column: 5,
-								Line:   235,
+								Line:   236,
 							},
 						},
 					},
@@ -12731,13 +12765,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 35,
-										Line:   241,
+										Line:   242,
 									},
 									File:   "universe.flux",
 									Source: "n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom",
 									Start: ast.Position{
 										Column: 17,
-										Line:   237,
+										Line:   238,
 									},
 								},
 							},
@@ -12747,13 +12781,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 20,
-											Line:   237,
+											Line:   238,
 										},
 										File:   "universe.flux",
 										Source: "n:n",
 										Start: ast.Position{
 											Column: 17,
-											Line:   237,
+											Line:   238,
 										},
 									},
 								},
@@ -12763,13 +12797,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 18,
-												Line:   237,
+												Line:   238,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 17,
-												Line:   237,
+												Line:   238,
 											},
 										},
 									},
@@ -12781,13 +12815,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   237,
+												Line:   238,
 											},
 											File:   "universe.flux",
 											Source: "n",
 											Start: ast.Position{
 												Column: 19,
-												Line:   237,
+												Line:   238,
 											},
 										},
 									},
@@ -12799,13 +12833,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   238,
+											Line:   239,
 										},
 										File:   "universe.flux",
 										Source: "column:column",
 										Start: ast.Position{
 											Column: 17,
-											Line:   238,
+											Line:   239,
 										},
 									},
 								},
@@ -12815,13 +12849,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   238,
+												Line:   239,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 17,
-												Line:   238,
+												Line:   239,
 											},
 										},
 									},
@@ -12833,13 +12867,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   238,
+												Line:   239,
 											},
 											File:   "universe.flux",
 											Source: "column",
 											Start: ast.Position{
 												Column: 24,
-												Line:   238,
+												Line:   239,
 											},
 										},
 									},
@@ -12851,13 +12885,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 42,
-											Line:   239,
+											Line:   240,
 										},
 										File:   "universe.flux",
 										Source: "groupColumns:groupColumns",
 										Start: ast.Position{
 											Column: 17,
-											Line:   239,
+											Line:   240,
 										},
 									},
 								},
@@ -12867,13 +12901,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   239,
+												Line:   240,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 17,
-												Line:   239,
+												Line:   240,
 											},
 										},
 									},
@@ -12885,13 +12919,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   239,
+												Line:   240,
 											},
 											File:   "universe.flux",
 											Source: "groupColumns",
 											Start: ast.Position{
 												Column: 30,
-												Line:   239,
+												Line:   240,
 											},
 										},
 									},
@@ -12903,13 +12937,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 70,
-											Line:   240,
+											Line:   241,
 										},
 										File:   "universe.flux",
 										Source: "reducer: (tables=<-) => tables |> last(column:column)",
 										Start: ast.Position{
 											Column: 17,
-											Line:   240,
+											Line:   241,
 										},
 									},
 								},
@@ -12919,13 +12953,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   240,
+												Line:   241,
 											},
 											File:   "universe.flux",
 											Source: "reducer",
 											Start: ast.Position{
 												Column: 17,
-												Line:   240,
+												Line:   241,
 											},
 										},
 									},
@@ -12937,13 +12971,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 70,
-												Line:   240,
+												Line:   241,
 											},
 											File:   "universe.flux",
 											Source: "(tables=<-) => tables |> last(column:column)",
 											Start: ast.Position{
 												Column: 26,
-												Line:   240,
+												Line:   241,
 											},
 										},
 									},
@@ -12954,13 +12988,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 47,
-														Line:   240,
+														Line:   241,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 41,
-														Line:   240,
+														Line:   241,
 													},
 												},
 											},
@@ -12971,13 +13005,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 70,
-													Line:   240,
+													Line:   241,
 												},
 												File:   "universe.flux",
 												Source: "tables |> last(column:column)",
 												Start: ast.Position{
 													Column: 41,
-													Line:   240,
+													Line:   241,
 												},
 											},
 										},
@@ -12988,13 +13022,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 69,
-															Line:   240,
+															Line:   241,
 														},
 														File:   "universe.flux",
 														Source: "column:column",
 														Start: ast.Position{
 															Column: 56,
-															Line:   240,
+															Line:   241,
 														},
 													},
 												},
@@ -13004,13 +13038,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 69,
-																Line:   240,
+																Line:   241,
 															},
 															File:   "universe.flux",
 															Source: "column:column",
 															Start: ast.Position{
 																Column: 56,
-																Line:   240,
+																Line:   241,
 															},
 														},
 													},
@@ -13020,13 +13054,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 62,
-																	Line:   240,
+																	Line:   241,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 56,
-																	Line:   240,
+																	Line:   241,
 																},
 															},
 														},
@@ -13038,13 +13072,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 69,
-																	Line:   240,
+																	Line:   241,
 																},
 																File:   "universe.flux",
 																Source: "column",
 																Start: ast.Position{
 																	Column: 63,
-																	Line:   240,
+																	Line:   241,
 																},
 															},
 														},
@@ -13058,13 +13092,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 70,
-														Line:   240,
+														Line:   241,
 													},
 													File:   "universe.flux",
 													Source: "last(column:column)",
 													Start: ast.Position{
 														Column: 51,
-														Line:   240,
+														Line:   241,
 													},
 												},
 											},
@@ -13074,13 +13108,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 55,
-															Line:   240,
+															Line:   241,
 														},
 														File:   "universe.flux",
 														Source: "last",
 														Start: ast.Position{
 															Column: 51,
-															Line:   240,
+															Line:   241,
 														},
 													},
 												},
@@ -13094,13 +13128,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   240,
+													Line:   241,
 												},
 												File:   "universe.flux",
 												Source: "tables=<-",
 												Start: ast.Position{
 													Column: 27,
-													Line:   240,
+													Line:   241,
 												},
 											},
 										},
@@ -13110,13 +13144,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   240,
+														Line:   241,
 													},
 													File:   "universe.flux",
 													Source: "tables",
 													Start: ast.Position{
 														Column: 27,
-														Line:   240,
+														Line:   241,
 													},
 												},
 											},
@@ -13127,13 +13161,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   240,
+													Line:   241,
 												},
 												File:   "universe.flux",
 												Source: "<-",
 												Start: ast.Position{
 													Column: 34,
-													Line:   240,
+													Line:   241,
 												},
 											},
 										}},
@@ -13145,13 +13179,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 35,
-											Line:   241,
+											Line:   242,
 										},
 										File:   "universe.flux",
 										Source: "_sortLimit: bottom",
 										Start: ast.Position{
 											Column: 17,
-											Line:   241,
+											Line:   242,
 										},
 									},
 								},
@@ -13161,13 +13195,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 27,
-												Line:   241,
+												Line:   242,
 											},
 											File:   "universe.flux",
 											Source: "_sortLimit",
 											Start: ast.Position{
 												Column: 17,
-												Line:   241,
+												Line:   242,
 											},
 										},
 									},
@@ -13179,13 +13213,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 35,
-												Line:   241,
+												Line:   242,
 											},
 											File:   "universe.flux",
 											Source: "bottom",
 											Start: ast.Position{
 												Column: 29,
-												Line:   241,
+												Line:   242,
 											},
 										},
 									},
@@ -13199,13 +13233,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   242,
+									Line:   243,
 								},
 								File:   "universe.flux",
 								Source: "_highestOrLowest(\n                n:n,\n                column:column,\n                groupColumns:groupColumns,\n                reducer: (tables=<-) => tables |> last(column:column),\n                _sortLimit: bottom,\n            )",
 								Start: ast.Position{
 									Column: 12,
-									Line:   236,
+									Line:   237,
 								},
 							},
 						},
@@ -13215,13 +13249,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 28,
-										Line:   236,
+										Line:   237,
 									},
 									File:   "universe.flux",
 									Source: "_highestOrLowest",
 									Start: ast.Position{
 										Column: 12,
-										Line:   236,
+										Line:   237,
 									},
 								},
 							},
@@ -13235,13 +13269,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 19,
-								Line:   234,
+								Line:   235,
 							},
 							File:   "universe.flux",
 							Source: "n",
 							Start: ast.Position{
 								Column: 18,
-								Line:   234,
+								Line:   235,
 							},
 						},
 					},
@@ -13251,13 +13285,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 19,
-									Line:   234,
+									Line:   235,
 								},
 								File:   "universe.flux",
 								Source: "n",
 								Start: ast.Position{
 									Column: 18,
-									Line:   234,
+									Line:   235,
 								},
 							},
 						},
@@ -13270,13 +13304,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 36,
-								Line:   234,
+								Line:   235,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
 								Column: 21,
-								Line:   234,
+								Line:   235,
 							},
 						},
 					},
@@ -13286,13 +13320,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 27,
-									Line:   234,
+									Line:   235,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
 									Column: 21,
-									Line:   234,
+									Line:   235,
 								},
 							},
 						},
@@ -13304,13 +13338,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 36,
-									Line:   234,
+									Line:   235,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
 									Column: 28,
-									Line:   234,
+									Line:   235,
 								},
 							},
 						},
@@ -13322,13 +13356,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 53,
-								Line:   234,
+								Line:   235,
 							},
 							File:   "universe.flux",
 							Source: "groupColumns=[]",
 							Start: ast.Position{
 								Column: 38,
-								Line:   234,
+								Line:   235,
 							},
 						},
 					},
@@ -13338,13 +13372,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 50,
-									Line:   234,
+									Line:   235,
 								},
 								File:   "universe.flux",
 								Source: "groupColumns",
 								Start: ast.Position{
 									Column: 38,
-									Line:   234,
+									Line:   235,
 								},
 							},
 						},
@@ -13356,13 +13390,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 53,
-									Line:   234,
+									Line:   235,
 								},
 								File:   "universe.flux",
 								Source: "[]",
 								Start: ast.Position{
 									Column: 51,
-									Line:   234,
+									Line:   235,
 								},
 							},
 						},
@@ -13374,13 +13408,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 64,
-								Line:   234,
+								Line:   235,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 55,
-								Line:   234,
+								Line:   235,
 							},
 						},
 					},
@@ -13390,13 +13424,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 61,
-									Line:   234,
+									Line:   235,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 55,
-									Line:   234,
+									Line:   235,
 								},
 							},
 						},
@@ -13407,13 +13441,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 64,
-								Line:   234,
+								Line:   235,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 62,
-								Line:   234,
+								Line:   235,
 							},
 						},
 					}},
@@ -13424,14 +13458,14 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 31,
-						Line:   252,
+						Column: 30,
+						Line:   253,
 					},
 					File:   "universe.flux",
-					Source: "movingAverage = (every, period, column=\"_value\", tables=<-) =>\n     tables\n         |> window(every: every, period: period)\n         |> mean(column:column)\n         |> duplicate(column: \"_stop\", as: \"_time\")\n         |> window(every: inf)",
+					Source: "timedMovingAverage = (every, period, column=\"_value\", tables=<-) =>\n    tables\n        |> window(every: every, period: period)\n        |> mean(column:column)\n        |> duplicate(column: \"_stop\", as: \"_time\")\n        |> window(every: inf)",
 					Start: ast.Position{
-						Column: 2,
-						Line:   247,
+						Column: 1,
+						Line:   248,
 					},
 				},
 			},
@@ -13440,32 +13474,32 @@ var pkgAST = &ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 15,
-							Line:   247,
+							Column: 19,
+							Line:   248,
 						},
 						File:   "universe.flux",
-						Source: "movingAverage",
+						Source: "timedMovingAverage",
 						Start: ast.Position{
-							Column: 2,
-							Line:   247,
+							Column: 1,
+							Line:   248,
 						},
 					},
 				},
-				Name: "movingAverage",
+				Name: "timedMovingAverage",
 			},
 			Init: &ast.FunctionExpression{
 				BaseNode: ast.BaseNode{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 31,
-							Line:   252,
+							Column: 30,
+							Line:   253,
 						},
 						File:   "universe.flux",
-						Source: "(every, period, column=\"_value\", tables=<-) =>\n     tables\n         |> window(every: every, period: period)\n         |> mean(column:column)\n         |> duplicate(column: \"_stop\", as: \"_time\")\n         |> window(every: inf)",
+						Source: "(every, period, column=\"_value\", tables=<-) =>\n    tables\n        |> window(every: every, period: period)\n        |> mean(column:column)\n        |> duplicate(column: \"_stop\", as: \"_time\")\n        |> window(every: inf)",
 						Start: ast.Position{
-							Column: 18,
-							Line:   247,
+							Column: 22,
+							Line:   248,
 						},
 					},
 				},
@@ -13478,14 +13512,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 12,
-												Line:   248,
+												Column: 11,
+												Line:   249,
 											},
 											File:   "universe.flux",
 											Source: "tables",
 											Start: ast.Position{
-												Column: 6,
-												Line:   248,
+												Column: 5,
+												Line:   249,
 											},
 										},
 									},
@@ -13495,14 +13529,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 49,
-											Line:   249,
+											Column: 48,
+											Line:   250,
 										},
 										File:   "universe.flux",
-										Source: "tables\n         |> window(every: every, period: period)",
+										Source: "tables\n        |> window(every: every, period: period)",
 										Start: ast.Position{
-											Column: 6,
-											Line:   248,
+											Column: 5,
+											Line:   249,
 										},
 									},
 								},
@@ -13512,14 +13546,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 48,
-													Line:   249,
+													Column: 47,
+													Line:   250,
 												},
 												File:   "universe.flux",
 												Source: "every: every, period: period",
 												Start: ast.Position{
-													Column: 20,
-													Line:   249,
+													Column: 19,
+													Line:   250,
 												},
 											},
 										},
@@ -13528,14 +13562,14 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 32,
-														Line:   249,
+														Column: 31,
+														Line:   250,
 													},
 													File:   "universe.flux",
 													Source: "every: every",
 													Start: ast.Position{
-														Column: 20,
-														Line:   249,
+														Column: 19,
+														Line:   250,
 													},
 												},
 											},
@@ -13544,14 +13578,14 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 25,
-															Line:   249,
+															Column: 24,
+															Line:   250,
 														},
 														File:   "universe.flux",
 														Source: "every",
 														Start: ast.Position{
-															Column: 20,
-															Line:   249,
+															Column: 19,
+															Line:   250,
 														},
 													},
 												},
@@ -13562,14 +13596,14 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 32,
-															Line:   249,
+															Column: 31,
+															Line:   250,
 														},
 														File:   "universe.flux",
 														Source: "every",
 														Start: ast.Position{
-															Column: 27,
-															Line:   249,
+															Column: 26,
+															Line:   250,
 														},
 													},
 												},
@@ -13580,14 +13614,14 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 48,
-														Line:   249,
+														Column: 47,
+														Line:   250,
 													},
 													File:   "universe.flux",
 													Source: "period: period",
 													Start: ast.Position{
-														Column: 34,
-														Line:   249,
+														Column: 33,
+														Line:   250,
 													},
 												},
 											},
@@ -13596,14 +13630,14 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 40,
-															Line:   249,
+															Column: 39,
+															Line:   250,
 														},
 														File:   "universe.flux",
 														Source: "period",
 														Start: ast.Position{
-															Column: 34,
-															Line:   249,
+															Column: 33,
+															Line:   250,
 														},
 													},
 												},
@@ -13614,14 +13648,14 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 48,
-															Line:   249,
+															Column: 47,
+															Line:   250,
 														},
 														File:   "universe.flux",
 														Source: "period",
 														Start: ast.Position{
-															Column: 42,
-															Line:   249,
+															Column: 41,
+															Line:   250,
 														},
 													},
 												},
@@ -13634,14 +13668,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 49,
-												Line:   249,
+												Column: 48,
+												Line:   250,
 											},
 											File:   "universe.flux",
 											Source: "window(every: every, period: period)",
 											Start: ast.Position{
-												Column: 13,
-												Line:   249,
+												Column: 12,
+												Line:   250,
 											},
 										},
 									},
@@ -13650,14 +13684,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 19,
-													Line:   249,
+													Column: 18,
+													Line:   250,
 												},
 												File:   "universe.flux",
 												Source: "window",
 												Start: ast.Position{
-													Column: 13,
-													Line:   249,
+													Column: 12,
+													Line:   250,
 												},
 											},
 										},
@@ -13669,14 +13703,14 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 32,
-										Line:   250,
+										Column: 31,
+										Line:   251,
 									},
 									File:   "universe.flux",
-									Source: "tables\n         |> window(every: every, period: period)\n         |> mean(column:column)",
+									Source: "tables\n        |> window(every: every, period: period)\n        |> mean(column:column)",
 									Start: ast.Position{
-										Column: 6,
-										Line:   248,
+										Column: 5,
+										Line:   249,
 									},
 								},
 							},
@@ -13686,14 +13720,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 31,
-												Line:   250,
+												Column: 30,
+												Line:   251,
 											},
 											File:   "universe.flux",
 											Source: "column:column",
 											Start: ast.Position{
-												Column: 18,
-												Line:   250,
+												Column: 17,
+												Line:   251,
 											},
 										},
 									},
@@ -13702,14 +13736,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 31,
-													Line:   250,
+													Column: 30,
+													Line:   251,
 												},
 												File:   "universe.flux",
 												Source: "column:column",
 												Start: ast.Position{
-													Column: 18,
-													Line:   250,
+													Column: 17,
+													Line:   251,
 												},
 											},
 										},
@@ -13718,14 +13752,14 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 24,
-														Line:   250,
+														Column: 23,
+														Line:   251,
 													},
 													File:   "universe.flux",
 													Source: "column",
 													Start: ast.Position{
-														Column: 18,
-														Line:   250,
+														Column: 17,
+														Line:   251,
 													},
 												},
 											},
@@ -13736,14 +13770,14 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 31,
-														Line:   250,
+														Column: 30,
+														Line:   251,
 													},
 													File:   "universe.flux",
 													Source: "column",
 													Start: ast.Position{
-														Column: 25,
-														Line:   250,
+														Column: 24,
+														Line:   251,
 													},
 												},
 											},
@@ -13756,14 +13790,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 32,
-											Line:   250,
+											Column: 31,
+											Line:   251,
 										},
 										File:   "universe.flux",
 										Source: "mean(column:column)",
 										Start: ast.Position{
-											Column: 13,
-											Line:   250,
+											Column: 12,
+											Line:   251,
 										},
 									},
 								},
@@ -13772,14 +13806,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 17,
-												Line:   250,
+												Column: 16,
+												Line:   251,
 											},
 											File:   "universe.flux",
 											Source: "mean",
 											Start: ast.Position{
-												Column: 13,
-												Line:   250,
+												Column: 12,
+												Line:   251,
 											},
 										},
 									},
@@ -13791,14 +13825,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 52,
-									Line:   251,
+									Column: 51,
+									Line:   252,
 								},
 								File:   "universe.flux",
-								Source: "tables\n         |> window(every: every, period: period)\n         |> mean(column:column)\n         |> duplicate(column: \"_stop\", as: \"_time\")",
+								Source: "tables\n        |> window(every: every, period: period)\n        |> mean(column:column)\n        |> duplicate(column: \"_stop\", as: \"_time\")",
 								Start: ast.Position{
-									Column: 6,
-									Line:   248,
+									Column: 5,
+									Line:   249,
 								},
 							},
 						},
@@ -13808,14 +13842,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 51,
-											Line:   251,
+											Column: 50,
+											Line:   252,
 										},
 										File:   "universe.flux",
 										Source: "column: \"_stop\", as: \"_time\"",
 										Start: ast.Position{
-											Column: 23,
-											Line:   251,
+											Column: 22,
+											Line:   252,
 										},
 									},
 								},
@@ -13824,14 +13858,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 38,
-												Line:   251,
+												Column: 37,
+												Line:   252,
 											},
 											File:   "universe.flux",
 											Source: "column: \"_stop\"",
 											Start: ast.Position{
-												Column: 23,
-												Line:   251,
+												Column: 22,
+												Line:   252,
 											},
 										},
 									},
@@ -13840,14 +13874,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 29,
-													Line:   251,
+													Column: 28,
+													Line:   252,
 												},
 												File:   "universe.flux",
 												Source: "column",
 												Start: ast.Position{
-													Column: 23,
-													Line:   251,
+													Column: 22,
+													Line:   252,
 												},
 											},
 										},
@@ -13858,14 +13892,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 38,
-													Line:   251,
+													Column: 37,
+													Line:   252,
 												},
 												File:   "universe.flux",
 												Source: "\"_stop\"",
 												Start: ast.Position{
-													Column: 31,
-													Line:   251,
+													Column: 30,
+													Line:   252,
 												},
 											},
 										},
@@ -13876,14 +13910,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 51,
-												Line:   251,
+												Column: 50,
+												Line:   252,
 											},
 											File:   "universe.flux",
 											Source: "as: \"_time\"",
 											Start: ast.Position{
-												Column: 40,
-												Line:   251,
+												Column: 39,
+												Line:   252,
 											},
 										},
 									},
@@ -13892,14 +13926,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 42,
-													Line:   251,
+													Column: 41,
+													Line:   252,
 												},
 												File:   "universe.flux",
 												Source: "as",
 												Start: ast.Position{
-													Column: 40,
-													Line:   251,
+													Column: 39,
+													Line:   252,
 												},
 											},
 										},
@@ -13910,14 +13944,14 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 51,
-													Line:   251,
+													Column: 50,
+													Line:   252,
 												},
 												File:   "universe.flux",
 												Source: "\"_time\"",
 												Start: ast.Position{
-													Column: 44,
-													Line:   251,
+													Column: 43,
+													Line:   252,
 												},
 											},
 										},
@@ -13930,14 +13964,14 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 52,
-										Line:   251,
+										Column: 51,
+										Line:   252,
 									},
 									File:   "universe.flux",
 									Source: "duplicate(column: \"_stop\", as: \"_time\")",
 									Start: ast.Position{
-										Column: 13,
-										Line:   251,
+										Column: 12,
+										Line:   252,
 									},
 								},
 							},
@@ -13946,14 +13980,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 22,
-											Line:   251,
+											Column: 21,
+											Line:   252,
 										},
 										File:   "universe.flux",
 										Source: "duplicate",
 										Start: ast.Position{
-											Column: 13,
-											Line:   251,
+											Column: 12,
+											Line:   252,
 										},
 									},
 								},
@@ -13965,14 +13999,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 31,
-								Line:   252,
+								Column: 30,
+								Line:   253,
 							},
 							File:   "universe.flux",
-							Source: "tables\n         |> window(every: every, period: period)\n         |> mean(column:column)\n         |> duplicate(column: \"_stop\", as: \"_time\")\n         |> window(every: inf)",
+							Source: "tables\n        |> window(every: every, period: period)\n        |> mean(column:column)\n        |> duplicate(column: \"_stop\", as: \"_time\")\n        |> window(every: inf)",
 							Start: ast.Position{
-								Column: 6,
-								Line:   248,
+								Column: 5,
+								Line:   249,
 							},
 						},
 					},
@@ -13982,14 +14016,14 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 30,
-										Line:   252,
+										Column: 29,
+										Line:   253,
 									},
 									File:   "universe.flux",
 									Source: "every: inf",
 									Start: ast.Position{
-										Column: 20,
-										Line:   252,
+										Column: 19,
+										Line:   253,
 									},
 								},
 							},
@@ -13998,14 +14032,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 30,
-											Line:   252,
+											Column: 29,
+											Line:   253,
 										},
 										File:   "universe.flux",
 										Source: "every: inf",
 										Start: ast.Position{
-											Column: 20,
-											Line:   252,
+											Column: 19,
+											Line:   253,
 										},
 									},
 								},
@@ -14014,14 +14048,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 25,
-												Line:   252,
+												Column: 24,
+												Line:   253,
 											},
 											File:   "universe.flux",
 											Source: "every",
 											Start: ast.Position{
-												Column: 20,
-												Line:   252,
+												Column: 19,
+												Line:   253,
 											},
 										},
 									},
@@ -14032,14 +14066,14 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 30,
-												Line:   252,
+												Column: 29,
+												Line:   253,
 											},
 											File:   "universe.flux",
 											Source: "inf",
 											Start: ast.Position{
-												Column: 27,
-												Line:   252,
+												Column: 26,
+												Line:   253,
 											},
 										},
 									},
@@ -14052,14 +14086,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 31,
-									Line:   252,
+									Column: 30,
+									Line:   253,
 								},
 								File:   "universe.flux",
 								Source: "window(every: inf)",
 								Start: ast.Position{
-									Column: 13,
-									Line:   252,
+									Column: 12,
+									Line:   253,
 								},
 							},
 						},
@@ -14068,14 +14102,14 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 19,
-										Line:   252,
+										Column: 18,
+										Line:   253,
 									},
 									File:   "universe.flux",
 									Source: "window",
 									Start: ast.Position{
-										Column: 13,
-										Line:   252,
+										Column: 12,
+										Line:   253,
 									},
 								},
 							},
@@ -14088,14 +14122,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 24,
-								Line:   247,
+								Column: 28,
+								Line:   248,
 							},
 							File:   "universe.flux",
 							Source: "every",
 							Start: ast.Position{
-								Column: 19,
-								Line:   247,
+								Column: 23,
+								Line:   248,
 							},
 						},
 					},
@@ -14104,14 +14138,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 24,
-									Line:   247,
+									Column: 28,
+									Line:   248,
 								},
 								File:   "universe.flux",
 								Source: "every",
 								Start: ast.Position{
-									Column: 19,
-									Line:   247,
+									Column: 23,
+									Line:   248,
 								},
 							},
 						},
@@ -14123,14 +14157,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 32,
-								Line:   247,
+								Column: 36,
+								Line:   248,
 							},
 							File:   "universe.flux",
 							Source: "period",
 							Start: ast.Position{
-								Column: 26,
-								Line:   247,
+								Column: 30,
+								Line:   248,
 							},
 						},
 					},
@@ -14139,14 +14173,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 32,
-									Line:   247,
+									Column: 36,
+									Line:   248,
 								},
 								File:   "universe.flux",
 								Source: "period",
 								Start: ast.Position{
-									Column: 26,
-									Line:   247,
+									Column: 30,
+									Line:   248,
 								},
 							},
 						},
@@ -14158,14 +14192,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 49,
-								Line:   247,
+								Column: 53,
+								Line:   248,
 							},
 							File:   "universe.flux",
 							Source: "column=\"_value\"",
 							Start: ast.Position{
-								Column: 34,
-								Line:   247,
+								Column: 38,
+								Line:   248,
 							},
 						},
 					},
@@ -14174,14 +14208,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 40,
-									Line:   247,
+									Column: 44,
+									Line:   248,
 								},
 								File:   "universe.flux",
 								Source: "column",
 								Start: ast.Position{
-									Column: 34,
-									Line:   247,
+									Column: 38,
+									Line:   248,
 								},
 							},
 						},
@@ -14192,14 +14226,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 49,
-									Line:   247,
+									Column: 53,
+									Line:   248,
 								},
 								File:   "universe.flux",
 								Source: "\"_value\"",
 								Start: ast.Position{
-									Column: 41,
-									Line:   247,
+									Column: 45,
+									Line:   248,
 								},
 							},
 						},
@@ -14210,14 +14244,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 60,
-								Line:   247,
+								Column: 64,
+								Line:   248,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
-								Column: 51,
-								Line:   247,
+								Column: 55,
+								Line:   248,
 							},
 						},
 					},
@@ -14226,14 +14260,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 57,
-									Line:   247,
+									Column: 61,
+									Line:   248,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
-									Column: 51,
-									Line:   247,
+									Column: 55,
+									Line:   248,
 								},
 							},
 						},
@@ -14243,14 +14277,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 60,
-								Line:   247,
+								Column: 64,
+								Line:   248,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
-								Column: 58,
-								Line:   247,
+								Column: 62,
+								Line:   248,
 							},
 						},
 					}},
@@ -14262,13 +14296,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 91,
-						Line:   254,
+						Line:   255,
 					},
 					File:   "universe.flux",
 					Source: "toString   = (tables=<-) => tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))",
 					Start: ast.Position{
 						Column: 1,
-						Line:   254,
+						Line:   255,
 					},
 				},
 			},
@@ -14278,13 +14312,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 9,
-							Line:   254,
+							Line:   255,
 						},
 						File:   "universe.flux",
 						Source: "toString",
 						Start: ast.Position{
 							Column: 1,
-							Line:   254,
+							Line:   255,
 						},
 					},
 				},
@@ -14296,13 +14330,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 91,
-							Line:   254,
+							Line:   255,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-) => tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))",
 						Start: ast.Position{
 							Column: 14,
-							Line:   254,
+							Line:   255,
 						},
 					},
 				},
@@ -14313,13 +14347,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 35,
-									Line:   254,
+									Line:   255,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 29,
-									Line:   254,
+									Line:   255,
 								},
 							},
 						},
@@ -14330,13 +14364,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 91,
-								Line:   254,
+								Line:   255,
 							},
 							File:   "universe.flux",
 							Source: "tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))",
 							Start: ast.Position{
 								Column: 29,
-								Line:   254,
+								Line:   255,
 							},
 						},
 					},
@@ -14347,13 +14381,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 89,
-										Line:   254,
+										Line:   255,
 									},
 									File:   "universe.flux",
 									Source: "fn:(r) => ({r with _value: string(v:r._value)}",
 									Start: ast.Position{
 										Column: 43,
-										Line:   254,
+										Line:   255,
 									},
 								},
 							},
@@ -14363,13 +14397,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 89,
-											Line:   254,
+											Line:   255,
 										},
 										File:   "universe.flux",
 										Source: "fn:(r) => ({r with _value: string(v:r._value)}",
 										Start: ast.Position{
 											Column: 43,
-											Line:   254,
+											Line:   255,
 										},
 									},
 								},
@@ -14379,13 +14413,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   254,
+												Line:   255,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 43,
-												Line:   254,
+												Line:   255,
 											},
 										},
 									},
@@ -14397,13 +14431,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 89,
-												Line:   254,
+												Line:   255,
 											},
 											File:   "universe.flux",
 											Source: "(r) => ({r with _value: string(v:r._value)}",
 											Start: ast.Position{
 												Column: 46,
-												Line:   254,
+												Line:   255,
 											},
 										},
 									},
@@ -14413,13 +14447,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 89,
-													Line:   254,
+													Line:   255,
 												},
 												File:   "universe.flux",
 												Source: "{r with _value: string(v:r._value)}",
 												Start: ast.Position{
 													Column: 54,
-													Line:   254,
+													Line:   255,
 												},
 											},
 										},
@@ -14429,13 +14463,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 88,
-														Line:   254,
+														Line:   255,
 													},
 													File:   "universe.flux",
 													Source: "_value: string(v:r._value)",
 													Start: ast.Position{
 														Column: 62,
-														Line:   254,
+														Line:   255,
 													},
 												},
 											},
@@ -14445,13 +14479,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   254,
+															Line:   255,
 														},
 														File:   "universe.flux",
 														Source: "_value",
 														Start: ast.Position{
 															Column: 62,
-															Line:   254,
+															Line:   255,
 														},
 													},
 												},
@@ -14464,13 +14498,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 87,
-																Line:   254,
+																Line:   255,
 															},
 															File:   "universe.flux",
 															Source: "v:r._value",
 															Start: ast.Position{
 																Column: 77,
-																Line:   254,
+																Line:   255,
 															},
 														},
 													},
@@ -14480,13 +14514,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 87,
-																	Line:   254,
+																	Line:   255,
 																},
 																File:   "universe.flux",
 																Source: "v:r._value",
 																Start: ast.Position{
 																	Column: 77,
-																	Line:   254,
+																	Line:   255,
 																},
 															},
 														},
@@ -14496,13 +14530,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 78,
-																		Line:   254,
+																		Line:   255,
 																	},
 																	File:   "universe.flux",
 																	Source: "v",
 																	Start: ast.Position{
 																		Column: 77,
-																		Line:   254,
+																		Line:   255,
 																	},
 																},
 															},
@@ -14514,13 +14548,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 87,
-																		Line:   254,
+																		Line:   255,
 																	},
 																	File:   "universe.flux",
 																	Source: "r._value",
 																	Start: ast.Position{
 																		Column: 79,
-																		Line:   254,
+																		Line:   255,
 																	},
 																},
 															},
@@ -14530,13 +14564,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 80,
-																			Line:   254,
+																			Line:   255,
 																		},
 																		File:   "universe.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 79,
-																			Line:   254,
+																			Line:   255,
 																		},
 																	},
 																},
@@ -14548,13 +14582,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 87,
-																			Line:   254,
+																			Line:   255,
 																		},
 																		File:   "universe.flux",
 																		Source: "_value",
 																		Start: ast.Position{
 																			Column: 81,
-																			Line:   254,
+																			Line:   255,
 																		},
 																	},
 																},
@@ -14569,13 +14603,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 88,
-															Line:   254,
+															Line:   255,
 														},
 														File:   "universe.flux",
 														Source: "string(v:r._value)",
 														Start: ast.Position{
 															Column: 70,
-															Line:   254,
+															Line:   255,
 														},
 													},
 												},
@@ -14585,13 +14619,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 76,
-																Line:   254,
+																Line:   255,
 															},
 															File:   "universe.flux",
 															Source: "string",
 															Start: ast.Position{
 																Column: 70,
-																Line:   254,
+																Line:   255,
 															},
 														},
 													},
@@ -14605,13 +14639,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   254,
+														Line:   255,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 55,
-														Line:   254,
+														Line:   255,
 													},
 												},
 											},
@@ -14624,13 +14658,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   254,
+													Line:   255,
 												},
 												File:   "universe.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 47,
-													Line:   254,
+													Line:   255,
 												},
 											},
 										},
@@ -14640,13 +14674,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   254,
+														Line:   255,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   254,
+														Line:   255,
 													},
 												},
 											},
@@ -14663,13 +14697,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 91,
-									Line:   254,
+									Line:   255,
 								},
 								File:   "universe.flux",
 								Source: "map(fn:(r) => ({r with _value: string(v:r._value)}))",
 								Start: ast.Position{
 									Column: 39,
-									Line:   254,
+									Line:   255,
 								},
 							},
 						},
@@ -14679,13 +14713,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   254,
+										Line:   255,
 									},
 									File:   "universe.flux",
 									Source: "map",
 									Start: ast.Position{
 										Column: 39,
-										Line:   254,
+										Line:   255,
 									},
 								},
 							},
@@ -14699,13 +14733,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   254,
+								Line:   255,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 15,
-								Line:   254,
+								Line:   255,
 							},
 						},
 					},
@@ -14715,13 +14749,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   254,
+									Line:   255,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 15,
-									Line:   254,
+									Line:   255,
 								},
 							},
 						},
@@ -14732,13 +14766,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   254,
+								Line:   255,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 22,
-								Line:   254,
+								Line:   255,
 							},
 						},
 					}},
@@ -14750,13 +14784,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 88,
-						Line:   255,
+						Line:   256,
 					},
 					File:   "universe.flux",
 					Source: "toInt      = (tables=<-) => tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))",
 					Start: ast.Position{
 						Column: 1,
-						Line:   255,
+						Line:   256,
 					},
 				},
 			},
@@ -14766,13 +14800,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 6,
-							Line:   255,
+							Line:   256,
 						},
 						File:   "universe.flux",
 						Source: "toInt",
 						Start: ast.Position{
 							Column: 1,
-							Line:   255,
+							Line:   256,
 						},
 					},
 				},
@@ -14784,13 +14818,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 88,
-							Line:   255,
+							Line:   256,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-) => tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))",
 						Start: ast.Position{
 							Column: 14,
-							Line:   255,
+							Line:   256,
 						},
 					},
 				},
@@ -14801,13 +14835,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 35,
-									Line:   255,
+									Line:   256,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 29,
-									Line:   255,
+									Line:   256,
 								},
 							},
 						},
@@ -14818,13 +14852,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 88,
-								Line:   255,
+								Line:   256,
 							},
 							File:   "universe.flux",
 							Source: "tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))",
 							Start: ast.Position{
 								Column: 29,
-								Line:   255,
+								Line:   256,
 							},
 						},
 					},
@@ -14835,13 +14869,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 86,
-										Line:   255,
+										Line:   256,
 									},
 									File:   "universe.flux",
 									Source: "fn:(r) => ({r with _value: int(v:r._value)}",
 									Start: ast.Position{
 										Column: 43,
-										Line:   255,
+										Line:   256,
 									},
 								},
 							},
@@ -14851,13 +14885,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 86,
-											Line:   255,
+											Line:   256,
 										},
 										File:   "universe.flux",
 										Source: "fn:(r) => ({r with _value: int(v:r._value)}",
 										Start: ast.Position{
 											Column: 43,
-											Line:   255,
+											Line:   256,
 										},
 									},
 								},
@@ -14867,13 +14901,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   255,
+												Line:   256,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 43,
-												Line:   255,
+												Line:   256,
 											},
 										},
 									},
@@ -14885,13 +14919,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 86,
-												Line:   255,
+												Line:   256,
 											},
 											File:   "universe.flux",
 											Source: "(r) => ({r with _value: int(v:r._value)}",
 											Start: ast.Position{
 												Column: 46,
-												Line:   255,
+												Line:   256,
 											},
 										},
 									},
@@ -14901,13 +14935,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 86,
-													Line:   255,
+													Line:   256,
 												},
 												File:   "universe.flux",
 												Source: "{r with _value: int(v:r._value)}",
 												Start: ast.Position{
 													Column: 54,
-													Line:   255,
+													Line:   256,
 												},
 											},
 										},
@@ -14917,13 +14951,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 85,
-														Line:   255,
+														Line:   256,
 													},
 													File:   "universe.flux",
 													Source: "_value: int(v:r._value)",
 													Start: ast.Position{
 														Column: 62,
-														Line:   255,
+														Line:   256,
 													},
 												},
 											},
@@ -14933,13 +14967,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   255,
+															Line:   256,
 														},
 														File:   "universe.flux",
 														Source: "_value",
 														Start: ast.Position{
 															Column: 62,
-															Line:   255,
+															Line:   256,
 														},
 													},
 												},
@@ -14952,13 +14986,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 84,
-																Line:   255,
+																Line:   256,
 															},
 															File:   "universe.flux",
 															Source: "v:r._value",
 															Start: ast.Position{
 																Column: 74,
-																Line:   255,
+																Line:   256,
 															},
 														},
 													},
@@ -14968,13 +15002,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 84,
-																	Line:   255,
+																	Line:   256,
 																},
 																File:   "universe.flux",
 																Source: "v:r._value",
 																Start: ast.Position{
 																	Column: 74,
-																	Line:   255,
+																	Line:   256,
 																},
 															},
 														},
@@ -14984,13 +15018,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 75,
-																		Line:   255,
+																		Line:   256,
 																	},
 																	File:   "universe.flux",
 																	Source: "v",
 																	Start: ast.Position{
 																		Column: 74,
-																		Line:   255,
+																		Line:   256,
 																	},
 																},
 															},
@@ -15002,13 +15036,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 84,
-																		Line:   255,
+																		Line:   256,
 																	},
 																	File:   "universe.flux",
 																	Source: "r._value",
 																	Start: ast.Position{
 																		Column: 76,
-																		Line:   255,
+																		Line:   256,
 																	},
 																},
 															},
@@ -15018,13 +15052,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 77,
-																			Line:   255,
+																			Line:   256,
 																		},
 																		File:   "universe.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 76,
-																			Line:   255,
+																			Line:   256,
 																		},
 																	},
 																},
@@ -15036,13 +15070,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 84,
-																			Line:   255,
+																			Line:   256,
 																		},
 																		File:   "universe.flux",
 																		Source: "_value",
 																		Start: ast.Position{
 																			Column: 78,
-																			Line:   255,
+																			Line:   256,
 																		},
 																	},
 																},
@@ -15057,13 +15091,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 85,
-															Line:   255,
+															Line:   256,
 														},
 														File:   "universe.flux",
 														Source: "int(v:r._value)",
 														Start: ast.Position{
 															Column: 70,
-															Line:   255,
+															Line:   256,
 														},
 													},
 												},
@@ -15073,13 +15107,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 73,
-																Line:   255,
+																Line:   256,
 															},
 															File:   "universe.flux",
 															Source: "int",
 															Start: ast.Position{
 																Column: 70,
-																Line:   255,
+																Line:   256,
 															},
 														},
 													},
@@ -15093,13 +15127,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   255,
+														Line:   256,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 55,
-														Line:   255,
+														Line:   256,
 													},
 												},
 											},
@@ -15112,13 +15146,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   255,
+													Line:   256,
 												},
 												File:   "universe.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 47,
-													Line:   255,
+													Line:   256,
 												},
 											},
 										},
@@ -15128,13 +15162,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   255,
+														Line:   256,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   255,
+														Line:   256,
 													},
 												},
 											},
@@ -15151,13 +15185,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 88,
-									Line:   255,
+									Line:   256,
 								},
 								File:   "universe.flux",
 								Source: "map(fn:(r) => ({r with _value: int(v:r._value)}))",
 								Start: ast.Position{
 									Column: 39,
-									Line:   255,
+									Line:   256,
 								},
 							},
 						},
@@ -15167,13 +15201,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   255,
+										Line:   256,
 									},
 									File:   "universe.flux",
 									Source: "map",
 									Start: ast.Position{
 										Column: 39,
-										Line:   255,
+										Line:   256,
 									},
 								},
 							},
@@ -15187,13 +15221,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   255,
+								Line:   256,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 15,
-								Line:   255,
+								Line:   256,
 							},
 						},
 					},
@@ -15203,13 +15237,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   255,
+									Line:   256,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 15,
-									Line:   255,
+									Line:   256,
 								},
 							},
 						},
@@ -15220,13 +15254,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   255,
+								Line:   256,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 22,
-								Line:   255,
+								Line:   256,
 							},
 						},
 					}},
@@ -15238,13 +15272,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 89,
-						Line:   256,
+						Line:   257,
 					},
 					File:   "universe.flux",
 					Source: "toUInt     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: uint(v:r._value)}))",
 					Start: ast.Position{
 						Column: 1,
-						Line:   256,
+						Line:   257,
 					},
 				},
 			},
@@ -15254,13 +15288,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   256,
+							Line:   257,
 						},
 						File:   "universe.flux",
 						Source: "toUInt",
 						Start: ast.Position{
 							Column: 1,
-							Line:   256,
+							Line:   257,
 						},
 					},
 				},
@@ -15272,13 +15306,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 89,
-							Line:   256,
+							Line:   257,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-) => tables |> map(fn:(r) => ({r with _value: uint(v:r._value)}))",
 						Start: ast.Position{
 							Column: 14,
-							Line:   256,
+							Line:   257,
 						},
 					},
 				},
@@ -15289,13 +15323,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 35,
-									Line:   256,
+									Line:   257,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 29,
-									Line:   256,
+									Line:   257,
 								},
 							},
 						},
@@ -15306,13 +15340,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 89,
-								Line:   256,
+								Line:   257,
 							},
 							File:   "universe.flux",
 							Source: "tables |> map(fn:(r) => ({r with _value: uint(v:r._value)}))",
 							Start: ast.Position{
 								Column: 29,
-								Line:   256,
+								Line:   257,
 							},
 						},
 					},
@@ -15323,13 +15357,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 87,
-										Line:   256,
+										Line:   257,
 									},
 									File:   "universe.flux",
 									Source: "fn:(r) => ({r with _value: uint(v:r._value)}",
 									Start: ast.Position{
 										Column: 43,
-										Line:   256,
+										Line:   257,
 									},
 								},
 							},
@@ -15339,13 +15373,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 87,
-											Line:   256,
+											Line:   257,
 										},
 										File:   "universe.flux",
 										Source: "fn:(r) => ({r with _value: uint(v:r._value)}",
 										Start: ast.Position{
 											Column: 43,
-											Line:   256,
+											Line:   257,
 										},
 									},
 								},
@@ -15355,13 +15389,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   256,
+												Line:   257,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 43,
-												Line:   256,
+												Line:   257,
 											},
 										},
 									},
@@ -15373,13 +15407,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 87,
-												Line:   256,
+												Line:   257,
 											},
 											File:   "universe.flux",
 											Source: "(r) => ({r with _value: uint(v:r._value)}",
 											Start: ast.Position{
 												Column: 46,
-												Line:   256,
+												Line:   257,
 											},
 										},
 									},
@@ -15389,13 +15423,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 87,
-													Line:   256,
+													Line:   257,
 												},
 												File:   "universe.flux",
 												Source: "{r with _value: uint(v:r._value)}",
 												Start: ast.Position{
 													Column: 54,
-													Line:   256,
+													Line:   257,
 												},
 											},
 										},
@@ -15405,13 +15439,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 86,
-														Line:   256,
+														Line:   257,
 													},
 													File:   "universe.flux",
 													Source: "_value: uint(v:r._value)",
 													Start: ast.Position{
 														Column: 62,
-														Line:   256,
+														Line:   257,
 													},
 												},
 											},
@@ -15421,13 +15455,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   256,
+															Line:   257,
 														},
 														File:   "universe.flux",
 														Source: "_value",
 														Start: ast.Position{
 															Column: 62,
-															Line:   256,
+															Line:   257,
 														},
 													},
 												},
@@ -15440,13 +15474,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 85,
-																Line:   256,
+																Line:   257,
 															},
 															File:   "universe.flux",
 															Source: "v:r._value",
 															Start: ast.Position{
 																Column: 75,
-																Line:   256,
+																Line:   257,
 															},
 														},
 													},
@@ -15456,13 +15490,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 85,
-																	Line:   256,
+																	Line:   257,
 																},
 																File:   "universe.flux",
 																Source: "v:r._value",
 																Start: ast.Position{
 																	Column: 75,
-																	Line:   256,
+																	Line:   257,
 																},
 															},
 														},
@@ -15472,13 +15506,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 76,
-																		Line:   256,
+																		Line:   257,
 																	},
 																	File:   "universe.flux",
 																	Source: "v",
 																	Start: ast.Position{
 																		Column: 75,
-																		Line:   256,
+																		Line:   257,
 																	},
 																},
 															},
@@ -15490,13 +15524,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 85,
-																		Line:   256,
+																		Line:   257,
 																	},
 																	File:   "universe.flux",
 																	Source: "r._value",
 																	Start: ast.Position{
 																		Column: 77,
-																		Line:   256,
+																		Line:   257,
 																	},
 																},
 															},
@@ -15506,13 +15540,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 78,
-																			Line:   256,
+																			Line:   257,
 																		},
 																		File:   "universe.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 77,
-																			Line:   256,
+																			Line:   257,
 																		},
 																	},
 																},
@@ -15524,13 +15558,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 85,
-																			Line:   256,
+																			Line:   257,
 																		},
 																		File:   "universe.flux",
 																		Source: "_value",
 																		Start: ast.Position{
 																			Column: 79,
-																			Line:   256,
+																			Line:   257,
 																		},
 																	},
 																},
@@ -15545,13 +15579,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 86,
-															Line:   256,
+															Line:   257,
 														},
 														File:   "universe.flux",
 														Source: "uint(v:r._value)",
 														Start: ast.Position{
 															Column: 70,
-															Line:   256,
+															Line:   257,
 														},
 													},
 												},
@@ -15561,13 +15595,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 74,
-																Line:   256,
+																Line:   257,
 															},
 															File:   "universe.flux",
 															Source: "uint",
 															Start: ast.Position{
 																Column: 70,
-																Line:   256,
+																Line:   257,
 															},
 														},
 													},
@@ -15581,13 +15615,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   256,
+														Line:   257,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 55,
-														Line:   256,
+														Line:   257,
 													},
 												},
 											},
@@ -15600,13 +15634,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   256,
+													Line:   257,
 												},
 												File:   "universe.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 47,
-													Line:   256,
+													Line:   257,
 												},
 											},
 										},
@@ -15616,13 +15650,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   256,
+														Line:   257,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   256,
+														Line:   257,
 													},
 												},
 											},
@@ -15639,13 +15673,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 89,
-									Line:   256,
+									Line:   257,
 								},
 								File:   "universe.flux",
 								Source: "map(fn:(r) => ({r with _value: uint(v:r._value)}))",
 								Start: ast.Position{
 									Column: 39,
-									Line:   256,
+									Line:   257,
 								},
 							},
 						},
@@ -15655,13 +15689,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   256,
+										Line:   257,
 									},
 									File:   "universe.flux",
 									Source: "map",
 									Start: ast.Position{
 										Column: 39,
-										Line:   256,
+										Line:   257,
 									},
 								},
 							},
@@ -15675,13 +15709,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   256,
+								Line:   257,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 15,
-								Line:   256,
+								Line:   257,
 							},
 						},
 					},
@@ -15691,13 +15725,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   256,
+									Line:   257,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 15,
-									Line:   256,
+									Line:   257,
 								},
 							},
 						},
@@ -15708,13 +15742,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   256,
+								Line:   257,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 22,
-								Line:   256,
+								Line:   257,
 							},
 						},
 					}},
@@ -15726,13 +15760,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 90,
-						Line:   257,
+						Line:   258,
 					},
 					File:   "universe.flux",
 					Source: "toFloat    = (tables=<-) => tables |> map(fn:(r) => ({r with _value: float(v:r._value)}))",
 					Start: ast.Position{
 						Column: 1,
-						Line:   257,
+						Line:   258,
 					},
 				},
 			},
@@ -15742,13 +15776,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 8,
-							Line:   257,
+							Line:   258,
 						},
 						File:   "universe.flux",
 						Source: "toFloat",
 						Start: ast.Position{
 							Column: 1,
-							Line:   257,
+							Line:   258,
 						},
 					},
 				},
@@ -15760,13 +15794,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 90,
-							Line:   257,
+							Line:   258,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-) => tables |> map(fn:(r) => ({r with _value: float(v:r._value)}))",
 						Start: ast.Position{
 							Column: 14,
-							Line:   257,
+							Line:   258,
 						},
 					},
 				},
@@ -15777,13 +15811,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 35,
-									Line:   257,
+									Line:   258,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 29,
-									Line:   257,
+									Line:   258,
 								},
 							},
 						},
@@ -15794,13 +15828,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 90,
-								Line:   257,
+								Line:   258,
 							},
 							File:   "universe.flux",
 							Source: "tables |> map(fn:(r) => ({r with _value: float(v:r._value)}))",
 							Start: ast.Position{
 								Column: 29,
-								Line:   257,
+								Line:   258,
 							},
 						},
 					},
@@ -15811,13 +15845,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 88,
-										Line:   257,
+										Line:   258,
 									},
 									File:   "universe.flux",
 									Source: "fn:(r) => ({r with _value: float(v:r._value)}",
 									Start: ast.Position{
 										Column: 43,
-										Line:   257,
+										Line:   258,
 									},
 								},
 							},
@@ -15827,13 +15861,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 88,
-											Line:   257,
+											Line:   258,
 										},
 										File:   "universe.flux",
 										Source: "fn:(r) => ({r with _value: float(v:r._value)}",
 										Start: ast.Position{
 											Column: 43,
-											Line:   257,
+											Line:   258,
 										},
 									},
 								},
@@ -15843,13 +15877,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   257,
+												Line:   258,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 43,
-												Line:   257,
+												Line:   258,
 											},
 										},
 									},
@@ -15861,13 +15895,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 88,
-												Line:   257,
+												Line:   258,
 											},
 											File:   "universe.flux",
 											Source: "(r) => ({r with _value: float(v:r._value)}",
 											Start: ast.Position{
 												Column: 46,
-												Line:   257,
+												Line:   258,
 											},
 										},
 									},
@@ -15877,13 +15911,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 88,
-													Line:   257,
+													Line:   258,
 												},
 												File:   "universe.flux",
 												Source: "{r with _value: float(v:r._value)}",
 												Start: ast.Position{
 													Column: 54,
-													Line:   257,
+													Line:   258,
 												},
 											},
 										},
@@ -15893,13 +15927,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 87,
-														Line:   257,
+														Line:   258,
 													},
 													File:   "universe.flux",
 													Source: "_value: float(v:r._value)",
 													Start: ast.Position{
 														Column: 62,
-														Line:   257,
+														Line:   258,
 													},
 												},
 											},
@@ -15909,13 +15943,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   257,
+															Line:   258,
 														},
 														File:   "universe.flux",
 														Source: "_value",
 														Start: ast.Position{
 															Column: 62,
-															Line:   257,
+															Line:   258,
 														},
 													},
 												},
@@ -15928,13 +15962,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 86,
-																Line:   257,
+																Line:   258,
 															},
 															File:   "universe.flux",
 															Source: "v:r._value",
 															Start: ast.Position{
 																Column: 76,
-																Line:   257,
+																Line:   258,
 															},
 														},
 													},
@@ -15944,13 +15978,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 86,
-																	Line:   257,
+																	Line:   258,
 																},
 																File:   "universe.flux",
 																Source: "v:r._value",
 																Start: ast.Position{
 																	Column: 76,
-																	Line:   257,
+																	Line:   258,
 																},
 															},
 														},
@@ -15960,13 +15994,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 77,
-																		Line:   257,
+																		Line:   258,
 																	},
 																	File:   "universe.flux",
 																	Source: "v",
 																	Start: ast.Position{
 																		Column: 76,
-																		Line:   257,
+																		Line:   258,
 																	},
 																},
 															},
@@ -15978,13 +16012,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 86,
-																		Line:   257,
+																		Line:   258,
 																	},
 																	File:   "universe.flux",
 																	Source: "r._value",
 																	Start: ast.Position{
 																		Column: 78,
-																		Line:   257,
+																		Line:   258,
 																	},
 																},
 															},
@@ -15994,13 +16028,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 79,
-																			Line:   257,
+																			Line:   258,
 																		},
 																		File:   "universe.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 78,
-																			Line:   257,
+																			Line:   258,
 																		},
 																	},
 																},
@@ -16012,13 +16046,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 86,
-																			Line:   257,
+																			Line:   258,
 																		},
 																		File:   "universe.flux",
 																		Source: "_value",
 																		Start: ast.Position{
 																			Column: 80,
-																			Line:   257,
+																			Line:   258,
 																		},
 																	},
 																},
@@ -16033,13 +16067,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 87,
-															Line:   257,
+															Line:   258,
 														},
 														File:   "universe.flux",
 														Source: "float(v:r._value)",
 														Start: ast.Position{
 															Column: 70,
-															Line:   257,
+															Line:   258,
 														},
 													},
 												},
@@ -16049,13 +16083,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 75,
-																Line:   257,
+																Line:   258,
 															},
 															File:   "universe.flux",
 															Source: "float",
 															Start: ast.Position{
 																Column: 70,
-																Line:   257,
+																Line:   258,
 															},
 														},
 													},
@@ -16069,13 +16103,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   257,
+														Line:   258,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 55,
-														Line:   257,
+														Line:   258,
 													},
 												},
 											},
@@ -16088,13 +16122,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   257,
+													Line:   258,
 												},
 												File:   "universe.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 47,
-													Line:   257,
+													Line:   258,
 												},
 											},
 										},
@@ -16104,13 +16138,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   257,
+														Line:   258,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   257,
+														Line:   258,
 													},
 												},
 											},
@@ -16127,13 +16161,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 90,
-									Line:   257,
+									Line:   258,
 								},
 								File:   "universe.flux",
 								Source: "map(fn:(r) => ({r with _value: float(v:r._value)}))",
 								Start: ast.Position{
 									Column: 39,
-									Line:   257,
+									Line:   258,
 								},
 							},
 						},
@@ -16143,13 +16177,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   257,
+										Line:   258,
 									},
 									File:   "universe.flux",
 									Source: "map",
 									Start: ast.Position{
 										Column: 39,
-										Line:   257,
+										Line:   258,
 									},
 								},
 							},
@@ -16163,13 +16197,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   257,
+								Line:   258,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 15,
-								Line:   257,
+								Line:   258,
 							},
 						},
 					},
@@ -16179,13 +16213,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   257,
+									Line:   258,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 15,
-									Line:   257,
+									Line:   258,
 								},
 							},
 						},
@@ -16196,13 +16230,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   257,
+								Line:   258,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 22,
-								Line:   257,
+								Line:   258,
 							},
 						},
 					}},
@@ -16214,13 +16248,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 89,
-						Line:   258,
+						Line:   259,
 					},
 					File:   "universe.flux",
 					Source: "toBool     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: bool(v:r._value)}))",
 					Start: ast.Position{
 						Column: 1,
-						Line:   258,
+						Line:   259,
 					},
 				},
 			},
@@ -16230,13 +16264,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   258,
+							Line:   259,
 						},
 						File:   "universe.flux",
 						Source: "toBool",
 						Start: ast.Position{
 							Column: 1,
-							Line:   258,
+							Line:   259,
 						},
 					},
 				},
@@ -16248,13 +16282,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 89,
-							Line:   258,
+							Line:   259,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-) => tables |> map(fn:(r) => ({r with _value: bool(v:r._value)}))",
 						Start: ast.Position{
 							Column: 14,
-							Line:   258,
+							Line:   259,
 						},
 					},
 				},
@@ -16265,13 +16299,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 35,
-									Line:   258,
+									Line:   259,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 29,
-									Line:   258,
+									Line:   259,
 								},
 							},
 						},
@@ -16282,13 +16316,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 89,
-								Line:   258,
+								Line:   259,
 							},
 							File:   "universe.flux",
 							Source: "tables |> map(fn:(r) => ({r with _value: bool(v:r._value)}))",
 							Start: ast.Position{
 								Column: 29,
-								Line:   258,
+								Line:   259,
 							},
 						},
 					},
@@ -16299,13 +16333,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 87,
-										Line:   258,
+										Line:   259,
 									},
 									File:   "universe.flux",
 									Source: "fn:(r) => ({r with _value: bool(v:r._value)}",
 									Start: ast.Position{
 										Column: 43,
-										Line:   258,
+										Line:   259,
 									},
 								},
 							},
@@ -16315,13 +16349,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 87,
-											Line:   258,
+											Line:   259,
 										},
 										File:   "universe.flux",
 										Source: "fn:(r) => ({r with _value: bool(v:r._value)}",
 										Start: ast.Position{
 											Column: 43,
-											Line:   258,
+											Line:   259,
 										},
 									},
 								},
@@ -16331,13 +16365,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   258,
+												Line:   259,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 43,
-												Line:   258,
+												Line:   259,
 											},
 										},
 									},
@@ -16349,13 +16383,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 87,
-												Line:   258,
+												Line:   259,
 											},
 											File:   "universe.flux",
 											Source: "(r) => ({r with _value: bool(v:r._value)}",
 											Start: ast.Position{
 												Column: 46,
-												Line:   258,
+												Line:   259,
 											},
 										},
 									},
@@ -16365,13 +16399,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 87,
-													Line:   258,
+													Line:   259,
 												},
 												File:   "universe.flux",
 												Source: "{r with _value: bool(v:r._value)}",
 												Start: ast.Position{
 													Column: 54,
-													Line:   258,
+													Line:   259,
 												},
 											},
 										},
@@ -16381,13 +16415,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 86,
-														Line:   258,
+														Line:   259,
 													},
 													File:   "universe.flux",
 													Source: "_value: bool(v:r._value)",
 													Start: ast.Position{
 														Column: 62,
-														Line:   258,
+														Line:   259,
 													},
 												},
 											},
@@ -16397,13 +16431,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   258,
+															Line:   259,
 														},
 														File:   "universe.flux",
 														Source: "_value",
 														Start: ast.Position{
 															Column: 62,
-															Line:   258,
+															Line:   259,
 														},
 													},
 												},
@@ -16416,13 +16450,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 85,
-																Line:   258,
+																Line:   259,
 															},
 															File:   "universe.flux",
 															Source: "v:r._value",
 															Start: ast.Position{
 																Column: 75,
-																Line:   258,
+																Line:   259,
 															},
 														},
 													},
@@ -16432,13 +16466,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 85,
-																	Line:   258,
+																	Line:   259,
 																},
 																File:   "universe.flux",
 																Source: "v:r._value",
 																Start: ast.Position{
 																	Column: 75,
-																	Line:   258,
+																	Line:   259,
 																},
 															},
 														},
@@ -16448,13 +16482,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 76,
-																		Line:   258,
+																		Line:   259,
 																	},
 																	File:   "universe.flux",
 																	Source: "v",
 																	Start: ast.Position{
 																		Column: 75,
-																		Line:   258,
+																		Line:   259,
 																	},
 																},
 															},
@@ -16466,13 +16500,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 85,
-																		Line:   258,
+																		Line:   259,
 																	},
 																	File:   "universe.flux",
 																	Source: "r._value",
 																	Start: ast.Position{
 																		Column: 77,
-																		Line:   258,
+																		Line:   259,
 																	},
 																},
 															},
@@ -16482,13 +16516,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 78,
-																			Line:   258,
+																			Line:   259,
 																		},
 																		File:   "universe.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 77,
-																			Line:   258,
+																			Line:   259,
 																		},
 																	},
 																},
@@ -16500,13 +16534,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 85,
-																			Line:   258,
+																			Line:   259,
 																		},
 																		File:   "universe.flux",
 																		Source: "_value",
 																		Start: ast.Position{
 																			Column: 79,
-																			Line:   258,
+																			Line:   259,
 																		},
 																	},
 																},
@@ -16521,13 +16555,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 86,
-															Line:   258,
+															Line:   259,
 														},
 														File:   "universe.flux",
 														Source: "bool(v:r._value)",
 														Start: ast.Position{
 															Column: 70,
-															Line:   258,
+															Line:   259,
 														},
 													},
 												},
@@ -16537,13 +16571,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 74,
-																Line:   258,
+																Line:   259,
 															},
 															File:   "universe.flux",
 															Source: "bool",
 															Start: ast.Position{
 																Column: 70,
-																Line:   258,
+																Line:   259,
 															},
 														},
 													},
@@ -16557,13 +16591,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   258,
+														Line:   259,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 55,
-														Line:   258,
+														Line:   259,
 													},
 												},
 											},
@@ -16576,13 +16610,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   258,
+													Line:   259,
 												},
 												File:   "universe.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 47,
-													Line:   258,
+													Line:   259,
 												},
 											},
 										},
@@ -16592,13 +16626,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   258,
+														Line:   259,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   258,
+														Line:   259,
 													},
 												},
 											},
@@ -16615,13 +16649,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 89,
-									Line:   258,
+									Line:   259,
 								},
 								File:   "universe.flux",
 								Source: "map(fn:(r) => ({r with _value: bool(v:r._value)}))",
 								Start: ast.Position{
 									Column: 39,
-									Line:   258,
+									Line:   259,
 								},
 							},
 						},
@@ -16631,13 +16665,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   258,
+										Line:   259,
 									},
 									File:   "universe.flux",
 									Source: "map",
 									Start: ast.Position{
 										Column: 39,
-										Line:   258,
+										Line:   259,
 									},
 								},
 							},
@@ -16651,13 +16685,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   258,
+								Line:   259,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 15,
-								Line:   258,
+								Line:   259,
 							},
 						},
 					},
@@ -16667,13 +16701,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   258,
+									Line:   259,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 15,
-									Line:   258,
+									Line:   259,
 								},
 							},
 						},
@@ -16684,13 +16718,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   258,
+								Line:   259,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 22,
-								Line:   258,
+								Line:   259,
 							},
 						},
 					}},
@@ -16702,13 +16736,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 89,
-						Line:   259,
+						Line:   260,
 					},
 					File:   "universe.flux",
 					Source: "toTime     = (tables=<-) => tables |> map(fn:(r) => ({r with _value: time(v:r._value)}))",
 					Start: ast.Position{
 						Column: 1,
-						Line:   259,
+						Line:   260,
 					},
 				},
 			},
@@ -16718,13 +16752,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   259,
+							Line:   260,
 						},
 						File:   "universe.flux",
 						Source: "toTime",
 						Start: ast.Position{
 							Column: 1,
-							Line:   259,
+							Line:   260,
 						},
 					},
 				},
@@ -16736,13 +16770,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 89,
-							Line:   259,
+							Line:   260,
 						},
 						File:   "universe.flux",
 						Source: "(tables=<-) => tables |> map(fn:(r) => ({r with _value: time(v:r._value)}))",
 						Start: ast.Position{
 							Column: 14,
-							Line:   259,
+							Line:   260,
 						},
 					},
 				},
@@ -16753,13 +16787,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 35,
-									Line:   259,
+									Line:   260,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 29,
-									Line:   259,
+									Line:   260,
 								},
 							},
 						},
@@ -16770,13 +16804,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 89,
-								Line:   259,
+								Line:   260,
 							},
 							File:   "universe.flux",
 							Source: "tables |> map(fn:(r) => ({r with _value: time(v:r._value)}))",
 							Start: ast.Position{
 								Column: 29,
-								Line:   259,
+								Line:   260,
 							},
 						},
 					},
@@ -16787,13 +16821,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 87,
-										Line:   259,
+										Line:   260,
 									},
 									File:   "universe.flux",
 									Source: "fn:(r) => ({r with _value: time(v:r._value)}",
 									Start: ast.Position{
 										Column: 43,
-										Line:   259,
+										Line:   260,
 									},
 								},
 							},
@@ -16803,13 +16837,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 87,
-											Line:   259,
+											Line:   260,
 										},
 										File:   "universe.flux",
 										Source: "fn:(r) => ({r with _value: time(v:r._value)}",
 										Start: ast.Position{
 											Column: 43,
-											Line:   259,
+											Line:   260,
 										},
 									},
 								},
@@ -16819,13 +16853,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 45,
-												Line:   259,
+												Line:   260,
 											},
 											File:   "universe.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 43,
-												Line:   259,
+												Line:   260,
 											},
 										},
 									},
@@ -16837,13 +16871,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 87,
-												Line:   259,
+												Line:   260,
 											},
 											File:   "universe.flux",
 											Source: "(r) => ({r with _value: time(v:r._value)}",
 											Start: ast.Position{
 												Column: 46,
-												Line:   259,
+												Line:   260,
 											},
 										},
 									},
@@ -16853,13 +16887,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 87,
-													Line:   259,
+													Line:   260,
 												},
 												File:   "universe.flux",
 												Source: "{r with _value: time(v:r._value)}",
 												Start: ast.Position{
 													Column: 54,
-													Line:   259,
+													Line:   260,
 												},
 											},
 										},
@@ -16869,13 +16903,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 86,
-														Line:   259,
+														Line:   260,
 													},
 													File:   "universe.flux",
 													Source: "_value: time(v:r._value)",
 													Start: ast.Position{
 														Column: 62,
-														Line:   259,
+														Line:   260,
 													},
 												},
 											},
@@ -16885,13 +16919,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 68,
-															Line:   259,
+															Line:   260,
 														},
 														File:   "universe.flux",
 														Source: "_value",
 														Start: ast.Position{
 															Column: 62,
-															Line:   259,
+															Line:   260,
 														},
 													},
 												},
@@ -16904,13 +16938,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 85,
-																Line:   259,
+																Line:   260,
 															},
 															File:   "universe.flux",
 															Source: "v:r._value",
 															Start: ast.Position{
 																Column: 75,
-																Line:   259,
+																Line:   260,
 															},
 														},
 													},
@@ -16920,13 +16954,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 85,
-																	Line:   259,
+																	Line:   260,
 																},
 																File:   "universe.flux",
 																Source: "v:r._value",
 																Start: ast.Position{
 																	Column: 75,
-																	Line:   259,
+																	Line:   260,
 																},
 															},
 														},
@@ -16936,13 +16970,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 76,
-																		Line:   259,
+																		Line:   260,
 																	},
 																	File:   "universe.flux",
 																	Source: "v",
 																	Start: ast.Position{
 																		Column: 75,
-																		Line:   259,
+																		Line:   260,
 																	},
 																},
 															},
@@ -16954,13 +16988,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 85,
-																		Line:   259,
+																		Line:   260,
 																	},
 																	File:   "universe.flux",
 																	Source: "r._value",
 																	Start: ast.Position{
 																		Column: 77,
-																		Line:   259,
+																		Line:   260,
 																	},
 																},
 															},
@@ -16970,13 +17004,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 78,
-																			Line:   259,
+																			Line:   260,
 																		},
 																		File:   "universe.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 77,
-																			Line:   259,
+																			Line:   260,
 																		},
 																	},
 																},
@@ -16988,13 +17022,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 85,
-																			Line:   259,
+																			Line:   260,
 																		},
 																		File:   "universe.flux",
 																		Source: "_value",
 																		Start: ast.Position{
 																			Column: 79,
-																			Line:   259,
+																			Line:   260,
 																		},
 																	},
 																},
@@ -17009,13 +17043,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 86,
-															Line:   259,
+															Line:   260,
 														},
 														File:   "universe.flux",
 														Source: "time(v:r._value)",
 														Start: ast.Position{
 															Column: 70,
-															Line:   259,
+															Line:   260,
 														},
 													},
 												},
@@ -17025,13 +17059,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 74,
-																Line:   259,
+																Line:   260,
 															},
 															File:   "universe.flux",
 															Source: "time",
 															Start: ast.Position{
 																Column: 70,
-																Line:   259,
+																Line:   260,
 															},
 														},
 													},
@@ -17045,13 +17079,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 56,
-														Line:   259,
+														Line:   260,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 55,
-														Line:   259,
+														Line:   260,
 													},
 												},
 											},
@@ -17064,13 +17098,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   259,
+													Line:   260,
 												},
 												File:   "universe.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 47,
-													Line:   259,
+													Line:   260,
 												},
 											},
 										},
@@ -17080,13 +17114,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   259,
+														Line:   260,
 													},
 													File:   "universe.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   259,
+														Line:   260,
 													},
 												},
 											},
@@ -17103,13 +17137,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 89,
-									Line:   259,
+									Line:   260,
 								},
 								File:   "universe.flux",
 								Source: "map(fn:(r) => ({r with _value: time(v:r._value)}))",
 								Start: ast.Position{
 									Column: 39,
-									Line:   259,
+									Line:   260,
 								},
 							},
 						},
@@ -17119,13 +17153,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 42,
-										Line:   259,
+										Line:   260,
 									},
 									File:   "universe.flux",
 									Source: "map",
 									Start: ast.Position{
 										Column: 39,
-										Line:   259,
+										Line:   260,
 									},
 								},
 							},
@@ -17139,13 +17173,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   259,
+								Line:   260,
 							},
 							File:   "universe.flux",
 							Source: "tables=<-",
 							Start: ast.Position{
 								Column: 15,
-								Line:   259,
+								Line:   260,
 							},
 						},
 					},
@@ -17155,13 +17189,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   259,
+									Line:   260,
 								},
 								File:   "universe.flux",
 								Source: "tables",
 								Start: ast.Position{
 									Column: 15,
-									Line:   259,
+									Line:   260,
 								},
 							},
 						},
@@ -17172,13 +17206,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 24,
-								Line:   259,
+								Line:   260,
 							},
 							File:   "universe.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 22,
-								Line:   259,
+								Line:   260,
 							},
 						},
 					}},

--- a/stdlib/universe/moving_average.go
+++ b/stdlib/universe/moving_average.go
@@ -1,0 +1,557 @@
+package universe
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
+)
+
+const MovingAverageKind = "movingAverage"
+
+type MovingAverageOpSpec struct {
+	N       int64    `json:"n"`
+	Columns []string `json:"columns"`
+}
+
+func init() {
+	movingAverageSignature := flux.FunctionSignature(
+		map[string]semantic.PolyType{
+			"n":       semantic.Int,
+			"columns": semantic.NewArrayPolyType(semantic.String),
+		},
+		[]string{"n"},
+	)
+
+	flux.RegisterPackageValue("universe", MovingAverageKind, flux.FunctionValue(MovingAverageKind, createMovingAverageOpSpec, movingAverageSignature))
+	flux.RegisterOpSpec(MovingAverageKind, newMovingAverageOp)
+	plan.RegisterProcedureSpec(MovingAverageKind, newMovingAverageProcedure, MovingAverageKind)
+	execute.RegisterTransformation(MovingAverageKind, createMovingAverageTransformation)
+}
+
+func createMovingAverageOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	if err := a.AddParentFromArgs(args); err != nil {
+		return nil, err
+	}
+
+	spec := new(MovingAverageOpSpec)
+
+	if n, err := args.GetRequiredInt("n"); err != nil {
+		return nil, err
+	} else {
+		spec.N = n
+	}
+
+	if cols, ok, err := args.GetArray("columns", semantic.String); err != nil {
+		return nil, err
+	} else if ok {
+		columns, err := interpreter.ToStringArray(cols)
+		if err != nil {
+			return nil, err
+		}
+		spec.Columns = columns
+	} else {
+		spec.Columns = []string{execute.DefaultValueColLabel}
+	}
+
+	return spec, nil
+}
+
+func newMovingAverageOp() flux.OperationSpec {
+	return new(MovingAverageOpSpec)
+}
+
+func (s *MovingAverageOpSpec) Kind() flux.OperationKind {
+	return MovingAverageKind
+}
+
+type MovingAverageProcedureSpec struct {
+	plan.DefaultCost
+	N       int64    `json:"n"`
+	Columns []string `json:"columns"`
+}
+
+func newMovingAverageProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*MovingAverageOpSpec)
+	if !ok {
+		return nil, fmt.Errorf("invalid spec type %T", qs)
+	}
+
+	return &MovingAverageProcedureSpec{
+		N:       spec.N,
+		Columns: spec.Columns,
+	}, nil
+}
+
+func (s *MovingAverageProcedureSpec) Kind() plan.ProcedureKind {
+	return MovingAverageKind
+}
+
+func (s *MovingAverageProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(MovingAverageProcedureSpec)
+	*ns = *s
+	if s.Columns != nil {
+		ns.Columns = make([]string, len(s.Columns))
+		copy(ns.Columns, s.Columns)
+	}
+	return ns
+}
+
+// TriggerSpec implements plan.TriggerAwareProcedureSpec
+func (s *MovingAverageProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
+func createMovingAverageTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*MovingAverageProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+	}
+	cache := execute.NewTableBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, cache)
+	t := NewMovingAverageTransformation(d, cache, s)
+	return t, d, nil
+}
+
+type movingAverageTransformation struct {
+	d     execute.Dataset
+	cache execute.TableBuilderCache
+
+	n       int64
+	columns []string
+
+	i      []int
+	sum    []interface{}
+	count  []int
+	window [][]interface{}
+}
+
+func NewMovingAverageTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *MovingAverageProcedureSpec) *movingAverageTransformation {
+	return &movingAverageTransformation{
+		d:       d,
+		cache:   cache,
+		n:       spec.N,
+		columns: spec.Columns,
+	}
+}
+
+func (t *movingAverageTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	return t.d.RetractTable(key)
+}
+
+func (t *movingAverageTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	builder, created := t.cache.TableBuilder(tbl.Key())
+	if !created {
+		return fmt.Errorf("moving average found duplicate table with key: %v", tbl.Key())
+	}
+	cols := tbl.Cols()
+	doMovingAverage := make([]bool, len(cols))
+	for j, c := range cols {
+		found := false
+		for _, label := range t.columns {
+			if c.Label == label {
+				if c.Type != flux.TInt && c.Type != flux.TUInt && c.Type != flux.TFloat {
+					return fmt.Errorf("cannot take moving average of column %s (type %s)", c.Label, c.Type.String())
+				}
+				found = true
+				break
+			}
+		}
+
+		if found {
+			mac := c
+			mac.Type = flux.TFloat
+			_, err := builder.AddCol(mac)
+			if err != nil {
+				return err
+			}
+			doMovingAverage[j] = true
+		} else {
+			_, err := builder.AddCol(c)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	t.i = make([]int, len(cols))
+	t.sum = make([]interface{}, len(cols))
+	t.count = make([]int, len(cols))
+	t.window = make([][]interface{}, len(cols))
+
+	return tbl.Do(func(cr flux.ColReader) error {
+		if cr.Len() == 0 {
+			return nil
+		}
+
+		for j, c := range cr.Cols() {
+			var err error
+			switch c.Type {
+			case flux.TBool:
+				err = t.passThroughBool(cr.Bools(j), builder, j)
+			case flux.TInt:
+				err = t.doInt(cr.Ints(j), builder, j, doMovingAverage[j])
+			case flux.TUInt:
+				err = t.doUInt(cr.UInts(j), builder, j, doMovingAverage[j])
+			case flux.TFloat:
+				err = t.doFloat(cr.Floats(j), builder, j, doMovingAverage[j])
+			case flux.TString:
+				err = t.passThroughString(cr.Strings(j), builder, j)
+			case flux.TTime:
+				err = t.passThroughTime(cr.Times(j), builder, j)
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func (t *movingAverageTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return t.d.UpdateWatermark(mark)
+}
+
+func (t *movingAverageTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
+}
+
+func (t *movingAverageTransformation) Finish(id execute.DatasetID, err error) {
+	t.d.Finish(err)
+}
+
+func (t *movingAverageTransformation) passThroughBool(vs *array.Boolean, b execute.TableBuilder, bj int) error {
+	if int64(vs.Len()) < t.n {
+		if vs.IsNull(vs.Len() - 1) {
+			if err := b.AppendNil(bj); err != nil {
+				return err
+			}
+		} else {
+			if err := b.AppendBool(bj, vs.Value(vs.Len()-1)); err != nil {
+				return nil
+			}
+		}
+		return nil
+	} else {
+		s := arrow.BoolSlice(vs, int(t.n-1), vs.Len())
+		defer s.Release()
+		return b.AppendBools(bj, s)
+	}
+}
+
+func (t *movingAverageTransformation) doInt(vs *array.Int64, b execute.TableBuilder, bj int, doMovingAverage bool) error {
+	if t.window[bj] == nil {
+		t.window[bj] = make([]interface{}, t.n)
+	}
+	if t.sum[bj] == nil {
+		t.sum[bj] = new(int64)
+	}
+	sumPointer := &t.sum[bj]
+	sum := (*sumPointer).(*int64)
+
+	j := 0
+
+	if vs.IsValid(j) {
+		*sum += vs.Value(j)
+		t.count[bj]++
+		t.window[bj][0] = vs.Value(j)
+	} else {
+		t.window[bj][0] = nil
+	}
+	j++
+	t.i[bj]++
+
+	l := vs.Len()
+	for ; j < l; j++ {
+
+		if !vs.IsNull(j) {
+			t.count[bj]++
+			t.window[bj][int64(t.i[bj])%t.n] = vs.Value(j)
+		} else {
+			t.window[bj][int64(t.i[bj])%t.n] = nil
+		}
+		*sum += vs.Value(j)
+
+		if int64(t.i[bj]) < t.n-1 {
+			t.i[bj]++
+			continue
+		}
+
+		if !doMovingAverage {
+			if vs.IsValid(j) {
+				if err := b.AppendInt(bj, vs.Value(j)); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			}
+		} else {
+			average := 0.0
+			if t.count[bj] != 0 {
+				average = float64(*sum) / float64(t.count[bj])
+				if err := b.AppendFloat(bj, average); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			}
+
+			next := t.window[bj][int64(t.i[bj]+1)%t.n]
+			if next != nil {
+				*sum -= next.(int64)
+				t.count[bj]--
+			}
+
+		}
+		t.i[bj]++
+	}
+	if int64(t.i[bj]) < t.n-1 {
+		if !doMovingAverage {
+			if vs.IsNull(j - 1) {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendInt(bj, vs.Value(j-1)); err != nil {
+					return err
+				}
+			}
+		} else {
+			average := float64(*sum) / float64(t.count[bj])
+			if err := b.AppendFloat(bj, average); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *movingAverageTransformation) doUInt(vs *array.Uint64, b execute.TableBuilder, bj int, doMovingAverage bool) error {
+	if t.window[bj] == nil {
+		t.window[bj] = make([]interface{}, t.n)
+	}
+	if t.sum[bj] == nil {
+		t.sum[bj] = new(uint64)
+	}
+	sumPointer := &t.sum[bj]
+	sum := (*sumPointer).(*uint64)
+
+	j := 0
+
+	if vs.IsValid(j) {
+		*sum += vs.Value(j)
+		t.count[bj]++
+		t.window[bj][0] = vs.Value(j)
+	} else {
+		t.window[bj][0] = nil
+	}
+	j++
+	t.i[bj]++
+
+	l := vs.Len()
+	for ; j < l; j++ {
+
+		if !vs.IsNull(j) {
+			t.count[bj]++
+			t.window[bj][int64(t.i[bj])%t.n] = vs.Value(j)
+		} else {
+			t.window[bj][int64(t.i[bj])%t.n] = nil
+		}
+		*sum += vs.Value(j)
+
+		if int64(t.i[bj]) < t.n-1 {
+			t.i[bj]++
+			continue
+		}
+
+		if !doMovingAverage {
+			if vs.IsValid(j) {
+				if err := b.AppendUInt(bj, vs.Value(j)); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			}
+		} else {
+			average := 0.0
+			if t.count[bj] != 0 {
+				average = float64(*sum) / float64(t.count[bj])
+				if err := b.AppendFloat(bj, average); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			}
+
+			next := t.window[bj][int64(t.i[bj]+1)%t.n]
+			if next != nil {
+				*sum -= next.(uint64)
+				t.count[bj]--
+			}
+
+		}
+		t.i[bj]++
+	}
+	if int64(t.i[bj]) < t.n-1 {
+		if !doMovingAverage {
+			if vs.IsNull(j - 1) {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendUInt(bj, vs.Value(j-1)); err != nil {
+					return err
+				}
+			}
+		} else {
+			average := float64(*sum) / float64(t.count[bj])
+			if err := b.AppendFloat(bj, average); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *movingAverageTransformation) doFloat(vs *array.Float64, b execute.TableBuilder, bj int, doMovingAverage bool) error {
+	if t.window[bj] == nil {
+		t.window[bj] = make([]interface{}, t.n)
+	}
+	if t.sum[bj] == nil {
+		t.sum[bj] = new(float64)
+	}
+	sumPointer := &t.sum[bj]
+	sum := (*sumPointer).(*float64)
+
+	j := 0
+
+	if vs.IsValid(j) {
+		*sum += vs.Value(j)
+		t.count[bj]++
+		t.window[bj][0] = vs.Value(j)
+	} else {
+		t.window[bj][0] = nil
+	}
+	j++
+	t.i[bj]++
+
+	l := vs.Len()
+	for ; j < l; j++ {
+
+		if !vs.IsNull(j) {
+			t.count[bj]++
+			t.window[bj][int64(t.i[bj])%t.n] = vs.Value(j)
+		} else {
+			t.window[bj][int64(t.i[bj])%t.n] = nil
+		}
+		*sum += vs.Value(j)
+
+		if int64(t.i[bj]) < t.n-1 {
+			t.i[bj]++
+			continue
+		}
+
+		if !doMovingAverage {
+			if vs.IsValid(j) {
+				if err := b.AppendFloat(bj, vs.Value(j)); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			}
+		} else {
+			average := 0.0
+			if t.count[bj] != 0 {
+				average = float64(*sum) / float64(t.count[bj])
+				if err := b.AppendFloat(bj, average); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			}
+
+			next := t.window[bj][int64(t.i[bj]+1)%t.n]
+			if next != nil {
+				*sum -= next.(float64)
+				t.count[bj]--
+			}
+
+		}
+		t.i[bj]++
+	}
+	if int64(t.i[bj]) < t.n-1 {
+		if !doMovingAverage {
+			if vs.IsNull(j - 1) {
+				if err := b.AppendNil(bj); err != nil {
+					return err
+				}
+			} else {
+				if err := b.AppendFloat(bj, vs.Value(j-1)); err != nil {
+					return err
+				}
+			}
+		} else {
+			average := float64(*sum) / float64(t.count[bj])
+			if err := b.AppendFloat(bj, average); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (t *movingAverageTransformation) passThroughString(vs *array.Binary, b execute.TableBuilder, bj int) error {
+	if int64(vs.Len()) < t.n {
+		if vs.IsNull(vs.Len() - 1) {
+			if err := b.AppendNil(bj); err != nil {
+				return err
+			}
+		} else {
+			if err := b.AppendString(bj, string(vs.Value(vs.Len()-1))); err != nil {
+				return nil
+			}
+		}
+		return nil
+	} else {
+		s := arrow.StringSlice(vs, int(t.n-1), vs.Len())
+		defer s.Release()
+		return b.AppendStrings(bj, s)
+	}
+}
+
+func (t *movingAverageTransformation) passThroughTime(vs *array.Int64, b execute.TableBuilder, bj int) error {
+	if int64(vs.Len()) < t.n {
+		if vs.IsNull(vs.Len() - 1) {
+			if err := b.AppendNil(bj); err != nil {
+				return err
+			}
+		} else {
+			if err := b.AppendTime(bj, execute.Time(vs.Value(vs.Len()-1))); err != nil {
+				return nil
+			}
+		}
+		return nil
+	} else {
+		s := arrow.IntSlice(vs, int(t.n-1), vs.Len())
+		defer s.Release()
+		return b.AppendTimes(bj, s)
+	}
+}

--- a/stdlib/universe/moving_average_test.go
+++ b/stdlib/universe/moving_average_test.go
@@ -1,0 +1,494 @@
+package universe_test
+
+import (
+	"fmt"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/querytest"
+	"github.com/influxdata/flux/stdlib/universe"
+	"testing"
+	"time"
+)
+
+func TestMovingAverageOperation_Marshaling(t *testing.T) {
+	data := []byte(`{"id":"movingAverage","kind":"movingAverage","spec":{"n":1}}`)
+	op := &flux.Operation{
+		ID: "movingAverage",
+		Spec: &universe.MovingAverageOpSpec{
+			N: 1,
+		},
+	}
+	querytest.OperationMarshalingTestHelper(t, data, op)
+}
+
+func TestMovingAverage_PassThrough(t *testing.T) {
+	executetest.TransformationPassThroughTestHelper(t, func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
+		s := universe.NewMovingAverageTransformation(
+			d,
+			c,
+			&universe.MovingAverageProcedureSpec{},
+		)
+		return s
+	})
+}
+
+func TestMovingAverage_Process(t *testing.T) {
+	testCases := []struct {
+		name    string
+		spec    *universe.MovingAverageProcedureSpec
+		data    []flux.Table
+		want    []*executetest.Table
+		wantErr error
+	}{
+		{
+			name: "float",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0},
+					{execute.Time(2), 4.0},
+					{execute.Time(3), 5.0},
+					{execute.Time(4), 9.0},
+					{execute.Time(5), 8.0},
+					{execute.Time(6), 11.0},
+					{execute.Time(7), 15.0},
+					{execute.Time(8), 12.0},
+					{execute.Time(9), 5.0},
+					{execute.Time(10), 7.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.5},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.5},
+					{execute.Time(6), 9.5},
+					{execute.Time(7), 13.0},
+					{execute.Time(8), 13.5},
+					{execute.Time(9), 8.5},
+					{execute.Time(10), 6.0},
+				},
+			}},
+		},
+		{
+			name: "float with 3",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1 * time.Second), 2.0},
+					{execute.Time(2 * time.Second), 4.0},
+					{execute.Time(3 * time.Second), 5.0},
+					{execute.Time(4 * time.Second), 9.0},
+					{execute.Time(5 * time.Second), 8.0},
+					{execute.Time(6 * time.Second), 11.0},
+					{execute.Time(7 * time.Second), 15.0},
+					{execute.Time(8 * time.Second), 12.0},
+					{execute.Time(9 * time.Second), 5.0},
+					{execute.Time(10 * time.Second), 7.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3},
+					{execute.Time(4 * time.Second), 6.0},
+					{execute.Time(5 * time.Second), 22.0 / 3},
+					{execute.Time(6 * time.Second), 28.0 / 3},
+					{execute.Time(7 * time.Second), 34.0 / 3},
+					{execute.Time(8 * time.Second), 38.0 / 3},
+					{execute.Time(9 * time.Second), 32.0 / 3},
+					{execute.Time(10 * time.Second), 8.0},
+				},
+			}},
+		},
+		{
+			name: "int",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), int64(2)},
+					{execute.Time(2), int64(4)},
+					{execute.Time(3), int64(5)},
+					{execute.Time(4), int64(9)},
+					{execute.Time(5), int64(8)},
+					{execute.Time(6), int64(11)},
+					{execute.Time(7), int64(15)},
+					{execute.Time(8), int64(12)},
+					{execute.Time(9), int64(5)},
+					{execute.Time(10), int64(7)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.5},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.5},
+					{execute.Time(6), 9.5},
+					{execute.Time(7), 13.0},
+					{execute.Time(8), 13.5},
+					{execute.Time(9), 8.5},
+					{execute.Time(10), 6.0},
+				},
+			}},
+		},
+		{
+			name: "int with 3",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1 * time.Second), int64(2)},
+					{execute.Time(2 * time.Second), int64(4)},
+					{execute.Time(3 * time.Second), int64(5)},
+					{execute.Time(4 * time.Second), int64(9)},
+					{execute.Time(5 * time.Second), int64(8)},
+					{execute.Time(6 * time.Second), int64(11)},
+					{execute.Time(7 * time.Second), int64(15)},
+					{execute.Time(8 * time.Second), int64(12)},
+					{execute.Time(9 * time.Second), int64(5)},
+					{execute.Time(10 * time.Second), int64(7)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3},
+					{execute.Time(4 * time.Second), 6.0},
+					{execute.Time(5 * time.Second), 22.0 / 3},
+					{execute.Time(6 * time.Second), 28.0 / 3},
+					{execute.Time(7 * time.Second), 34.0 / 3},
+					{execute.Time(8 * time.Second), 38.0 / 3},
+					{execute.Time(9 * time.Second), 32.0 / 3},
+					{execute.Time(10 * time.Second), 8.0},
+				},
+			}},
+		},
+		{
+			name: "uint",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(2)},
+					{execute.Time(2), uint64(4)},
+					{execute.Time(3), uint64(5)},
+					{execute.Time(4), uint64(9)},
+					{execute.Time(5), uint64(8)},
+					{execute.Time(6), uint64(11)},
+					{execute.Time(7), uint64(15)},
+					{execute.Time(8), uint64(12)},
+					{execute.Time(9), uint64(5)},
+					{execute.Time(10), uint64(7)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.5},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.5},
+					{execute.Time(6), 9.5},
+					{execute.Time(7), 13.0},
+					{execute.Time(8), 13.5},
+					{execute.Time(9), 8.5},
+					{execute.Time(10), 6.0},
+				},
+			}},
+		},
+		{
+			name: "uint with 3",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1 * time.Second), uint64(2)},
+					{execute.Time(2 * time.Second), uint64(4)},
+					{execute.Time(3 * time.Second), uint64(5)},
+					{execute.Time(4 * time.Second), uint64(9)},
+					{execute.Time(5 * time.Second), uint64(8)},
+					{execute.Time(6 * time.Second), uint64(11)},
+					{execute.Time(7 * time.Second), uint64(15)},
+					{execute.Time(8 * time.Second), uint64(12)},
+					{execute.Time(9 * time.Second), uint64(5)},
+					{execute.Time(10 * time.Second), uint64(7)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3},
+					{execute.Time(4 * time.Second), 6.0},
+					{execute.Time(5 * time.Second), 22.0 / 3},
+					{execute.Time(6 * time.Second), 28.0 / 3},
+					{execute.Time(7 * time.Second), 34.0 / 3},
+					{execute.Time(8 * time.Second), 38.0 / 3},
+					{execute.Time(9 * time.Second), 32.0 / 3},
+					{execute.Time(10 * time.Second), 8.0},
+				},
+			}},
+		},
+		{
+			name: "float with tags",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1 * time.Second), 2.0, "a"},
+					{execute.Time(2 * time.Second), 4.0, "b"},
+					{execute.Time(3 * time.Second), 5.0, "c"},
+					{execute.Time(4 * time.Second), 9.0, "d"},
+					{execute.Time(5 * time.Second), 8.0, "e"},
+					{execute.Time(6 * time.Second), 11.0, "f"},
+					{execute.Time(7 * time.Second), 15.0, "g"},
+					{execute.Time(8 * time.Second), 12.0, "h"},
+					{execute.Time(9 * time.Second), 5.0, "i"},
+					{execute.Time(10 * time.Second), 7.0, "j"},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3, "c"},
+					{execute.Time(4 * time.Second), 6.0, "d"},
+					{execute.Time(5 * time.Second), 22.0 / 3, "e"},
+					{execute.Time(6 * time.Second), 28.0 / 3, "f"},
+					{execute.Time(7 * time.Second), 34.0 / 3, "g"},
+					{execute.Time(8 * time.Second), 38.0 / 3, "h"},
+					{execute.Time(9 * time.Second), 32.0 / 3, "i"},
+					{execute.Time(10 * time.Second), 8.0, "j"},
+				},
+			}},
+		},
+		{
+			name: "nulls in time column",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{"x", "y"},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "x", Type: flux.TFloat},
+					{Label: "y", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{nil, 2.0, 3.0},
+					{execute.Time(2), nil, 10.0},
+					{nil, 8.0, 20.0},
+					{execute.Time(4), 8.0, 20.0},
+					{nil, 8.0, 20.0},
+					{execute.Time(6), 10.0, 25.0},
+					{nil, 8.0, 20.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "x", Type: flux.TFloat},
+					{Label: "y", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 2.0, 13.0 / 2},
+					{nil, 8.0, 15.0},
+					{execute.Time(4), 8.0, 20.0},
+					{nil, 8.0, 20.0},
+					{execute.Time(6), 9.0, 22.5},
+					{nil, 9.0, 22.5},
+				},
+			}},
+		},
+		{
+			name: "mean average of non-numerical column",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{"x", "y"},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "x", Type: flux.TFloat},
+					{Label: "y", Type: flux.TString},
+				},
+			}},
+			wantErr: fmt.Errorf("cannot take moving average of column y (type string)"),
+		},
+		{
+			name: "int nulls",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{"x", "y", "z"},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "x", Type: flux.TInt},
+					{Label: "y", Type: flux.TInt},
+					{Label: "z", Type: flux.TInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, int64(1), int64(2)},
+					{execute.Time(2), nil, int64(2), nil},
+					{execute.Time(3), int64(4), nil, int64(4)},
+					{execute.Time(4), int64(2), nil, int64(4)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "x", Type: flux.TFloat},
+					{Label: "y", Type: flux.TFloat},
+					{Label: "z", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), nil, 1.5, 2.0},
+					{execute.Time(3), 4.0, 2.0, 4.0},
+					{execute.Time(4), 3.0, nil, 4.0},
+				},
+			}},
+		},
+		{
+			name: "less rows than period",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       5,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "passInt", Type: flux.TInt},
+					{Label: "passUint", Type: flux.TUInt},
+					{Label: "passFloat", Type: flux.TFloat},
+					{Label: "passNull", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), int64(2), int64(2), uint64(1), 5.0, nil},
+					{execute.Time(2), int64(4), int64(3), uint64(2), 4.0, nil},
+					{execute.Time(3), int64(5), int64(4), uint64(3), 3.0, nil},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "passInt", Type: flux.TInt},
+					{Label: "passUint", Type: flux.TUInt},
+					{Label: "passFloat", Type: flux.TFloat},
+					{Label: "passNull", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), 11.0 / 3, int64(4), uint64(3), 3.0, nil},
+				},
+			}},
+		},
+		{
+			name: "empty table",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}(nil),
+			}},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			executetest.ProcessTestHelper(
+				t,
+				tc.data,
+				tc.want,
+				tc.wantErr,
+				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
+					return universe.NewMovingAverageTransformation(d, c, tc.spec)
+				},
+			)
+		})
+	}
+}

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -38,6 +38,7 @@ builtin max
 builtin mean
 builtin min
 builtin mode
+builtin movingAverage
 builtin quantile
 builtin pivot
 builtin range
@@ -241,15 +242,15 @@ lowestCurrent = (n, column="_value", groupColumns=[], tables=<-) =>
                 _sortLimit: bottom,
             )
 
-// movingAverage constructs a simple moving average over windows of 'period' duration
+// timedMovingAverage constructs a simple moving average over windows of 'period' duration
 // eg: A 5 year moving average would be called as such:
 //    movingAverage(1y, 5y)
- movingAverage = (every, period, column="_value", tables=<-) =>
-     tables
-         |> window(every: every, period: period)
-         |> mean(column:column)
-         |> duplicate(column: "_stop", as: "_time")
-         |> window(every: inf)
+timedMovingAverage = (every, period, column="_value", tables=<-) =>
+    tables
+        |> window(every: every, period: period)
+        |> mean(column:column)
+        |> duplicate(column: "_stop", as: "_time")
+        |> window(every: inf)
 
 toString   = (tables=<-) => tables |> map(fn:(r) => ({r with _value: string(v:r._value)}))
 toInt      = (tables=<-) => tables |> map(fn:(r) => ({r with _value: int(v:r._value)}))


### PR DESCRIPTION
Added the go version of `movingAverage`, which follows the spec used by InfluxQL. It means over `n` points.
The pure flux implementation is changed to `timedMovingAverage` for the time being, since it means over a time window.


### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
