### PR TITLE
fix(stdlib): add a filesystem service

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/secret"
 	"github.com/influxdata/flux/repl"
 	"github.com/spf13/cobra"
@@ -27,6 +28,7 @@ func init() {
 func execute(cmd *cobra.Command, args []string) error {
 	deps := dependencies.NewDefaults()
 	deps.Deps.SecretService = secret.EmptySecretService{}
+	deps.Deps.FilesystemService = filesystem.SystemFS
 	r := repl.New(context.Background(), deps, querier{})
 	if err := r.Input(args[0]); err != nil {
 		return fmt.Errorf("failed to execute query: %v", err)

--- a/cmd/flux/cmd/repl.go
+++ b/cmd/flux/cmd/repl.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/secret"
 	fexecute "github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/lang"
@@ -23,6 +24,7 @@ var replCmd = &cobra.Command{
 		ctx := context.Background()
 		deps := dependencies.NewDefaults()
 		deps.Deps.SecretService = secret.EmptySecretService{}
+		deps.Deps.FilesystemService = filesystem.SystemFS
 		r := repl.New(ctx, deps, querier{})
 		r.Run()
 	},

--- a/dependencies/filesystem/ioutil.go
+++ b/dependencies/filesystem/ioutil.go
@@ -1,0 +1,14 @@
+package filesystem
+
+import "io/ioutil"
+
+// ReadFile will open the file from the service and read
+// the entire contents.
+func ReadFile(fs Service, filename string) ([]byte, error) {
+	f, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return ioutil.ReadAll(f)
+}

--- a/dependencies/filesystem/service.go
+++ b/dependencies/filesystem/service.go
@@ -1,0 +1,20 @@
+package filesystem
+
+import (
+	"io"
+	"os"
+)
+
+// File is an interface for interacting with a file.
+type File interface {
+	io.ReadWriteCloser
+	io.Seeker
+	Stat() (os.FileInfo, error)
+}
+
+// Service is the service for accessing the filesystem.
+type Service interface {
+	Open(fpath string) (File, error)
+	Create(fpath string) (File, error)
+	Stat(fpath string) (os.FileInfo, error)
+}

--- a/dependencies/filesystem/systemfs.go
+++ b/dependencies/filesystem/systemfs.go
@@ -1,0 +1,29 @@
+package filesystem
+
+import "os"
+
+// SystemFS implements the filesystem.Service by proxying all requests
+// to the filesystem.
+var SystemFS Service = systemFS{}
+
+type systemFS struct{}
+
+func (systemFS) Open(fpath string) (File, error) {
+	f, err := os.Open(fpath)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (systemFS) Create(fpath string) (File, error) {
+	f, err := os.Create(fpath)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (systemFS) Stat(fpath string) (os.FileInfo, error) {
+	return os.Stat(fpath)
+}

--- a/dependencies/filesystem/systemfs_test.go
+++ b/dependencies/filesystem/systemfs_test.go
@@ -1,0 +1,129 @@
+package filesystem_test
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/influxdata/flux/dependencies/filesystem"
+)
+
+func TestSystemFS_Open(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "flux-systemfs-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+	defer func() { _ = tmpfile.Close() }()
+
+	if _, err := io.WriteString(tmpfile, "Hello, World!"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := filesystem.SystemFS
+	f, err := fs.Open(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(data), "Hello, World!"; got != want {
+		t.Fatalf("unexpected file contents -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSystemFS_Create(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "flux-systemfs-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpdir) }()
+
+	fullpath := filepath.Join(tmpdir, "hello.txt")
+	fs := filesystem.SystemFS
+	f, err := fs.Create(fullpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.WriteString(f, "Hello, World!"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := ioutil.ReadFile(fullpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(data), "Hello, World!"; got != want {
+		t.Fatalf("unexpected file contents -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
+func TestSystemFS_Stat(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "flux-systemfs-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+	defer func() { _ = tmpfile.Close() }()
+
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := filesystem.SystemFS
+	fi, err := fs.Stat(tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := fi.Name(), filepath.Base(tmpfile.Name()); got != want {
+		t.Fatalf("unexpected file info name -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
+func TestReadFile(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "flux-systemfs-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
+	defer func() { _ = tmpfile.Close() }()
+
+	if _, err := io.WriteString(tmpfile, "Hello, World!"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := filesystem.SystemFS
+	data, err := filesystem.ReadFile(fs, tmpfile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(data), "Hello, World!"; got != want {
+		t.Fatalf("unexpected file contents -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}

--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
@@ -117,7 +118,13 @@ func createFromCSVSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 	csvText := spec.CSV
 	// if spec.File non-empty then spec.CSV is empty
 	if spec.File != "" {
-		csvBytes, err := ioutil.ReadFile(spec.File)
+		deps := a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Dependencies)
+		fs, err := deps.FilesystemService()
+		if err != nil {
+			return nil, err
+		}
+
+		csvBytes, err := filesystem.ReadFile(fs, spec.File)
 		if err != nil {
 			return nil, errors.Wrap(err, codes.Inherit, "csv.from() failed to read file")
 		}

--- a/stdlib/influxdata/influxdb/v1/from_influx_json.go
+++ b/stdlib/influxdata/influxdb/v1/from_influx_json.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/influxql"
 	"github.com/influxdata/flux/internal/errors"
@@ -120,8 +121,14 @@ func createFromInfluxJSONSource(prSpec plan.ProcedureSpec, dsid execute.DatasetI
 
 	var jsonReader io.Reader
 
+	deps := a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Dependencies)
+	fs, err := deps.FilesystemService()
+	if err != nil {
+		return nil, err
+	}
+
 	if spec.File != "" {
-		f, err := os.Open(spec.File)
+		f, err := fs.Open(spec.File)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds a filesystem service for accessing files and changes the file
access functions inside of flux to use it. This allows the user who is
running queries to control the kinds of files that can be accessed or
whether they can access files at all.

Backport of #1849.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written