### PR TITLE
feat(stdlib): add a function that creates the basic auth authorization header

### DIFF
--- a/stdlib/http/basic_auth.go
+++ b/stdlib/http/basic_auth.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func init() {
+	flux.RegisterPackageValue("http", "basicAuth", basicAuthFunc)
+}
+
+const (
+	basicAuthUsernameArg = "u"
+	basicAuthPasswordArg = "p"
+)
+
+var basicAuthFunc = values.NewFunction(
+	"basicAuth",
+	semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+		Parameters: map[string]semantic.PolyType{
+			basicAuthUsernameArg: semantic.String,
+			basicAuthPasswordArg: semantic.String,
+		},
+		Required: semantic.LabelSet{basicAuthUsernameArg, basicAuthPasswordArg},
+		Return:   semantic.String,
+	}),
+	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		return interpreter.DoFunctionCall(BasicAuth, args)
+	},
+	false,
+)
+
+func BasicAuth(args interpreter.Arguments) (values.Value, error) {
+	u, err := args.GetRequiredString(basicAuthUsernameArg)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := args.GetRequiredString(basicAuthPasswordArg)
+	if err != nil {
+		return nil, err
+	}
+
+	combined := fmt.Sprintf("%s:%s", u, p)
+	v := base64.StdEncoding.EncodeToString([]byte(combined))
+	return values.NewString("Basic " + v), nil
+}

--- a/stdlib/http/basic_auth_test.go
+++ b/stdlib/http/basic_auth_test.go
@@ -1,0 +1,29 @@
+package http_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/stdlib/http"
+	"github.com/influxdata/flux/values"
+)
+
+func TestBasicAuth(t *testing.T) {
+	u, p := "me", "mypassword"
+	want := values.NewString("Basic bWU6bXlwYXNzd29yZA==")
+
+	args := interpreter.NewArguments(values.NewObjectWithValues(
+		map[string]values.Value{
+			"u": values.NewString(u),
+			"p": values.NewString(p),
+		}),
+	)
+	got, err := http.BasicAuth(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !want.Equal(got) {
+		t.Fatalf("unexpected value -want/+got:\n\t- %#v\n\t+ %#v", want, got)
+	}
+}

--- a/stdlib/http/flux_gen.go
+++ b/stdlib/http/flux_gen.go
@@ -22,10 +22,10 @@ var pkgAST = &ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 72,
-					Line:   19,
+					Line:   23,
 				},
 				File:   "http.flux",
-				Source: "package http\n\nimport \"experimental\"\n\n// Post submits an HTTP post request to the specified URL with headers and data.\n// The HTTP status code is returned.\nbuiltin post\n\nendpoint =  (url) =>\n    (mapFn) =>\n        (tables=<-) =>\n            tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
+				Source: "package http\n\nimport \"experimental\"\n\n// Post submits an HTTP post request to the specified URL with headers and data.\n// The HTTP status code is returned.\nbuiltin post\n\n// basicAuth will take a username/password combination and return the authorization\n// header value.\nbuiltin basicAuth\n\nendpoint =  (url) =>\n    (mapFn) =>\n        (tables=<-) =>\n            tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -66,19 +66,53 @@ var pkgAST = &ast.Package{
 				},
 				Name: "post",
 			},
+		}, &ast.BuiltinStatement{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 18,
+						Line:   11,
+					},
+					File:   "http.flux",
+					Source: "builtin basicAuth",
+					Start: ast.Position{
+						Column: 1,
+						Line:   11,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 18,
+							Line:   11,
+						},
+						File:   "http.flux",
+						Source: "basicAuth",
+						Start: ast.Position{
+							Column: 9,
+							Line:   11,
+						},
+					},
+				},
+				Name: "basicAuth",
+			},
 		}, &ast.VariableAssignment{
 			BaseNode: ast.BaseNode{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 72,
-						Line:   19,
+						Line:   23,
 					},
 					File:   "http.flux",
 					Source: "endpoint =  (url) =>\n    (mapFn) =>\n        (tables=<-) =>\n            tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 					Start: ast.Position{
 						Column: 1,
-						Line:   9,
+						Line:   13,
 					},
 				},
 			},
