### PR TITLE
feat: convert the flux memory allocator into an arrow allocator

### DIFF
--- a/arrow/allocator.go
+++ b/arrow/allocator.go
@@ -5,42 +5,6 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-type allocator struct {
-	arrowmemory.Allocator
-	alloc *memory.Allocator
-}
-
 func NewAllocator(a *memory.Allocator) arrowmemory.Allocator {
-	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
-	if a != nil {
-		alloc = &allocator{
-			Allocator: alloc,
-			alloc:     a,
-		}
-	}
-	return alloc
-}
-
-func (a *allocator) Allocate(size int) []byte {
-	if err := a.alloc.Allocate(size); err != nil {
-		panic(err)
-	}
-	return a.Allocator.Allocate(size)
-}
-
-func (a *allocator) Reallocate(size int, b []byte) []byte {
-	sizediff := size - cap(b)
-	if sizediff > 0 {
-		if err := a.alloc.Allocate(sizediff); err != nil {
-			panic(err)
-		}
-	} else {
-		a.alloc.Free(-sizediff)
-	}
-	return a.Allocator.Reallocate(size, b)
-}
-
-func (a *allocator) Free(b []byte) {
-	a.alloc.Free(cap(b))
-	a.Allocator.Free(b)
+	return a
 }

--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -2,7 +2,6 @@ package arrow
 
 import (
 	"github.com/apache/arrow/go/arrow/array"
-	arrowmemory "github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -24,12 +23,5 @@ func BoolSlice(arr *array.Boolean, i, j int) *array.Boolean {
 }
 
 func NewBoolBuilder(a *memory.Allocator) *array.BooleanBuilder {
-	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
-	if a != nil {
-		alloc = &allocator{
-			Allocator: alloc,
-			alloc:     a,
-		}
-	}
-	return array.NewBooleanBuilder(alloc)
+	return array.NewBooleanBuilder(a)
 }

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -2,7 +2,6 @@ package arrow
 
 import (
 	"github.com/apache/arrow/go/arrow/array"
-	arrowmemory "github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -24,12 +23,5 @@ func FloatSlice(arr *array.Float64, i, j int) *array.Float64 {
 }
 
 func NewFloatBuilder(a *memory.Allocator) *array.Float64Builder {
-	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
-	if a != nil {
-		alloc = &allocator{
-			Allocator: alloc,
-			alloc:     a,
-		}
-	}
-	return array.NewFloat64Builder(alloc)
+	return array.NewFloat64Builder(a)
 }

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -2,7 +2,6 @@ package arrow
 
 import (
 	"github.com/apache/arrow/go/arrow/array"
-	arrowmemory "github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -24,12 +23,5 @@ func IntSlice(arr *array.Int64, i, j int) *array.Int64 {
 }
 
 func NewIntBuilder(a *memory.Allocator) *array.Int64Builder {
-	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
-	if a != nil {
-		alloc = &allocator{
-			Allocator: alloc,
-			alloc:     a,
-		}
-	}
-	return array.NewInt64Builder(alloc)
+	return array.NewInt64Builder(a)
 }

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -3,7 +3,6 @@ package arrow
 import (
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
-	arrowmemory "github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -30,12 +29,5 @@ func StringSlice(arr *array.Binary, i, j int) *array.Binary {
 }
 
 func NewStringBuilder(a *memory.Allocator) *array.BinaryBuilder {
-	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
-	if a != nil {
-		alloc = &allocator{
-			Allocator: alloc,
-			alloc:     a,
-		}
-	}
-	return array.NewBinaryBuilder(alloc, arrow.BinaryTypes.String)
+	return array.NewBinaryBuilder(a, arrow.BinaryTypes.String)
 }

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -2,7 +2,6 @@ package arrow
 
 import (
 	"github.com/apache/arrow/go/arrow/array"
-	arrowmemory "github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -24,12 +23,5 @@ func UintSlice(arr *array.Uint64, i, j int) *array.Uint64 {
 }
 
 func NewUintBuilder(a *memory.Allocator) *array.Uint64Builder {
-	var alloc arrowmemory.Allocator = arrowmemory.NewGoAllocator()
-	if a != nil {
-		alloc = &allocator{
-			Allocator: alloc,
-			alloc:     a,
-		}
-	}
-	return array.NewUint64Builder(alloc)
+	return array.NewUint64Builder(a)
 }

--- a/execute/allocator.go
+++ b/execute/allocator.go
@@ -22,11 +22,11 @@ type Allocator struct {
 
 // Free informs the allocator that memory has been freed.
 func (a *Allocator) Free(n, size int) {
-	a.Allocator.Free(n * size)
+	_ = a.Allocator.Account(-n * size)
 }
 
 func (a *Allocator) account(n, size int) {
-	if err := a.Allocator.Allocate(n * size); err != nil {
+	if err := a.Allocator.Account(n * size); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
This converts the flux memory allocator to support the same interface as
the arrow memory allocator so the two can be used interchangeably.

The purpose of this is to allow greater integration of arrow allocators
and to open up the possibility of pooled memory for buffers to reduce
memory load. At the moment, the flux memory allocator is shared among
the entire query and is commonly wrapped by a temporary arrow allocator
that combines the two. This change reverses that dynamic by having the
flux memory allocator invoke the arrow allocator directly since that is
now possible with the changed interface.

This will allow us to set a single arrow allocator for the entire query
instead of creating a new one for each builder like we currently do.

BREAKING CHANGE: The `*memory.Allocator` interface has changed so
`Allocate` and `Free` are now just `Account`.

#1861

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written