### PR TITLE
fix(stdlib): sleep function now gets canceled when the context is canceled

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -582,9 +582,22 @@ func functionName(call *semantic.CallExpression) string {
 	}
 }
 
+// DoFunctionCall will call DoFunctionCallContext with a background context.
 func DoFunctionCall(f func(args Arguments) (values.Value, error), argsObj values.Object) (values.Value, error) {
+	return DoFunctionCallContext(func(_ context.Context, args Arguments) (values.Value, error) {
+		return f(args)
+	}, context.Background(), argsObj)
+}
+
+// DoFunctionCallContext will treat the argsObj as the arguments to a function.
+// It will then invoke that function with the Arguments and return the
+// value from the function.
+//
+// This function verifies that all of the arguments have been consumed
+// by the function call.
+func DoFunctionCallContext(f func(ctx context.Context, args Arguments) (values.Value, error), ctx context.Context, argsObj values.Object) (values.Value, error) {
 	args := NewArguments(argsObj)
-	v, err := f(args)
+	v, err := f(ctx, args)
 	if err != nil {
 		return nil, err
 	}

--- a/stdlib/universe/sleep_test.go
+++ b/stdlib/universe/sleep_test.go
@@ -1,0 +1,49 @@
+package universe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/flux/values"
+)
+
+func TestSleep(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		myval := values.NewString("myvalue")
+		args := values.NewObjectWithValues(
+			map[string]values.Value{
+				"v":        myval,
+				"duration": values.NewDuration(values.Duration(time.Microsecond)),
+			},
+		)
+		v, err := sleepFunc.Call(ctx, nil, args)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+
+		if want, got := myval, v; !want.Equal(got) {
+			t.Fatalf("unexpected value -want/+got:\n\t- %#v\n\t+ %#v", want, got)
+		}
+	})
+
+	t.Run("Interrupted", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
+		defer cancel()
+
+		myval := values.NewString("myvalue")
+		args := values.NewObjectWithValues(
+			map[string]values.Value{
+				"v":        myval,
+				"duration": values.NewDuration(values.Duration(200 * time.Millisecond)),
+			},
+		)
+		_, err := sleepFunc.Call(ctx, nil, args)
+		if want, got := context.DeadlineExceeded, err; want != got {
+			t.Fatalf("unexpected error -want/+got:\n\t- %v\n\t+ %v", want, got)
+		}
+	})
+}


### PR DESCRIPTION
The current version of the sleep function will continue sleeping
indefinitely even if the context is canceled. This prevents the sleep
function from running indefinitely and causing the query queue from
being stalled forever.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written