@@ -88,13 +122,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 9,
-							Line:   9,
+							Line:   13,
 						},
 						File:   "http.flux",
 						Source: "endpoint",
 						Start: ast.Position{
 							Column: 1,
-							Line:   9,
+							Line:   13,
 						},
 					},
 				},
@@ -106,13 +140,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 72,
-							Line:   19,
+							Line:   23,
 						},
 						File:   "http.flux",
 						Source: "(url) =>\n    (mapFn) =>\n        (tables=<-) =>\n            tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 						Start: ast.Position{
 							Column: 13,
-							Line:   9,
+							Line:   13,
 						},
 					},
 				},
@@ -122,13 +156,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 72,
-								Line:   19,
+								Line:   23,
 							},
 							File:   "http.flux",
 							Source: "(mapFn) =>\n        (tables=<-) =>\n            tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 							Start: ast.Position{
 								Column: 5,
-								Line:   10,
+								Line:   14,
 							},
 						},
 					},
@@ -138,13 +172,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 72,
-									Line:   19,
+									Line:   23,
 								},
 								File:   "http.flux",
 								Source: "(tables=<-) =>\n            tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 								Start: ast.Position{
 									Column: 9,
-									Line:   11,
+									Line:   15,
 								},
 							},
 						},
@@ -156,13 +190,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 19,
-												Line:   12,
+												Line:   16,
 											},
 											File:   "http.flux",
 											Source: "tables",
 											Start: ast.Position{
 												Column: 13,
-												Line:   12,
+												Line:   16,
 											},
 										},
 									},
@@ -173,13 +207,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 19,
-											Line:   18,
+											Line:   22,
 										},
 										File:   "http.flux",
 										Source: "tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })",
 										Start: ast.Position{
 											Column: 13,
-											Line:   12,
+											Line:   16,
 										},
 									},
 								},
@@ -190,13 +224,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 18,
-													Line:   18,
+													Line:   22,
 												},
 												File:   "http.flux",
 												Source: "fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                }",
 												Start: ast.Position{
 													Column: 24,
-													Line:   13,
+													Line:   17,
 												},
 											},
 										},
@@ -206,13 +240,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 18,
-														Line:   18,
+														Line:   22,
 													},
 													File:   "http.flux",
 													Source: "fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                }",
 													Start: ast.Position{
 														Column: 24,
-														Line:   13,
+														Line:   17,
 													},
 												},
 											},
@@ -222,13 +256,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 26,
-															Line:   13,
+															Line:   17,
 														},
 														File:   "http.flux",
 														Source: "fn",
 														Start: ast.Position{
 															Column: 24,
-															Line:   13,
+															Line:   17,
 														},
 													},
 												},
@@ -240,13 +274,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 18,
-															Line:   18,
+															Line:   22,
 														},
 														File:   "http.flux",
 														Source: "(r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                }",
 														Start: ast.Position{
 															Column: 28,
-															Line:   13,
+															Line:   17,
 														},
 													},
 												},
@@ -256,13 +290,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 18,
-																Line:   18,
+																Line:   22,
 															},
 															File:   "http.flux",
 															Source: "{\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                }",
 															Start: ast.Position{
 																Column: 35,
-																Line:   13,
+																Line:   17,
 															},
 														},
 													},
@@ -272,13 +306,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 38,
-																	Line:   14,
+																	Line:   18,
 																},
 																File:   "http.flux",
 																Source: "obj = mapFn(r: r)",
 																Start: ast.Position{
 																	Column: 21,
-																	Line:   14,
+																	Line:   18,
 																},
 															},
 														},
@@ -288,13 +322,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 24,
-																		Line:   14,
+																		Line:   18,
 																	},
 																	File:   "http.flux",
 																	Source: "obj",
 																	Start: ast.Position{
 																		Column: 21,
-																		Line:   14,
+																		Line:   18,
 																	},
 																},
 															},
