### PR TITLE
chore(circleci): use latest image now that changes are in master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: nathanielc/flux-build:rust
+      - image: nathanielc/flux-build:latest
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: -p=8


### PR DESCRIPTION
This must be rebased and merged to master after https://github.com/influxdata/flux/pull/1477 has merged.