### PR TITLE
refactor: wrap errors with flux.Error instead of github.com/pkg/errors

### DIFF
--- a/ast/edit/option_editor_test.go
+++ b/ast/edit/option_editor_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/influxdata/flux/ast/edit"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 func TestEditor(t *testing.T) {
@@ -241,7 +240,7 @@ option task = {
 			p := parser.ParseSource(tc.in)
 			if ast.Check(p) > 0 {
 				err := ast.GetError(p)
-				t.Fatal(errors.Wrapf(err, "input source has bad syntax:\n%s", tc.in))
+				t.Fatalf("input source has bad syntax: %s\n%s", err, tc.in)
 			}
 
 			edited, err := tc.edit(p)
@@ -250,7 +249,7 @@ option task = {
 			}
 
 			if err != nil {
-				t.Fatal(errors.Wrap(err, "got unexpected error from edit"))
+				t.Fatalf("got unexpected error from edit: %s", err)
 			}
 
 			if edited && tc.unchanged {

--- a/ast/errors.go
+++ b/ast/errors.go
@@ -6,7 +6,8 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // Check will inspect each node and annotate it with any AST errors.
@@ -93,7 +94,7 @@ func GetErrors(n Node) (errs []error) {
 	Walk(CreateVisitor(func(node Node) {
 		if nerrs := node.Errs(); len(nerrs) > 0 {
 			for _, err := range nerrs {
-				errs = append(errs, errors.Wrapf(err, "loc %v", node.Location()))
+				errs = append(errs, errors.Wrapf(err, codes.Inherit, "loc %v", node.Location()))
 			}
 		}
 	}), n)

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/parser"
-	"github.com/pkg/errors"
 )
 
 var skip = map[string]string{
@@ -36,7 +35,7 @@ func formatTestHelper(t *testing.T, testCases []formatTestCase) {
 			pkg := parser.ParseSource(tc.script)
 			if ast.Check(pkg) > 0 {
 				err := ast.GetError(pkg)
-				t.Fatal(errors.Wrapf(err, "source has bad syntax:\n%s", tc.script))
+				t.Fatalf("source has bad syntax: %s\n%s", err, tc.script)
 			}
 
 			stringResult := ast.Format(pkg.Files[0])

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -1,6 +1,7 @@
 package compiler
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -8,7 +9,6 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 type Func interface {

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -1,6 +1,7 @@
 package execute
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/apache/arrow/go/arrow/array"
@@ -8,7 +9,6 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 type aggregateTransformation struct {

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -1,6 +1,7 @@
 package execute
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/influxdata/flux/compiler"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 type dynamicFn struct {

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/segmentio/kafka-go v0.1.0

--- a/internal/cmd/builtin/cmd/generate.go
+++ b/internal/cmd/builtin/cmd/generate.go
@@ -13,9 +13,10 @@ import (
 
 	"github.com/dave/jennifer/jen"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/token"
 	"github.com/influxdata/flux/parser"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -102,7 +103,7 @@ func generate(cmd *cobra.Command, args []string) error {
 
 		if fluxPkg != nil {
 			if ast.Check(fluxPkg) > 0 {
-				return errors.Wrapf(ast.GetError(fluxPkg), "failed to parse package %q", fluxPkg.Package)
+				return errors.Wrapf(ast.GetError(fluxPkg), codes.Inherit, "failed to parse package %q", fluxPkg.Package)
 			}
 			// Assign import path
 			fluxPkg.Path = fluxPath
@@ -118,7 +119,7 @@ func generate(cmd *cobra.Command, args []string) error {
 		}
 		if testPkg != nil {
 			if ast.Check(testPkg) > 0 {
-				return errors.Wrapf(ast.GetError(testPkg), "failed to parse test package %q", testPkg.Package)
+				return errors.Wrapf(ast.GetError(testPkg), codes.Inherit, "failed to parse test package %q", testPkg.Package)
 			}
 			// Validate test package file use _test.flux suffix for the file name
 			for _, f := range testPkg.Files {

--- a/internal/cmd/refactortests/cmd/refactortests.go
+++ b/internal/cmd/refactortests/cmd/refactortests.go
@@ -11,18 +11,18 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/influxdata/flux/memory"
-	_ "github.com/influxdata/flux/stdlib" // Import the Flux standard library
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/parser"
+	_ "github.com/influxdata/flux/stdlib" // Import the Flux standard library
 	"github.com/influxdata/flux/stdlib/testing"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -169,7 +169,7 @@ func loadScript(fname string) (*ast.Package, error) {
 func executeScript(pkg *ast.Package) (string, string, error) {
 	testPkg, err := inPlaceTestGen(pkg)
 	if err != nil {
-		return "", "", errors.Wrap(err, "error during test generation")
+		return "", "", errors.Wrap(err, codes.Inherit, "error during test generation")
 	}
 
 	c := lang.FluxCompiler{
@@ -179,13 +179,13 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 	program, err := c.Compile(context.Background())
 	if err != nil {
 		fmt.Println(ast.Format(testPkg))
-		return "", "", errors.Wrap(err, "error during compilation, check your script and retry")
+		return "", "", errors.Wrap(err, codes.Inherit, "error during compilation, check your script and retry")
 	}
 
 	alloc := &memory.Allocator{}
 	q, err := program.Start(context.Background(), alloc)
 	if err != nil {
-		return "", "", errors.Wrap(err, "error while executing program")
+		return "", "", errors.Wrap(err, codes.Inherit, "error while executing program")
 	}
 	defer q.Done()
 	results := make(map[string]flux.Result)
@@ -193,7 +193,7 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 		results[r.Name()] = r
 	}
 	if err := q.Err(); err != nil {
-		return "", "", errors.Wrap(err, "error retrieving query result")
+		return "", "", errors.Wrap(err, codes.Inherit, "error retrieving query result")
 	}
 
 	var diffBuf, resultBuf bytes.Buffer
@@ -204,7 +204,7 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 			return nil
 		}); err != nil {
 			// do not return diff error, but show it
-			fmt.Fprintln(os.Stderr, errors.Wrap(err, "error while running test script"))
+			fmt.Fprintln(os.Stderr, errors.Wrap(err, codes.Inherit, "error while running test script"))
 		}
 	}
 
@@ -213,7 +213,7 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 	// encode test result if present
 	if tr, in := results["_test_result"]; in {
 		if _, err := enc.Encode(&resultBuf, tr); err != nil {
-			fmt.Fprintln(os.Stderr, errors.Wrap(err, "encoding error while running test script"))
+			fmt.Fprintln(os.Stderr, errors.Wrap(err, codes.Inherit, "encoding error while running test script"))
 		}
 	} else {
 		// cannot use MultiResultEncoder, because it encodes errors, but I need that
@@ -222,9 +222,8 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 		fmt.Fprintf(os.Stderr, "The tool will check for assertEquals errors.\n\n")
 		for _, r := range results {
 			if _, err := enc.Encode(&resultBuf, r); err != nil {
-				fmt.Fprintln(os.Stderr, errors.Wrap(err, "encoding error while running test script"))
-				cause := errors.Cause(err)
-				if e, ok := cause.(*testing.AssertEqualsError); ok {
+				fmt.Fprintln(os.Stderr, errors.Wrap(err, codes.Inherit, "encoding error while running test script"))
+				if e := asAssertEqualsErrors(err); e != nil {
 					aee = e
 				}
 			}
@@ -386,4 +385,21 @@ func yesOrNo(question string, forceY bool) (bool, error) {
 	} else {
 		return ans == "y\n" || (!forceY && ans == "\n"), nil
 	}
+}
+
+// asAssertEqualsError will return the error as a *testing.AssertEqualsError
+// if it is in the error chain.
+func asAssertEqualsErrors(err error) *testing.AssertEqualsError {
+	for err != nil {
+		if aee, ok := err.(*testing.AssertEqualsError); ok {
+			return aee
+		}
+
+		wrapErr, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			break
+		}
+		err = wrapErr.Unwrap()
+	}
+	return nil
 }

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -314,14 +315,14 @@ func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Q
 
 	s, err := spec.FromAST(ctx, astPkg, p.Now)
 	if err != nil {
-		return nil, errors.Wrap(err, "error in evaluating AST while starting program")
+		return nil, errors.Wrap(err, codes.Inherit, "error in evaluating AST while starting program")
 	}
 	if p.opts.verbose {
 		log.Println("Query Spec: ", flux.Formatted(s, flux.FmtJSON))
 	}
 	ps, err := buildPlan(s, p.opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "error in building plan while starting program")
+		return nil, errors.Wrap(err, codes.Inherit, "error in building plan while starting program")
 	}
 	p.PlanSpec = ps
 

--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -5,12 +5,10 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/influxdata/flux/builtin"
-
 	"github.com/influxdata/flux"
+	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
-	"github.com/pkg/errors"
 )
 
 func runQuery(script string) (flux.Query, error) {
@@ -48,7 +46,7 @@ csv.from(csv: data) |> yield(name: "res")`
 func TestQuery_Results(t *testing.T) {
 	q, err := runQuery(validScript)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "unexpected error while creating query"))
+		t.Fatalf("unexpected error while creating query: %s", err)
 	}
 
 	// gather counts
@@ -65,7 +63,7 @@ func TestQuery_Results(t *testing.T) {
 				return nil
 			})
 		}); err != nil {
-			t.Fatal(errors.Wrap(err, "unexpected error while iterating over tables"))
+			t.Fatalf("unexpected error while iterating over tables: %s", err)
 		}
 	}
 
@@ -84,7 +82,7 @@ func TestQuery_Results(t *testing.T) {
 	q.Done()
 
 	if q.Err() != nil {
-		t.Fatal(errors.Wrap(q.Err(), "unexpected error from query execution"))
+		t.Fatalf("unexpected error from query execution: %s", q.Err())
 	}
 }
 
@@ -93,7 +91,7 @@ func TestQuery_Stats(t *testing.T) {
 
 	q, err := runQuery(validScript)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "unexpected error while creating query"))
+		t.Fatalf("unexpected error while creating query: %s", err)
 	}
 
 	// consume results
@@ -103,7 +101,7 @@ func TestQuery_Stats(t *testing.T) {
 				return nil
 			})
 		}); err != nil {
-			t.Fatal(errors.Wrap(err, "unexpected error while iterating over tables"))
+			t.Fatalf("unexpected error while iterating over tables: %s", err)
 		}
 	}
 
@@ -147,7 +145,7 @@ csv.from(csv: data) |> map(fn: (r) => r.nonexistent)`
 
 	q, err := runQuery(invalidScript)
 	if err != nil {
-		t.Fatal(errors.Wrap(err, "unexpected error while creating query"))
+		t.Fatalf("unexpected error while creating query: %s", err)
 	}
 
 	// consume and check for error
@@ -163,6 +161,6 @@ csv.from(csv: data) |> map(fn: (r) => r.nonexistent)`
 	}
 
 	if q.Err() != nil {
-		t.Fatal(errors.Wrap(q.Err(), "unexpected error from query execution"))
+		t.Fatalf("unexpected error from query execution: %s", q.Err())
 	}
 }

--- a/operation.go
+++ b/operation.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // Operation denotes a single operation in a query.
@@ -29,7 +30,7 @@ func (o *Operation) UnmarshalJSON(data []byte) error {
 	}
 	spec, err := unmarshalOpSpec(raw.Kind, raw.Spec)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal operation %q", o.ID)
+		return errors.Wrapf(err, codes.Inherit, "failed to unmarshal operation %q", o.ID)
 	}
 	o.Spec = spec
 	return nil

--- a/plan/plantest/cmp.go
+++ b/plan/plantest/cmp.go
@@ -12,7 +12,6 @@ import (
 	"github.com/influxdata/flux/stdlib/kafka"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values/valuestest"
-	"github.com/pkg/errors"
 )
 
 // CmpOptions are the options needed to compare plan.ProcedureSpecs inside plan.Spec.
@@ -73,7 +72,7 @@ func ComparePlansShallow(p, q *plan.Spec) error {
 func compareMetadata(p, q *plan.Spec) error {
 	opts := cmpopts.IgnoreFields(plan.Spec{}, "Roots")
 	if diff := cmp.Diff(p, q, opts); diff != "" {
-		return errors.Errorf("plan metadata not equal; -want/+got:\n%v", diff)
+		return fmt.Errorf("plan metadata not equal; -want/+got:\n%v", diff)
 	}
 	return nil
 }

--- a/plan/walk.go
+++ b/plan/walk.go
@@ -1,7 +1,7 @@
 package plan
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 	"sort"
 )
 

--- a/resource_management.go
+++ b/resource_management.go
@@ -4,7 +4,8 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // ResourceManagement defines how the query should consume avaliable resources.
@@ -54,7 +55,7 @@ func (p *Priority) UnmarshalText(txt []byte) error {
 	default:
 		i, err := strconv.ParseInt(s, 10, 32)
 		if err != nil {
-			return errors.Wrap(err, "invalid priority, must be an integer or 'low','high'")
+			return errors.Wrap(err, codes.Invalid, "invalid priority, must be an integer or 'low','high'")
 		}
 		*p = Priority(i)
 	}

--- a/result.go
+++ b/result.go
@@ -7,7 +7,6 @@ import (
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 type Result interface {
@@ -245,10 +244,10 @@ type EncoderError interface {
 	IsEncoderError() bool
 }
 
-// IsEncoderError reports whether or not the underlying cause of
+// isEncoderError reports whether or not the underlying cause of
 // an error is a valid EncoderError.
-func IsEncoderError(err error) bool {
-	encErr, ok := errors.Cause(err).(EncoderError)
+func isEncoderError(err error) bool {
+	encErr, ok := err.(EncoderError)
 	return ok && encErr.IsEncoderError()
 }
 
@@ -287,7 +286,7 @@ func (e *DelimitedMultiResultEncoder) Encode(w io.Writer, results ResultIterator
 		if _, err := e.Encoder.Encode(wc, result); err != nil {
 			// If we have an error that's from encoding or if we have not
 			// yet written any data to the writer, return the error.
-			if IsEncoderError(err) || wc.Count() == 0 {
+			if isEncoderError(err) || wc.Count() == 0 {
 				return wc.Count(), err
 			}
 			// Otherwise, the error happened during query execution and we

--- a/result_iterator_test.go
+++ b/result_iterator_test.go
@@ -1,6 +1,7 @@
 package flux_test
 
 import (
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/mock"
-	"github.com/pkg/errors"
 )
 
 // ---- Helpers.
@@ -204,7 +204,7 @@ func TestQueryResultIterator_Results(t *testing.T) {
 	}
 
 	if ri.Err() != nil {
-		t.Fatal(errors.Wrap(ri.Err(), "unexpected error in result iterator"))
+		t.Fatalf("unexpected error in result iterator: %s", ri.Err())
 	}
 
 	want := []row{

--- a/semantic/package.go
+++ b/semantic/package.go
@@ -1,7 +1,8 @@
 package semantic
 
 import (
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 const PackageMain = "main"
@@ -18,7 +19,7 @@ func CreatePackage(n Node, importer Importer) (PackageType, error) {
 	v := new(packageCreateVisitor)
 	Walk(v, n)
 	if v.name == "" {
-		return PackageType{}, errors.New("no package clause found")
+		return PackageType{}, errors.New(codes.Unknown, "no package clause found")
 	}
 	ts, err := InferTypes(n, importer)
 	if err != nil {

--- a/semantic/poly_types.go
+++ b/semantic/poly_types.go
@@ -1,11 +1,13 @@
 package semantic
 
 import (
+	stderrors "errors"
 	"fmt"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // TypeExpression represents an expression describing a type.
@@ -694,13 +696,13 @@ func (l KClass) unifyKind(kinds map[Tvar]Kind, r Kind) (Kind, Substitution, erro
 	return nil, nil, nil
 }
 func (k KClass) resolveType(map[Tvar]Kind) (Type, error) {
-	return nil, errors.New("KClass has no type")
+	return nil, stderrors.New("KClass has no type")
 }
 func (k KClass) MonoType() (Type, bool) {
 	return nil, false
 }
 func (k KClass) resolvePolyType(map[Tvar]Kind) (PolyType, error) {
-	return nil, errors.New("KClass has no poly type")
+	return nil, stderrors.New("KClass has no poly type")
 }
 func (k KClass) occurs(Tvar) bool { return false }
 
@@ -810,7 +812,7 @@ func (l ObjectKind) unifyKind(kinds map[Tvar]Kind, k Kind) (Kind, Substitution, 
 		with = new(Tvar)
 		*with = *l.with
 	case l.with != nil && r.with != nil:
-		return nil, nil, errors.New("cannot unify two object each having a with constraint")
+		return nil, nil, stderrors.New("cannot unify two object each having a with constraint")
 	}
 
 	kr := ObjectKind{
@@ -823,7 +825,7 @@ func (l ObjectKind) unifyKind(kinds map[Tvar]Kind, k Kind) (Kind, Substitution, 
 	for lbl, t := range kr.properties {
 		i, ok := t.(invalid)
 		if ok {
-			return nil, nil, errors.Wrapf(i.err, "invalid record access %q", lbl)
+			return nil, nil, errors.Wrapf(i.err, codes.Inherit, "invalid record access %q", lbl)
 		}
 	}
 	return kr, subst, nil

--- a/spec.go
+++ b/spec.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // Spec specifies a query.
@@ -46,7 +47,7 @@ func (q *Spec) Walk(f func(o *Operation) error) error {
 // Validate ensures the query is a valid DAG.
 func (q *Spec) Validate() error {
 	if q.Now.IsZero() {
-		return errors.New("now time must be set")
+		return errors.New(codes.Invalid, "now time must be set")
 	}
 	return q.prepare()
 }
@@ -85,7 +86,7 @@ func (q *Spec) prepare() error {
 		return err
 	}
 	if len(roots) == 0 {
-		return errors.New("query has no root nodes")
+		return errors.New(codes.Invalid, "query has no root nodes")
 	}
 
 	q.parents = parents
@@ -153,7 +154,7 @@ func (q *Spec) determineParentsChildrenAndRoots() (parents, children map[Operati
 func (q *Spec) visit(tMarks, pMarks map[OperationID]bool, o *Operation) error {
 	id := o.ID
 	if tMarks[id] {
-		return errors.New("found cycle in query")
+		return errors.New(codes.Invalid, "found cycle in query")
 	}
 
 	if !pMarks[id] {

--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -2,6 +2,7 @@ package mqtt
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -10,7 +11,6 @@ import (
 	"time"
 
 	MQTT "github.com/eclipse/paho.mqtt.golang"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/pkg/syncutil"
@@ -18,7 +18,6 @@ import (
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	protocol "github.com/influxdata/line-protocol"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -368,7 +367,7 @@ func (t *ToMQTTTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 	timeColIdx, ok := labels[timeColLabel]
 
 	if !ok {
-		return errors.New("Could not get time column")
+		return errors.New("could not get time column")
 	}
 	if timeColIdx.Type != flux.TTime {
 		return fmt.Errorf("column %s is not of type %s", timeColLabel, timeColIdx.Type)

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -17,7 +18,6 @@ import (
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	protocol "github.com/influxdata/line-protocol"
-	"github.com/pkg/errors"
 	kafka "github.com/segmentio/kafka-go"
 )
 
@@ -309,7 +309,7 @@ func (t *ToKafkaTransformation) Process(id execute.DatasetID, tbl flux.Table) (e
 	timeColLabel := t.spec.Spec.TimeColumn
 	timeColIdx, ok := labels[timeColLabel]
 	if !ok {
-		return errors.New("Could not get time column")
+		return errors.New("could not get time column")
 	}
 	if timeColIdx.Type != flux.TTime {
 		return fmt.Errorf("column %s is not of type %s", timeColLabel, timeColIdx.Type)

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -13,7 +13,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	pkgErrors "github.com/pkg/errors"
 )
 
 const (
@@ -199,10 +198,10 @@ func (t *ToSQLTransformation) Finish(id execute.DatasetID, err error) {
 			txErr = t.tx.Rollback()
 		}
 		if txErr != nil {
-			err = pkgErrors.Wrap(err, txErr.Error())
+			err = errors.Wrap(err, codes.Inherit, txErr)
 		}
 		if dbErr := t.db.Close(); dbErr != nil {
-			err = pkgErrors.Wrap(err, dbErr.Error())
+			err = errors.Wrap(err, codes.Inherit, dbErr)
 		}
 	}
 	t.d.Finish(err)

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -1,13 +1,16 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
+// MakeContainsFunc will construct the "contains()" function.
+//
 // Contains will test whether a given value is a member of the given set array.
 func MakeContainsFunc() values.Function {
 	return values.NewFunction(

--- a/stdlib/universe/covariance.go
+++ b/stdlib/universe/covariance.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 const CovarianceKind = "covariance"

--- a/stdlib/universe/derivative.go
+++ b/stdlib/universe/derivative.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 const DerivativeKind = "derivative"

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/compiler"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 const FilterKind = "filter"
@@ -156,7 +157,7 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 		l := cr.Len()
 		for i := 0; i < l; i++ {
 			if pass, err := t.fn.Eval(i, cr); err != nil {
-				return errors.Wrap(err, "failed to evaluate filter function")
+				return errors.Wrap(err, codes.Inherit, "failed to evaluate filter function")
 			} else if !pass {
 				// No match, skipping
 				continue

--- a/stdlib/universe/histogram.go
+++ b/stdlib/universe/histogram.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -12,7 +13,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 const HistogramKind = "histogram"

--- a/stdlib/universe/histogram_quantile.go
+++ b/stdlib/universe/histogram_quantile.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -9,7 +10,6 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 const HistogramQuantileKind = "histogramQuantile"

--- a/stdlib/universe/histogram_quantile_test.go
+++ b/stdlib/universe/histogram_quantile_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"errors"
 	"math"
 	"testing"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/stdlib/universe"
-	"github.com/pkg/errors"
 )
 
 var linearHist = func() []flux.Table {

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -13,7 +14,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 const JoinKind = "join"

--- a/stdlib/universe/length.go
+++ b/stdlib/universe/length.go
@@ -1,12 +1,15 @@
 package universe
 
 import (
+	"errors"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
+// MakeLengthFunc create the "length()" function.
+//
 // Length will return the length of the given arr array.
 func MakeLengthFunc() values.Function {
 	return values.NewFunction(

--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/influxdata/flux"
@@ -8,7 +9,6 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 const LimitKind = "limit"

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -13,7 +14,6 @@ import (
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/tdigest"
-	"github.com/pkg/errors"
 )
 
 const QuantileKind = "quantile"
@@ -68,7 +68,7 @@ func createQuantileOpSpec(args flux.Arguments, a *flux.Administration) (flux.Ope
 	spec.Quantile = p
 
 	if spec.Quantile < 0 || spec.Quantile > 1 {
-		return nil, errors.New("quantile must be between 0 and 1.")
+		return nil, errors.New("quantile must be between 0 and 1")
 	}
 
 	if m, ok, err := args.GetString("method"); err != nil {
@@ -84,7 +84,7 @@ func createQuantileOpSpec(args flux.Arguments, a *flux.Administration) (flux.Ope
 	}
 
 	if spec.Compression > 0 && spec.Method != methodEstimateTdigest {
-		return nil, errors.New("compression parameter is only valid for method estimate_tdigest.")
+		return nil, errors.New("compression parameter is only valid for method estimate_tdigest")
 	}
 
 	// Set default Compression if not exact

--- a/stdlib/universe/range.go
+++ b/stdlib/universe/range.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/influxdata/flux"
@@ -8,7 +9,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 const RangeKind = "range"

--- a/stdlib/universe/range_test.go
+++ b/stdlib/universe/range_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 func TestRange_NewQuery(t *testing.T) {

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/influxdata/flux"
@@ -9,7 +10,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 const RenameKind = "rename"

--- a/stdlib/universe/schema_functions_test.go
+++ b/stdlib/universe/schema_functions_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values/valuestest"
-	"github.com/pkg/errors"
 )
 
 func TestSchemaMutions_NewQueries(t *testing.T) {

--- a/stdlib/universe/schema_mutators.go
+++ b/stdlib/universe/schema_mutators.go
@@ -1,14 +1,16 @@
 package universe
 
 import (
+	stderrors "errors"
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/compiler"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 type BuilderContext struct {
@@ -104,7 +106,7 @@ func NewRenameMutator(qs flux.OperationSpec) (*RenameMutator, error) {
 
 func (m *RenameMutator) renameCol(col *flux.ColMeta) error {
 	if col == nil {
-		return errors.New("rename error: cannot rename nil column")
+		return stderrors.New("rename error: cannot rename nil column")
 	}
 	if m.Columns != nil {
 		if newName, ok := m.Columns[col.Label]; ok {
@@ -124,7 +126,7 @@ func (m *RenameMutator) renameCol(col *flux.ColMeta) error {
 func (m *RenameMutator) checkColumns(tableCols []flux.ColMeta) error {
 	for c := range m.Columns {
 		if err := checkCol(c, tableCols); err != nil {
-			return errors.Wrap(err, "rename error")
+			return errors.Wrap(err, codes.Inherit, "rename error")
 		}
 	}
 	return nil

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 const StateTrackingKind = "stateTracking"

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values/valuestest"
-	"github.com/pkg/errors"
 )
 
 func TestStateTracking_NewQuery(t *testing.T) {

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -6,15 +6,16 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/compiler"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/flux/values/objects"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -87,12 +88,12 @@ func tableFindCall(args values.Object) (values.Value, error) {
 
 	p, err := c.Compile(context.Background())
 	if err != nil {
-		return nil, errors.Wrap(err, "error in table object compilation")
+		return nil, errors.Wrap(err, codes.Inherit, "error in table object compilation")
 	}
 
 	q, err := p.Start(context.Background(), &memory.Allocator{})
 	if err != nil {
-		return nil, errors.Wrap(err, "error in table object start")
+		return nil, errors.Wrap(err, codes.Inherit, "error in table object start")
 	}
 
 	var t *objects.Table
@@ -112,7 +113,7 @@ func tableFindCall(args values.Object) (values.Value, error) {
 			var err error
 			found, err = fn.Eval(tbl)
 			if err != nil {
-				return errors.Wrap(err, "failed to evaluate group key predicate function")
+				return errors.Wrap(err, codes.Inherit, "failed to evaluate group key predicate function")
 			}
 
 			if found {

--- a/stdlib/universe/table_fns_test.go
+++ b/stdlib/universe/table_fns_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/flux/values/objects"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -39,7 +39,7 @@ csv.from(csv: data)`
 
 	vs, _, err := flux.Eval(script)
 	if err != nil {
-		panic(errors.Wrap(err, "cannot compile simple script to prepare test"))
+		panic(fmt.Errorf("cannot compile simple script to prepare test: %s", err))
 	}
 	for _, v := range vs {
 		if v, ok := v.Value.(*flux.TableObject); ok {

--- a/stdlib/universe/tail.go
+++ b/stdlib/universe/tail.go
@@ -1,12 +1,13 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 const TailKind = "tail"

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
-	"github.com/pkg/errors"
 )
 
 const WindowKind = "window"

--- a/values/values.go
+++ b/values/values.go
@@ -3,13 +3,13 @@ package values
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"regexp"
 	"runtime/debug"
 	"strconv"
 
 	"github.com/influxdata/flux/semantic"
-	"github.com/pkg/errors"
 )
 
 type Typer interface {


### PR DESCRIPTION
This removes the `github.com/pkg/errors` dependency completely and
changes all usages to either directly call `errors.New` from the errors
package or `errors.Wrap` with the inherit code from our own wrapping
library.

This will allow us to later on start annotating errors so that not
everything shows up as an internal error and using our own wrapping will
ensure that actually gets transmitted to the user.

Previously, the `github.com/pkg/errors` wrapping would cause an error in
the wrapping chain because the code that identifies the error code would
not recognize the error as a flux error because it was wrapped by the
errors package.

#1623

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written