### PR TITLE
fix(interpreter): use non-pointer receiver for interpreter.function

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -379,7 +379,9 @@ func (itrp *Interpreter) doExpression(expr semantic.Expression, scope values.Sco
 				polyTypes[node] = polyType
 			}
 		}), e)
-		return &function{
+		// In the case of builtin functions this function value is shared across all query requests
+		// and as such must NOT be a pointer value.
+		return function{
 			e:         e,
 			scope:     scope,
 			types:     types,
@@ -498,7 +500,7 @@ func (itrp *Interpreter) doCall(call *semantic.CallExpression, scope values.Scop
 	}
 
 	// Check if the function is an interpFunction and rebind it.
-	if af, ok := f.(*function); ok {
+	if af, ok := f.(function); ok {
 		semantic.Walk(semantic.CreateVisitor(func(node semantic.Node) {
 			if typ, ok := af.TypeOf(node); ok {
 				itrp.types[node] = typ
@@ -572,10 +574,12 @@ type Value interface {
 	Property(name string) (values.Value, error)
 }
 
+// function represents an interpretable function definition.
+// Values of this type are shared across multiple interpreter runs as such
+// this type implements the values.Function interface using a non-pointer receiver.
 type function struct {
-	e                *semantic.FunctionExpression
-	scope            values.Scope
-	localIdentifiers []string
+	e     *semantic.FunctionExpression
+	scope values.Scope
 
 	types     map[semantic.Node]semantic.Type
 	polyTypes map[semantic.Node]semantic.PolyType
@@ -583,80 +587,80 @@ type function struct {
 	itrp *Interpreter
 }
 
-func (f *function) TypeOf(node semantic.Node) (semantic.Type, bool) {
+func (f function) TypeOf(node semantic.Node) (semantic.Type, bool) {
 	t, ok := f.types[node]
 	return t, ok
 }
-func (f *function) PolyTypeOf(node semantic.Node) (semantic.PolyType, bool) {
+func (f function) PolyTypeOf(node semantic.Node) (semantic.PolyType, bool) {
 	p, ok := f.polyTypes[node]
 	return p, ok
 }
-func (f *function) Type() semantic.Type {
+func (f function) Type() semantic.Type {
 	if t, ok := f.TypeOf(f.e); ok {
 		return t
 	}
 	return semantic.Invalid
 }
-func (f *function) PolyType() semantic.PolyType {
+func (f function) PolyType() semantic.PolyType {
 	if t, ok := f.PolyTypeOf(f.e); ok {
 		return t
 	}
 	return semantic.Invalid
 }
 
-func (f *function) IsNull() bool {
+func (f function) IsNull() bool {
 	return false
 }
-func (f *function) Str() string {
+func (f function) Str() string {
 	panic(values.UnexpectedKind(semantic.Function, semantic.String))
 }
-func (f *function) Bytes() []byte {
+func (f function) Bytes() []byte {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Bytes))
 }
-func (f *function) Int() int64 {
+func (f function) Int() int64 {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Int))
 }
-func (f *function) UInt() uint64 {
+func (f function) UInt() uint64 {
 	panic(values.UnexpectedKind(semantic.Function, semantic.UInt))
 }
-func (f *function) Float() float64 {
+func (f function) Float() float64 {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Float))
 }
-func (f *function) Bool() bool {
+func (f function) Bool() bool {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Bool))
 }
-func (f *function) Time() values.Time {
+func (f function) Time() values.Time {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Time))
 }
-func (f *function) Duration() values.Duration {
+func (f function) Duration() values.Duration {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Duration))
 }
-func (f *function) Regexp() *regexp.Regexp {
+func (f function) Regexp() *regexp.Regexp {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Regexp))
 }
-func (f *function) Array() values.Array {
+func (f function) Array() values.Array {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Array))
 }
-func (f *function) Object() values.Object {
+func (f function) Object() values.Object {
 	panic(values.UnexpectedKind(semantic.Function, semantic.Object))
 }
-func (f *function) Function() values.Function {
+func (f function) Function() values.Function {
 	return f
 }
-func (f *function) Equal(rhs values.Value) bool {
+func (f function) Equal(rhs values.Value) bool {
 	if f.Type() != rhs.Type() {
 		return false
 	}
-	v, ok := rhs.(*function)
+	v, ok := rhs.(function)
 	return ok && f.e == v.e && f.scope == v.scope
 }
-func (f *function) HasSideEffect() bool {
+func (f function) HasSideEffect() bool {
 	// Function definitions do not produce side effects.
 	// Only a function call expression can produce side effects.
 	return false
 }
 
-func (f *function) Call(argsObj values.Object) (values.Value, error) {
+func (f function) Call(argsObj values.Object) (values.Value, error) {
 	args := newArguments(argsObj)
 	v, err := f.doCall(args)
 	if err != nil {
@@ -667,7 +671,7 @@ func (f *function) Call(argsObj values.Object) (values.Value, error) {
 	}
 	return v, nil
 }
-func (f *function) doCall(args Arguments) (values.Value, error) {
+func (f function) doCall(args Arguments) (values.Value, error) {
 	if f.itrp == nil {
 		f.itrp = &Interpreter{
 			types:     f.types,
@@ -733,7 +737,7 @@ func (f *function) doCall(args Arguments) (values.Value, error) {
 	}
 }
 
-func (f *function) String() string {
+func (f function) String() string {
 	return fmt.Sprintf("%v", f.PolyType())
 }
 
@@ -787,24 +791,25 @@ func (r ResolvedFunction) Copy() ResolvedFunction {
 	return nr
 }
 
-func (f *function) Scope() values.Scope {
+func (f function) Scope() values.Scope {
 	return f.scope
 }
 
 // Resolve rewrites the function resolving any identifiers not listed in the function params.
-func (f *function) Resolve() (semantic.Node, error) {
+func (f function) Resolve() (semantic.Node, error) {
 	n := f.e.Copy()
-	node, err := f.resolveIdentifiers(n)
+	localIdentifiers := make([]string, 0, 10)
+	node, err := f.resolveIdentifiers(n, &localIdentifiers)
 	if err != nil {
 		return nil, err
 	}
 	return node, nil
 }
 
-func (f *function) resolveIdentifiers(n semantic.Node) (semantic.Node, error) {
+func (f function) resolveIdentifiers(n semantic.Node, localIdentifiers *[]string) (semantic.Node, error) {
 	switch n := n.(type) {
 	case *semantic.MemberExpression:
-		node, err := f.resolveIdentifiers(n.Object)
+		node, err := f.resolveIdentifiers(n.Object, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
@@ -821,7 +826,7 @@ func (f *function) resolveIdentifiers(n semantic.Node) (semantic.Node, error) {
 
 		// if we are looking at a reference to a locally defined variable,
 		// then we can't resolve it because it hasn't been evaluated yet.
-		for _, id := range f.localIdentifiers {
+		for _, id := range *localIdentifiers {
 			if id == n.Name {
 				return n, nil
 			}
@@ -839,127 +844,127 @@ func (f *function) resolveIdentifiers(n semantic.Node) (semantic.Node, error) {
 		return nil, fmt.Errorf("name %q does not exist in scope", n.Name)
 	case *semantic.Block:
 		for i, s := range n.Body {
-			node, err := f.resolveIdentifiers(s)
+			node, err := f.resolveIdentifiers(s, localIdentifiers)
 			if err != nil {
 				return nil, err
 			}
 			n.Body[i] = node.(semantic.Statement)
 		}
 	case *semantic.OptionStatement:
-		node, err := f.resolveIdentifiers(n.Assignment)
+		node, err := f.resolveIdentifiers(n.Assignment, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Assignment = node.(semantic.Assignment)
 	case *semantic.ExpressionStatement:
-		node, err := f.resolveIdentifiers(n.Expression)
+		node, err := f.resolveIdentifiers(n.Expression, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Expression = node.(semantic.Expression)
 	case *semantic.ReturnStatement:
-		node, err := f.resolveIdentifiers(n.Argument)
+		node, err := f.resolveIdentifiers(n.Argument, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Argument = node.(semantic.Expression)
 	case *semantic.NativeVariableAssignment:
-		node, err := f.resolveIdentifiers(n.Init)
+		node, err := f.resolveIdentifiers(n.Init, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
-		f.localIdentifiers = append(f.localIdentifiers, n.Identifier.Name)
+		*localIdentifiers = append(*localIdentifiers, n.Identifier.Name)
 		n.Init = node.(semantic.Expression)
 	case *semantic.CallExpression:
-		node, err := f.resolveIdentifiers(n.Arguments)
+		node, err := f.resolveIdentifiers(n.Arguments, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		// TODO(adam): lookup the function definition, call the function if it's found in scope.
 		n.Arguments = node.(*semantic.ObjectExpression)
 	case *semantic.FunctionExpression:
-		node, err := f.resolveIdentifiers(n.Block.Body)
+		node, err := f.resolveIdentifiers(n.Block.Body, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Block.Body = node
 	case *semantic.BinaryExpression:
-		node, err := f.resolveIdentifiers(n.Left)
+		node, err := f.resolveIdentifiers(n.Left, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Left = node.(semantic.Expression)
 
-		node, err = f.resolveIdentifiers(n.Right)
+		node, err = f.resolveIdentifiers(n.Right, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Right = node.(semantic.Expression)
 	case *semantic.UnaryExpression:
-		node, err := f.resolveIdentifiers(n.Argument)
+		node, err := f.resolveIdentifiers(n.Argument, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Argument = node.(semantic.Expression)
 
 	case *semantic.LogicalExpression:
-		node, err := f.resolveIdentifiers(n.Left)
+		node, err := f.resolveIdentifiers(n.Left, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Left = node.(semantic.Expression)
-		node, err = f.resolveIdentifiers(n.Right)
+		node, err = f.resolveIdentifiers(n.Right, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Right = node.(semantic.Expression)
 	case *semantic.ArrayExpression:
 		for i, el := range n.Elements {
-			node, err := f.resolveIdentifiers(el)
+			node, err := f.resolveIdentifiers(el, localIdentifiers)
 			if err != nil {
 				return nil, err
 			}
 			n.Elements[i] = node.(semantic.Expression)
 		}
 	case *semantic.IndexExpression:
-		node, err := f.resolveIdentifiers(n.Array)
+		node, err := f.resolveIdentifiers(n.Array, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Array = node.(semantic.Expression)
-		node, err = f.resolveIdentifiers(n.Index)
+		node, err = f.resolveIdentifiers(n.Index, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Index = node.(semantic.Expression)
 	case *semantic.ObjectExpression:
 		for i, p := range n.Properties {
-			node, err := f.resolveIdentifiers(p)
+			node, err := f.resolveIdentifiers(p, localIdentifiers)
 			if err != nil {
 				return nil, err
 			}
 			n.Properties[i] = node.(*semantic.Property)
 		}
 	case *semantic.ConditionalExpression:
-		node, err := f.resolveIdentifiers(n.Test)
+		node, err := f.resolveIdentifiers(n.Test, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Test = node.(semantic.Expression)
 
-		node, err = f.resolveIdentifiers(n.Alternate)
+		node, err = f.resolveIdentifiers(n.Alternate, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Alternate = node.(semantic.Expression)
 
-		node, err = f.resolveIdentifiers(n.Consequent)
+		node, err = f.resolveIdentifiers(n.Consequent, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}
 		n.Consequent = node.(semantic.Expression)
 	case *semantic.Property:
-		node, err := f.resolveIdentifiers(n.Value)
+		node, err := f.resolveIdentifiers(n.Value, localIdentifiers)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change fixes a race condition when the function is shared via a
scope across many interpreters (i.e. builtin functions)


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
