### PR TITLE
fix(stdlib): correct moving average behavior with chunking

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -3171,7 +3171,7 @@ Moving Average has the following properties:
 
 | Name        | Type     | Description
 | ----        | ----     | -----------
-| n           | duration | N specifies the number of points to mean.       
+| n           | int      | N specifies the number of points to mean.       
 | columns     | []string | Columns is list of all columns that `movingAverage` should be performed on. Defaults to `["_value"]`. |
 
 Rules for taking the moving average for numeric types:

--- a/stdlib/universe/moving_average_test.go
+++ b/stdlib/universe/moving_average_test.go
@@ -84,6 +84,50 @@ func TestMovingAverage_Process(t *testing.T) {
 			}},
 		},
 		{
+			name: "float with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 2.0},
+						{execute.Time(2), 4.0},
+						{execute.Time(3), 5.0},
+						{execute.Time(4), 9.0},
+						{execute.Time(5), 8.0},
+						{execute.Time(6), 11.0},
+						{execute.Time(7), 15.0},
+						{execute.Time(8), 12.0},
+						{execute.Time(9), 5.0},
+						{execute.Time(10), 7.0},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.5},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.5},
+					{execute.Time(6), 9.5},
+					{execute.Time(7), 13.0},
+					{execute.Time(8), 13.5},
+					{execute.Time(9), 8.5},
+					{execute.Time(10), 6.0},
+				},
+			}},
+		},
+		{
 			name: "float with 3",
 			spec: &universe.MovingAverageProcedureSpec{
 				Columns: []string{execute.DefaultValueColLabel},
@@ -105,6 +149,49 @@ func TestMovingAverage_Process(t *testing.T) {
 					{execute.Time(8 * time.Second), 12.0},
 					{execute.Time(9 * time.Second), 5.0},
 					{execute.Time(10 * time.Second), 7.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3},
+					{execute.Time(4 * time.Second), 6.0},
+					{execute.Time(5 * time.Second), 22.0 / 3},
+					{execute.Time(6 * time.Second), 28.0 / 3},
+					{execute.Time(7 * time.Second), 34.0 / 3},
+					{execute.Time(8 * time.Second), 38.0 / 3},
+					{execute.Time(9 * time.Second), 32.0 / 3},
+					{execute.Time(10 * time.Second), 8.0},
+				},
+			}},
+		},
+		{
+			name: "float with 3 with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1 * time.Second), 2.0},
+						{execute.Time(2 * time.Second), 4.0},
+						{execute.Time(3 * time.Second), 5.0},
+						{execute.Time(4 * time.Second), 9.0},
+						{execute.Time(5 * time.Second), 8.0},
+						{execute.Time(6 * time.Second), 11.0},
+						{execute.Time(7 * time.Second), 15.0},
+						{execute.Time(8 * time.Second), 12.0},
+						{execute.Time(9 * time.Second), 5.0},
+						{execute.Time(10 * time.Second), 7.0},
+					},
 				},
 			}},
 			want: []*executetest.Table{{
@@ -167,6 +254,50 @@ func TestMovingAverage_Process(t *testing.T) {
 			}},
 		},
 		{
+			name: "int with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TInt},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), int64(2)},
+						{execute.Time(2), int64(4)},
+						{execute.Time(3), int64(5)},
+						{execute.Time(4), int64(9)},
+						{execute.Time(5), int64(8)},
+						{execute.Time(6), int64(11)},
+						{execute.Time(7), int64(15)},
+						{execute.Time(8), int64(12)},
+						{execute.Time(9), int64(5)},
+						{execute.Time(10), int64(7)},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.5},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.5},
+					{execute.Time(6), 9.5},
+					{execute.Time(7), 13.0},
+					{execute.Time(8), 13.5},
+					{execute.Time(9), 8.5},
+					{execute.Time(10), 6.0},
+				},
+			}},
+		},
+		{
 			name: "int with 3",
 			spec: &universe.MovingAverageProcedureSpec{
 				Columns: []string{execute.DefaultValueColLabel},
@@ -188,6 +319,49 @@ func TestMovingAverage_Process(t *testing.T) {
 					{execute.Time(8 * time.Second), int64(12)},
 					{execute.Time(9 * time.Second), int64(5)},
 					{execute.Time(10 * time.Second), int64(7)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3},
+					{execute.Time(4 * time.Second), 6.0},
+					{execute.Time(5 * time.Second), 22.0 / 3},
+					{execute.Time(6 * time.Second), 28.0 / 3},
+					{execute.Time(7 * time.Second), 34.0 / 3},
+					{execute.Time(8 * time.Second), 38.0 / 3},
+					{execute.Time(9 * time.Second), 32.0 / 3},
+					{execute.Time(10 * time.Second), 8.0},
+				},
+			}},
+		},
+		{
+			name: "int with 3 with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TInt},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1 * time.Second), int64(2)},
+						{execute.Time(2 * time.Second), int64(4)},
+						{execute.Time(3 * time.Second), int64(5)},
+						{execute.Time(4 * time.Second), int64(9)},
+						{execute.Time(5 * time.Second), int64(8)},
+						{execute.Time(6 * time.Second), int64(11)},
+						{execute.Time(7 * time.Second), int64(15)},
+						{execute.Time(8 * time.Second), int64(12)},
+						{execute.Time(9 * time.Second), int64(5)},
+						{execute.Time(10 * time.Second), int64(7)},
+					},
 				},
 			}},
 			want: []*executetest.Table{{
@@ -250,6 +424,50 @@ func TestMovingAverage_Process(t *testing.T) {
 			}},
 		},
 		{
+			name: "uint with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TUInt},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), uint64(2)},
+						{execute.Time(2), uint64(4)},
+						{execute.Time(3), uint64(5)},
+						{execute.Time(4), uint64(9)},
+						{execute.Time(5), uint64(8)},
+						{execute.Time(6), uint64(11)},
+						{execute.Time(7), uint64(15)},
+						{execute.Time(8), uint64(12)},
+						{execute.Time(9), uint64(5)},
+						{execute.Time(10), uint64(7)},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), 3.0},
+					{execute.Time(3), 4.5},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), 8.5},
+					{execute.Time(6), 9.5},
+					{execute.Time(7), 13.0},
+					{execute.Time(8), 13.5},
+					{execute.Time(9), 8.5},
+					{execute.Time(10), 6.0},
+				},
+			}},
+		},
+		{
 			name: "uint with 3",
 			spec: &universe.MovingAverageProcedureSpec{
 				Columns: []string{execute.DefaultValueColLabel},
@@ -271,6 +489,49 @@ func TestMovingAverage_Process(t *testing.T) {
 					{execute.Time(8 * time.Second), uint64(12)},
 					{execute.Time(9 * time.Second), uint64(5)},
 					{execute.Time(10 * time.Second), uint64(7)},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3},
+					{execute.Time(4 * time.Second), 6.0},
+					{execute.Time(5 * time.Second), 22.0 / 3},
+					{execute.Time(6 * time.Second), 28.0 / 3},
+					{execute.Time(7 * time.Second), 34.0 / 3},
+					{execute.Time(8 * time.Second), 38.0 / 3},
+					{execute.Time(9 * time.Second), 32.0 / 3},
+					{execute.Time(10 * time.Second), 8.0},
+				},
+			}},
+		},
+		{
+			name: "uint with 3 with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TUInt},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1 * time.Second), uint64(2)},
+						{execute.Time(2 * time.Second), uint64(4)},
+						{execute.Time(3 * time.Second), uint64(5)},
+						{execute.Time(4 * time.Second), uint64(9)},
+						{execute.Time(5 * time.Second), uint64(8)},
+						{execute.Time(6 * time.Second), uint64(11)},
+						{execute.Time(7 * time.Second), uint64(15)},
+						{execute.Time(8 * time.Second), uint64(12)},
+						{execute.Time(9 * time.Second), uint64(5)},
+						{execute.Time(10 * time.Second), uint64(7)},
+					},
 				},
 			}},
 			want: []*executetest.Table{{
@@ -334,25 +595,72 @@ func TestMovingAverage_Process(t *testing.T) {
 			}},
 		},
 		{
+			name: "float with tags with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       3,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "t", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1 * time.Second), 2.0, "a"},
+						{execute.Time(2 * time.Second), 4.0, "b"},
+						{execute.Time(3 * time.Second), 5.0, "c"},
+						{execute.Time(4 * time.Second), 9.0, "d"},
+						{execute.Time(5 * time.Second), 8.0, "e"},
+						{execute.Time(6 * time.Second), 11.0, "f"},
+						{execute.Time(7 * time.Second), 15.0, "g"},
+						{execute.Time(8 * time.Second), 12.0, "h"},
+						{execute.Time(9 * time.Second), 5.0, "i"},
+						{execute.Time(10 * time.Second), 7.0, "j"},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3 * time.Second), 11.0 / 3, "c"},
+					{execute.Time(4 * time.Second), 6.0, "d"},
+					{execute.Time(5 * time.Second), 22.0 / 3, "e"},
+					{execute.Time(6 * time.Second), 28.0 / 3, "f"},
+					{execute.Time(7 * time.Second), 34.0 / 3, "g"},
+					{execute.Time(8 * time.Second), 38.0 / 3, "h"},
+					{execute.Time(9 * time.Second), 32.0 / 3, "i"},
+					{execute.Time(10 * time.Second), 8.0, "j"},
+				},
+			}},
+		},
+		{
 			name: "nulls in time column",
 			spec: &universe.MovingAverageProcedureSpec{
 				Columns: []string{"x", "y"},
 				N:       2,
 			},
-			data: []flux.Table{&executetest.Table{
-				ColMeta: []flux.ColMeta{
-					{Label: "_time", Type: flux.TTime},
-					{Label: "x", Type: flux.TFloat},
-					{Label: "y", Type: flux.TFloat},
-				},
-				Data: [][]interface{}{
-					{nil, 2.0, 3.0},
-					{execute.Time(2), nil, 10.0},
-					{nil, 8.0, 20.0},
-					{execute.Time(4), 8.0, 20.0},
-					{nil, 8.0, 20.0},
-					{execute.Time(6), 10.0, 25.0},
-					{nil, 8.0, 20.0},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "x", Type: flux.TFloat},
+						{Label: "y", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{nil, 2.0, 3.0},
+						{execute.Time(2), nil, 10.0},
+						{nil, 8.0, 20.0},
+						{execute.Time(4), 8.0, 20.0},
+						{nil, 8.0, 20.0},
+						{execute.Time(6), 10.0, 25.0},
+						{nil, 8.0, 20.0},
+					},
 				},
 			}},
 			want: []*executetest.Table{{
@@ -421,6 +729,42 @@ func TestMovingAverage_Process(t *testing.T) {
 			}},
 		},
 		{
+			name: "int nulls with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{"x", "y", "z"},
+				N:       2,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "x", Type: flux.TInt},
+						{Label: "y", Type: flux.TInt},
+						{Label: "z", Type: flux.TInt},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), nil, int64(1), int64(2)},
+						{execute.Time(2), nil, int64(2), nil},
+						{execute.Time(3), int64(4), nil, int64(4)},
+						{execute.Time(4), int64(2), nil, int64(4)},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "x", Type: flux.TFloat},
+					{Label: "y", Type: flux.TFloat},
+					{Label: "z", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(2), nil, 1.5, 2.0},
+					{execute.Time(3), 4.0, 2.0, 4.0},
+					{execute.Time(4), 3.0, nil, 4.0},
+				},
+			}},
+		},
+		{
 			name: "less rows than period",
 			spec: &universe.MovingAverageProcedureSpec{
 				Columns: []string{execute.DefaultValueColLabel},
@@ -439,6 +783,43 @@ func TestMovingAverage_Process(t *testing.T) {
 					{execute.Time(1), int64(2), int64(2), uint64(1), 5.0, nil},
 					{execute.Time(2), int64(4), int64(3), uint64(2), 4.0, nil},
 					{execute.Time(3), int64(5), int64(4), uint64(3), 3.0, nil},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "passInt", Type: flux.TInt},
+					{Label: "passUint", Type: flux.TUInt},
+					{Label: "passFloat", Type: flux.TFloat},
+					{Label: "passNull", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(3), 11.0 / 3, int64(4), uint64(3), 3.0, nil},
+				},
+			}},
+		},
+		{
+			name: "less rows than period with chunking",
+			spec: &universe.MovingAverageProcedureSpec{
+				Columns: []string{execute.DefaultValueColLabel},
+				N:       5,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TInt},
+						{Label: "passInt", Type: flux.TInt},
+						{Label: "passUint", Type: flux.TUInt},
+						{Label: "passFloat", Type: flux.TFloat},
+						{Label: "passNull", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), int64(2), int64(2), uint64(1), 5.0, nil},
+						{execute.Time(2), int64(4), int64(3), uint64(2), 4.0, nil},
+						{execute.Time(3), int64(5), int64(4), uint64(3), 3.0, nil},
+					},
 				},
 			}},
 			want: []*executetest.Table{{


### PR DESCRIPTION
The previous implementation incorrectly accounted for the case where a chunk ends but the specified period has not beed reached. This was being called at the end of every chunk, which produced the unwanted behavior of appending even if there are more rows in different chunks ([see here](https://github.com/influxdata/flux/pull/1443/files#r302745293)). The solution is to check if the specified period has been reached after iterating through all the chunks, at the end of the `Process` method.

In addition, an arrayContainer interface is created to reduce the number of functions needed for different column types.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