@@ -307,13 +341,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 37,
-																			Line:   14,
+																			Line:   18,
 																		},
 																		File:   "http.flux",
 																		Source: "r: r",
 																		Start: ast.Position{
 																			Column: 33,
-																			Line:   14,
+																			Line:   18,
 																		},
 																	},
 																},
@@ -323,13 +357,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 37,
-																				Line:   14,
+																				Line:   18,
 																			},
 																			File:   "http.flux",
 																			Source: "r: r",
 																			Start: ast.Position{
 																				Column: 33,
-																				Line:   14,
+																				Line:   18,
 																			},
 																		},
 																	},
@@ -339,13 +373,13 @@ var pkgAST = &ast.Package{
 																			Loc: &ast.SourceLocation{
 																				End: ast.Position{
 																					Column: 34,
-																					Line:   14,
+																					Line:   18,
 																				},
 																				File:   "http.flux",
 																				Source: "r",
 																				Start: ast.Position{
 																					Column: 33,
-																					Line:   14,
+																					Line:   18,
 																				},
 																			},
 																		},
@@ -357,13 +391,13 @@ var pkgAST = &ast.Package{
 																			Loc: &ast.SourceLocation{
 																				End: ast.Position{
 																					Column: 37,
-																					Line:   14,
+																					Line:   18,
 																				},
 																				File:   "http.flux",
 																				Source: "r",
 																				Start: ast.Position{
 																					Column: 36,
-																					Line:   14,
+																					Line:   18,
 																				},
 																			},
 																		},
@@ -377,13 +411,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 38,
-																		Line:   14,
+																		Line:   18,
 																	},
 																	File:   "http.flux",
 																	Source: "mapFn(r: r)",
 																	Start: ast.Position{
 																		Column: 27,
-																		Line:   14,
+																		Line:   18,
 																	},
 																},
 															},
@@ -393,13 +427,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 32,
-																			Line:   14,
+																			Line:   18,
 																		},
 																		File:   "http.flux",
 																		Source: "mapFn",
 																		Start: ast.Position{
 																			Column: 27,
-																			Line:   14,
+																			Line:   18,
 																		},
 																	},
 																},
@@ -413,13 +447,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 22,
-																		Line:   17,
+																		Line:   21,
 																	},
 																	File:   "http.flux",
 																	Source: "{r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }",
 																	Start: ast.Position{
 																		Column: 28,
-																		Line:   15,
+																		Line:   19,
 																	},
 																},
 															},
@@ -429,13 +463,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 102,
-																			Line:   16,
+																			Line:   20,
 																		},
 																		File:   "http.flux",
 																		Source: "_sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))",
 																		Start: ast.Position{
 																			Column: 25,
-																			Line:   16,
+																			Line:   20,
 																		},
 																	},
 																},
@@ -445,13 +479,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 30,
-																				Line:   16,
+																				Line:   20,
 																			},
 																			File:   "http.flux",
 																			Source: "_sent",
 																			Start: ast.Position{
 																				Column: 25,
-																				Line:   16,
+																				Line:   20,
 																			},
 																		},
 																	},
@@ -464,13 +498,13 @@ var pkgAST = &ast.Package{
 																			Loc: &ast.SourceLocation{
 																				End: ast.Position{
 																					Column: 101,
-																					Line:   16,
+																					Line:   20,
 																				},
 																				File:   "http.flux",
 																				Source: "v: 200 == post(url: url, headers: obj.headers, data: obj.data)",
 																				Start: ast.Position{
 																					Column: 39,
-																					Line:   16,
+																					Line:   20,
 																				},
 																			},
 																		},
@@ -480,13 +514,13 @@ var pkgAST = &ast.Package{
 																				Loc: &ast.SourceLocation{
 																					End: ast.Position{
 																						Column: 101,
-																						Line:   16,
+																						Line:   20,
 																					},
 																					File:   "http.flux",
 																					Source: "v: 200 == post(url: url, headers: obj.headers, data: obj.data)",
 																					Start: ast.Position{
 																						Column: 39,
-																						Line:   16,
+																						Line:   20,
 																					},
 																				},
 																			},
