### PR TITLE
feat(stdlib/http): add post method implementation

### DIFF
--- a/stdlib/http/post.go
+++ b/stdlib/http/post.go
@@ -1,9 +1,12 @@
 package http
 
 import (
-	"log"
+	"bytes"
+	"net/http"
 
 	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -15,15 +18,53 @@ func init() {
 			Parameters: map[string]semantic.PolyType{
 				"url":     semantic.String,
 				"headers": semantic.Tvar(1),
-				"data":    semantic.Tvar(2),
+				"data":    semantic.Bytes,
 			},
 			Required: []string{"url"},
 			Return:   semantic.Int,
 		}),
 		func(args values.Object) (values.Value, error) {
-			//TODO: Implement
-			log.Println("http.post args", args)
-			return values.NewInt(200), nil
+			url, ok := args.Get("url")
+			if !ok {
+				return nil, errors.New(codes.Invalid, "missing \"url\" parameter")
+			}
+			var data []byte
+			dataV, ok := args.Get("data")
+			if ok {
+				data = dataV.Bytes()
+			}
+
+			// Construct HTTP request
+			req, err := http.NewRequest("POST", url.Str(), bytes.NewReader(data))
+			if err != nil {
+				return nil, err
+			}
+
+			// Add headers to request
+			header, ok := args.Get("headers")
+			if ok {
+				var rangeErr error
+				header.Object().Range(func(k string, v values.Value) {
+					if v.Type() == semantic.String {
+						req.Header.Set(k, v.Str())
+					} else {
+						rangeErr = errors.Newf(codes.Invalid, "header value %q must be a string", k)
+					}
+				})
+				if rangeErr != nil {
+					return nil, rangeErr
+				}
+			}
+
+			// Perform request
+			response, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return nil, err
+			}
+			defer response.Body.Close()
+
+			// return status code
+			return values.NewInt(int64(response.StatusCode)), nil
 		},
 		true, // post has side-effects
 	))

--- a/stdlib/http/post_test.go
+++ b/stdlib/http/post_test.go
@@ -1,0 +1,79 @@
+package http_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func addFail(scope interpreter.Scope) {
+	scope.Set("fail", values.NewFunction(
+		"fail",
+		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+			Return: semantic.Bool,
+		}),
+		func(args values.Object) (values.Value, error) {
+			return nil, errors.New(codes.Aborted, "fail")
+		},
+		false,
+	))
+}
+
+func TestPost(t *testing.T) {
+	var req *http.Request
+	var body []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req = r
+		var err error
+		body, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(500)
+			w.Write([]byte(err.Error()))
+		}
+		w.WriteHeader(204)
+	}))
+	defer ts.Close()
+
+	script := fmt.Sprintf(`
+import "http"
+
+status = http.post(url:"%s/path/a/b/c", headers: {x:"a",y:"b",z:"c"}, data: bytes(v: "body"))
+status == 204 or fail()
+`, ts.URL)
+
+	if _, _, err := flux.Eval(script, addFail); err != nil {
+		t.Fatal("evaluation of http.post failed: ", err)
+	}
+	if want, got := "/path/a/b/c", req.URL.Path; want != got {
+		t.Errorf("unexpected url want: %q got: %q", want, got)
+	}
+	if want, got := "POST", req.Method; want != got {
+		t.Errorf("unexpected method want: %q got: %q", want, got)
+	}
+	header := make(http.Header)
+	header.Set("x", "a")
+	header.Set("y", "b")
+	header.Set("z", "c")
+	header.Set("Accept-Encoding", "gzip")
+	header.Set("Content-Length", "4")
+	header.Set("User-Agent", "Go-http-client/1.1")
+	if !cmp.Equal(header, req.Header) {
+		t.Errorf("unexpected header -want/+got\n%s", cmp.Diff(header, req.Header))
+	}
+
+	expBody := []byte("body")
+	if !bytes.Equal(body, expBody) {
+		t.Errorf("unexpected body want: %q got: %q", string(expBody), string(body))
+	}
+}


### PR DESCRIPTION
Uses http.DefaultClient for now.
We can inject a custom shared client later.
Only reports the status code, the response body is otherwise ignored.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
