### PR TITLE
chore: add go 1.12 directive to the go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/influxdata/flux
 
+go 1.12
+
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/DATA-DOG/go-sqlmock v1.3.3


### PR DESCRIPTION
This directive will be mandatory starting with go 1.13 and it specifies
the minimum version a module can be built with. We currently support
back to go 1.11, but there's no directive to say that because 1.11 only
had experimental support.

Since the only location where we use go 1.11 is InfluxDB 1.x and that
uses dep instead of go modules, this should be safe and we will specify
go 1.12 as our minimum for systems using modules since we would set that
as the minimum if InfluxDB 1.x was using go 1.12 anyway.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written