### PR TITLE
chore(internal/scanner): do not regenerate unicode.rl every time

### DIFF
--- a/internal/scanner/Makefile
+++ b/internal/scanner/Makefile
@@ -1,7 +1,7 @@
 # List any generated files here
-TARGETS = scanner.gen.go unicode.rl
+TARGETS = scanner.gen.go
 # List any source files used to generate the targets here
-SOURCES = gen.go scanner.rl unicode2ragel.rb
+SOURCES = gen.go scanner.rl unicode.rl
 # List any directories that have their own Makefile here
 SUBDIRS =
 
@@ -11,6 +11,9 @@ generate: $(SUBDIRS) $(TARGETS)
 # Recurse into subdirs for same make goal
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)
+
+unicode.rl: unicode2ragel.rb
+	ruby unicode2ragel.rb -e utf8 -o unicode.rl
 
 # Clean all targets recursively
 clean: $(SUBDIRS)

--- a/internal/scanner/gen.go
+++ b/internal/scanner/gen.go
@@ -1,5 +1,4 @@
 package scanner
 
-//go:generate ruby unicode2ragel.rb -e utf8 -o unicode.rl
 //go:generate ragel -I. -Z scanner.rl -o scanner.gen.go
 //go:generate sh -c "go fmt scanner.gen.go > /dev/null"


### PR DESCRIPTION
The `unicode.rl` file rarely changes and it does not need to be updated
every time. This updates the `go:generate` directive to defer to the
makefile for whether `unicode.rl` needs to be regenerated and adds
instructions for how to generate the file using `unicode2ragel.rb`.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written