### PR TITLE
fix(compiler): panic from CheckKind in memberEvaluator

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -545,7 +545,7 @@ func (e *memberEvaluator) Eval(ctx context.Context, deps dependencies.Interface,
 		return nil, err
 	}
 	v, _ := o.Object().Get(e.property)
-	values.CheckKind(v.PolyType().Nature(), e.t.Nature())
+	// values.CheckKind(v.PolyType().Nature(), e.t.Nature())
 	return v, nil
 }
 


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

This line was supposed to be commented out with the pagerduty endpoint but must have been missed. This should fix #1814 .