### PR TITLE
fix(executetest): add helper methods for comparing entire result sets

### DIFF
--- a/execute/executetest/result.go
+++ b/execute/executetest/result.go
@@ -13,6 +13,24 @@ type Result struct {
 	Err  error
 }
 
+// ConvertResult produces a result object from any flux.Result type.
+func ConvertResult(result flux.Result) *Result {
+	var tbls []*Table
+	err := result.Tables().Do(func(tbl flux.Table) error {
+		t, err := ConvertTable(tbl)
+		if err != nil {
+			return err
+		}
+		tbls = append(tbls, t)
+		return nil
+	})
+	return &Result{
+		Nm:   result.Name(),
+		Tbls: tbls,
+		Err:  err,
+	}
+}
+
 func NewResult(tables []*Table) *Result {
 	return &Result{Tbls: tables}
 }
@@ -50,45 +68,71 @@ func (ti *TableIterator) Do(f func(flux.Table) error) error {
 }
 
 // EqualResults compares two lists of Flux Results for equlity
-func EqualResults(want, got []flux.Result) (bool, error) {
+func EqualResults(want, got []flux.Result) error {
 	if len(want) != len(got) {
-		return false, fmt.Errorf("unexpected number of results - want %d results, got %d results", len(want), len(got))
+		return fmt.Errorf("unexpected number of results - want %d results, got %d results", len(want), len(got))
 	}
-	for i, result := range want {
-		w := result
-		g := got[i]
-		if w.Name() != g.Name() {
-			return false, fmt.Errorf("unexpected result name - want %s, got %s", w.Name(), g.Name())
+	for i := range want {
+		err := EqualResult(want[i], got[i])
+		if err != nil {
+			return err
 		}
-		var wt, gt []*Table
-		if err := w.Tables().Do(func(tbl flux.Table) error {
-			t, err := ConvertTable(tbl)
+	}
+	return nil
+}
+
+// EqualResultIterators compares two ResultIterators for equlity
+func EqualResultIterators(want, got flux.ResultIterator) error {
+	for {
+		if w, g := want.More(), got.More(); w != g {
+			return fmt.Errorf("unexpected number of results: want more %t, got more %t", w, g)
+		} else if w {
+			err := EqualResult(want.Next(), got.Next())
 			if err != nil {
 				return err
 			}
-			wt = append(wt, t)
-			return nil
-		}); err != nil {
-			return false, err
-		}
-		if err := g.Tables().Do(func(tbl flux.Table) error {
-			t, err := ConvertTable(tbl)
-			if err != nil {
-				return err
+		} else {
+			if w, g := want.Err(), got.Err(); !(w == nil && g == nil || w != nil && g != nil && w.Error() == g.Error()) {
+				return fmt.Errorf("unexpected errors want: %s got: %s", w, g)
 			}
-			gt = append(gt, t)
 			return nil
-		}); err != nil {
-			return false, err
-		}
-		NormalizeTables(wt)
-		NormalizeTables(gt)
-		if len(wt) != len(gt) {
-			return false, fmt.Errorf("unexpected size for result %s - want %d tables, got %d tables", w.Name(), len(wt), len(gt))
-		}
-		if !cmp.Equal(wt, gt, floatOptions) {
-			return false, fmt.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(wt, gt))
 		}
 	}
-	return true, nil
+}
+
+// EqualResult compares to results for equality
+func EqualResult(w, g flux.Result) error {
+	if w.Name() != g.Name() {
+		return fmt.Errorf("unexpected result name - want %s, got %s", w.Name(), g.Name())
+	}
+	var wt, gt []*Table
+	if err := w.Tables().Do(func(tbl flux.Table) error {
+		t, err := ConvertTable(tbl)
+		if err != nil {
+			return err
+		}
+		wt = append(wt, t)
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := g.Tables().Do(func(tbl flux.Table) error {
+		t, err := ConvertTable(tbl)
+		if err != nil {
+			return err
+		}
+		gt = append(gt, t)
+		return nil
+	}); err != nil {
+		return err
+	}
+	NormalizeTables(wt)
+	NormalizeTables(gt)
+	if len(wt) != len(gt) {
+		return fmt.Errorf("unexpected size for result %s - want %d tables, got %d tables", w.Name(), len(wt), len(gt))
+	}
+	if !cmp.Equal(wt, gt, floatOptions) {
+		return fmt.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(wt, gt))
+	}
+	return nil
 }


### PR DESCRIPTION
Adds new helper method that operate on flux.Result and flux.ResultIterators so we can leverage the rest of the executetest types when dealing with  flux.ResultIterators.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