@@ -496,13 +530,13 @@ var pkgAST = &ast.Package{
 																					Loc: &ast.SourceLocation{
 																						End: ast.Position{
 																							Column: 40,
-																							Line:   16,
+																							Line:   20,
 																						},
 																						File:   "http.flux",
 																						Source: "v",
 																						Start: ast.Position{
 																							Column: 39,
-																							Line:   16,
+																							Line:   20,
 																						},
 																					},
 																				},
@@ -514,13 +548,13 @@ var pkgAST = &ast.Package{
 																					Loc: &ast.SourceLocation{
 																						End: ast.Position{
 																							Column: 101,
-																							Line:   16,
+																							Line:   20,
 																						},
 																						File:   "http.flux",
 																						Source: "200 == post(url: url, headers: obj.headers, data: obj.data)",
 																						Start: ast.Position{
 																							Column: 42,
-																							Line:   16,
+																							Line:   20,
 																						},
 																					},
 																				},
@@ -530,13 +564,13 @@ var pkgAST = &ast.Package{
 																						Loc: &ast.SourceLocation{
 																							End: ast.Position{
 																								Column: 45,
-																								Line:   16,
+																								Line:   20,
 																							},
 																							File:   "http.flux",
 																							Source: "200",
 																							Start: ast.Position{
 																								Column: 42,
-																								Line:   16,
+																								Line:   20,
 																							},
 																						},
 																					},
@@ -550,13 +584,13 @@ var pkgAST = &ast.Package{
 																							Loc: &ast.SourceLocation{
 																								End: ast.Position{
 																									Column: 100,
-																									Line:   16,
+																									Line:   20,
 																								},
 																								File:   "http.flux",
 																								Source: "url: url, headers: obj.headers, data: obj.data",
 																								Start: ast.Position{
 																									Column: 54,
-																									Line:   16,
+																									Line:   20,
 																								},
 																							},
 																						},
@@ -566,13 +600,13 @@ var pkgAST = &ast.Package{
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
 																										Column: 62,
-																										Line:   16,
+																										Line:   20,
 																									},
 																									File:   "http.flux",
 																									Source: "url: url",
 																									Start: ast.Position{
 																										Column: 54,
-																										Line:   16,
+																										Line:   20,
 																									},
 																								},
 																							},
@@ -582,13 +616,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 57,
-																											Line:   16,
+																											Line:   20,
 																										},
 																										File:   "http.flux",
 																										Source: "url",
 																										Start: ast.Position{
 																											Column: 54,
-																											Line:   16,
+																											Line:   20,
 																										},
 																									},
 																								},
@@ -600,13 +634,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 62,
-																											Line:   16,
+																											Line:   20,
 																										},
 																										File:   "http.flux",
 																										Source: "url",
 																										Start: ast.Position{
 																											Column: 59,
-																											Line:   16,
+																											Line:   20,
 																										},
 																									},
 																								},
@@ -618,13 +652,13 @@ var pkgAST = &ast.Package{
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
 																										Column: 84,
-																										Line:   16,
+																										Line:   20,
 																									},
 																									File:   "http.flux",
 																									Source: "headers: obj.headers",
 																									Start: ast.Position{
 																										Column: 64,
-																										Line:   16,
+																										Line:   20,
 																									},
 																								},
 																							},
@@ -634,13 +668,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 71,
-																											Line:   16,
+																											Line:   20,
 																										},
 																										File:   "http.flux",
 																										Source: "headers",
 																										Start: ast.Position{
 																											Column: 64,
-																											Line:   16,
+																											Line:   20,
 																										},
 																									},
 																								},
@@ -652,13 +686,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 84,
-																											Line:   16,
+																											Line:   20,
 																										},
 																										File:   "http.flux",
 																										Source: "obj.headers",
 																										Start: ast.Position{
 																											Column: 73,
-																											Line:   16,
+																											Line:   20,
 																										},
 																									},
 																								},
