### PR TITLE
feat(http): add skeleton http.post function

### DIFF
--- a/stdlib/http/flux_gen.go
+++ b/stdlib/http/flux_gen.go
@@ -21,11 +21,11 @@ var pkgAST = &ast.Package{
 			Errors: nil,
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
-					Column: 11,
-					Line:   3,
+					Column: 13,
+					Line:   5,
 				},
 				File:   "http.flux",
-				Source: "package http\n\nbuiltin to",
+				Source: "package http\n\nbuiltin to\n\nbuiltin post",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -65,6 +65,40 @@ var pkgAST = &ast.Package{
 					},
 				},
 				Name: "to",
+			},
+		}, &ast.BuiltinStatement{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 13,
+						Line:   5,
+					},
+					File:   "http.flux",
+					Source: "builtin post",
+					Start: ast.Position{
+						Column: 1,
+						Line:   5,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 13,
+							Line:   5,
+						},
+						File:   "http.flux",
+						Source: "post",
+						Start: ast.Position{
+							Column: 9,
+							Line:   5,
+						},
+					},
+				},
+				Name: "post",
 			},
 		}},
 		Imports: nil,

--- a/stdlib/http/http.flux
+++ b/stdlib/http/http.flux
@@ -1,3 +1,5 @@
 package http
 
 builtin to
+
+builtin post

--- a/stdlib/http/post.go
+++ b/stdlib/http/post.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"log"
+
+	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func init() {
+	flux.RegisterPackageValue("http", "post", values.NewFunction(
+		"post",
+		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+			Parameters: map[string]semantic.PolyType{
+				"url":     semantic.String,
+				"headers": semantic.Tvar(1),
+				"data":    semantic.Tvar(2),
+			},
+			Required: []string{"url"},
+			Return:   semantic.Int,
+		}),
+		func(args values.Object) (values.Value, error) {
+			//TODO: Implement
+			log.Println("http.post args", args)
+			return values.NewInt(200), nil
+		},
+		true, // post has side-effects
+	))
+}


### PR DESCRIPTION
Adds no-op http.post so we can unblock work on developing endpoints.

This specifically unblocks  unblock #1689 and #1690