### PR TITLE
feat: add mutable arrow array builders

### DIFF
--- a/internal/mutable/numericarray.go
+++ b/internal/mutable/numericarray.go
@@ -1,0 +1,397 @@
+package mutable
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
+)
+
+// Int64Array is an array of int64 values.
+type Int64Array struct {
+	refCount int64
+	mem      memory.Allocator
+	data     *memory.Buffer
+	rawData  []int64
+	length   int
+}
+
+// NewInt64Array constructs a new Int64Array.
+func NewInt64Array(mem memory.Allocator) *Int64Array {
+	return &Int64Array{
+		refCount: 1,
+		mem:      mem,
+	}
+}
+
+// Append will append a value to the array. This will increase
+// the length by 1 and may trigger a reallocation if the length
+// would go over the current capacity.
+func (b *Int64Array) Append(v int64) {
+	b.Reserve(1)
+	b.rawData = append(b.rawData, v)
+	b.length = len(b.rawData)
+}
+
+// AppendValues will append the given values to the array.
+// This will increase the length for the new values and may
+// trigger a reallocation if the length would go over the current
+// capacity.
+func (b *Int64Array) AppendValues(v []int64) {
+	b.Reserve(len(v))
+	b.rawData = append(b.rawData, v...)
+	b.length = len(b.rawData)
+}
+
+// Cap returns the capacity of the array.
+func (b *Int64Array) Cap() int { return cap(b.rawData) }
+
+// Len returns the length of the array.
+func (b *Int64Array) Len() int { return len(b.rawData) }
+
+// NewArray returns a new array from the data using NewInt64Array.
+func (b *Int64Array) NewArray() array.Interface {
+	return b.NewInt64Array()
+}
+
+// NewInt64Array will construct a new arrow array from the
+// buffered data.
+//
+// This will reset the current array.
+func (b *Int64Array) NewInt64Array() *array.Int64 {
+	data := array.NewData(
+		arrow.PrimitiveTypes.Int64,
+		len(b.rawData),
+		[]*memory.Buffer{nil, b.data},
+		nil, 0, 0,
+	)
+	b.reset()
+
+	a := array.NewInt64Data(data)
+	data.Release()
+	return a
+}
+
+func (b *Int64Array) init() {
+	b.data = memory.NewResizableBuffer(b.mem)
+}
+
+func (b *Int64Array) reset() {
+	b.data.Release()
+	b.data = nil
+	b.rawData = nil
+}
+
+// Retain will retain a reference to the builder.
+func (b *Int64Array) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+// Release will release any reference to data buffers.
+func (b *Int64Array) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		if b.data != nil {
+			b.reset()
+		}
+	}
+}
+
+// Reserve will reserve additional capacity in the array for
+// the number of elements to be appended.
+//
+// This does not change the length of the array, but only the capacity.
+func (b *Int64Array) Reserve(n int) {
+	if len(b.rawData)+n > cap(b.rawData) {
+		if b.data == nil {
+			b.init()
+		}
+		capacity := arrow.Int64Traits.BytesRequired(n)
+		b.data.Reserve(capacity)
+		b.rawData = arrow.Int64Traits.CastFromBytes(b.data.Bytes())
+	}
+}
+
+// Resize will resize the array to the given size. It will potentially
+// shrink the array if the requested size is less than the current size.
+//
+// This will change the length of the array.
+func (b *Int64Array) Resize(n int) {
+	if b.data == nil {
+		b.init()
+	}
+	newSize := arrow.Int64Traits.BytesRequired(n)
+	b.data.Resize(newSize)
+	b.rawData = arrow.Int64Traits.CastFromBytes(b.data.Buf())[:n]
+	b.length = n
+}
+
+// Value will return the value at index i.
+func (b *Int64Array) Value(i int) int64 {
+	return b.rawData[i]
+}
+
+// Set will set the value at index i.
+func (b *Int64Array) Set(i int, v int64) {
+	b.rawData[i] = v
+}
+
+// Uint64Array is an array of uint64 values.
+type Uint64Array struct {
+	refCount int64
+	mem      memory.Allocator
+	data     *memory.Buffer
+	rawData  []uint64
+	length   int
+}
+
+// NewUint64Array constructs a new Uint64Array.
+func NewUint64Array(mem memory.Allocator) *Uint64Array {
+	return &Uint64Array{
+		refCount: 1,
+		mem:      mem,
+	}
+}
+
+// Append will append a value to the array. This will increase
+// the length by 1 and may trigger a reallocation if the length
+// would go over the current capacity.
+func (b *Uint64Array) Append(v uint64) {
+	b.Reserve(1)
+	b.rawData = append(b.rawData, v)
+	b.length = len(b.rawData)
+}
+
+// AppendValues will append the given values to the array.
+// This will increase the length for the new values and may
+// trigger a reallocation if the length would go over the current
+// capacity.
+func (b *Uint64Array) AppendValues(v []uint64) {
+	b.Reserve(len(v))
+	b.rawData = append(b.rawData, v...)
+	b.length = len(b.rawData)
+}
+
+// Cap returns the capacity of the array.
+func (b *Uint64Array) Cap() int { return cap(b.rawData) }
+
+// Len returns the length of the array.
+func (b *Uint64Array) Len() int { return len(b.rawData) }
+
+// NewArray returns a new array from the data using NewUint64Array.
+func (b *Uint64Array) NewArray() array.Interface {
+	return b.NewUint64Array()
+}
+
+// NewUint64Array will construct a new arrow array from the
+// buffered data.
+//
+// This will reset the current array.
+func (b *Uint64Array) NewUint64Array() *array.Uint64 {
+	data := array.NewData(
+		arrow.PrimitiveTypes.Uint64,
+		len(b.rawData),
+		[]*memory.Buffer{nil, b.data},
+		nil, 0, 0,
+	)
+	b.reset()
+
+	a := array.NewUint64Data(data)
+	data.Release()
+	return a
+}
+
+func (b *Uint64Array) init() {
+	b.data = memory.NewResizableBuffer(b.mem)
+}
+
+func (b *Uint64Array) reset() {
+	b.data.Release()
+	b.data = nil
+	b.rawData = nil
+}
+
+// Retain will retain a reference to the builder.
+func (b *Uint64Array) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+// Release will release any reference to data buffers.
+func (b *Uint64Array) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		if b.data != nil {
+			b.data.Release()
+			b.data = nil
+			b.rawData = nil
+		}
+	}
+}
+
+// Reserve will reserve additional capacity in the array for
+// the number of elements to be appended.
+//
+// This does not change the length of the array, but only the capacity.
+func (b *Uint64Array) Reserve(n int) {
+	if len(b.rawData)+n > cap(b.rawData) {
+		if b.data == nil {
+			b.init()
+		}
+		capacity := arrow.Uint64Traits.BytesRequired(n)
+		b.data.Reserve(capacity)
+		b.rawData = arrow.Uint64Traits.CastFromBytes(b.data.Bytes())
+	}
+}
+
+// Resize will resize the array to the given size. It will potentially
+// shrink the array if the requested size is less than the current size.
+//
+// This will change the length of the array.
+func (b *Uint64Array) Resize(n int) {
+	if b.data == nil {
+		b.init()
+	}
+	newSize := arrow.Uint64Traits.BytesRequired(n)
+	b.data.Resize(newSize)
+	b.rawData = arrow.Uint64Traits.CastFromBytes(b.data.Buf())[:n]
+	b.length = n
+}
+
+// Value will return the value at index i.
+func (b *Uint64Array) Value(i int) uint64 {
+	return b.rawData[i]
+}
+
+// Set will set the value at index i.
+func (b *Uint64Array) Set(i int, v uint64) {
+	b.rawData[i] = v
+}
+
+// Float64Array is an array of float64 values.
+type Float64Array struct {
+	refCount int64
+	mem      memory.Allocator
+	data     *memory.Buffer
+	rawData  []float64
+	length   int
+}
+
+// NewFloat64Array constructs a new Float64Array.
+func NewFloat64Array(mem memory.Allocator) *Float64Array {
+	return &Float64Array{
+		refCount: 1,
+		mem:      mem,
+	}
+}
+
+// Append will append a value to the array. This will increase
+// the length by 1 and may trigger a reallocation if the length
+// would go over the current capacity.
+func (b *Float64Array) Append(v float64) {
+	b.Reserve(1)
+	b.rawData = append(b.rawData, v)
+	b.length = len(b.rawData)
+}
+
+// AppendValues will append the given values to the array.
+// This will increase the length for the new values and may
+// trigger a reallocation if the length would go over the current
+// capacity.
+func (b *Float64Array) AppendValues(v []float64) {
+	b.Reserve(len(v))
+	b.rawData = append(b.rawData, v...)
+	b.length = len(b.rawData)
+}
+
+// Cap returns the capacity of the array.
+func (b *Float64Array) Cap() int { return cap(b.rawData) }
+
+// Len returns the length of the array.
+func (b *Float64Array) Len() int { return len(b.rawData) }
+
+// NewArray returns a new array from the data using NewFloat64Array.
+func (b *Float64Array) NewArray() array.Interface {
+	return b.NewFloat64Array()
+}
+
+// NewFloat64Array will construct a new arrow array from the
+// buffered data.
+//
+// This will reset the current array.
+func (b *Float64Array) NewFloat64Array() *array.Float64 {
+	data := array.NewData(
+		arrow.PrimitiveTypes.Float64,
+		len(b.rawData),
+		[]*memory.Buffer{nil, b.data},
+		nil, 0, 0,
+	)
+	b.reset()
+
+	a := array.NewFloat64Data(data)
+	data.Release()
+	return a
+}
+
+func (b *Float64Array) init() {
+	b.data = memory.NewResizableBuffer(b.mem)
+}
+
+func (b *Float64Array) reset() {
+	b.data.Release()
+	b.data = nil
+	b.rawData = nil
+}
+
+// Retain will retain a reference to the builder.
+func (b *Float64Array) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+// Release will release any reference to data buffers.
+func (b *Float64Array) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		if b.data != nil {
+			b.data.Release()
+			b.data = nil
+			b.rawData = nil
+		}
+	}
+}
+
+// Reserve will reserve additional capacity in the array for
+// the number of elements to be appended.
+//
+// This does not change the length of the array, but only the capacity.
+func (b *Float64Array) Reserve(n int) {
+	if len(b.rawData)+n > cap(b.rawData) {
+		if b.data == nil {
+			b.init()
+		}
+		capacity := arrow.Float64Traits.BytesRequired(n)
+		b.data.Reserve(capacity)
+		b.rawData = arrow.Float64Traits.CastFromBytes(b.data.Bytes())
+	}
+}
+
+// Resize will resize the array to the given size. It will potentially
+// shrink the array if the requested size is less than the current size.
+//
+// This will change the length of the array.
+func (b *Float64Array) Resize(n int) {
+	if b.data == nil {
+		b.init()
+	}
+	newSize := arrow.Float64Traits.BytesRequired(n)
+	b.data.Resize(newSize)
+	b.rawData = arrow.Float64Traits.CastFromBytes(b.data.Buf())[:n]
+	b.length = n
+}
+
+// Value will return the value at index i.
+func (b *Float64Array) Value(i int) float64 {
+	return b.rawData[i]
+}
+
+// Set will set the value at index i.
+func (b *Float64Array) Set(i int, v float64) {
+	b.rawData[i] = v
+}

