### PR TITLE
fix(pagerduty): add severity level formatting helper function

### DIFF
--- a/stdlib/pagerduty/pagerduty.flux
+++ b/stdlib/pagerduty/pagerduty.flux
@@ -12,18 +12,19 @@ option defaultURL = "https://events.pagerduty.com/v2/enqueue"
 
 // severity levels on status objects can be one of the following: ok,info,warn,crit,unknown
 // but pagerduty only accepts critical, error, warning or info.
-// formatSeverity turns a level from the status object into a pagerduty severity
-formatSeverity = (severity) => {
-    sev = strings.toLower(v:severity) 
-    if sev == "warn" then "warning"
-    else if sev == "crit" then "critical"
-    else if sev == "info" then "info"
-    else if sev == "ok" then "info"
-    else "unknown"
+// severityFromLevel turns a level from the status object into a pagerduty severity
+severityFromLevel = (level) => {
+    lvl = strings.toLower(v:level)
+    sev = if lvl == "warn" then "warning" 
+        else if lvl == "crit" then "critical" 
+        else if lvl == "info" then "info" 
+        else if lvl == "ok" then "info" 
+        else "error"
+    return sev
 }
 
-// `actionFromSeverity` converts a severity to an action; "ok" becomes "resolve" everything else converts to "trigger".
-actionFromSeverity = (severity)=> if strings.toLower(v:severity) == "ok" then "resolve" else "trigger"
+// `actionFromLevel` converts a monitoring level to an action; "ok" becomes "resolve" everything else converts to "trigger".
+actionFromLevel = (level)=> if strings.toLower(v:level) == "ok" then "resolve" else "trigger"
 
 // `sendEvent` sends an event to PagerDuty, the description of some of these parameters taken from the pagerduty documentation at https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
 // `pagerdutyURL` - sring - URL of the pagerduty endpoint.  Defaults to: `option defaultURL = "https://events.pagerduty.com/v2/enqueue"`
@@ -35,6 +36,7 @@ actionFromSeverity = (severity)=> if strings.toLower(v:severity) == "ok" then "r
 // `class` - string - The class/type of the event, for example ping failure or cpu load.
 // `group` - string - Logical grouping of components of a service, for example app-stack.
 // `severity` - string - The perceived severity of the status the event is describing with respect to the affected system. This can be critical, error, warning or info.
+// `eventAction` - string - The type of event to send to PagerDuty (ex. trigger, resolve, acknowledge)
 // `component` - string - Component of the source machine that is responsible for the event, for example mysql or eth0.
 // `source` - string - The unique location of the affected system, preferably a hostname or FQDN.
 // `summary` - string - A brief text summary of the event, used to generate the summaries/titles of any associated alerts. The maximum permitted length of this property is 1024 characters.
@@ -48,6 +50,7 @@ sendEvent = (pagerdutyURL=defaultURL,
     class,
     group,
     severity,
+    eventAction,
     component,
     source,
     summary,
@@ -57,7 +60,7 @@ sendEvent = (pagerdutyURL=defaultURL,
             summary: summary,
             timestamp: timestamp,
             source: source,
-            severity: formatSeverity(severity),
+            severity: severity,
             component: component,
             group: group,
             class: class,
@@ -66,7 +69,7 @@ sendEvent = (pagerdutyURL=defaultURL,
         payload: payload,
         routing_key: routingKey,
         dedup_key: dedupKey,
-        event_action: actionFromSeverity(severity: severity),
+        event_action: eventAction,
         client: client,
         client_url: clientURL,
     }
@@ -84,7 +87,7 @@ sendEvent = (pagerdutyURL=defaultURL,
 // `url` - string - URL of the slack endpoint. Defaults to: "https://events.pagerduty.com/v2/enqueue".
 // `token` - string - token for the pagerduty endpoint.
 // The returned factory function accepts a `mapFn` parameter.
-// The `mapFn` parameter must be a function that returns an object with `routingKey`, `client`, `client_url`,`class`,`group`, `severity`, `component`, `source`, `summary`, and `timestamp` as defined in the sendEvent function.
+// The `mapFn` parameter must be a function that returns an object with `routingKey`, `client`, `client_url`, `class`, `group`, `severity`, `eventAction`, `component`, `source`, `summary`, and `timestamp` as defined in the sendEvent function.
 // Note that while sendEvent accepts a dedup key, endpoint gets the dedupkey from the groupkey of the input table instead of it being handled by the `mapFn`.
 endpoint = (url=defaultURL, token="") =>
     (mapFn) =>
@@ -102,6 +105,7 @@ endpoint = (url=defaultURL, token="") =>
                     class: obj.class,
                     group: obj.group,
                     severity: obj.severity, 
+                    eventAction: obj.eventAction,
                     component: obj.component, 
                     source: obj.source, 
                     summary: obj.summary, 

--- a/stdlib/pagerduty/pagerduty.flux
+++ b/stdlib/pagerduty/pagerduty.flux
@@ -10,6 +10,18 @@ builtin dedupKey
 option defaultURL = "https://events.pagerduty.com/v2/enqueue"
 
 
+// severity levels on status objects can be one of the following: ok,info,warn,crit,unknown
+// but pagerduty only accepts critical, error, warning or info.
+// formatSeverity turns a level from the status object into a pagerduty severity
+formatSeverity = (severity) => {
+    sev = strings.toLower(v:severity) 
+    if sev == "warn" then "warning"
+    else if sev == "crit" then "critical"
+    else if sev == "info" then "info"
+    else if sev == "ok" then "info"
+    else "unknown"
+}
+
 // `actionFromSeverity` converts a severity to an action; "ok" becomes "resolve" everything else converts to "trigger".
 actionFromSeverity = (severity)=> if strings.toLower(v:severity) == "ok" then "resolve" else "trigger"
 
@@ -45,7 +57,7 @@ sendEvent = (pagerdutyURL=defaultURL,
             summary: summary,
             timestamp: timestamp,
             source: source,
-            severity: severity,
+            severity: formatSeverity(severity),
             component: component,
             group: group,
             class: class,

--- a/stdlib/pagerduty/pagerduty_test.go
+++ b/stdlib/pagerduty/pagerduty_test.go
@@ -151,7 +151,7 @@ func TestPagerdutySendEvent(t *testing.T) {
 			clientURL:     "http://fakepagerduty.com",
 			class:         "deploy",
 			group:         "app-stack",
-			severity:      "warning",
+			severity:      "warn",
 			component:     "influxdb",
 			source:        "monitoringtool:vendor:region",
 			summary:       "this is a testing summary",

--- a/stdlib/pagerduty/pagerduty_test.go
+++ b/stdlib/pagerduty/pagerduty_test.go
@@ -140,9 +140,10 @@ func TestPagerdutySendEvent(t *testing.T) {
 		summary       string
 		timestamp     string
 		eventAction   string
+		level         string
 	}{
 		{
-			name:          "testCase1",
+			name:          "warning",
 			otherGroupKey: "foo",
 			pagerdutyURL:  s.URL,
 			token:         "fakeToken1",
@@ -151,15 +152,34 @@ func TestPagerdutySendEvent(t *testing.T) {
 			clientURL:     "http://fakepagerduty.com",
 			class:         "deploy",
 			group:         "app-stack",
-			severity:      "warn",
+			severity:      "warning",
 			component:     "influxdb",
 			source:        "monitoringtool:vendor:region",
 			summary:       "this is a testing summary",
 			timestamp:     "2015-07-17T08:42:58.315+0000",
 			eventAction:   "trigger",
+			level:         "warn",
 		},
 		{
-			name:          "testCase2",
+			name:          "critical",
+			otherGroupKey: "foo",
+			pagerdutyURL:  s.URL,
+			token:         "fakeToken1",
+			routingKey:    "fakeRoutingKey",
+			client:        "fakeClient1",
+			clientURL:     "http://fakepagerduty.com",
+			class:         "deploy",
+			group:         "app-stack",
+			severity:      "critical",
+			component:     "influxdb",
+			source:        "monitoringtool:vendor:region",
+			summary:       "this is a testing summary",
+			timestamp:     "2015-07-17T08:42:58.315+0000",
+			eventAction:   "trigger",
+			level:         "crit",
+		},
+		{
+			name:          "resolve",
 			otherGroupKey: "foo2",
 			pagerdutyURL:  s.URL,
 			token:         "fakeToken2",
@@ -168,12 +188,13 @@ func TestPagerdutySendEvent(t *testing.T) {
 			clientURL:     "http://fakepagerduty.com",
 			class:         "deploy",
 			group:         "app-stack",
-			severity:      "ok",
+			severity:      "info",
 			component:     "postgres",
 			source:        "monitoringtool:vendor:region",
 			summary:       "this is another testing summary",
 			timestamp:     "2016-07-17T08:42:58.315+0000",
 			eventAction:   "resolve",
+			level:         "ok",
 		},
 	}
 
@@ -184,13 +205,16 @@ func TestPagerdutySendEvent(t *testing.T) {
 import "pagerduty"
 
 endpoint = pagerduty.endpoint(url:url, token:token)(mapFn: (r) => {
+	sev = pagerduty.severityFromLevel(level: r.wlevel)
+	action = pagerduty.actionFromLevel(level: r.wlevel)
     return {
 		routingKey:r.froutingKey,
 		client:r.qclient,
 		clientURL:r.qclientURL,
 		class:r.wclass,
 		group:r.wgroup,
-		severity:r.wseverity,
+		severity: sev,
+		eventAction:action,
 		component:r.wcomponent,
 		source:r.wsource,
 		summary:r.wsummary,
@@ -226,14 +250,14 @@ csv.from(csv:data) |> endpoint()
 						Value: `#datatype,string,string,string,string,string,string,string,string,string,string,string,string,string,string,long
 #group,false,false,false,true,false,false,false,false,false,false,false,false,true,true,true
 #default,_result,,,,,,,,,,,,,,
-,result,,froutingKey,qclient,qclientURL,wclass,wgroup,wseverity,wcomponent,wsource,wsummary,wtimestamp,name,otherGroupKey,groupKey2
+,result,,froutingKey,qclient,qclientURL,wclass,wgroup,wlevel,wcomponent,wsource,wsummary,wtimestamp,name,otherGroupKey,groupKey2
 ,,,` + strings.Join([]string{
 							tc.routingKey,
 							tc.client,
 							tc.clientURL,
 							tc.class,
 							tc.group,
-							tc.severity,
+							tc.level,
 							tc.component,
 							tc.source,
 							tc.summary,


### PR DESCRIPTION
Severity levels on status objects can be one of the following: `ok, info, warn, crit, unknown` according to the spec shown here: https://github.com/influxdata/idpe/blob/master/docs/content/rfcs/alerts_and_notifications.md#bucket-data-model

However, pagerduty only accepts: `critical, error, warning, info`

This PR adds a helper function called `severityFromLevel` turns a level from the status object into a pagerduty severity

For example, changing `warn` -> `warning`

The `endpoint` and `sendEvent` functions will both take data in the form that Pagerduty expects. This means that the user or the generated monitoring code will need to call the helper functions `severityFromLevel` and `actionFromLevel` if passing data directly from a status object


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
