### PR TITLE
feat(dependencies): added a SecretService interface and a new dependencies package and a basic test of functionality

### DIFF
--- a/dependencies/secret_service.go
+++ b/dependencies/secret_service.go
@@ -1,0 +1,11 @@
+package dependencies
+
+import (
+	"context"
+)
+
+// SecretService generalizes the process of looking up secrets based on a key.
+type SecretService interface {
+	// LoadSecret retrieves the secret value v found at key k given the calling context ctx.
+	LoadSecret(ctx context.Context, k string) (string, error)
+}

--- a/dependencies/secret_service_test.go
+++ b/dependencies/secret_service_test.go
@@ -1,0 +1,23 @@
+package dependencies_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/flux/mock"
+)
+
+func TestSecret_Service(t *testing.T) {
+	ss := mock.SecretService{"key": "val"}
+	val, err := ss.LoadSecret(context.Background(), "key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "val" {
+		t.Error("secret service returned wrong value")
+	}
+
+	if _, err = ss.LoadSecret(context.Background(), "k"); err == nil {
+		t.Error("secret service should have errored on key lookup")
+	}
+}

--- a/mock/secret_service.go
+++ b/mock/secret_service.go
@@ -1,0 +1,17 @@
+package mock
+
+import (
+	"context"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+type SecretService map[string]string
+
+func (s SecretService) LoadSecret(ctx context.Context, k string) (string, error) {
+	v, ok := s[k]
+	if ok {
+		return v, nil
+	}
+	return "", errors.New(codes.NotFound, "key not found")
+}


### PR DESCRIPTION
service takes a key and a context which are known at the flux level.  In influxdb or other services, we have utilities that can process the context for proper authentication.   This design prevents a dependency on an external service.  

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