--- a/internal/mutable/numericarray_test.go
+++ b/internal/mutable/numericarray_test.go
@@ -1,0 +1,632 @@
+package mutable_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux/internal/mutable"
+)
+
+func TestInt64Array_Append(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Appending will change the length to 1.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Appending again changes the length to 2.
+	b.Append(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestInt64Array_AppendValues(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	b.AppendValues([]int64{1, 2})
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestInt64Array_Reserve(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Reserve will increase the capacity, but not the length.
+	// We do not verify the exact capacity because that doesn't matter,
+	// just that it is greater than or equal to 2.
+	b.Reserve(2)
+	if got, want := b.Len(), 0; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := b.Cap(); got < 2 {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %s\n\t+ %d", "at least 2", got)
+	}
+
+	// If we append a value, the capacity should not change.
+	want := b.Cap()
+	b.Append(1)
+	if got := b.Cap(); got != want {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestInt64Array_Resize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Resize to 2 for 2 elements.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with default values.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(0); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(0); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestInt64Array_Set(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	// Resize the array to two values and set each of the values.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Set the values.
+	b.Set(0, 1)
+	b.Set(1, 2)
+
+	// Verify the values using Value.
+	if got, want := b.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := b.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestInt64Array_NewArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append a value.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Construct an array. This should reset the builder.
+	b.NewArray().Release()
+
+	// Append a value to the builder again.
+	b.Append(2)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(2); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestUint64Array_Append(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewUint64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Appending will change the length to 1.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Appending again changes the length to 2.
+	b.Append(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewUint64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), uint64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), uint64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestUint64Array_AppendValues(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewUint64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	b.AppendValues([]uint64{1, 2})
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewUint64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), uint64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), uint64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestUint64Array_Reserve(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewUint64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Reserve will increase the capacity, but not the length.
+	// We do not verify the exact capacity because that doesn't matter,
+	// just that it is greater than or equal to 2.
+	b.Reserve(2)
+	if got, want := b.Len(), 0; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := b.Cap(); got < 2 {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %s\n\t+ %d", "at least 2", got)
+	}
+
+	// If we append a value, the capacity should not change.
+	want := b.Cap()
+	b.Append(1)
+	if got := b.Cap(); got != want {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestUint64Array_Resize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewUint64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Resize to 2 for 2 elements.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with default values.
+	a := b.NewUint64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), uint64(0); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), uint64(0); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestUint64Array_Set(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewUint64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	// Resize the array to two values and set each of the values.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Set the values.
+	b.Set(0, 1)
+	b.Set(1, 2)
+
+	// Verify the values using Value.
+	if got, want := b.Value(0), uint64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := b.Value(1), uint64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewUint64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), uint64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), uint64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestUint64Array_NewArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewUint64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append a value.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Construct an array. This should reset the builder.
+	b.NewArray().Release()
+
+	// Append a value to the builder again.
+	b.Append(2)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewUint64Array()
+	if got, want := a.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), uint64(2); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestFloat64Array_Append(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewFloat64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Appending will change the length to 1.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Appending again changes the length to 2.
+	b.Append(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewFloat64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), float64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if got, want := a.Value(1), float64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestFloat64Array_AppendValues(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewFloat64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	b.AppendValues([]float64{1, 2})
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewFloat64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), float64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if got, want := a.Value(1), float64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestFloat64Array_Reserve(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewFloat64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Reserve will increase the capacity, but not the length.
+	// We do not verify the exact capacity because that doesn't matter,
+	// just that it is greater than or equal to 2.
+	b.Reserve(2)
+	if got, want := b.Len(), 0; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := b.Cap(); got < 2 {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %s\n\t+ %d", "at least 2", got)
+	}
+
+	// If we append a value, the capacity should not change.
+	want := b.Cap()
+	b.Append(1)
+	if got := b.Cap(); got != want {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestFloat64Array_Resize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewFloat64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Resize to 2 for 2 elements.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with default values.
+	a := b.NewFloat64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), float64(0); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if got, want := a.Value(1), float64(0); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	a.Release()
+}
+
+func TestFloat64Array_Set(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewFloat64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	// Resize the array to two values and set each of the values.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Set the values.
+	b.Set(0, 1)
+	b.Set(1, 2)
+
+	// Verify the values using Value.
+	if got, want := b.Value(0), float64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if got, want := b.Value(1), float64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewFloat64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), float64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	if got, want := a.Value(1), float64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	a.Release()
+}
+
+func TestFloat64Array_NewArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewFloat64Array(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append a value.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Construct an array. This should reset the builder.
+	b.NewArray().Release()
+
+	// Append a value to the builder again.
+	b.Append(2)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewFloat64Array()
+	if got, want := a.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), float64(2); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", want, got)
+	}
+	a.Release()
+}


### PR DESCRIPTION
The mutable arrow array builders use the arrow library's allocator
interface and the memory buffer, but it exposes the ability to set
values as part of the builder such as the ones that would be exposed if
the values were in a slice.

This is only included for the numeric targets at the moment because
those are the most simple to implement. String builders would likely not
be possible and boolean values can be included in the future when we
need them.

These builders do not support null values. We may support that in the
future if it is needed.

These builders are being added as an internal package while we
experiment with this idea in order to avoid adding it as a publicly
exposed API.

#1532 

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written