### PR TITLE
feat(stdlib): add objectKeys function

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -302,8 +302,8 @@ func compile(n semantic.Node, typeSol semantic.TypeSolution, builtIns Scope, fun
 		rt := r.Type()
 		f, err := values.LookupBinaryFunction(values.BinaryFuncSignature{
 			Operator: n.Operator,
-			Left:     lt,
-			Right:    rt,
+			Left:     lt.Nature(),
+			Right:    rt.Nature(),
 		})
 		if err != nil {
 			return nil, err

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -324,8 +324,8 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope Scope) (va
 		}
 		bf, err := values.LookupBinaryFunction(values.BinaryFuncSignature{
 			Operator: e.Operator,
-			Left:     ltyp,
-			Right:    rtyp,
+			Left:     ltyp.Nature(),
+			Right:    rtyp.Nature(),
 		})
 		if err != nil {
 			return nil, err

--- a/stdlib/experimental/experimental.flux
+++ b/stdlib/experimental/experimental.flux
@@ -5,3 +5,6 @@ builtin subDuration
 
 // An experimental version of group that has mode: "extend"
 builtin group
+
+// objectKeys produces a list of the keys existing on the object
+builtin objectKeys

--- a/stdlib/experimental/flux_gen.go
+++ b/stdlib/experimental/flux_gen.go
@@ -21,11 +21,11 @@ var pkgAST = &ast.Package{
 			Errors: nil,
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
-					Column: 14,
-					Line:   7,
+					Column: 19,
+					Line:   10,
 				},
 				File:   "experimental.flux",
-				Source: "package experimental\n\nbuiltin addDuration\nbuiltin subDuration\n\n// An experimental version of group that has mode: \"extend\"\nbuiltin group",
+				Source: "package experimental\n\nbuiltin addDuration\nbuiltin subDuration\n\n// An experimental version of group that has mode: \"extend\"\nbuiltin group\n\n// objectKeys produces a list of the keys existing on the object\nbuiltin objectKeys",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -133,6 +133,40 @@ var pkgAST = &ast.Package{
 					},
 				},
 				Name: "group",
+			},
+		}, &ast.BuiltinStatement{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 19,
+						Line:   10,
+					},
+					File:   "experimental.flux",
+					Source: "builtin objectKeys",
+					Start: ast.Position{
+						Column: 1,
+						Line:   10,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 19,
+							Line:   10,
+						},
+						File:   "experimental.flux",
+						Source: "objectKeys",
+						Start: ast.Position{
+							Column: 9,
+							Line:   10,
+						},
+					},
+				},
+				Name: "objectKeys",
 			},
 		}},
 		Imports: nil,

--- a/stdlib/experimental/object_keys.go
+++ b/stdlib/experimental/object_keys.go
@@ -1,0 +1,38 @@
+package experimental
+
+import (
+	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func init() {
+	flux.RegisterPackageValue("experimental", "objectKeys", values.NewFunction(
+		"objectKeys",
+		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+			Parameters: map[string]semantic.PolyType{
+				"o": semantic.Tvar(1),
+			},
+			Required: []string{"o"},
+			Return:   semantic.NewArrayPolyType(semantic.String),
+		}),
+		func(args values.Object) (values.Value, error) {
+			o, ok := args.Get("o")
+			if !ok {
+				return nil, errors.New(codes.Invalid, "missing parameter \"o\"")
+			}
+			if o.Type().Nature() != semantic.Object {
+				return nil, errors.New(codes.Invalid, "parameter \"o\" is not an object")
+			}
+			obj := o.Object()
+			keys := make([]values.Value, 0, obj.Len())
+			obj.Range(func(name string, _ values.Value) {
+				keys = append(keys, values.NewString(name))
+			})
+			return values.NewArrayWithBacking(semantic.String, keys), nil
+		},
+		false,
+	))
+}

--- a/stdlib/experimental/object_keys_test.go
+++ b/stdlib/experimental/object_keys_test.go
@@ -1,0 +1,37 @@
+package experimental_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func addFail(scope interpreter.Scope) {
+	scope.Set("fail", values.NewFunction(
+		"fail",
+		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+			Return: semantic.Bool,
+		}),
+		func(args values.Object) (values.Value, error) {
+			return nil, errors.New(codes.Aborted, "fail")
+		},
+		false,
+	))
+}
+
+func TestObjectKeys(t *testing.T) {
+	script := `
+import "experimental"
+
+o = {a: 1, b: 2, c: 3}
+experimental.objectKeys(o: o) == ["a", "b", "c"] or fail()
+`
+	if _, _, err := flux.Eval(script, addFail); err != nil {
+		t.Fatal("evaluation of objectKeys failed: ", err)
+	}
+}

