### PR TITLE
build(release.sh): remove the logic around maint

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,18 +11,8 @@ if ! env | grep GITHUB_TOKEN= > /dev/null; then
   exit 1
 fi
 
-# Run git fetch to ensure that the origin is updated.
-git fetch
-
-# Ensure that the maint branch is included in this release.
-if ! git merge-base --is-ancestor origin/maint HEAD; then
-  echo "maint branch has not been merged into $(git rev-parse --abbrev-ref HEAD)." 2>&1
-  exit 1
-fi
-
 export GO111MODULE=on
 
 version=$(go run github.com/influxdata/changelog nextver)
 git tag -s -m "Release $version" $version
-git push origin "$version" "HEAD:maint"
 go run github.com/goreleaser/goreleaser release --rm-dist --release-notes <(go run github.com/influxdata/changelog generate --version $version --commit-url https://github.com/influxdata/flux/commit)


### PR DESCRIPTION
The release process is changing to create specific release branches per minor version.
As such the maint branch no longer needs to be maintained via the release script.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
