### PR TITLE
feat(stdlib/influxdata/influxdb/monitor): add measurement filtering

### DIFF
--- a/stdlib/influxdata/influxdb/monitor/monitor.flux
+++ b/stdlib/influxdata/influxdb/monitor/monitor.flux
@@ -16,6 +16,7 @@ option log = (tables=<-) => tables |> experimental.to(bucket: bucket)
 from = (start, stop=now(), fn=(r) => true) =>
     influxdb.from(bucket: bucket)
         |> range(start: start, stop: stop)
+        |> filter(fn: (r) => r._measurement == "statuses")
         |> filter(fn: fn)
         |> v1.fieldsAsCols()
 
@@ -70,6 +71,7 @@ notify = (tables=<-, endpoint, data={}) =>
 logs = (start, stop=now(), fn) =>
     influxdb.from(bucket: bucket)
         |> range(start: start, stop: stop)
+        |> filter(fn: (r) => r._measurement == "notifications")
         |> filter(fn: fn)
         |> v1.fieldsAsCols()
 


### PR DESCRIPTION
Closes #1805

Previously, the data from monitoring would include both the statuses and notifications measurements.
This resulted in odd results in which it looked like more events were happening in the system then there
really was.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
