### PR TITLE
docs(parser): design how string expressions will work

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -270,8 +270,7 @@ String literals support several escape sequences.
     \t   U+0009 horizontal tab
     \"   U+0022 double quote
     \\   U+005C backslash
-    \{   U+007B open curly bracket
-    \}   U+007D close curly bracket
+    \${  U+0024 U+007B dollar sign and opening curly bracket
 
 Additionally any byte value may be specified via a hex encoding using `\x` as the prefix.
 
@@ -281,7 +280,7 @@ Additionally any byte value may be specified via a hex encoding using `\x` as th
     hex_digit        = "0" … "9" | "A" … "F" | "a" … "f" .
     unicode_value    = unicode_char | escaped_char .
     escaped_char     = `\` ( "n" | "r" | "t" | `\` | `"` ) .
-    StringExpression = "{" Expression "}" .
+    StringExpression = "${" Expression "}" .
 
 TODO(nathanielc): With string interpolation string_lit is not longer a lexical token as part of a literal, but an entire expression in and of itself.
 
@@ -311,10 +310,9 @@ To include the literal curly brackets within a string they must be escaped.
 Interpolation example:
 
     n = 42
-    "the answer is {n}" // the answer is 42
-    "the answer is not {n+1}" // the answer is not 43
-    "openinng curly bracket \{" // openinng curly bracket {
-    "closing curly bracket \}" // closing curly bracket }
+    "the answer is ${n}" // the answer is 42
+    "the answer is not ${n+1}" // the answer is not 43
+    "dollar sign opening curly bracket \${" // dollar sign opening curly bracket ${
 
 [IMPL#251](https://github.com/influxdata/platform/issues/251) Add string interpolation support
 

--- a/internal/parser/grammar.md
+++ b/internal/parser/grammar.md
@@ -63,10 +63,14 @@ The parser directly implements the following grammar.
     MemberBracketExpression        = "[" string "]" .
     CallExpression                 = "(" ParameterList ")" .
     IndexExpression                = "[" Expression "]" .
+    StringExpression               = "\"" [ StringExpressionPart ] "\"" .
+    StringExpressionPart           = text | StringExpressionBlock .
+    StringExpressionBlock          = "${" Expression "}" .
     PrimaryExpression              = identifer
                                    | int_lit
                                    | float_lit
                                    | string_lit
+                                   | StringExpression
                                    | regex_lit
                                    | duration_lit
                                    | pipe_receive_lit


### PR DESCRIPTION
The grammar now includes a `StringExpression`. The scanner will be
updated so that a string literal cannot contain a left bracket in the
string. The scanner will also be updated to include a double quote as a
possible token so that the parser can recognize that the quote begins a
string expression.

A string expression is then processed with an alternate scanner
implementation which recognizes a text token, which is the literal
component of the string expression, and an ability to recognize when a
left bracket occurs.

#1620

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written