### PR TITLE
feat(stdlib/universe): add keepFirst to difference

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -3076,6 +3076,7 @@ Difference has the following properties:
 | ----        | ----     | -----------                                                                                                                                                 |
 | nonNegative | bool     | NonNegative indicates if the difference is allowed to be negative. If a value is encountered which is less than the previous value then the result is null. |
 | columns     | []string | Columns is a list of columns on which to compute the difference. Defaults to `["_value"]`.                                                                  |
+| keepFirst   | bool     | KeepFirst indicates if the first row should be kept. If `true`, then the difference will be `null`. Defaults to `false`. 
 
 Rules for subtracting values for numeric types:
 
@@ -3110,6 +3111,16 @@ Result (`nonNegative: true`):
 |  0003 | null |   0  |   2  |  tv |
 |  0004 |   6  |   8  | null |  tv |
 |  0005 | null | null | null |  tv |
+
+Result (`nonNegative: false`, `keepFirst: true`):
+
+| _time |   A  |   B  |   C  | tag |
+|:-----:|:----:|:----:|:----:|:---:|
+|  0001 | null | null | null |  tv |
+|  0002 | null |   1  | null |  tv |
+|  0003 |  -2  |   0  |   2  |  tv |
+|  0004 |   6  |   8  |  -2  |  tv |
+|  0005 | null | null |  -1  |  tv |
 
 Example of script:
 

--- a/stdlib/testing/testdata/difference_keepfirst.flux
+++ b/stdlib/testing/testdata/difference_keepfirst.flux
@@ -1,0 +1,52 @@
+package testdata_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string,string
+#group,false,false,false,false,true,true,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,path
+,,0,2018-05-22T19:53:26Z,34.98234271799806,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:36Z,34.98234941084654,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:46Z,34.982447293755506,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:56Z,34.982447293755506,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:54:06Z,34.98204153981662,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:54:16Z,34.982252364543626,used_percent,disk,disk1s1,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,34.98234271799806,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:36Z,34.98234941084654,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:46Z,34.982447293755506,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:56Z,34.982447293755506,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:54:06Z,34.98204153981662,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:54:16Z,34.982252364543626,used_percent,disk,disk1s2,apfs,host.local,/
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string,string
+#group,false,false,true,true,false,false,true,true,true,true,true,true
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:36Z,0.000006692848479872282,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:46Z,0.00009788290896750595,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:56Z,0,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:06Z,-0.0004057539388853115,used_percent,disk,disk1s1,apfs,host.local,/
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:16Z,0.00021082472700584276,used_percent,disk,disk1s1,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:36Z,0.000006692848479872282,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:46Z,0.00009788290896750595,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:56Z,0,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:06Z,-0.0004057539388853115,used_percent,disk,disk1s2,apfs,host.local,/
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:16Z,0.00021082472700584276,used_percent,disk,disk1s2,apfs,host.local,/
+"
+
+t_difference = (table=<-) =>
+	(table
+		|> range(start: 2018-05-22T19:53:26Z)
+		|> difference(keepFirst: true))
+
+test _difference = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_difference})
+

--- a/stdlib/universe/difference_test.go
+++ b/stdlib/universe/difference_test.go
@@ -426,6 +426,186 @@ func TestDifference_Process(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "float with tags and keepFirst",
+			spec: &universe.DifferenceProcedureSpec{
+				Columns:   []string{execute.DefaultValueColLabel},
+				KeepFirst: true,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 2.0, "a"},
+					{execute.Time(2), 1.0, "b"},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, "a"},
+					{execute.Time(2), -1.0, "b"},
+				},
+			}},
+		},
+		{
+			name: "float with tags and keepFirst and chunks",
+			spec: &universe.DifferenceProcedureSpec{
+				Columns:   []string{execute.DefaultValueColLabel},
+				KeepFirst: true,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "t", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), 2.0, "a"},
+						{execute.Time(2), 1.0, "b"},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, "a"},
+					{execute.Time(2), -1.0, "b"},
+				},
+			}},
+		},
+		{
+			name: "int with tags and keepFirst",
+			spec: &universe.DifferenceProcedureSpec{
+				Columns:   []string{execute.DefaultValueColLabel},
+				KeepFirst: true,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), int64(2), "a"},
+					{execute.Time(2), int64(1), "b"},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, "a"},
+					{execute.Time(2), int64(-1), "b"},
+				},
+			}},
+		},
+		{
+			name: "int with tags and keepFirst and chunks",
+			spec: &universe.DifferenceProcedureSpec{
+				Columns:   []string{execute.DefaultValueColLabel},
+				KeepFirst: true,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TInt},
+						{Label: "t", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), int64(2), "a"},
+						{execute.Time(2), int64(1), "b"},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, "a"},
+					{execute.Time(2), int64(-1), "b"},
+				},
+			}},
+		},
+		{
+			name: "uint with tags and keepFirst",
+			spec: &universe.DifferenceProcedureSpec{
+				Columns:   []string{execute.DefaultValueColLabel},
+				KeepFirst: true,
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(2), "a"},
+					{execute.Time(2), uint64(1), "b"},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, "a"},
+					{execute.Time(2), int64(-1), "b"},
+				},
+			}},
+		},
+		{
+			name: "uint with tags and keepFirst and chunks",
+			spec: &universe.DifferenceProcedureSpec{
+				Columns:   []string{execute.DefaultValueColLabel},
+				KeepFirst: true,
+			},
+			data: []flux.Table{&executetest.RowWiseTable{
+				Table: &executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TUInt},
+						{Label: "t", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(1), uint64(2), "a"},
+						{execute.Time(2), uint64(1), "b"},
+					},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "t", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), nil, "a"},
+					{execute.Time(2), int64(-1), "b"},
+				},
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
- keepFirst is an optional parameter for whether to keep the first row or not
- default behavior is to drop the first row

This parameter would allow for `tripleExponentialDerivative` to be written in pure flux. Currently, this can't be done because `join` after using `difference` causes the first row to be lost.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