@@ -668,13 +702,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 76,
-																												Line:   16,
+																												Line:   20,
 																											},
 																											File:   "http.flux",
 																											Source: "obj",
 																											Start: ast.Position{
 																												Column: 73,
-																												Line:   16,
+																												Line:   20,
 																											},
 																										},
 																									},
@@ -686,13 +720,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 84,
-																												Line:   16,
+																												Line:   20,
 																											},
 																											File:   "http.flux",
 																											Source: "headers",
 																											Start: ast.Position{
 																												Column: 77,
-																												Line:   16,
+																												Line:   20,
 																											},
 																										},
 																									},
@@ -705,13 +739,13 @@ var pkgAST = &ast.Package{
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
 																										Column: 100,
-																										Line:   16,
+																										Line:   20,
 																									},
 																									File:   "http.flux",
 																									Source: "data: obj.data",
 																									Start: ast.Position{
 																										Column: 86,
-																										Line:   16,
+																										Line:   20,
 																									},
 																								},
 																							},
@@ -721,13 +755,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 90,
-																											Line:   16,
+																											Line:   20,
 																										},
 																										File:   "http.flux",
 																										Source: "data",
 																										Start: ast.Position{
 																											Column: 86,
-																											Line:   16,
+																											Line:   20,
 																										},
 																									},
 																								},
@@ -739,13 +773,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 100,
-																											Line:   16,
+																											Line:   20,
 																										},
 																										File:   "http.flux",
 																										Source: "obj.data",
 																										Start: ast.Position{
 																											Column: 92,
-																											Line:   16,
+																											Line:   20,
 																										},
 																									},
 																								},
@@ -755,13 +789,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 95,
-																												Line:   16,
+																												Line:   20,
 																											},
 																											File:   "http.flux",
 																											Source: "obj",
 																											Start: ast.Position{
 																												Column: 92,
-																												Line:   16,
+																												Line:   20,
 																											},
 																										},
 																									},
@@ -773,13 +807,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 100,
-																												Line:   16,
+																												Line:   20,
 																											},
 																											File:   "http.flux",
 																											Source: "data",
 																											Start: ast.Position{
 																												Column: 96,
-																												Line:   16,
+																												Line:   20,
 																											},
 																										},
 																									},
@@ -794,13 +828,13 @@ var pkgAST = &ast.Package{
 																						Loc: &ast.SourceLocation{
 																							End: ast.Position{
 																								Column: 101,
-																								Line:   16,
+																								Line:   20,
 																							},
 																							File:   "http.flux",
 																							Source: "post(url: url, headers: obj.headers, data: obj.data)",
 																							Start: ast.Position{
 																								Column: 49,
-																								Line:   16,
+																								Line:   20,
 																							},
 																						},
 																					},
@@ -810,13 +844,13 @@ var pkgAST = &ast.Package{
 																							Loc: &ast.SourceLocation{
 																								End: ast.Position{
 																									Column: 53,
-																									Line:   16,
+																									Line:   20,
 																								},
 																								File:   "http.flux",
 																								Source: "post",
 																								Start: ast.Position{
 																									Column: 49,
-																									Line:   16,
+																									Line:   20,
 																								},
 																							},
 																						},
@@ -832,13 +866,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 102,
-																				Line:   16,
+																				Line:   20,
 																			},
 																			File:   "http.flux",
 																			Source: "string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))",
 																			Start: ast.Position{
 																				Column: 32,
-																				Line:   16,
+																				Line:   20,
 																			},
 																		},
 																	},
@@ -848,13 +882,13 @@ var pkgAST = &ast.Package{
 																			Loc: &ast.SourceLocation{
 																				End: ast.Position{
 																					Column: 38,
-																					Line:   16,
+																					Line:   20,
 																				},
 																				File:   "http.flux",
 																				Source: "string",
 																				Start: ast.Position{
 																					Column: 32,
-																					Line:   16,
+																					Line:   20,
 																				},
 																			},
 																		},
@@ -868,13 +902,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 30,
-																			Line:   15,
+																			Line:   19,
 																		},
 																		File:   "http.flux",
 																		Source: "r",
 																		Start: ast.Position{
 																			Column: 29,
-																			Line:   15,
+																			Line:   19,
 																		},
 																	},
 																},
