### PR TITLE
ci: save the go/pkg/mod cache only when it would reasonably be changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,7 @@ jobs:
       - restore_cache:
           name: Restoring GOPATH/pkg/mod
           keys:
-            - flux-gomod-{{ .Branch }}-{{ .Revision }} # Matches when retrying a single run.
-            - flux-gomod-{{ .Branch }}-                # Matches a new commit on an existing branch.
-            - flux-gomod-                              # Matches a new branch.
+            - flux-gomod-{{checksum "go.sum"}}
       # Populate Rust cache
       - restore_cache:
           name: Restoring Rust Cache
@@ -51,10 +49,9 @@ jobs:
           when: always
       - save_cache:
           name: Saving GOPATH/pkg/mod
-          key: flux-gomod-{{ .Branch }}-{{ .Revision }}
+          key: flux-gomod-{{checksum "go.sum"}}
           paths:
             - /tmp/go/pkg/mod
-          when: always
       - save_cache:
           name: Saving Rust Cache
           key: flux-rust-{{ .Branch }}-{{ .Revision }}
@@ -75,9 +72,7 @@ jobs:
       - restore_cache:
           name: Restoring GOPATH/pkg/mod
           keys:
-            - flux-gomod-{{ .Branch }}-{{ .Revision }} # Matches when retrying a single run.
-            - flux-gomod-{{ .Branch }}-                # Matches a new commit on an existing branch.
-            - flux-gomod-                              # Matches a new branch.
+            - flux-gomod-{{checksum "go.sum"}}
       # Run tests
       - run: make test-race
       # No need to save the pkg/mod cache since the other job does it


### PR DESCRIPTION
The go/pkg/mod will contain the files from modules and will be populated
mostly from the contents of `go.sum` which is informed by `go.mod`.

Instead of saving the cache for every new branch and revision
combination, which makes the build noticeably slower, it will only save
the cache when the cache could reasonably be different because `go.sum`
has changed.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written