### PR TITLE
refactor(dependencies): change helper method to expose true defaults

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/dependencies"
@@ -25,7 +24,9 @@ func init() {
 }
 
 func execute(cmd *cobra.Command, args []string) error {
-	r := repl.New(context.Background(), dependencies.NewDependenciesInterface(http.DefaultClient, dependencies.EnvironmentSecretService{}), querier{})
+	deps := dependencies.NewDefaults()
+	deps.Deps.SecretService = dependencies.EnvironmentSecretService{}
+	r := repl.New(context.Background(), deps, querier{})
 	if err := r.Input(args[0]); err != nil {
 		return fmt.Errorf("failed to execute query: %v", err)
 	}

--- a/cmd/flux/cmd/repl.go
+++ b/cmd/flux/cmd/repl.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
@@ -21,7 +20,8 @@ var replCmd = &cobra.Command{
 	Long:  "Launch a Flux REPL (Read-Eval-Print-Loop)",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
-		deps := dependencies.NewDependenciesInterface(http.DefaultClient, dependencies.EnvironmentSecretService{})
+		deps := dependencies.NewDefaults()
+		deps.Deps.SecretService = dependencies.EnvironmentSecretService{}
 		r := repl.New(ctx, deps, querier{})
 		r.Run()
 	},

--- a/compile.go
+++ b/compile.go
@@ -324,7 +324,7 @@ func evalBuiltInPackages() error {
 		}
 
 		itrp := interpreter.NewInterpreter(pkg)
-		if _, err := itrp.Eval(context.Background(), dependencies.NewDefaultDependencies(), semPkg, preludeScope.Nest(pkg), stdlib); err != nil {
+		if _, err := itrp.Eval(context.Background(), dependencies.NewEmpty(), semPkg, preludeScope.Nest(pkg), stdlib); err != nil {
 			return errors.Wrapf(err, codes.Inherit, "failed to evaluate builtin package %q", astPkg.Path)
 		}
 	}

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -14,38 +14,44 @@ type Interface interface {
 	SecretService() (SecretService, error)
 }
 
-type DefaultDependencies struct {
-	httpclient    *http.Client
-	secretservice SecretService
+// Dependencies implemnents the Interface.
+// Any deps which are nil will produce an explicit error.
+type Dependencies struct {
+	Deps Deps
 }
 
-func (d DefaultDependencies) HTTPClient() (*http.Client, error) {
-	if d.httpclient != nil {
-		return d.httpclient, nil
+type Deps struct {
+	HTTPClient    *http.Client
+	SecretService SecretService
+}
+
+func (d Dependencies) HTTPClient() (*http.Client, error) {
+	if d.Deps.HTTPClient != nil {
+		return d.Deps.HTTPClient, nil
 	}
 	return nil, errors.New(codes.Unimplemented, "http client uninitialized in dependencies")
 }
 
-func (d DefaultDependencies) SecretService() (SecretService, error) {
-	if d.secretservice != nil {
-		return d.secretservice, nil
+func (d Dependencies) SecretService() (SecretService, error) {
+	if d.Deps.SecretService != nil {
+		return d.Deps.SecretService, nil
 	}
 	return nil, errors.New(codes.Unimplemented, "secret service uninitialized in dependencies")
 }
 
-// The values defined below come from the default implementation of Transport.
-// It establishes network connections as needed and caches them for reuse by subsequent calls.
-// It uses HTTP proxies as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment variables.
-func NewDefaultDependencies() Interface {
-	return &DefaultDependencies{
-		httpclient:    nil,
-		secretservice: nil,
+// NewDefaults produces a set of dependencies.
+// Not all dependencies have valid defaults and will not be set.
+func NewDefaults() Dependencies {
+	return Dependencies{
+		Deps: Deps{
+			HTTPClient:    http.DefaultClient,
+			SecretService: nil,
+		},
 	}
 }
 
-func NewDependenciesInterface(hc *http.Client, ss SecretService) Interface {
-	return &DefaultDependencies{
-		httpclient:    hc,
-		secretservice: ss,
-	}
+// NewEmpty produces an empty set of dependencies.
+// Accessing any dependency will result in an error.
+func NewEmpty() Interface {
+	return Dependencies{}
 }

--- a/dependencies/dependenciestest/dependencies.go
+++ b/dependencies/dependenciestest/dependencies.go
@@ -4,9 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies"
-	"github.com/influxdata/flux/internal/errors"
 )
 
 type RoundTripFunc func(req *http.Request) *http.Response
@@ -32,33 +30,10 @@ func defaultTestFunction(req *http.Request) *http.Response {
 	}
 }
 
-var _ dependencies.Interface = (*Interface)(nil)
-
-type Interface struct {
-	Services struct {
-		HTTPClient    *http.Client
-		SecretService dependencies.SecretService
-	}
-}
-
-func (d *Interface) HTTPClient() (*http.Client, error) {
-	if d.Services.HTTPClient != nil {
-		return d.Services.HTTPClient, nil
-	}
-	return nil, errors.New(codes.Unimplemented, "http client is not set")
-}
-
-func (d *Interface) SecretService() (dependencies.SecretService, error) {
-	if d.Services.SecretService != nil {
-		return d.Services.SecretService, nil
-	}
-	return nil, errors.New(codes.Unimplemented, "secret service is not set")
-}
-
-func Default() *Interface {
-	var deps Interface
-	deps.Services.HTTPClient = &http.Client{
+func Default() dependencies.Dependencies {
+	var deps dependencies.Dependencies
+	deps.Deps.HTTPClient = &http.Client{
 		Transport: RoundTripFunc(defaultTestFunction),
 	}
-	return &deps
+	return deps
 }

--- a/internal/cmd/refactortests/cmd/refactortests.go
+++ b/internal/cmd/refactortests/cmd/refactortests.go
@@ -179,7 +179,7 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 
 	program, err := c.Compile(context.Background())
 	if p, ok := program.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewDefaultDependencies()})
+		p.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewEmpty()})
 	}
 	if err != nil {
 		fmt.Println(ast.Format(testPkg))

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -135,7 +135,7 @@ func CompileTableObject(to *flux.TableObject, now time.Time, opts ...CompileOpti
 // WalkIR applies the function `f` to each operation in the compiled spec.
 func WalkIR(astPkg *ast.Package, f func(o *flux.Operation) error) error {
 
-	if spec, err := spec.FromAST(context.Background(), dependencies.NewDefaultDependencies(), astPkg, time.Now()); err != nil {
+	if spec, err := spec.FromAST(context.Background(), dependencies.NewEmpty(), astPkg, time.Now()); err != nil {
 		return err
 	} else {
 		return spec.Walk(f)

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -157,7 +157,7 @@ func (r *REPL) executeLine(t string) error {
 				if !ok {
 					return fmt.Errorf("now option not set")
 				}
-				nowTime, err := now.Function().Call(context.TODO(), dependencies.NewDefaultDependencies(), nil)
+				nowTime, err := now.Function().Call(context.TODO(), dependencies.NewDefaults(), nil)
 				if err != nil {
 					return err
 				}

--- a/stdlib/http/post_test.go
+++ b/stdlib/http/post_test.go
@@ -54,7 +54,7 @@ status = http.post(url:"%s/path/a/b/c", headers: {x:"a",y:"b",z:"c"}, data: byte
 status == 204 or fail()
 `, ts.URL)
 
-	if _, _, err := flux.Eval(context.Background(), dependencies.NewDependenciesInterface(http.DefaultClient, nil), script, addFail); err != nil {
+	if _, _, err := flux.Eval(context.Background(), dependencies.NewDefaults(), script, addFail); err != nil {
 		t.Fatal("evaluation of http.post failed: ", err)
 	}
 	if want, got := "/path/a/b/c", req.URL.Path; want != got {

--- a/stdlib/influxdata/influxdb/secrets/get_test.go
+++ b/stdlib/influxdata/influxdb/secrets/get_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestGet(t *testing.T) {
 	deps := dependenciestest.Default()
-	deps.Services.SecretService = &mock.SecretService{
+	deps.Deps.SecretService = &mock.SecretService{
 		"mykey": "myvalue",
 	}
 
@@ -49,7 +49,7 @@ func TestGet(t *testing.T) {
 			args: map[string]values.Value{
 				"key": values.NewString("mykey"),
 			},
-			err: "cannot retrieve secret \"mykey\": secret service is not set",
+			err: "cannot retrieve secret \"mykey\": secret service uninitialized in dependencies",
 		},
 		{
 			name:    "missing argument",
@@ -60,7 +60,7 @@ func TestGet(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			deps := dependenciestest.Default()
-			deps.Services.SecretService = tt.secrets
+			deps.Deps.SecretService = tt.secrets
 
 			args := values.NewObjectWithValues(tt.args)
 			got, err := secrets.Get(context.Background(), deps, args)

--- a/stdlib/slack/slack_test.go
+++ b/stdlib/slack/slack_test.go
@@ -3,14 +3,15 @@ package slack_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/influxdata/flux/dependencies"
-	"github.com/influxdata/flux/execute"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/execute"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
@@ -201,7 +202,7 @@ csv.from(csv:data) |> endpoint()`
 			if err != nil {
 				t.Fatal(err)
 			}
-			prog.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewDependenciesInterface(http.DefaultClient, nil)})
+			prog.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewDefaults()})
 			query, err := prog.Start(context.Background(), &memory.Allocator{})
 
 			if err != nil {

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -1373,7 +1373,7 @@ func TestMap_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					f, err := universe.NewMapTransformation(context.Background(), dependencies.NewDefaultDependencies(), tc.spec, d, c)
+					f, err := universe.NewMapTransformation(context.Background(), dependenciestest.Default(), tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -376,7 +376,7 @@ func TestStateTracking_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					tx, err := universe.NewStateTrackingTransformation(context.Background(), dependencies.NewDefaultDependencies(), tc.spec, d, c)
+					tx, err := universe.NewStateTrackingTransformation(context.Background(), dependenciestest.Default(), tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/table_fns_test.go
+++ b/stdlib/universe/table_fns_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -39,7 +39,7 @@ data = "#datatype,string,long,dateTime:RFC3339,double,string,string
 
 csv.from(csv: data)`
 
-	vs, _, err := flux.Eval(context.Background(), dependencies.NewDefaultDependencies(), script)
+	vs, _, err := flux.Eval(context.Background(), dependenciestest.Default(), script)
 	if err != nil {
 		panic(fmt.Errorf("cannot compile simple script to prepare test: %s", err))
 	}
@@ -119,7 +119,7 @@ func mustLookup(s values.Scope, valueID string) values.Value {
 func evalOrFail(t *testing.T, script string, mutator flux.ScopeMutator) values.Scope {
 	t.Helper()
 
-	_, s, err := flux.Eval(context.Background(), dependencies.NewDefaultDependencies(), script, func(s values.Scope) {
+	_, s, err := flux.Eval(context.Background(), dependenciestest.Default(), script, func(s values.Scope) {
 		if mutator != nil {
 			mutator(s)
 		}
@@ -167,7 +167,7 @@ func TestTableFind_Call(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, scope, err := flux.Eval(context.Background(), dependencies.NewDefaultDependencies(), tc.fn)
+			_, scope, err := flux.Eval(context.Background(), dependenciestest.Default(), tc.fn)
 			if err != nil {
 				t.Fatalf("error compiling function: %v", err)
 			}
@@ -178,7 +178,7 @@ func TestTableFind_Call(t *testing.T) {
 			}
 
 			f := universe.NewTableFindFunction()
-			res, err := f.Function().Call(context.Background(), dependencies.NewDefaultDependencies(),
+			res, err := f.Function().Call(context.Background(), dependenciestest.Default(),
 				values.NewObjectWithValues(map[string]values.Value{
 					"tables": to,
 					"fn":     fn,
@@ -217,7 +217,7 @@ t = inj |> tableFind(fn: (key) => key.user == "user1")`
 	tbl := mustLookup(s, "t")
 
 	f := universe.NewGetColumnFunction()
-	res, err := f.Function().Call(context.Background(), dependencies.NewDefaultDependencies(),
+	res, err := f.Function().Call(context.Background(), dependenciestest.Default(),
 		values.NewObjectWithValues(map[string]values.Value{
 			"table":  tbl.(*objects.Table),
 			"column": values.New("user"),
@@ -235,7 +235,7 @@ t = inj |> tableFind(fn: (key) => key.user == "user1")`
 
 	// test for error
 	f = universe.NewGetColumnFunction()
-	_, err = f.Function().Call(context.Background(), dependencies.NewDefaultDependencies(),
+	_, err = f.Function().Call(context.Background(), dependenciestest.Default(),
 		values.NewObjectWithValues(map[string]values.Value{
 			"table":  tbl.(*objects.Table),
 			"column": values.New("idk"),
@@ -263,7 +263,7 @@ t = inj |> tableFind(fn: (key) => key.user == "user1")`
 	tbl := mustLookup(s, "t")
 
 	f := universe.NewGetRecordFunction()
-	res, err := f.Function().Call(context.Background(), dependencies.NewDefaultDependencies(),
+	res, err := f.Function().Call(context.Background(), dependenciestest.Default(),
 		values.NewObjectWithValues(map[string]values.Value{
 			"table": tbl.(*objects.Table),
 			"idx":   values.New(int64(1)),
@@ -286,7 +286,7 @@ t = inj |> tableFind(fn: (key) => key.user == "user1")`
 
 	// test for error
 	f = universe.NewGetRecordFunction()
-	_, err = f.Function().Call(context.Background(), dependencies.NewDefaultDependencies(),
+	_, err = f.Function().Call(context.Background(), dependenciestest.Default(),
 		values.NewObjectWithValues(map[string]values.Value{
 			"table": tbl.(*objects.Table),
 			"idx":   values.New(int64(42)),


### PR DESCRIPTION
This change updates the helper methods for creating dependencies so that
there is a common set of default dependencies.

The builtins now use an explicitly empty set of dependencies as they
should not be allowed to consume any dependencies.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
