### PR TITLE
refactor(execute): add context arguments to SourceDecoder methods

### DIFF
--- a/stdlib/generate/from.go
+++ b/stdlib/generate/from.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -153,15 +154,15 @@ func NewGeneratorSource(a *memory.Allocator) *GeneratorSource {
 	return &GeneratorSource{alloc: a}
 }
 
-func (s *GeneratorSource) Connect() error {
+func (s *GeneratorSource) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (s *GeneratorSource) Fetch() (bool, error) {
+func (s *GeneratorSource) Fetch(ctx context.Context) (bool, error) {
 	return !s.done, nil
 }
 
-func (s *GeneratorSource) Decode() (flux.Table, error) {
+func (s *GeneratorSource) Decode(ctx context.Context) (flux.Table, error) {
 	defer func() {
 		s.done = true
 	}()

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	_ "github.com/go-sql-driver/mysql"
@@ -126,7 +127,9 @@ type SQLIterator struct {
 	reader         *execute.RowReader
 }
 
-func (c *SQLIterator) Connect() error {
+var _ execute.SourceDecoder = (*SQLIterator)(nil)
+
+func (c *SQLIterator) Connect(ctx context.Context) error {
 	db, err := sql.Open(c.spec.DriverName, c.spec.DataSourceName)
 
 	if err != nil {
@@ -140,7 +143,7 @@ func (c *SQLIterator) Connect() error {
 	return nil
 }
 
-func (c *SQLIterator) Fetch() (bool, error) {
+func (c *SQLIterator) Fetch(ctx context.Context) (bool, error) {
 	rows, err := c.db.Query(c.spec.Query)
 	if err != nil {
 		return false, err
@@ -164,7 +167,7 @@ func (c *SQLIterator) Fetch() (bool, error) {
 	return false, nil
 }
 
-func (c *SQLIterator) Decode() (flux.Table, error) {
+func (c *SQLIterator) Decode(ctx context.Context) (flux.Table, error) {
 	groupKey := execute.NewGroupKey(nil, nil)
 	builder := execute.NewColListTableBuilder(groupKey, c.administration.Allocator())
 

--- a/stdlib/sql/sql_test.go
+++ b/stdlib/sql/sql_test.go
@@ -100,7 +100,7 @@ func TestFromRowReader(t *testing.T) {
 
 		rr.InitColumnTypes(nil)
 
-		table, err := sqliter.Decode()
+		table, err := sqliter.Decode(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This enables us to pass a context down to sources, which is needed for authz checking in influxdb.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
