### PR TITLE
fix(internal/spec): do a pointer comparison for table objects instead of a deep compare

### DIFF
--- a/internal/spec/build.go
+++ b/internal/spec/build.go
@@ -159,7 +159,7 @@ func isDuplicateTableObject(ctx context.Context, op *flux.TableObject, objs []*f
 	defer s.Finish()
 
 	for _, tableObject := range objs {
-		if op.Equal(tableObject) {
+		if op == tableObject {
 			return true
 		}
 	}

--- a/internal/spec/build_test.go
+++ b/internal/spec/build_test.go
@@ -1,0 +1,43 @@
+package spec_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	_ "github.com/influxdata/flux/builtin"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/internal/spec"
+)
+
+func Benchmark_FromScript(b *testing.B) {
+	query := `
+import "influxdata/influxdb/monitor"
+// Disable to the call to to since that isn't enabled
+// in the flux repository.
+option monitor.write = (tables=<-) => tables
+check = from(bucket: "telegraf")
+	|> range(start: -5m)
+	|> mean()
+	|> monitor.check(
+		data: {tags: {}},
+		crit: (r) => r._value > 90,
+		messageFn: (r) => "${r._value} is greater than 90",
+	)
+	|> monitor.stateChanges(toLevel: "crit")
+
+// Multiple yield calls to the same table object so that
+// we check whether we have a duplicate table object node
+// to exercise that piece of code.
+check |> yield(name: "checkResult")
+check |> yield(name: "mean")
+`
+	ctx := context.Background()
+	deps := dependenciestest.Default()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := spec.FromScript(ctx, deps, time.Now(), query); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
The conversion from an AST to a spec would evaluate the AST and then
return a spec from the side effects that were related to table objects.

In order to do this, the code that converted a table object into a spec
would also check to see if that table object had already been seen
before.

This caused a performance problem because the `Equal` method for a
`TableObject` would recursively check the `TableObject` which also
included checking the parents. If you had a reasonably complex query,
this could take a very long time as that code was not very efficient and
involved lots of small memory allocations.

This changes it so that instead of recursively checking, it just checks
the memory location which should be the same when they are duplicates
anyway.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written