### PR TITLE
feat(internal/mutable): tracked slice

### DIFF
--- a/arrow/allocator.go
+++ b/arrow/allocator.go
@@ -10,6 +10,17 @@ type allocator struct {
 	alloc *memory.Allocator
 }
 
+func NewAllocator(a *memory.Allocator) arrowmemory.Allocator {
+	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
+	if a != nil {
+		alloc = &allocator{
+			Allocator: alloc,
+			alloc:     a,
+		}
+	}
+	return alloc
+}
+
 func (a *allocator) Allocate(size int) []byte {
 	if err := a.alloc.Allocate(size); err != nil {
 		panic(err)

--- a/internal/mutable/benchmarks_test.go
+++ b/internal/mutable/benchmarks_test.go
@@ -1,0 +1,189 @@
+package mutable_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux/internal/mutable"
+	fluxmemory "github.com/influxdata/flux/memory"
+)
+
+func createArraysWithSize(n, s int) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	for i := 0; i < n; i++ {
+		b := mutable.NewInt64Array(mem)
+		b.Resize(s)
+		b.Release()
+	}
+}
+
+func createSlicesWithSize(n, s int) {
+	mem := &fluxmemory.Allocator{}
+	for i := 0; i < n; i++ {
+		b := mutable.NewInt64TrackedSlice(mem, s, s)
+		b.Release()
+	}
+}
+
+func BenchmarkInt64SizedArray(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createArraysWithSize(100, 100)
+	}
+}
+
+func BenchmarkInt64SizedSlice(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createSlicesWithSize(100, 100)
+	}
+}
+
+func createArraysWithSizeAndCapacity(n, s int) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	for i := 0; i < n; i++ {
+		b := mutable.NewInt64Array(mem)
+		b.Resize(s)
+		b.Reserve(s)
+		b.Release()
+	}
+}
+
+func createSlicesWithSizeAndCapacity(n, s int) {
+	mem := &fluxmemory.Allocator{}
+	for i := 0; i < n; i++ {
+		b := mutable.NewInt64TrackedSlice(mem, s, s*2)
+		b.Release()
+	}
+}
+
+func BenchmarkInt64ArrayWCapacity(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createArraysWithSizeAndCapacity(100, 100)
+	}
+}
+
+func BenchmarkInt64SliceWCapacity(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createSlicesWithSizeAndCapacity(100, 100)
+	}
+}
+
+func createArraySetReserveAppend(s int) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	b.Resize(s)
+	for i := 0; i < s; i++ {
+		b.Set(i, int64(i))
+	}
+	b.Reserve(s)
+	for i := 0; i < s; i++ {
+		b.Append(int64(i))
+	}
+}
+
+func createSliceSetReserveAppend(s int) {
+	mem := &fluxmemory.Allocator{}
+	b := mutable.NewInt64TrackedSlice(mem, s, s)
+	defer b.Release()
+	b.Resize(s)
+	for i := 0; i < s; i++ {
+		b.Set(i, int64(i))
+	}
+	b.Reserve(s)
+	for i := 0; i < s; i++ {
+		b.Append(int64(i))
+	}
+}
+
+func BenchmarkInt64ArrayAddValues(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createArraySetReserveAppend(1000)
+	}
+}
+
+func BenchmarkInt64SliceAddValues(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createSliceSetReserveAppend(1000)
+	}
+}
+
+func createArrayKnownCapacity(s int) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	b.Resize(s)
+	b.Reserve(s)
+	for i := 0; i < s; i++ {
+		b.Set(i, int64(i))
+	}
+	for i := 0; i < s; i++ {
+		b.Append(int64(i))
+	}
+}
+
+func createSliceKnownCapacity(s int) {
+	mem := &fluxmemory.Allocator{}
+	b := mutable.NewInt64TrackedSlice(mem, s, s*2)
+	defer b.Release()
+	for i := 0; i < s; i++ {
+		b.Set(i, int64(i))
+	}
+	for i := 0; i < s; i++ {
+		b.Append(int64(i))
+	}
+}
+
+func BenchmarkInt64ArrayAddValuesKnownCapacity(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createArrayKnownCapacity(1000)
+	}
+}
+
+func BenchmarkInt64SliceAddValuesKnownCapacity(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createSliceKnownCapacity(1000)
+	}
+}
+
+func createArrowArrayFromArray(s int) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	b := mutable.NewInt64Array(mem)
+	defer b.Release()
+	b.Resize(s)
+	for i := 0; i < s; i++ {
+		b.Set(i, int64(i))
+	}
+	b.NewInt64Array().Release()
+}
+
+func createArrowArrayFromSlice(s int) {
+	mem := &fluxmemory.Allocator{}
+	b := mutable.NewInt64TrackedSlice(mem, s, s)
+	defer b.Release()
+	for i := 0; i < s; i++ {
+		b.Set(i, int64(i))
+	}
+	b.NewInt64Array().Release()
+}
+
+func BenchmarkInt64ArrayArrowArray(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createArrowArrayFromArray(1000)
+	}
+}
+
+func BenchmarkInt64SliceArrowArray(b *testing.B) {
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		createArrowArrayFromSlice(1000)
+	}
+}

