### PR TITLE
refactor(csv): csv table iterators now pass the table tests

### DIFF
--- a/csv/result_internal_test.go
+++ b/csv/result_internal_test.go
@@ -1,0 +1,7 @@
+package csv
+
+import "sync/atomic"
+
+func (d *tableDecoder) IsDone() bool {
+	return d.empty || atomic.LoadInt32(&d.used) != 0
+}

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -219,7 +219,7 @@ func TestColListTable(t *testing.T) {
 				nil,
 			))
 			tbl1, _ := b1.Table()
-			b1.ClearData()
+			b1.Release()
 
 			b2 := execute.NewColListTableBuilder(execute.NewGroupKey(
 				[]flux.ColMeta{
@@ -233,7 +233,7 @@ func TestColListTable(t *testing.T) {
 			_, _ = b2.AddCol(flux.ColMeta{Label: "host", Type: flux.TString})
 			_, _ = b2.AddCol(flux.ColMeta{Label: "_value", Type: flux.TFloat})
 			tbl2, _ := b2.Table()
-			b2.ClearData()
+			b2.Release()
 			return TableIterator{
 				Tables: []flux.Table{tbl1, tbl2},
 			}

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -194,7 +194,7 @@ func Input(schema Schema) (flux.ResultIterator, error) {
 			return
 		}
 		tables = append(tables, tbl)
-		builder.ClearData()
+		builder.Release()
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This should be the final of the table implementations to implement the
full contract for the `flux.Table` so that it passes the common table
tests with no memory leaks.

This involved changing the `TableBuilder` slightly to expose a new
`Release()` method. The `ClearData()` method was being overloaded to
both free memory and clear data. Clearing data can be useful when
reusing the buffers since `TableBuilder` doesn't use the arrow buffers
for legacy reasons so it is more efficient to reuse its internal ones,
but it meant there was no way to signal that you did not want those
buffers anymore.

That meant the old version decreased the allocated memory without
actually freeing it and then reusing that memory led to the system
thinking it had double freed the memory.

The new method makes it much more clear what the intention is so the
implementation can do the correct thing.

Fixes #1318.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written