### PR TITLE
fix(parser): catch integer overflow and underflow for literals

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/internal/scanner"
@@ -888,7 +889,21 @@ func (p *parser) parseIdentifier() *ast.Identifier {
 func (p *parser) parseIntLiteral() *ast.IntegerLiteral {
 	pos, lit := p.expect(token.INT)
 	// todo(jsternberg): handle errors.
-	value, _ := strconv.ParseInt(lit, 10, 64)
+	value, err := strconv.ParseInt(lit, 10, 64)
+	if err != nil {
+		// If the error message comes from strconv.ParseInt, we want
+		// to remove the first two parts from the error message as they are
+		// very Go specific and we want a generic error message.
+		msg := err.Error()
+		if strings.HasPrefix(msg, "strconv.ParseInt:") {
+			parts := strings.SplitN(err.Error(), ": ", 3)
+			msg = parts[len(parts)-1]
+		}
+		p.error(fmt.Sprintf("invalid integer literal %q: %s", lit, msg))
+
+		// Reset this to zero for consistency with the Rust implementation.
+		value = 0
+	}
 	return &ast.IntegerLiteral{
 		Value:    value,
 		BaseNode: p.posRange(pos, len(lit)),
@@ -916,12 +931,9 @@ func (p *parser) parseStringLiteral() *ast.StringLiteral {
 
 func (p *parser) parseRegexpLiteral() *ast.RegexpLiteral {
 	pos, lit := p.expect(token.REGEX)
-	// todo(jsternberg): handle errors.
 	value, err := ParseRegexp(lit)
 	if err != nil {
-		p.errs = append(p.errs, ast.Error{
-			Msg: err.Error(),
-		})
+		p.error(err.Error())
 	}
 	return &ast.RegexpLiteral{
 		Value:    value,
@@ -1484,6 +1496,12 @@ func (p *parser) baseNode(loc *ast.SourceLocation) ast.BaseNode {
 	}
 	p.errs = nil
 	return bnode
+}
+
+func (p *parser) error(msg string) {
+	p.errs = append(p.errs, ast.Error{
+		Msg: msg,
+	})
 }
 
 // locStart is a utility method for retrieving the start position

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -5703,6 +5703,27 @@ string"
 				},
 			},
 		},
+		{
+			name: "integer literal overflow",
+			raw:  `100000000000000000000000000000`,
+			want: &ast.File{
+				BaseNode: base("1:1", "1:31"),
+				Body: []ast.Statement{
+					&ast.ExpressionStatement{
+						BaseNode: base("1:1", "1:31"),
+						Expression: &ast.IntegerLiteral{
+							BaseNode: ast.BaseNode{
+								Loc: loc("1:1", "1:31"),
+								Errors: []ast.Error{
+									{Msg: `invalid integer literal "100000000000000000000000000000": value out of range`},
+								},
+							},
+						},
+					},
+				},
+			},
+			nerrs: 1,
+		},
 	} {
 		runFn(tt.name, func(tb testing.TB) {
 			if reason, ok := skip[tt.name]; ok {

--- a/internal/rust/parser/src/lib.rs
+++ b/internal/rust/parser/src/lib.rs
@@ -951,13 +951,21 @@ impl Parser {
             name: t.lit,
         };
     }
-    // TODO(affo): handle errors for literals.
     fn parse_int_literal(&mut self) -> IntegerLiteral {
         let t = self.expect(T_INT);
-        return IntegerLiteral {
-            base: self.base_node(),
-            value: (&t.lit).parse::<i64>().unwrap(),
-        };
+        match (&t.lit).parse::<i64>() {
+            Err(_e) => {
+                self.errs.push(format!("invalid integer literal \"{}\": value out of range", t.lit));
+                IntegerLiteral {
+                    base: self.base_node(),
+                    value: 0,
+                }
+            }
+            Ok(v) => IntegerLiteral {
+                base: self.base_node(),
+                value: v,
+            }
+        }
     }
     fn parse_float_literal(&mut self) -> FloatLiteral {
         let t = self.expect(T_FLOAT);

--- a/internal/rust/parser/src/tests.rs
+++ b/internal/rust/parser/src/tests.rs
@@ -6072,6 +6072,28 @@ fn invalid_expression_in_array() {
     )
 }
 
+#[test]
+fn integer_literal_overflow() {
+    let mut p = Parser::new(r#"100000000000000000000000000000"#);
+    let parsed = p.parse_file("".to_string());
+    assert_eq!(
+        parsed,
+        File {
+            base: BaseNode { errors: vec![] },
+            name: "".to_string(),
+            package: None,
+            imports: vec![],
+            body: vec![Expr(ExpressionStatement {
+                base: BaseNode { errors: vec![] },
+                expression: Int(IntegerLiteral {
+                    base: BaseNode { errors: vec!["invalid integer literal \"100000000000000000000000000000\": value out of range".to_string()] },
+                    value: 0,
+                })
+            })]
+        },
+    )
+}
+
 // TODO(affo): that error is injected by ast.Check().
 #[test]
 fn multiple_idents_in_parens() {


### PR DESCRIPTION
The parser will now report an error when parsing an integer fails
because the value is out of range. The rust parser also now does the
same.

#1560

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written