### PR TITLE
fix(stdlib): fix some of the memory leaks within the standard library

### DIFF
--- a/stdlib/testing/diff.go
+++ b/stdlib/testing/diff.go
@@ -311,6 +311,7 @@ func (t *DiffTransformation) Process(id execute.DatasetID, tbl flux.Table) error
 	// to prematurely declare the other table as finished so we
 	// don't do more work on something that failed anyway.
 	if t.finished[id] {
+		tbl.Done()
 		return nil
 	}
 
@@ -402,6 +403,9 @@ func (t *DiffTransformation) createSchema(builder execute.TableBuilder, want, go
 }
 
 func (t *DiffTransformation) diff(key flux.GroupKey, want, got *tableBuffer) error {
+	defer want.Release()
+	defer got.Release()
+
 	// Find the smallest size for the tables. We will only iterate
 	// over these rows.
 	sz := want.sz


### PR DESCRIPTION
Fix some of the remaining leaks within the standard library and enable
tests to ensure that memory leaks are checked for every end to end test.

There were two functions that I could not figure out how to fix for
memory leaks. The `join` function was too complex for me to feel
comfortable with deciding when to release memory. The `cov` function
uses the `join` function so I similarly could not fix that one. These
tests are specially skipped until we are able to address the memory
leaks in `join` with a possible refactor.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written