### PR TITLE
fix(stdlib): map will not panic when a record is null

### DIFF
--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -52,6 +52,12 @@ func ProcessTestHelper(
 ) {
 	t.Helper()
 
+	defer func() {
+		if err := recover(); err != nil {
+			t.Errorf("caught panic: %v", err)
+		}
+	}()
+
 	d := NewDataset(RandomDatasetID())
 	c := execute.NewTableBuilderCache(UnlimitedAllocator)
 	c.SetTriggerSpec(plan.DefaultTriggerSpec)

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -1126,6 +1126,109 @@ func TestMap_Process(t *testing.T) {
 			}},
 			wantErr: errors.New(`failed to evaluate map function: strconv.ParseFloat: parsing "foo": invalid syntax`),
 		},
+		{
+			name: `with null record`,
+			spec: &universe.MapProcedureSpec{
+				Fn: &semantic.FunctionExpression{
+					Block: &semantic.FunctionBlock{
+						Parameters: &semantic.FunctionParameters{
+							List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+						},
+						Body: &semantic.ObjectExpression{
+							Properties: []*semantic.Property{
+								{
+									Key: &semantic.Identifier{Name: "value"},
+									Value: &semantic.BinaryExpression{
+										Operator: ast.AdditionOperator,
+										Left: &semantic.MemberExpression{
+											Object: &semantic.IdentifierExpression{
+												Name: "r",
+											},
+											Property: "_value",
+										},
+										Right: &semantic.FloatLiteral{
+											Value: 5,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil},
+					{execute.Time(2), 6.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{nil},
+					{11.0},
+				},
+			}},
+		},
+		{
+			name: `with null column`,
+			spec: &universe.MapProcedureSpec{
+				Fn: &semantic.FunctionExpression{
+					Block: &semantic.FunctionBlock{
+						Parameters: &semantic.FunctionParameters{
+							List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+						},
+						Body: &semantic.ObjectExpression{
+							Properties: []*semantic.Property{
+								{
+									Key: &semantic.Identifier{Name: "value"},
+									Value: &semantic.MemberExpression{
+										Object: &semantic.IdentifierExpression{
+											Name: "r",
+										},
+										Property: "_value",
+									},
+								},
+								{
+									Key: &semantic.Identifier{Name: "missing"},
+									Value: &semantic.MemberExpression{
+										Object: &semantic.IdentifierExpression{
+											Name: "r",
+										},
+										Property: "_missing",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{1.0},
+					{6.0},
+				},
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Map will panic in two situations:

1. The entire column is null.
2. The first record is null.

This is because it attempts to create a column with the nil type which cannot
be represented on a record.

Ideally, the properties would be determined after compiling the function
since we should know the complete return type. Unfortunately, type
inference isn't currently capable of getting all of the types that will
be part of the return value when those values aren't directly referenced
such as in the case of merge key or using the `with` keyword.

In order to fix this, we use a hybrid approach where we determine the
types which are referenced from type inference and add or update these
types based on the first record that is returned. This should get us a
correct type for each of the values in the record.