--- a/values/array_test.go
+++ b/values/array_test.go
@@ -1,0 +1,33 @@
+package values_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func TestArrayEqual(t *testing.T) {
+	r := values.NewArray(semantic.Int)
+	r.Append(values.NewInt(1))
+	l := values.NewArray(semantic.Int)
+	l.Append(values.NewInt(1))
+
+	if !l.Equal(r) {
+		t.Fatal("expected arrays to be equal")
+	}
+
+	l.Set(0, values.NewInt(2))
+	if l.Equal(r) {
+		t.Fatal("expected arrays to be unequal")
+	}
+
+	r.Set(0, values.NewInt(2))
+	if !l.Equal(r) {
+		t.Fatal("expected objects to be equal")
+	}
+	l.Append(values.NewInt(1))
+	if l.Equal(r) {
+		t.Fatal("expected objects to be unequal")
+	}
+}

--- a/values/binary.go
+++ b/values/binary.go
@@ -12,7 +12,7 @@ type BinaryFunction func(l, r Value) (Value, error)
 
 type BinaryFuncSignature struct {
 	Operator    ast.OperatorKind
-	Left, Right semantic.Type
+	Left, Right semantic.Nature
 }
 
 // LookupBinaryFunction returns an appropriate binary function that evaluates two values and returns another value.
@@ -560,6 +560,12 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.EqualOperator, Left: semantic.Nil, Right: semantic.String}: nil,
 	{Operator: ast.EqualOperator, Left: semantic.Nil, Right: semantic.Time}:   nil,
 	{Operator: ast.EqualOperator, Left: semantic.Nil, Right: semantic.Nil}:    nil,
+	{Operator: ast.EqualOperator, Left: semantic.Array, Right: semantic.Array}: func(lv, rv Value) (Value, error) {
+		return NewBool(lv.Equal(rv)), nil
+	},
+	{Operator: ast.EqualOperator, Left: semantic.Object, Right: semantic.Object}: func(lv, rv Value) (Value, error) {
+		return NewBool(lv.Equal(rv)), nil
+	},
 
 	// NotEqualOperator
 

--- a/values/binary_test.go
+++ b/values/binary_test.go
@@ -558,8 +558,8 @@ func TestBinaryOperator(t *testing.T) {
 			left, right := Value(tt.lhs), Value(tt.rhs)
 			fn, err := values.LookupBinaryFunction(values.BinaryFuncSignature{
 				Operator: ast.OperatorLookup(tt.op),
-				Left:     left.Type(),
-				Right:    right.Type(),
+				Left:     left.Type().Nature(),
+				Right:    right.Type().Nature(),
 			})
 			if err != nil {
 				t.Fatal(err)

--- a/values/object.go
+++ b/values/object.go
@@ -171,7 +171,7 @@ func (o *object) Equal(rhs Value) bool {
 	}
 	for i, l := range o.labels {
 		val, ok := r.Get(l)
-		if !ok && !o.values[i].Equal(val) {
+		if ok && !o.values[i].Equal(val) {
 			return false
 		}
 	}

--- a/values/object_test.go
+++ b/values/object_test.go
@@ -1,0 +1,32 @@
+package values_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/values"
+)
+
+func TestObjectEqual(t *testing.T) {
+	r := values.NewObject()
+	r.Set("a", values.NewInt(1))
+	l := values.NewObject()
+	l.Set("a", values.NewInt(1))
+
+	if !l.Equal(r) {
+		t.Fatal("expected objects to be equal")
+	}
+
+	l.Set("a", values.NewInt(2))
+	if l.Equal(r) {
+		t.Fatal("expected objects to be unequal")
+	}
+
+	r.Set("a", values.NewInt(2))
+	if !l.Equal(r) {
+		t.Fatal("expected objects to be equal")
+	}
+	l.Set("b", values.NewInt(1))
+	if l.Equal(r) {
+		t.Fatal("expected objects to be unequal")
+	}
+}


### PR DESCRIPTION
Adds objectKeys function to extract the keys as a list.
Fixes two bugs found when writing a test case:
    1. Binary functions are now indexed by Nature not Type.
    2. Object Equal function has been fixed.

Tests have been added.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