--- a/internal/mutable/numericslice.go
+++ b/internal/mutable/numericslice.go
@@ -1,0 +1,133 @@
+package mutable
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	fluxarrow "github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/memory"
+)
+
+// Int64TrackedSlice wraps a slice of int64 values and tracks its memory usage.
+type Int64TrackedSlice struct {
+	refCount int64
+	alloc    *memory.Allocator
+	rawData  []int64
+}
+
+// NewInt64TrackedSlice constructs a new Int64TrackedSlice given an allocator, length, and capacity.
+func NewInt64TrackedSlice(alloc *memory.Allocator, l, c int) *Int64TrackedSlice {
+	s := &Int64TrackedSlice{
+		refCount: 1,
+		alloc:    alloc,
+		rawData:  make([]int64, l, c),
+	}
+	s.allocate()
+	return s
+}
+
+func (b *Int64TrackedSlice) allocate() {
+	bs := arrow.Int64Traits.BytesRequired(cap(b.rawData))
+	if err := b.alloc.Allocate(bs); err != nil {
+		panic(err)
+	}
+}
+
+func (b *Int64TrackedSlice) free() {
+	bs := arrow.Int64Traits.BytesRequired(cap(b.rawData))
+	b.alloc.Free(bs)
+}
+
+func (b *Int64TrackedSlice) reset() {
+	b.free()
+	b.rawData = nil
+}
+
+// Append will append a value to the array. This will increase
+// the length by 1 and may trigger a reallocation if the length
+// would go over the current capacity.
+func (b *Int64TrackedSlice) Append(v int64) {
+	b.Reserve(1)
+	b.rawData = append(b.rawData, v)
+}
+
+// AppendValues will append the given values to the array.
+// This will increase the length for the new values and may
+// trigger a reallocation if the length would go over the current
+// capacity.
+func (b *Int64TrackedSlice) AppendValues(v []int64) {
+	b.Reserve(len(v))
+	b.rawData = append(b.rawData, v...)
+}
+
+// Cap returns the capacity of the array.
+func (b *Int64TrackedSlice) Cap() int { return cap(b.rawData) }
+
+// Len returns the length of the array.
+func (b *Int64TrackedSlice) Len() int { return len(b.rawData) }
+
+// Retain will retain a reference to the builder.
+func (b *Int64TrackedSlice) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+// Release will release any reference to data buffers.
+func (b *Int64TrackedSlice) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		b.reset()
+	}
+}
+
+// Reserve will reserve additional capacity in the array for
+// the number of elements to be appended.
+//
+// This does not change the length of the array, but only the capacity.
+func (b *Int64TrackedSlice) Reserve(n int) {
+	if len(b.rawData)+n > cap(b.rawData) {
+		b.free()
+		t := make([]int64, len(b.rawData), len(b.rawData)+n)
+		copy(t, b.rawData)
+		b.rawData = t
+		b.allocate()
+	}
+}
+
+// Resize will resize the array to the given size. It will potentially
+// shrink the array if the requested size is less than the current size.
+//
+// This will change the length of the array.
+func (b *Int64TrackedSlice) Resize(n int) {
+	b.free()
+	t := make([]int64, n)
+	copy(t, b.rawData)
+	b.rawData = t
+	b.allocate()
+}
+
+// Value will return the value at index i.
+func (b *Int64TrackedSlice) Value(i int) int64 {
+	return b.rawData[i]
+}
+
+// Set will set the value at index i.
+func (b *Int64TrackedSlice) Set(i int, v int64) {
+	b.rawData[i] = v
+}
+
+// NewArray returns a new array from the data using NewInt64TrackedSlice.
+func (b *Int64TrackedSlice) NewArray() array.Interface {
+	return b.NewInt64Array()
+}
+
+// NewInt64TrackedSlice will construct a new arrow array from the
+// buffered data.
+//
+// This will reset the current array.
+func (b *Int64TrackedSlice) NewInt64Array() *array.Int64 {
+	builder := array.NewInt64Builder(fluxarrow.NewAllocator(b.alloc))
+	// every value is valid (for now).
+	builder.AppendValues(b.rawData, nil)
+	b.reset()
+	return builder.NewInt64Array()
+}