@@ -886,13 +920,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 22,
-																	Line:   17,
+																	Line:   21,
 																},
 																File:   "http.flux",
 																Source: "return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }",
 																Start: ast.Position{
 																	Column: 21,
-																	Line:   15,
+																	Line:   19,
 																},
 															},
 														},
@@ -904,13 +938,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 30,
-																Line:   13,
+																Line:   17,
 															},
 															File:   "http.flux",
 															Source: "r",
 															Start: ast.Position{
 																Column: 29,
-																Line:   13,
+																Line:   17,
 															},
 														},
 													},
@@ -920,13 +954,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 30,
-																	Line:   13,
+																	Line:   17,
 																},
 																File:   "http.flux",
 																Source: "r",
 																Start: ast.Position{
 																	Column: 29,
-																	Line:   13,
+																	Line:   17,
 																},
 															},
 														},
@@ -943,13 +977,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 19,
-												Line:   18,
+												Line:   22,
 											},
 											File:   "http.flux",
 											Source: "map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })",
 											Start: ast.Position{
 												Column: 20,
-												Line:   13,
+												Line:   17,
 											},
 										},
 									},
@@ -959,13 +993,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 23,
-													Line:   13,
+													Line:   17,
 												},
 												File:   "http.flux",
 												Source: "map",
 												Start: ast.Position{
 													Column: 20,
-													Line:   13,
+													Line:   17,
 												},
 											},
 										},
@@ -978,13 +1012,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 72,
-										Line:   19,
+										Line:   23,
 									},
 									File:   "http.flux",
 									Source: "tables\n                |> map(fn: (r) => {\n                    obj = mapFn(r: r)\n                    return {r with\n                        _sent: string(v: 200 == post(url: url, headers: obj.headers, data: obj.data))\n                    }\n                })\n                |> experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 									Start: ast.Position{
 										Column: 13,
-										Line:   12,
+										Line:   16,
 									},
 								},
 							},
@@ -995,13 +1029,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 71,
-												Line:   19,
+												Line:   23,
 											},
 											File:   "http.flux",
 											Source: "mode:\"extend\", columns:[\"_sent\"]",
 											Start: ast.Position{
 												Column: 39,
-												Line:   19,
+												Line:   23,
 											},
 										},
 									},
@@ -1011,13 +1045,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 52,
-													Line:   19,
+													Line:   23,
 												},
 												File:   "http.flux",
 												Source: "mode:\"extend\"",
 												Start: ast.Position{
 													Column: 39,
-													Line:   19,
+													Line:   23,
 												},
 											},
 										},
@@ -1027,13 +1061,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 43,
-														Line:   19,
+														Line:   23,
 													},
 													File:   "http.flux",
 													Source: "mode",
 													Start: ast.Position{
 														Column: 39,
-														Line:   19,
+														Line:   23,
 													},
 												},
 											},
@@ -1045,13 +1079,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 52,
-														Line:   19,
+														Line:   23,
 													},
 													File:   "http.flux",
 													Source: "\"extend\"",
 													Start: ast.Position{
 														Column: 44,
-														Line:   19,
+														Line:   23,
 													},
 												},
 											},
@@ -1063,13 +1097,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 71,
-													Line:   19,
+													Line:   23,
 												},
 												File:   "http.flux",
 												Source: "columns:[\"_sent\"]",
 												Start: ast.Position{
 													Column: 54,
-													Line:   19,
+													Line:   23,
 												},
 											},
 										},
@@ -1079,13 +1113,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 61,
-														Line:   19,
+														Line:   23,
 													},
 													File:   "http.flux",
 													Source: "columns",
 													Start: ast.Position{
 														Column: 54,
-														Line:   19,
+														Line:   23,
 													},
 												},
 											},
@@ -1097,13 +1131,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 71,
-														Line:   19,
+														Line:   23,
 													},
 													File:   "http.flux",
 													Source: "[\"_sent\"]",
 													Start: ast.Position{
 														Column: 62,
-														Line:   19,
+														Line:   23,
 													},
 												},
 											},
