### PR TITLE
fix(semantic): update type inference

### DIFF
--- a/semantic/poly_types.go
+++ b/semantic/poly_types.go
@@ -96,14 +96,8 @@ func (tv Tvar) freeVars(c *Constraints) TvarSet {
 func (l Tvar) unifyType(kinds map[Tvar]Kind, s Substitution, r PolyType) (Substitution, error) {
 	// Use the substitution to reduce the left and right hand sides.
 	// This ensures we never add a transitive cycle in the substitution.
-	tl, ok := l.apply(s)
-	for ok {
-		tl, ok = tl.apply(s)
-	}
-	tr, ok := r.apply(s)
-	for ok {
-		tr, ok = tr.apply(s)
-	}
+	tl := s.applyToType(l)
+	tr := s.applyToType(r)
 	switch tl := tl.(type) {
 	case Tvar:
 		tv, ok := tr.(Tvar)
@@ -448,15 +442,7 @@ func (l function) unifyType(kinds map[Tvar]Kind, s Substitution, r PolyType) (Su
 				// this must be the pipe parameter.
 				continue
 			}
-			typl, ok := tl.apply(s)
-			for ok {
-				typl, ok = typl.apply(s)
-			}
-			typr, ok := tr.apply(s)
-			for ok {
-				typr, ok = typr.apply(s)
-			}
-			sub, err := unifyTypes(kinds, s, typl, typr)
+			sub, err := unifyTypes(kinds, s, tl, tr)
 			if err != nil {
 				return nil, err
 			}
@@ -775,11 +761,7 @@ func (l ObjectKind) unifyKind(kinds map[Tvar]Kind, s Substitution, k Kind) (Kind
 		if err != nil {
 			properties[f] = invalid{err: err}
 		} else {
-			tp, ok := typL.apply(sub)
-			for ok {
-				tp, ok = tp.apply(sub)
-			}
-			properties[f] = tp
+			properties[f] = sub.applyToType(typL)
 		}
 		s = sub
 	}

--- a/semantic/poly_types.go
+++ b/semantic/poly_types.go
@@ -31,7 +31,12 @@ type PolyType interface {
 	// apply returns false if there were no substitutions made
 	apply(sub Substitution) (PolyType, bool)
 
-	// unifyType unifies the two types given the kind constraints and produces a substitution.
+	// unifyType unifies two parametric types by producing a substitution that
+	// when applied to both types, produces the same parametric type.
+	//
+	// If the input substitution is already a unifier for both types it returns
+	// that same substitution. Otherwise the input substitution is not a unifier
+	// for the two types, and it returns an expanded one that is.
 	unifyType(map[Tvar]Kind, Substitution, PolyType) (Substitution, error)
 
 	// Equal reports if two types are the same.
@@ -49,7 +54,12 @@ type Kind interface {
 	// apply returns false if there were no substitutions made
 	apply(sub Substitution) (Kind, bool)
 
-	// unifyKind unifies the two kinds producing a new merged kind and a substitution.
+	// unifyKind unifies two kinds producing a new merged kind and a new updated
+	// substitution.
+	//
+	// If the input substitution is already a unifier for both kinds it returns
+	// that same substitution. Otherwise the input substitution is not a unifier
+	// for the two kinds, and it returns an expanded one that is.
 	unifyKind(map[Tvar]Kind, Substitution, Kind) (Kind, Substitution, error)
 
 	// occurs reports whether tv occurs in this kind.

--- a/semantic/substitution.go
+++ b/semantic/substitution.go
@@ -9,56 +9,17 @@ import (
 // Substitution is a mapping of type variables to a poly type.
 type Substitution map[Tvar]PolyType
 
-func (s Substitution) ApplyType(t PolyType) PolyType {
-	for tv, typ := range s {
-		t = t.substituteType(tv, typ)
-	}
-	return t
-}
-func (s Substitution) ApplyScheme(ts Scheme) Scheme {
-	for tv, typ := range s {
-		ts.T = ts.T.substituteType(tv, typ)
-	}
-	return ts
-}
-
-func (s Substitution) ApplyKind(k Kind) Kind {
-	for tv, typ := range s {
-		k = k.substituteKind(tv, typ)
-	}
-	return k
-}
-
-func (s Substitution) ApplyEnv(env *Env) *Env {
-	for tv, typ := range s {
-		env.RangeSet(func(n string, scheme Scheme) Scheme {
-			return scheme.Substitute(tv, typ)
-		})
-	}
-	return env
-}
-
 func (s Substitution) ApplyTvar(tv Tvar) Tvar {
-	switch t := s[tv].(type) {
-	case Tvar:
-		return t
-	default:
-		return tv
-	}
-}
-
-// Merge r into l.
-func (l Substitution) Merge(r Substitution) {
-	// Apply right to all of l
-	for tvL, tL := range l {
-		l[r.ApplyTvar(tvL)] = r.ApplyType(tL)
-	}
-	// Add missing keys from r to l
-	for tvR, tR := range r {
-		if _, ok := l[tvR]; !ok {
-			l[tvR] = tR
+	tp, ok := s[tv]
+	for ok {
+		tvar, kk := tp.(Tvar)
+		if !kk {
+			break
 		}
+		tv = tvar
+		tp, ok = s[tv]
 	}
+	return tv
 }
 
 func (s Substitution) String() string {

--- a/semantic/substitution.go
+++ b/semantic/substitution.go
@@ -9,7 +9,21 @@ import (
 // Substitution is a mapping of type variables to a poly type.
 type Substitution map[Tvar]PolyType
 
-func (s Substitution) ApplyTvar(tv Tvar) Tvar {
+func (s Substitution) applyToType(t PolyType) PolyType {
+	tp, ok := t.apply(s)
+	for ok {
+		tp, ok = tp.apply(s)
+	}
+	return tp
+}
+func (s Substitution) applyToKind(k Kind) Kind {
+	kind, ok := k.apply(s)
+	for ok {
+		kind, ok = kind.apply(s)
+	}
+	return kind
+}
+func (s Substitution) applyToTvar(tv Tvar) Tvar {
 	tp, ok := s[tv]
 	for ok {
 		tvar, kk := tp.(Tvar)


### PR DESCRIPTION
BREAKING CHANGE: removed exported methods.

This commit updates type inference by removing most of the methods associated
with a substitution. In particular, substitutions are no longer merged.
Instead unifyType and unifyKind have been updated to take a substitution as input.

This allows type variables to be unified correctly as previously the Merge method
assumed that each substitution was distict from the other, where distinct means
no type variables in common. This assumption was not correct.

#1366.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