--- a/internal/mutable/numericslice_test.go
+++ b/internal/mutable/numericslice_test.go
@@ -1,0 +1,261 @@
+package mutable_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/internal/mutable"
+	"github.com/influxdata/flux/memory"
+)
+
+func assertSize(t *testing.T, a *memory.Allocator, n int) {
+	if got, want := a.Allocated(), int64(n); want != got {
+		t.Errorf("allocator got unexpected bytes allocated -want/+got:\t\n- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestInt64TrackedSlice_Append(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	// Appending will change the length to 1.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Appending again changes the length to 2.
+	b.Append(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestInt64TrackedSlice_AppendValues(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	// Append two values.
+	b.AppendValues([]int64{1, 2})
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestInt64TrackedSlice_Reserve(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	// Reserve will increase the capacity, but not the length.
+	// We do not verify the exact capacity because that doesn't matter,
+	// just that it is greater than or equal to 2.
+	b.Reserve(2)
+	if got, want := b.Len(), 0; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := b.Cap(); got < 2 {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %s\n\t+ %d", "at least 2", got)
+	}
+
+	// If we append a value, the capacity should not change.
+	want := b.Cap()
+	b.Append(1)
+	if got := b.Cap(); got != want {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestInt64TrackedSlice_Resize(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	// Resize to 2 for 2 elements.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with default values.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(0); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(0); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestInt64TrackedSlice_Set(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	// Append two values.
+	// Resize the array to two values and set each of the values.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Set the values.
+	b.Set(0, 1)
+	b.Set(1, 2)
+
+	// Verify the values using Value.
+	if got, want := b.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := b.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(1); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(1), int64(2); got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestInt64TrackedSlice_NewArray(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	// Append a value.
+	b.Append(1)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Construct an array. This should reset the builder.
+	b.NewArray().Release()
+
+	// Append a value to the builder again.
+	b.Append(2)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 1 with the same value.
+	a := b.NewInt64Array()
+	if got, want := a.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.Value(0), int64(2); got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	a.Release()
+}
+
+func TestInt64TrackedSlice_MixReserveResize(t *testing.T) {
+	mem := new(memory.Allocator)
+	defer assertSize(t, mem, 0)
+
+	b := mutable.NewInt64TrackedSlice(mem, 0, 0)
+	defer b.Release()
+	assertSize(t, mem, 0)
+
+	s1 := 10
+	s2 := 15
+	total := s1 + s2
+
+	// Mix resize and reserve.
+	b.Resize(s1)
+	b.Reserve(s2)
+	if got, want := b.Len(), s1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := b.Cap(), total; got < want {
+		t.Fatalf("unexpected capacity got < want: %d < %d", got, want)
+	}
+
+	for i := 0; i < total; i++ {
+		if i < s1 {
+			b.Set(i, int64(i))
+		} else {
+			b.Append(int64(i))
+		}
+	}
+	if got, want := b.Len(), total; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	for i := 0; i < total; i++ {
+		if got, want := b.Value(i), int64(i); got != want {
+			t.Fatalf("unexpected value at index %d: %d != %d", i, want, got)
+		}
+	}
+}


### PR DESCRIPTION
This is a tracked slices that uses Flux `memory.Allocator` and defers arrow memory tracking until the user requests for an arrow array.

This is a good use case for slices that remain slices. This happens, for example, in Holt Winters.

Benchmarks results:

```
pkg: github.com/influxdata/flux/internal/mutable
BenchmarkInt64SizedArray-12                     	   50000	     36218 ns/op	  102432 B/op	     301 allocs/op
BenchmarkInt64SizedSlice-12                     	   50000	     23274 ns/op	   94432 B/op	     201 allocs/op
BenchmarkInt64ArrayWCapacity-12                 	   50000	     35736 ns/op	  102432 B/op	     301 allocs/op
BenchmarkInt64SliceWCapacity-12                 	   50000	     29949 ns/op	  184032 B/op	     201 allocs/op
BenchmarkInt64ArrayAddValues-12                 	  100000	     13249 ns/op	   24736 B/op	       5 allocs/op
BenchmarkInt64SliceAddValues-12                 	  100000	     14074 ns/op	   32848 B/op	       5 allocs/op
BenchmarkInt64ArrayAddValuesKnownCapacity-12    	  100000	     13823 ns/op	   24736 B/op	       5 allocs/op
BenchmarkInt64SliceAddValuesKnownCapacity-12    	  100000	     10947 ns/op	   16464 B/op	       3 allocs/op
BenchmarkInt64ArrayArrowArray-12                	  300000	      5877 ns/op	    8528 B/op	       7 allocs/op
BenchmarkInt64SliceArrowArray-12                	  200000	      9547 ns/op	   26560 B/op	      13 allocs/op
```

This implementation performs better than the other implementation with the exception of reserving (requires growing the slice with -> copying) and creating the arrow array. Anyways, I would expect that the common usage for this implementation would be instantiating with a known size and capacity and not reserving any additional space.


I think that no implementation should survive the other. They should both exist. I see that yours is the best way of crafting an arrow array with a bit of overhead while manipulating, but significant less overhead when creating the final arrow array (perfect for creating something for the `TableBuilder`). Mine is for internal usage in algorithms that do not need a final arrow array and don't need overhead while manipulating (maybe this implementation doesn't even need to implement the very same interface of yours).

I won't proceed any further until I don't hear your opinion @jsternberg .

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