@@ -1113,13 +1147,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 70,
-															Line:   19,
+															Line:   23,
 														},
 														File:   "http.flux",
 														Source: "\"_sent\"",
 														Start: ast.Position{
 															Column: 63,
-															Line:   19,
+															Line:   23,
 														},
 													},
 												},
@@ -1134,13 +1168,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 72,
-											Line:   19,
+											Line:   23,
 										},
 										File:   "http.flux",
 										Source: "experimental.group(mode:\"extend\", columns:[\"_sent\"])",
 										Start: ast.Position{
 											Column: 20,
-											Line:   19,
+											Line:   23,
 										},
 									},
 								},
@@ -1150,13 +1184,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 38,
-												Line:   19,
+												Line:   23,
 											},
 											File:   "http.flux",
 											Source: "experimental.group",
 											Start: ast.Position{
 												Column: 20,
-												Line:   19,
+												Line:   23,
 											},
 										},
 									},
@@ -1166,13 +1200,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 32,
-													Line:   19,
+													Line:   23,
 												},
 												File:   "http.flux",
 												Source: "experimental",
 												Start: ast.Position{
 													Column: 20,
-													Line:   19,
+													Line:   23,
 												},
 											},
 										},
@@ -1184,13 +1218,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 38,
-													Line:   19,
+													Line:   23,
 												},
 												File:   "http.flux",
 												Source: "group",
 												Start: ast.Position{
 													Column: 33,
-													Line:   19,
+													Line:   23,
 												},
 											},
 										},
@@ -1205,13 +1239,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 19,
-										Line:   11,
+										Line:   15,
 									},
 									File:   "http.flux",
 									Source: "tables=<-",
 									Start: ast.Position{
 										Column: 10,
-										Line:   11,
+										Line:   15,
 									},
 								},
 							},
@@ -1221,13 +1255,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 16,
-											Line:   11,
+											Line:   15,
 										},
 										File:   "http.flux",
 										Source: "tables",
 										Start: ast.Position{
 											Column: 10,
-											Line:   11,
+											Line:   15,
 										},
 									},
 								},
@@ -1238,13 +1272,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 19,
-										Line:   11,
+										Line:   15,
 									},
 									File:   "http.flux",
 									Source: "<-",
 									Start: ast.Position{
 										Column: 17,
-										Line:   11,
+										Line:   15,
 									},
 								},
 							}},
@@ -1256,13 +1290,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   10,
+									Line:   14,
 								},
 								File:   "http.flux",
 								Source: "mapFn",
 								Start: ast.Position{
 									Column: 6,
-									Line:   10,
+									Line:   14,
 								},
 							},
 						},
@@ -1272,13 +1306,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 11,
-										Line:   10,
+										Line:   14,
 									},
 									File:   "http.flux",
 									Source: "mapFn",
 									Start: ast.Position{
 										Column: 6,
-										Line:   10,
+										Line:   14,
 									},
 								},
 							},
@@ -1293,13 +1327,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 17,
-								Line:   9,
+								Line:   13,
 							},
 							File:   "http.flux",
 							Source: "url",
 							Start: ast.Position{
 								Column: 14,
-								Line:   9,
+								Line:   13,
 							},
 						},
 					},
@@ -1309,13 +1343,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 17,
-									Line:   9,
+									Line:   13,
 								},
 								File:   "http.flux",
 								Source: "url",
 								Start: ast.Position{
 									Column: 14,
-									Line:   9,
+									Line:   13,
 								},
 							},
 						},

--- a/stdlib/http/http.flux
+++ b/stdlib/http/http.flux
@@ -6,6 +6,10 @@ import "experimental"
 // The HTTP status code is returned.
 builtin post
 
+// basicAuth will take a username/password combination and return the authorization
+// header value.
+builtin basicAuth
+
 endpoint =  (url) =>
     (mapFn) =>
         (tables=<-) =>


### PR DESCRIPTION
The `basicAuth(u, p)` function will take a username and password and
compute the basic authentication header for that username/password
combination.

#1808

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written