### PR TITLE
fix(stdlib): ensure http.post respects the context

### DIFF
--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -63,7 +63,7 @@ func newDefaultTransport() *http.Transport {
 			// DualStack is deprecated
 		}).DialContext,
 		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
+		IdleConnTimeout:       10 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		// Fields below are NOT part of Go's defaults

--- a/stdlib/http/post.go
+++ b/stdlib/http/post.go
@@ -56,6 +56,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
+			req = req.WithContext(ctx)
 
 			// Add headers to request
 			header, ok := args.Get("headers")


### PR DESCRIPTION
The `http.post` function now will respect the context so it will cancel
an outgoing request if its own context gets canceled.

This also updates the idle connect timeout to a much lower value since
any longer than 10 seconds likely indicates an error condition.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written