### PR TITLE
refactor: make inherit the default error code and remove ok

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -35,10 +35,7 @@ const (
 	// Inherit indicates that this error should inherit the code of the wrapped
 	// error. If the wrapped error does not have a code or the error does not
 	// have a wrapped error, then this will act the same as Unknown.
-	Inherit = ^Code(0)
-
-	// OK is returned on success.
-	OK Code = 0
+	Inherit Code = 0
 
 	// Canceled indicates the operation was canceled (typically by the caller).
 	Canceled Code = 1
@@ -157,7 +154,6 @@ func (c Code) MarshalText() ([]byte, error) {
 }
 
 var strToCode = map[string]Code{
-	"ok":                  OK,
 	"canceled":            Canceled,
 	"unknown":             Unknown,
 	"invalid":             Invalid,
@@ -176,6 +172,11 @@ var strToCode = map[string]Code{
 }
 
 func (c *Code) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		*c = Inherit
+		return nil
+	}
+
 	code, ok := strToCode[string(text)]
 	if ok {
 		*c = code
@@ -196,8 +197,8 @@ func (c *Code) UnmarshalText(text []byte) error {
 
 func (c Code) String() string {
 	switch c {
-	case OK:
-		return "ok"
+	case Inherit:
+		return ""
 	case Canceled:
 		return "canceled"
 	case Unknown:


### PR DESCRIPTION
The ok error code doesn't make much sense for flux since the ok error
code is mostly for grpc where the error is always present and there is
no such thing as null so there needs to be a default.

Inherit has been changed to be the default which should also make it
easier to use without the utility wrapping library. A wrapped error
would be `flux.Error{Err: err}` instead of requiring that
`codes.Inherit` be present or accidentally setting the code to ok.
Additionally, it means the default code returned would be unknown in
cases where one wasn't specified and could not be inherited.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written