### PR TITLE
feat(dependencies): new dependency injection framework

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/secret"
 	"github.com/influxdata/flux/repl"
@@ -26,10 +26,11 @@ func init() {
 }
 
 func execute(cmd *cobra.Command, args []string) error {
-	deps := dependencies.NewDefaults()
+	deps := flux.NewDefaultDependencies()
 	deps.Deps.SecretService = secret.EmptySecretService{}
 	deps.Deps.FilesystemService = filesystem.SystemFS
-	r := repl.New(context.Background(), deps, querier{})
+	ctx := deps.Inject(context.Background())
+	r := repl.New(ctx, deps, querier{})
 	if err := r.Input(args[0]); err != nil {
 		return fmt.Errorf("failed to execute query: %v", err)
 	}

--- a/compile.go
+++ b/compile.go
@@ -343,8 +343,7 @@ func evalBuiltInPackages() error {
 		}
 
 		itrp := interpreter.NewInterpreter(pkg)
-		ctx := NewEmptyDependencies().Inject(context.Background())
-		if _, err := itrp.Eval(ctx, semPkg, preludeScope.Nest(pkg), stdlib); err != nil {
+		if _, err := itrp.Eval(context.Background(), semPkg, preludeScope.Nest(pkg), stdlib); err != nil {
 			return errors.Wrapf(err, codes.Inherit, "failed to evaluate builtin package %q", astPkg.Path)
 		}
 	}

--- a/compile.go
+++ b/compile.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
@@ -40,16 +39,16 @@ func Parse(flux string) (*ast.Package, error) {
 }
 
 // Eval accepts a Flux script and evaluates it to produce a set of side effects (as a slice of values) and a scope.
-func Eval(ctx context.Context, deps dependencies.Interface, flux string, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
+func Eval(ctx context.Context, flux string, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
 	astPkg, err := Parse(flux)
 	if err != nil {
 		return nil, nil, err
 	}
-	return EvalAST(ctx, deps, astPkg, opts...)
+	return EvalAST(ctx, astPkg, opts...)
 }
 
 // EvalAST accepts a Flux AST and evaluates it to produce a set of side effects (as a slice of values) and a scope.
-func EvalAST(ctx context.Context, deps dependencies.Interface, astPkg *ast.Package, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
+func EvalAST(ctx context.Context, astPkg *ast.Package, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
 	semPkg, err := semantic.New(astPkg)
 	if err != nil {
 		return nil, nil, err
@@ -65,7 +64,7 @@ func EvalAST(ctx context.Context, deps dependencies.Interface, astPkg *ast.Packa
 		opt(scope)
 	}
 
-	sideEffects, err := itrp.Eval(ctx, deps, semPkg, scope, StdLib())
+	sideEffects, err := itrp.Eval(ctx, semPkg, scope, StdLib())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -93,7 +92,7 @@ func generateNowFunc(now time.Time) values.Function {
 	ftype := semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
 		Return: semantic.Time,
 	})
-	call := func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	call := func(ctx context.Context, args values.Object) (values.Value, error) {
 		return timeVal, nil
 	}
 	sideEffect := false
@@ -344,7 +343,8 @@ func evalBuiltInPackages() error {
 		}
 
 		itrp := interpreter.NewInterpreter(pkg)
-		if _, err := itrp.Eval(context.Background(), dependencies.NewEmpty(), semPkg, preludeScope.Nest(pkg), stdlib); err != nil {
+		ctx := NewEmptyDependencies().Inject(context.Background())
+		if _, err := itrp.Eval(ctx, semPkg, preludeScope.Nest(pkg), stdlib); err != nil {
 			return errors.Wrapf(err, codes.Inherit, "failed to evaluate builtin package %q", astPkg.Path)
 		}
 	}
@@ -675,7 +675,7 @@ func (f *function) HasSideEffect() bool {
 	return f.hasSideEffect
 }
 
-func (f *function) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (f *function) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	return interpreter.DoFunctionCall(f.call, args)
 }
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -6,11 +6,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/influxdata/flux/dependencies/dependenciestest"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/compiler"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/semantic/semantictest"
 	"github.com/influxdata/flux/values"
@@ -94,12 +93,12 @@ func TestCompilationCache(t *testing.T) {
 			if !reflect.DeepEqual(f0, f1) {
 				t.Errorf("unexpected new compilation result")
 			}
-			ctx, deps := context.Background(), dependenciestest.Default()
-			got0, err := f0.Eval(ctx, deps, tc.input)
+			ctx := dependenciestest.Default().Inject(context.Background())
+			got0, err := f0.Eval(ctx, tc.input)
 			if err != nil {
 				t.Fatal(err)
 			}
-			got1, err := f1.Eval(ctx, deps, tc.input)
+			got1, err := f1.Eval(ctx, tc.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1150,8 +1149,8 @@ func TestCompileAndEval(t *testing.T) {
 			if tc.wantErr && err != nil {
 				return
 			}
-			ctx, deps := context.Background(), dependenciestest.Default()
-			got, err := f.Eval(ctx, deps, tc.input)
+			ctx := dependenciestest.Default().Inject(context.Background())
+			got, err := f.Eval(ctx, tc.input)
 			if tc.wantErr != (err != nil) {
 				t.Errorf("unexpected error: %s", err)
 			}

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -9,19 +9,18 @@ import (
 	"strings"
 
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
 type Func interface {
 	Type() semantic.Type
-	Eval(ctx context.Context, deps dependencies.Interface, input values.Object) (values.Value, error)
+	Eval(ctx context.Context, input values.Object) (values.Value, error)
 }
 
 type Evaluator interface {
 	Type() semantic.Type
-	Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error)
+	Eval(ctx context.Context, scope Scope) (values.Value, error)
 }
 
 type compiledFn struct {
@@ -58,12 +57,12 @@ func (c compiledFn) Type() semantic.Type {
 	return c.fnType.FunctionSignature().Return
 }
 
-func (c compiledFn) Eval(ctx context.Context, deps dependencies.Interface, input values.Object) (values.Value, error) {
+func (c compiledFn) Eval(ctx context.Context, input values.Object) (values.Value, error) {
 	if err := c.buildScope(input); err != nil {
 		return nil, err
 	}
 
-	return eval(ctx, deps, c.root, c.inputScope)
+	return eval(ctx, c.root, c.inputScope)
 }
 
 type Scope interface {
@@ -95,8 +94,8 @@ func nestScope(scope Scope) Scope {
 	return compilerScope{scope.Nest(nil)}
 }
 
-func eval(ctx context.Context, deps dependencies.Interface, e Evaluator, scope Scope) (values.Value, error) {
-	v, err := e.Eval(ctx, deps, scope)
+func eval(ctx context.Context, e Evaluator, scope Scope) (values.Value, error) {
+	v, err := e.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -115,10 +114,10 @@ func (e *blockEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *blockEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *blockEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	var err error
 	for _, b := range e.body {
-		e.value, err = eval(ctx, deps, b, scope)
+		e.value, err = eval(ctx, b, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -141,8 +140,8 @@ func (e *declarationEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *declarationEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	v, err := eval(ctx, deps, e.init, scope)
+func (e *declarationEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	v, err := eval(ctx, e.init, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -160,10 +159,10 @@ func (e *stringExpressionEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *stringExpressionEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *stringExpressionEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	var b strings.Builder
 	for _, p := range e.parts {
-		v, err := p.Eval(ctx, deps, scope)
+		v, err := p.Eval(ctx, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -180,7 +179,7 @@ func (*textEvaluator) Type() semantic.Type {
 	return semantic.String
 }
 
-func (e *textEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *textEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewString(e.value), nil
 }
 
@@ -192,8 +191,8 @@ func (*interpolatedEvaluator) Type() semantic.Type {
 	return semantic.String
 }
 
-func (e *interpolatedEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	return e.s.Eval(ctx, deps, scope)
+func (e *interpolatedEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	return e.s.Eval(ctx, scope)
 }
 
 type objEvaluator struct {
@@ -206,10 +205,10 @@ func (e *objEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *objEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *objEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	obj := values.NewObject()
 	if e.with != nil {
-		with, err := e.with.Eval(ctx, deps, scope)
+		with, err := e.with.Eval(ctx, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +218,7 @@ func (e *objEvaluator) Eval(ctx context.Context, deps dependencies.Interface, sc
 	}
 
 	for k, node := range e.properties {
-		v, err := eval(ctx, deps, node, scope)
+		v, err := eval(ctx, node, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -238,10 +237,10 @@ func (e *arrayEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *arrayEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *arrayEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	arr := values.NewArray(e.t.ElementType())
 	for _, ev := range e.array {
-		v, err := eval(ctx, deps, ev, scope)
+		v, err := eval(ctx, ev, scope)
 		if err != nil {
 			return nil, err
 		}
@@ -260,8 +259,8 @@ func (e *logicalEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *logicalEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	l, err := e.left.Eval(ctx, deps, scope)
+func (e *logicalEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	l, err := e.left.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +279,7 @@ func (e *logicalEvaluator) Eval(ctx context.Context, deps dependencies.Interface
 		panic(fmt.Errorf("unknown logical operator %v", e.operator))
 	}
 
-	r, err := e.right.Eval(ctx, deps, scope)
+	r, err := e.right.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -298,16 +297,16 @@ func (e *conditionalEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *conditionalEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	t, err := eval(ctx, deps, e.test, scope)
+func (e *conditionalEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	t, err := eval(ctx, e.test, scope)
 	if err != nil {
 		return nil, err
 	}
 
 	if t.IsNull() || !t.Bool() {
-		return eval(ctx, deps, e.alternate, scope)
+		return eval(ctx, e.alternate, scope)
 	} else {
-		return eval(ctx, deps, e.consequent, scope)
+		return eval(ctx, e.consequent, scope)
 	}
 }
 
@@ -321,12 +320,12 @@ func (e *binaryEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *binaryEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	l, err := eval(ctx, deps, e.left, scope)
+func (e *binaryEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	l, err := eval(ctx, e.left, scope)
 	if err != nil {
 		return nil, err
 	}
-	r, err := eval(ctx, deps, e.right, scope)
+	r, err := eval(ctx, e.right, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -343,8 +342,8 @@ func (e *unaryEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *unaryEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	v, err := e.node.Eval(ctx, deps, scope)
+func (e *unaryEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	v, err := e.node.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +398,7 @@ func (e *integerEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *integerEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *integerEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewInt(e.i), nil
 }
 
@@ -412,7 +411,7 @@ func (e *unsignedIntegerEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *unsignedIntegerEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *unsignedIntegerEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewUInt(e.i), nil
 }
 
@@ -425,7 +424,7 @@ func (e *stringEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *stringEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *stringEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewString(e.s), nil
 }
 
@@ -438,7 +437,7 @@ func (e *regexpEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *regexpEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *regexpEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewRegexp(e.r), nil
 }
 
@@ -451,7 +450,7 @@ func (e *booleanEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *booleanEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *booleanEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewBool(e.b), nil
 }
 
@@ -464,7 +463,7 @@ func (e *floatEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *floatEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *floatEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewFloat(e.f), nil
 }
 
@@ -477,7 +476,7 @@ func (e *timeEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *timeEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *timeEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewTime(e.time), nil
 }
 
@@ -490,7 +489,7 @@ func (e *durationEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *durationEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *durationEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.NewDuration(e.duration), nil
 }
 
@@ -507,7 +506,7 @@ func (e *identifierEvaluator) Type() semantic.Type {
 	return t
 }
 
-func (e *identifierEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *identifierEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	v := scope.Get(e.name)
 	// Note this check pattern is slightly different than
 	// the usual one:
@@ -539,8 +538,8 @@ func (e *memberEvaluator) Type() semantic.Type {
 	return t
 }
 
-func (e *memberEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	o, err := e.object.Eval(ctx, deps, scope)
+func (e *memberEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	o, err := e.object.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -559,12 +558,12 @@ func (e *arrayIndexEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *arrayIndexEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	a, err := e.array.Eval(ctx, deps, scope)
+func (e *arrayIndexEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	a, err := e.array.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
-	i, err := e.index.Eval(ctx, deps, scope)
+	i, err := e.index.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -581,16 +580,16 @@ func (e *callEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *callEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
-	args, err := e.args.Eval(ctx, deps, scope)
+func (e *callEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
+	args, err := e.args.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
-	f, err := e.callee.Eval(ctx, deps, scope)
+	f, err := e.callee.Eval(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
-	return f.Function().Call(ctx, deps, args.Object())
+	return f.Function().Call(ctx, args.Object())
 }
 
 type functionEvaluator struct {
@@ -603,7 +602,7 @@ func (e *functionEvaluator) Type() semantic.Type {
 	return e.t
 }
 
-func (e *functionEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (e *functionEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return &functionValue{
 		t:      e.t,
 		body:   e.body,
@@ -629,12 +628,12 @@ func (f *functionValue) HasSideEffect() bool {
 	return false
 }
 
-func (f *functionValue) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (f *functionValue) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	scope := nestScope(f.scope)
 	for _, p := range f.params {
 		a, ok := args.Get(p.Key)
 		if !ok && p.Default != nil {
-			v, err := eval(ctx, deps, p.Default, f.scope)
+			v, err := eval(ctx, p.Default, f.scope)
 			if err != nil {
 				return nil, err
 			}
@@ -642,7 +641,7 @@ func (f *functionValue) Call(ctx context.Context, deps dependencies.Interface, a
 		}
 		scope.Set(p.Key, a)
 	}
-	return eval(ctx, deps, f.body, scope)
+	return eval(ctx, f.body, scope)
 }
 
 func (f *functionValue) Type() semantic.Type         { return f.t }
@@ -698,6 +697,6 @@ func (noopEvaluator) Type() semantic.Type {
 	return semantic.Nil
 }
 
-func (noopEvaluator) Eval(ctx context.Context, deps dependencies.Interface, scope Scope) (values.Value, error) {
+func (noopEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	return values.Null, nil
 }

--- a/complete/complete_test.go
+++ b/complete/complete_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/complete"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -49,7 +48,7 @@ func TestFunctionNames(t *testing.T) {
 		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
 			Return: semantic.Int,
 		}),
-		func(context.Context, dependencies.Interface, values.Object) (values.Value, error) {
+		func(context.Context, values.Object) (values.Value, error) {
 			return values.NewInt(5), nil
 		},
 		false,
@@ -79,7 +78,7 @@ func TestFunctionSuggestion(t *testing.T) {
 			},
 			Return: semantic.Int,
 		}),
-		func(context.Context, dependencies.Interface, values.Object) (values.Value, error) {
+		func(context.Context, values.Object) (values.Value, error) {
 			return values.NewInt(5), nil
 		},
 		false,

--- a/dependencies.go
+++ b/dependencies.go
@@ -78,7 +78,11 @@ func (d Deps) Inject(ctx context.Context) context.Context {
 }
 
 func GetDependencies(ctx context.Context) Dependencies {
-	return ctx.Value(dependenciesKey).(Dependencies)
+	deps := ctx.Value(dependenciesKey)
+	if deps == nil {
+		return NewEmptyDependencies()
+	}
+	return deps.(Dependencies)
 }
 
 // newDefaultTransport creates a new transport with sane defaults.

--- a/dependencies/dependenciestest/dependencies.go
+++ b/dependencies/dependenciestest/dependencies.go
@@ -1,10 +1,10 @@
 package dependenciestest
 
 import (
+	"github.com/influxdata/flux"
 	"io/ioutil"
 	"net/http"
 
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/mock"
@@ -33,8 +33,8 @@ func defaultTestFunction(req *http.Request) *http.Response {
 	}
 }
 
-func Default() dependencies.Dependencies {
-	var deps dependencies.Dependencies
+func Default() flux.Deps {
+	var deps flux.Deps
 	deps.Deps.HTTPClient = &http.Client{
 		Transport: RoundTripFunc(defaultTestFunction),
 	}

--- a/dependencies/dependenciestest/dependencies.go
+++ b/dependencies/dependenciestest/dependencies.go
@@ -1,10 +1,10 @@
 package dependenciestest
 
 import (
-	"github.com/influxdata/flux"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/mock"

--- a/examples/library/library_example_test.go
+++ b/examples/library/library_example_test.go
@@ -36,11 +36,8 @@ g.from(start: 1993-02-16T00:00:00Z, stop: 1993-02-16T00:03:00Z, count: 5, fn: (n
 		panic(err)
 	}
 
+	ctx = executetest.NewTestExecuteDependencies().Inject(ctx)
 	alloc := &memory.Allocator{}
-
-	if p, ok := program.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(executetest.NewTestExecuteDependencies())
-	}
 	q, err := program.Start(ctx, alloc)
 	if err != nil {
 		panic(err)

--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -1,11 +1,10 @@
 package executetest
 
 import (
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
-	"github.com/influxdata/flux/execute"
 )
 
-func NewTestExecuteDependencies() execute.Dependencies {
-	return execute.Dependencies{dependencies.InterpreterDepsKey: dependenciestest.Default()}
+func NewTestExecuteDependencies() flux.Dependencies {
+	return dependenciestest.Default()
 }

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -28,16 +28,14 @@ type Executor interface {
 }
 
 type executor struct {
-	deps   Dependencies
 	logger *zap.Logger
 }
 
-func NewExecutor(deps Dependencies, logger *zap.Logger) Executor {
+func NewExecutor(logger *zap.Logger) Executor {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
 	e := &executor{
-		deps:   deps,
 		logger: logger,
 	}
 	return e
@@ -52,8 +50,7 @@ func (ctx streamContext) Bounds() *Bounds {
 }
 
 type executionState struct {
-	p    *plan.Spec
-	deps Dependencies
+	p *plan.Spec
 
 	alloc *memory.Allocator
 
@@ -92,7 +89,6 @@ func (e *executor) createExecutionState(ctx context.Context, p *plan.Spec, a *me
 	}
 	es := &executionState{
 		p:         p,
-		deps:      e.deps,
 		alloc:     a,
 		resources: p.Resources,
 		results:   make(map[string]flux.Result),
@@ -341,8 +337,4 @@ func (ec executionContext) Allocator() *memory.Allocator {
 
 func (ec executionContext) Parents() []DatasetID {
 	return ec.parents
-}
-
-func (ec executionContext) Dependencies() Dependencies {
-	return ec.es.deps
 }

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -742,7 +742,7 @@ func TestExecutor_Execute(t *testing.T) {
 			// Construct physical query plan
 			plan := plantest.CreatePlanSpec(tc.spec)
 
-			exe := execute.NewExecutor(executetest.NewTestExecuteDependencies(), zaptest.NewLogger(t))
+			exe := execute.NewExecutor(zaptest.NewLogger(t))
 
 			alloc := tc.allocator
 			if alloc == nil {
@@ -750,7 +750,8 @@ func TestExecutor_Execute(t *testing.T) {
 			}
 
 			// Execute the query and preserve any error returned
-			results, _, err := exe.Execute(context.Background(), plan, alloc)
+			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+			results, _, err := exe.Execute(ctx, plan, alloc)
 			var got map[string][]*executetest.Table
 			if err == nil {
 				got = make(map[string][]*executetest.Table, len(results))

--- a/execute/row_fn_test.go
+++ b/execute/row_fn_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/compiler"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/semantic"
@@ -235,11 +235,11 @@ func TestRowMapFn_Eval(t *testing.T) {
 				want[i] = r
 			}
 
-			ctx, deps := context.Background(), dependenciestest.Default()
+			ctx := dependenciestest.Default().Inject(context.Background())
 			got := make([]*execute.Record, 0, len(tc.data.Data))
 			if err := tc.data.Do(func(cr flux.ColReader) error {
 				for i := 0; i < cr.Len(); i++ {
-					obj, err := f.Eval(ctx, deps, i, cr)
+					obj, err := f.Eval(ctx, i, cr)
 					if err != nil {
 						got = append(got, execute.NewRecord(semantic.Invalid))
 					} else {
@@ -352,11 +352,11 @@ func TestRowPredicateFn_Eval(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx, deps := context.Background(), dependenciestest.Default()
+			ctx := dependenciestest.Default().Inject(context.Background())
 			got := make([]bool, 0, len(tc.data.Data))
 			tc.data.Do(func(cr flux.ColReader) error {
 				for i := 0; i < cr.Len(); i++ {
-					b, err := f.Eval(ctx, deps, i, cr)
+					b, err := f.Eval(ctx, i, cr)
 					if err == nil {
 						got = append(got, b)
 					}

--- a/execute/transformation.go
+++ b/execute/transformation.go
@@ -36,13 +36,7 @@ type Administration interface {
 	StreamContext() StreamContext
 	Allocator() *memory.Allocator
 	Parents() []DatasetID
-
-	Dependencies() Dependencies
 }
-
-// Dependencies represents the provided dependencies to the execution environment.
-// The dependencies is opaque.
-type Dependencies map[string]interface{}
 
 type CreateTransformation func(id DatasetID, mode AccumulationMode, spec plan.ProcedureSpec, a Administration) (Transformation, Dataset, error)
 type CreateNewPlannerTransformation func(id DatasetID, mode AccumulationMode, spec plan.ProcedureSpec, a Administration) (Transformation, Dataset, error)

--- a/internal/cmd/refactortests/cmd/refactortests.go
+++ b/internal/cmd/refactortests/cmd/refactortests.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/internal/cmd/refactortests/cmd/refactortests.go
+++ b/internal/cmd/refactortests/cmd/refactortests.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,7 +17,6 @@ import (
 	"github.com/influxdata/flux/ast/edit"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/lang"
@@ -177,17 +177,15 @@ func executeScript(pkg *ast.Package) (string, string, error) {
 		Query: ast.Format(testPkg),
 	}
 
-	program, err := c.Compile(context.Background())
-	if p, ok := program.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewEmpty()})
-	}
+	ctx := flux.NewDefaultDependencies().Inject(context.Background())
+	program, err := c.Compile(ctx)
 	if err != nil {
 		fmt.Println(ast.Format(testPkg))
 		return "", "", errors.Wrap(err, codes.Inherit, "error during compilation, check your script and retry")
 	}
 
 	alloc := &memory.Allocator{}
-	q, err := program.Start(context.Background(), alloc)
+	q, err := program.Start(ctx, alloc)
 	if err != nil {
 		return "", "", errors.Wrap(err, codes.Inherit, "error while executing program")
 	}

--- a/internal/spec/build.go
+++ b/internal/spec/build.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/values"
 	"github.com/opentracing/opentracing-go"
@@ -131,7 +130,7 @@ func FromTableObject(ctx context.Context, to *flux.TableObject, now time.Time) (
 // FromScript returns a spec from a script expressed as a raw string.
 // This is duplicate logic for what happens when a flux.Program runs.
 // This function is used in tests that compare flux.Specs (e.g. in planner tests).
-func FromScript(ctx context.Context, deps dependencies.Interface, now time.Time, script string) (*flux.Spec, error) {
+func FromScript(ctx context.Context, now time.Time, script string) (*flux.Spec, error) {
 	s, _ := opentracing.StartSpanFromContext(ctx, "parse")
 	astPkg, err := flux.Parse(script)
 	if err != nil {
@@ -140,7 +139,7 @@ func FromScript(ctx context.Context, deps dependencies.Interface, now time.Time,
 	s.Finish()
 
 	s, cctx := opentracing.StartSpanFromContext(ctx, "eval")
-	sideEffects, scope, err := flux.EvalAST(cctx, deps, astPkg, flux.SetNowOption(now))
+	sideEffects, scope, err := flux.EvalAST(cctx, astPkg, flux.SetNowOption(now))
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +151,7 @@ func FromScript(ctx context.Context, deps dependencies.Interface, now time.Time,
 	if !ok {
 		return nil, fmt.Errorf("%q option not set", flux.NowOption)
 	}
-	nowTime, err := nowOpt.Function().Call(ctx, deps, nil)
+	nowTime, err := nowOpt.Function().Call(ctx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/spec/build_test.go
+++ b/internal/spec/build_test.go
@@ -32,11 +32,10 @@ check = from(bucket: "telegraf")
 check |> yield(name: "checkResult")
 check |> yield(name: "mean")
 `
-	ctx := context.Background()
-	deps := dependenciestest.Default()
+	ctx := dependenciestest.Default().Inject(context.Background())
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := spec.FromScript(ctx, deps, time.Now(), query); err != nil {
+		if _, err := spec.FromScript(ctx, time.Now(), query); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/interpreter/interptest/eval.go
+++ b/interpreter/interptest/eval.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/dependencies"
+
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
-func Eval(ctx context.Context, deps dependencies.Interface, itrp *interpreter.Interpreter, scope values.Scope, importer interpreter.Importer, src string) ([]interpreter.SideEffect, error) {
+func Eval(ctx context.Context, itrp *interpreter.Interpreter, scope values.Scope, importer interpreter.Importer, src string) ([]interpreter.SideEffect, error) {
 	pkg := parser.ParseSource(src)
 	if ast.Check(pkg) > 0 {
 		return nil, ast.GetError(pkg)
@@ -20,5 +20,5 @@ func Eval(ctx context.Context, deps dependencies.Interface, itrp *interpreter.In
 	if err != nil {
 		return nil, err
 	}
-	return itrp.Eval(ctx, deps, node, scope, importer)
+	return itrp.Eval(ctx, node, scope, importer)
 }

--- a/interpreter/interptest/eval.go
+++ b/interpreter/interptest/eval.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/influxdata/flux/ast"
-
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"

--- a/interpreter/package_test.go
+++ b/interpreter/package_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
-
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/interpreter/interptest"
 	"github.com/influxdata/flux/semantic"
@@ -85,8 +84,8 @@ func TestAccessNestedImport(t *testing.T) {
 	}
 
 	expectedError := fmt.Errorf(`cannot access imported package "a" of imported package "b"`)
-	ctx, deps := context.Background(), dependenciestest.Default()
-	_, err := interpreter.NewInterpreter(interpreter.NewPackage("")).Eval(ctx, deps, node, values.NewScope(), &importer)
+	ctx := dependenciestest.Default().Inject(context.Background())
+	_, err := interpreter.NewInterpreter(interpreter.NewPackage("")).Eval(ctx, node, values.NewScope(), &importer)
 
 	if err == nil {
 		t.Errorf("expected error")
@@ -363,14 +362,14 @@ func TestInterpreter_EvalPackage(t *testing.T) {
 
 func TestInterpreter_SetNewOption(t *testing.T) {
 	pkg := interpreter.NewPackage("alert")
-	ctx, deps := context.Background(), dependenciestest.Default()
+	ctx := dependenciestest.Default().Inject(context.Background())
 	itrp := interpreter.NewInterpreter(pkg)
 	script := `
 		package alert
 		option state = "Warning"
 		state
 `
-	if _, err := interptest.Eval(ctx, deps, itrp, values.NewNestedScope(nil, pkg), nil, script); err != nil {
+	if _, err := interptest.Eval(ctx, itrp, values.NewNestedScope(nil, pkg), nil, script); err != nil {
 		t.Fatalf("failed to evaluate package: %v", err)
 	}
 	option, ok := pkg.Get("state")
@@ -393,7 +392,7 @@ func TestInterpreter_SetQualifiedOption(t *testing.T) {
 			"alert": externalPackage,
 		},
 	}
-	ctx, deps := context.Background(), dependenciestest.Default()
+	ctx := dependenciestest.Default().Inject(context.Background())
 	itrp := interpreter.NewInterpreter(interpreter.NewPackage(""))
 	pkg := `
 		package foo
@@ -401,7 +400,7 @@ func TestInterpreter_SetQualifiedOption(t *testing.T) {
 		option alert.state = "Error"
 		alert.state
 `
-	if _, err := interptest.Eval(ctx, deps, itrp, values.NewScope(), importer, pkg); err != nil {
+	if _, err := interptest.Eval(ctx, itrp, values.NewScope(), importer, pkg); err != nil {
 		t.Fatalf("failed to evaluate package: %v", err)
 	}
 	option, ok := externalPackage.Get("state")

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/spec"
@@ -216,23 +215,17 @@ func (*TableObjectCompiler) CompilerType() flux.CompilerType {
 	panic("TableObjectCompiler is not associated with a CompilerType")
 }
 
-type DependenciesAwareProgram interface {
-	SetExecutorDependencies(execute.Dependencies)
+type LoggingProgram interface {
 	SetLogger(logger *zap.Logger)
 }
 
 // Program implements the flux.Program interface.
 // It will execute a compiled plan using an executor.
 type Program struct {
-	Dependencies execute.Dependencies
-	Logger       *zap.Logger
-	PlanSpec     *plan.Spec
+	Logger   *zap.Logger
+	PlanSpec *plan.Spec
 
 	opts *compileOptions
-}
-
-func (p *Program) SetExecutorDependencies(deps execute.Dependencies) {
-	p.Dependencies = deps
 }
 
 func (p *Program) SetLogger(logger *zap.Logger) {
@@ -255,7 +248,7 @@ func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Quer
 		},
 	}
 
-	e := execute.NewExecutor(p.Dependencies, p.Logger)
+	e := execute.NewExecutor(p.Logger)
 	resultMap, md, err := e.Execute(cctx, p.PlanSpec, q.alloc)
 	if err != nil {
 		s.Finish()
@@ -303,7 +296,7 @@ type AstProgram struct {
 	Now time.Time
 }
 
-func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Query, error) {
+func (p *AstProgram) getSpec(ctx context.Context, alloc *memory.Allocator) (*flux.Spec, values.Scope, error) {
 	if p.opts == nil {
 		p.opts = defaultOptions()
 	}
@@ -313,40 +306,44 @@ func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Q
 	if p.opts.extern != nil {
 		p.Ast.Files = append([]*ast.File{p.opts.extern}, p.Ast.Files...)
 	}
-	deps, ok := p.Dependencies[dependencies.InterpreterDepsKey]
-	if !ok {
-		// TODO(Adam): this should be more of a noop dependency package
-		return nil, fmt.Errorf("no interpreter dependencies found")
+	// The program must inject execution dependencies to make it available
+	// to function calls during the evaluation phase (see `tableFind`).
+	deps := ExecutionDependencies{
+		Allocator: alloc,
+		Logger:    p.Logger,
 	}
-	depsI := deps.(dependencies.Interface)
-
+	ctx = deps.Inject(ctx)
 	s, cctx := opentracing.StartSpanFromContext(ctx, "eval")
-	sideEffects, scope, err := flux.EvalAST(cctx, depsI, p.Ast, flux.SetNowOption(p.Now))
+	sideEffects, scope, err := flux.EvalAST(cctx, p.Ast, flux.SetNowOption(p.Now))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	s.Finish()
 
 	s, cctx = opentracing.StartSpanFromContext(ctx, "compile")
+	defer s.Finish()
 	nowOpt, ok := scope.Lookup(flux.NowOption)
 	if !ok {
-		return nil, fmt.Errorf("%q option not set", flux.NowOption)
+		return nil, nil, fmt.Errorf("%q option not set", flux.NowOption)
 	}
-	nowTime, err := nowOpt.Function().Call(ctx, depsI, nil)
+	nowTime, err := nowOpt.Function().Call(ctx, nil)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, codes.Inherit, "error in evaluating AST while starting program")
+	}
+	p.Now = nowTime.Time().Time()
+	sp, err := spec.FromEvaluation(cctx, sideEffects, p.Now)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, codes.Inherit, "error in query specification while starting program")
+	}
+	return sp, scope, nil
+}
+
+func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Query, error) {
+	sp, scope, err := p.getSpec(ctx, alloc)
 	if err != nil {
 		return nil, err
 	}
-	p.Now = nowTime.Time().Time()
-	if err != nil {
-		return nil, errors.Wrap(err, codes.Inherit, "error in evaluating AST while starting program")
-	}
-	sp, err := spec.FromEvaluation(cctx, sideEffects, p.Now)
-	if err != nil {
-		return nil, errors.Wrap(err, codes.Inherit, "error in query specification while starting program")
-	}
-	s.Finish()
-
-	s, cctx = opentracing.StartSpanFromContext(ctx, "plan")
+	s, cctx := opentracing.StartSpanFromContext(ctx, "plan")
 	if p.opts.verbose {
 		log.Println("Query Spec: ", flux.Formatted(sp, flux.FmtJSON))
 	}
@@ -448,4 +445,16 @@ func getRules(plannerPkg values.Object, optionName string) ([]string, error) {
 		rs[i] = v.Str()
 	})
 	return rs, nil
+}
+
+// WalkIR applies the function `f` to each operation in the compiled spec.
+// WARNING: this function evaluates the AST using an unlimited allocator.
+// In case of dynamic queries this could lead to unexpected memory usage.
+func WalkIR(astPkg *ast.Package, f func(o *flux.Operation) error) error {
+	p := CompileAST(astPkg, time.Now())
+	if sp, _, err := p.getSpec(context.Background(), new(memory.Allocator)); err != nil {
+		return err
+	} else {
+		return sp.Walk(f)
+	}
 }

--- a/lang/dependencies.go
+++ b/lang/dependencies.go
@@ -1,0 +1,28 @@
+package lang
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/memory"
+
+	"go.uber.org/zap"
+)
+
+type key int
+
+const executionDependenciesKey key = iota
+
+// ExecutionDependencies represents the dependencies that a function call
+// executed by the Interpreter needs in order to trigger the execution of a flux.Program
+type ExecutionDependencies struct {
+	Allocator *memory.Allocator
+	Logger    *zap.Logger
+}
+
+func (d ExecutionDependencies) Inject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, executionDependenciesKey, d)
+}
+
+func GetExecutionDependencies(ctx context.Context) ExecutionDependencies {
+	return ctx.Value(executionDependenciesKey).(ExecutionDependencies)
+}

--- a/lang/langtest/dependencies.go
+++ b/lang/langtest/dependencies.go
@@ -1,0 +1,12 @@
+package langtest
+
+import (
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
+)
+
+func DefaultExecutionDependencies() lang.ExecutionDependencies {
+	return lang.ExecutionDependencies{
+		Allocator: new(memory.Allocator),
+	}
+}

--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -17,9 +17,8 @@ func runQuery(script string) (flux.Query, error) {
 	if err != nil {
 		return nil, err
 	}
-	program.SetExecutorDependencies(executetest.NewTestExecuteDependencies())
-
-	q, err := program.Start(context.Background(), &memory.Allocator{})
+	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+	q, err := program.Start(ctx, &memory.Allocator{})
 	if err != nil {
 		return nil, err
 	}

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func compile(fluxText string, now time.Time) (*flux.Spec, error) {
-	return spec.FromScript(context.Background(), dependenciestest.Default(), now, fluxText)
+	return spec.FromScript(dependenciestest.Default().Inject(context.Background()), now, fluxText)
 }
 
 func TestPlan_LogicalPlanFromSpec(t *testing.T) {

--- a/plan/rules_test.go
+++ b/plan/rules_test.go
@@ -20,7 +20,7 @@ func TestRuleRegistration(t *testing.T) {
 	plan.RegisterLogicalRules(&simpleRule)
 
 	now := time.Now().UTC()
-	fluxSpec, err := spec.FromScript(context.Background(), dependenciestest.Default(), now, `from(bucket: "telegraf") |> range(start: -5m)`)
+	fluxSpec, err := spec.FromScript(dependenciestest.Default().Inject(context.Background()), now, `from(bucket: "telegraf") |> range(start: -5m)`)
 	if err != nil {
 		t.Fatalf("could not compile very simple Flux query: %v", err)
 	}

--- a/querytest/compile.go
+++ b/querytest/compile.go
@@ -38,7 +38,7 @@ func NewQueryTestHelper(t *testing.T, tc NewQueryTestCase) {
 	t.Helper()
 
 	now := time.Now().UTC()
-	got, err := spec.FromScript(context.Background(), dependenciestest.Default(), now, tc.Raw)
+	got, err := spec.FromScript(dependenciestest.Default().Inject(context.Background()), now, tc.Raw)
 	if (err != nil) != tc.WantErr {
 		t.Errorf("error compiling spec error = %v, wantErr %v", err, tc.WantErr)
 		return

--- a/querytest/execute.go
+++ b/querytest/execute.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute/executetest"
-	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -14,12 +13,10 @@ type Querier struct{}
 
 func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flux.Dialect) (int64, error) {
 	program, err := c.Compile(ctx)
-	if p, ok := program.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(executetest.NewTestExecuteDependencies())
-	}
 	if err != nil {
 		return 0, err
 	}
+	ctx = executetest.NewTestExecuteDependencies().Inject(ctx)
 	alloc := &memory.Allocator{}
 	query, err := program.Start(ctx, alloc)
 	if err != nil {

--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -10,7 +10,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
@@ -118,7 +117,7 @@ func createFromCSVSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 	csvText := spec.CSV
 	// if spec.File non-empty then spec.CSV is empty
 	if spec.File != "" {
-		deps := a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Dependencies)
+		deps := flux.GetDependencies(a.Context())
 		fs, err := deps.FilesystemService()
 		if err != nil {
 			return nil, err

--- a/stdlib/date/date.go
+++ b/stdlib/date/date.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -25,7 +24,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -44,7 +43,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -63,7 +62,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -82,7 +81,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -101,7 +100,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -120,7 +119,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -139,7 +138,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -158,7 +157,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -177,7 +176,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -197,7 +196,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -217,7 +216,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -237,7 +236,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -257,7 +256,7 @@ func init() {
 				Required:   semantic.LabelSet{"t"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")
@@ -276,7 +275,7 @@ func init() {
 				Required:   semantic.LabelSet{"t", "unit"},
 				Return:     semantic.Time,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("t")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument t")

--- a/stdlib/date/date_test.go
+++ b/stdlib/date/date_test.go
@@ -2,9 +2,9 @@ package date
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/values"
 )
 
@@ -89,7 +89,7 @@ func TestTimeFns(t *testing.T) {
 				t.Fatal(err)
 			}
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{"t": values.NewTime(time)})
-			got, err := fluxFn.Call(context.Background(), dependenciestest.Default(), fluxArg)
+			got, err := fluxFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -139,7 +139,7 @@ func TestTruncate(t *testing.T) {
 				t.Fatal(err)
 			}
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{"t": values.NewTime(time), "unit": values.NewDuration(values.Duration(unit))})
-			got, err := fluxFn.Call(context.Background(), dependenciestest.Default(), fluxArg)
+			got, err := fluxFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/experimental/bigtable/bigtable_test.go
+++ b/stdlib/experimental/bigtable/bigtable_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigtable"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
@@ -18,8 +19,6 @@ import (
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 	"github.com/stretchr/testify/assert"
-
-	"cloud.google.com/go/bigtable"
 )
 
 var rRowKey *semantic.MemberExpression = &semantic.MemberExpression{

--- a/stdlib/experimental/bigtable/bigtable_test.go
+++ b/stdlib/experimental/bigtable/bigtable_test.go
@@ -1,9 +1,11 @@
 package bigtable
 
 import (
-	"cloud.google.com/go/bigtable"
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
@@ -16,8 +18,8 @@ import (
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
+
+	"cloud.google.com/go/bigtable"
 )
 
 var rRowKey *semantic.MemberExpression = &semantic.MemberExpression{
@@ -423,9 +425,5 @@ func (a *MockAllocator) Allocator() *memory.Allocator {
 }
 
 func (a *MockAllocator) Parents() []execute.DatasetID {
-	return nil
-}
-
-func (a *MockAllocator) Dependencies() execute.Dependencies {
 	return nil
 }

--- a/stdlib/experimental/durations.go
+++ b/stdlib/experimental/durations.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -29,7 +28,7 @@ func addDuration(name string) values.Value {
 		Required: semantic.LabelSet{"d", "to"},
 		Return:   semantic.Time,
 	})
-	fn := func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	fn := func(ctx context.Context, args values.Object) (values.Value, error) {
 		d, ok := args.Get("d")
 		if !ok {
 			return nil, fmt.Errorf("%s requires 'd' parameter", name)
@@ -52,7 +51,7 @@ func subDuration(name string) values.Value {
 		Required: semantic.LabelSet{"d", "from"},
 		Return:   semantic.Time,
 	})
-	fn := func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	fn := func(ctx context.Context, args values.Object) (values.Value, error) {
 		d, ok := args.Get("d")
 		if !ok {
 			return nil, fmt.Errorf("%s requires 'd' parameter", name)

--- a/stdlib/experimental/object_keys.go
+++ b/stdlib/experimental/object_keys.go
@@ -5,7 +5,7 @@ import (
 
 	flux "github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
+
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -21,7 +21,7 @@ func init() {
 			Required: []string{"o"},
 			Return:   semantic.NewArrayPolyType(semantic.String),
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			o, ok := args.Get("o")
 			if !ok {
 				return nil, errors.New(codes.Invalid, "missing parameter \"o\"")

--- a/stdlib/experimental/object_keys_test.go
+++ b/stdlib/experimental/object_keys_test.go
@@ -2,12 +2,11 @@ package experimental_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -19,7 +18,7 @@ func addFail(scope values.Scope) {
 		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
 			Return: semantic.Bool,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			return nil, errors.New(codes.Aborted, "fail")
 		},
 		false,
@@ -33,7 +32,8 @@ import "experimental"
 o = {a: 1, b: 2, c: 3}
 experimental.objectKeys(o: o) == ["a", "b", "c"] or fail()
 `
-	if _, _, err := flux.Eval(context.Background(), dependenciestest.Default(), script, addFail); err != nil {
+	ctx := dependenciestest.Default().Inject(context.Background())
+	if _, _, err := flux.Eval(ctx, script, addFail); err != nil {
 		t.Fatal("evaluation of objectKeys failed: ", err)
 	}
 }

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -99,15 +99,13 @@ func testFlux(t testing.TB, pkg *ast.Package) {
 
 func doTestRun(t testing.TB, c flux.Compiler) {
 	program, err := c.Compile(context.Background())
-	if p, ok := program.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(executetest.NewTestExecuteDependencies())
-	}
 	if err != nil {
 		t.Fatalf("unexpected error while compiling query: %v", err)
 	}
 
+	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
 	alloc := &memory.Allocator{}
-	r, err := program.Start(context.Background(), alloc)
+	r, err := program.Start(ctx, alloc)
 	if err != nil {
 		t.Fatalf("unexpected error while executing testing.run: %v", err)
 	}
@@ -129,14 +127,12 @@ func doTestRun(t testing.TB, c flux.Compiler) {
 
 func doTestInspect(t testing.TB, c flux.Compiler) {
 	program, err := c.Compile(context.Background())
-	if p, ok := program.(lang.DependenciesAwareProgram); ok {
-		p.SetExecutorDependencies(executetest.NewTestExecuteDependencies())
-	}
 	if err != nil {
 		t.Fatalf("unexpected error while compiling query: %v", err)
 	}
+	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
 	alloc := &memory.Allocator{}
-	r, err := program.Start(context.Background(), alloc)
+	r, err := program.Start(ctx, alloc)
 	if err != nil {
 		t.Fatalf("unexpected error while executing testing.inspect: %v", err)
 	}

--- a/stdlib/http/basic_auth.go
+++ b/stdlib/http/basic_auth.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -31,7 +30,7 @@ var basicAuthFunc = values.NewFunction(
 		Required: semantic.LabelSet{basicAuthUsernameArg, basicAuthPasswordArg},
 		Return:   semantic.String,
 	}),
-	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	func(ctx context.Context, args values.Object) (values.Value, error) {
 		return interpreter.DoFunctionCall(BasicAuth, args)
 	},
 	false,

--- a/stdlib/http/post.go
+++ b/stdlib/http/post.go
@@ -8,9 +8,8 @@ import (
 	"net/http"
 	"net/url"
 
-	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/iocounter"
 	"github.com/influxdata/flux/semantic"
@@ -35,7 +34,7 @@ func init() {
 			Required: []string{"url"},
 			Return:   semantic.Int,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			// Get and validate URL
 			uV, ok := args.Get("url")
 			if !ok {
@@ -45,6 +44,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
+			deps := flux.GetDependencies(ctx)
 			validator, err := deps.URLValidator()
 			if err != nil {
 				return nil, err

--- a/stdlib/influxdata/influxdb/secrets/get.go
+++ b/stdlib/influxdata/influxdb/secrets/get.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
@@ -33,14 +32,14 @@ func makeGetFunc() values.Function {
 }
 
 // Get retrieves the secret key identifier for a given secret.
-func Get(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func Get(ctx context.Context, args values.Object) (values.Value, error) {
 	fargs := interpreter.NewArguments(args)
 	key, err := fargs.GetRequiredString("key")
 	if err != nil {
 		return nil, err
 	}
 
-	ss, err := deps.SecretService()
+	ss, err := flux.GetDependencies(ctx).SecretService()
 	if err != nil {
 		return nil, errors.Wrapf(err, codes.Inherit, "cannot retrieve secret %q", key)
 	}

--- a/stdlib/influxdata/influxdb/secrets/get_test.go
+++ b/stdlib/influxdata/influxdb/secrets/get_test.go
@@ -61,9 +61,10 @@ func TestGet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deps := dependenciestest.Default()
 			deps.Deps.SecretService = tt.secrets
+			ctx := deps.Inject(context.Background())
 
 			args := values.NewObjectWithValues(tt.args)
-			got, err := secrets.Get(context.Background(), deps, args)
+			got, err := secrets.Get(ctx, args)
 			if err != nil {
 				if tt.err != "" {
 					if want, got := tt.err, err.Error(); want != got {

--- a/stdlib/influxdata/influxdb/v1/from_influx_json.go
+++ b/stdlib/influxdata/influxdb/v1/from_influx_json.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/influxql"
 	"github.com/influxdata/flux/internal/errors"
@@ -121,7 +120,7 @@ func createFromInfluxJSONSource(prSpec plan.ProcedureSpec, dsid execute.DatasetI
 
 	var jsonReader io.Reader
 
-	deps := a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Dependencies)
+	deps := flux.GetDependencies(a.Context())
 	fs, err := deps.FilesystemService()
 	if err != nil {
 		return nil, err

--- a/stdlib/internal/promql/date_functions.go
+++ b/stdlib/internal/promql/date_functions.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	"github.com/pkg/errors"
@@ -20,7 +19,7 @@ func generateDateFunction(name string, dateFn func(time.Time) int) values.Functi
 			Required:   semantic.LabelSet{"timestamp"},
 			Return:     semantic.Float,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("timestamp")
 			if !ok {
 				return nil, errors.New("missing argument timestamp")

--- a/stdlib/json/encode.go
+++ b/stdlib/json/encode.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"time"
 
-	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -23,7 +22,7 @@ func init() {
 			Required: []string{"v"},
 			Return:   semantic.Bytes,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("v")
 			if !ok {
 				return nil, errors.New(codes.Invalid, "missing parameter \"v\"")

--- a/stdlib/json/encode_test.go
+++ b/stdlib/json/encode_test.go
@@ -2,13 +2,12 @@ package json_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -20,7 +19,7 @@ func addFail(scope values.Scope) {
 		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
 			Return: semantic.Bool,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			return nil, errors.New(codes.Aborted, "fail")
 		},
 		false,
@@ -45,7 +44,8 @@ o = {
 }
 json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":60000000000},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\"}")  or fail()
 `
-	if _, _, err := flux.Eval(context.Background(), dependenciestest.Default(), script, addFail); err != nil {
+	ctx := dependenciestest.Default().Inject(context.Background())
+	if _, _, err := flux.Eval(ctx, script, addFail); err != nil {
 		t.Fatal("evaluation of json.encode failed: ", err)
 	}
 }

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cespare/xxhash"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/pkg/syncutil"
 	"github.com/influxdata/flux/plan"
@@ -225,7 +224,7 @@ func createToKafkaTransformation(id execute.DatasetID, mode execute.Accumulation
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
-	deps := a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Interface)
+	deps := flux.GetDependencies(a.Context())
 	t, err := NewToKafkaTransformation(d, deps, cache, s)
 	return t, d, err
 }
@@ -239,7 +238,7 @@ type ToKafkaTransformation struct {
 func (t *ToKafkaTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
 	return t.d.RetractTable(key)
 }
-func NewToKafkaTransformation(d execute.Dataset, deps dependencies.Interface, cache execute.TableBuilderCache, spec *ToKafkaProcedureSpec) (*ToKafkaTransformation, error) {
+func NewToKafkaTransformation(d execute.Dataset, deps flux.Dependencies, cache execute.TableBuilderCache, spec *ToKafkaProcedureSpec) (*ToKafkaTransformation, error) {
 	validator, err := deps.URLValidator()
 	if err != nil {
 		return nil, err

--- a/stdlib/math/math.go
+++ b/stdlib/math/math.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -23,7 +22,7 @@ func generateMathFunctionX(name string, mathFn func(float64) float64) values.Fun
 			Required:   semantic.LabelSet{"x"},
 			Return:     semantic.Float,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("x")
 			if !ok {
 				return nil, errors.New(codes.Invalid, "missing argument x")
@@ -49,7 +48,7 @@ func generateMathFunctionXY(name string, mathFn func(float64, float64) float64, 
 			Required:   argNames,
 			Return:     semantic.Float,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v1, ok := args.Get(argNames[0])
 			if !ok {
 				return nil, fmt.Errorf("missing argument %s", argNames[0])
@@ -149,7 +148,7 @@ func init() {
 				Required:   semantic.LabelSet{"f"},
 				Return:     semantic.UInt,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument f")
@@ -168,7 +167,7 @@ func init() {
 				Required:   semantic.LabelSet{"b"},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("b")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument b")
@@ -188,7 +187,7 @@ func init() {
 				Required:   semantic.LabelSet{"x"},
 				Return:     semantic.Int,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument x")
@@ -208,7 +207,7 @@ func init() {
 				Required:   semantic.LabelSet{"f"},
 				Return:     semantic.NewObjectPolyType(map[string]semantic.PolyType{"frac": semantic.Float, "exp": semantic.Int}, semantic.LabelSet{"frac", "exp"}, nil),
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument f")
@@ -229,7 +228,7 @@ func init() {
 				Required:   semantic.LabelSet{"x"},
 				Return:     semantic.NewObjectPolyType(map[string]semantic.PolyType{"lgamma": semantic.Float, "sign": semantic.Int}, semantic.LabelSet{"lgamma", "sign"}, nil),
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument x")
@@ -250,7 +249,7 @@ func init() {
 				Required:   semantic.LabelSet{"f"},
 				Return:     semantic.NewObjectPolyType(map[string]semantic.PolyType{"int": semantic.Float, "frac": semantic.Float}, semantic.LabelSet{"int", "frac"}, nil),
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument f")
@@ -271,7 +270,7 @@ func init() {
 				Required:   semantic.LabelSet{"x"},
 				Return:     semantic.NewObjectPolyType(map[string]semantic.PolyType{"sin": semantic.Float, "cos": semantic.Float}, semantic.LabelSet{"sin", "cos"}, nil),
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument x")
@@ -292,7 +291,7 @@ func init() {
 				Required:   semantic.LabelSet{"f", "sign"},
 				Return:     semantic.Bool,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument f")
@@ -320,7 +319,7 @@ func init() {
 				Required:   semantic.LabelSet{"f"},
 				Return:     semantic.Bool,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument f")
@@ -340,7 +339,7 @@ func init() {
 				Required:   semantic.LabelSet{"x"},
 				Return:     semantic.Bool,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument x")
@@ -360,7 +359,7 @@ func init() {
 				Required:   semantic.LabelSet{},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				return values.NewFloat(math.NaN()), nil
 			}, false,
 		),
@@ -372,7 +371,7 @@ func init() {
 				Required:   semantic.LabelSet{"sign"},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 
 				v1, ok := args.Get("sign")
 				if !ok {
@@ -393,7 +392,7 @@ func init() {
 				Required:   semantic.LabelSet{"n", "x"},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("n")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument n")
@@ -421,7 +420,7 @@ func init() {
 				Required:   semantic.LabelSet{"n", "x"},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("n")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument n")
@@ -449,7 +448,7 @@ func init() {
 				Required:   semantic.LabelSet{"frac", "exp"},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("frac")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument frac")
@@ -477,7 +476,7 @@ func init() {
 				Required:   semantic.LabelSet{"n"},
 				Return:     semantic.Float,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("n")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument frac")

--- a/stdlib/math/math_test.go
+++ b/stdlib/math/math_test.go
@@ -2,11 +2,11 @@ package math
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"math"
 	"math/rand"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/values"
 )
 
@@ -63,7 +63,7 @@ func TestMathFunctionsX(t *testing.T) {
 			got := tc.mathFn(x)
 
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
-			result, err := fluxFn.Call(context.Background(), dependenciestest.Default(), fluxArg)
+			result, err := fluxFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -104,7 +104,7 @@ func TestMathFunctionsXY(t *testing.T) {
 			got := tc.mathFn(x, y)
 
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{tc.xname: values.NewFloat(x), tc.yname: values.NewFloat(y)})
-			result, err := fluxFn.Call(context.Background(), dependenciestest.Default(), fluxArg)
+			result, err := fluxFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -122,7 +122,7 @@ func TestFloat64Bits(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	want := math.Float64bits(f)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestFloat64FromBits(t *testing.T) {
 	b := rand.Uint64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"b": values.NewUInt(b)})
 	want := math.Float64frombits(b)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestIlogb(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	want := math.Ilogb(x)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestFrexp(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	wantfrac, wantexp := math.Frexp(f)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestLGamma(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	wantLGamma, wantSign := math.Lgamma(x)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestModf(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	wantInt, wantFrac := math.Modf(f)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestSinCos(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	wantSin, wantCos := math.Sincos(x)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func TestIsInf(t *testing.T) {
 	sign := rand.Int()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f), "sign": values.NewInt(int64(sign))})
 	want := math.IsInf(f, sign)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestIsNaN(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	want := math.IsNaN(f)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func TestSignBit(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	want := math.Signbit(x)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +309,7 @@ func TestNaN(t *testing.T) {
 
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{})
 	want := math.NaN()
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +325,7 @@ func TestInf(t *testing.T) {
 	sign := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"sign": values.NewInt(int64(sign))})
 	want := math.Inf(sign)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -341,7 +341,7 @@ func TestJn(t *testing.T) {
 	n := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x), "n": values.NewInt(int64(n))})
 	want := math.Jn(n, x)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestYn(t *testing.T) {
 	n := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x), "n": values.NewInt(int64(n))})
 	want := math.Yn(n, x)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +373,7 @@ func TestLdexp(t *testing.T) {
 	exp := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"frac": values.NewFloat(frac), "exp": values.NewInt(int64(exp))})
 	want := math.Ldexp(frac, exp)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +388,7 @@ func TestPow10(t *testing.T) {
 	n := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"n": values.NewInt(int64(n))})
 	want := math.Pow10(n)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stdlib/pagerduty/pagerduty_test.go
+++ b/stdlib/pagerduty/pagerduty_test.go
@@ -10,24 +10,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/flux/dependencies"
-	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/flux/memory"
-
-	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/lang"
-
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	_ "github.com/influxdata/flux/builtin"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/values"
-
-	_ "github.com/influxdata/flux/builtin"
 )
 
 func TestPagerduty(t *testing.T) {
-	ctx, deps := context.Background(), dependenciestest.Default()
-	_, _, err := flux.Eval(ctx, deps, `
+	ctx := dependenciestest.Default().Inject(context.Background())
+	_, _, err := flux.Eval(ctx, `
 import "csv"
 import "pagerduty"
 data = "
@@ -257,8 +252,8 @@ csv.from(csv:data) |> endpoint()
 			if err != nil {
 				t.Error(err)
 			}
-			prog.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewDefaults()})
-			query, err := prog.Start(context.Background(), &memory.Allocator{})
+			ctx := flux.NewDefaultDependencies().Inject(context.Background())
+			query, err := prog.Start(ctx, &memory.Allocator{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/regexp/regexp.go
+++ b/stdlib/regexp/regexp.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -24,7 +23,7 @@ func init() {
 				Required:   semantic.LabelSet{"v"},
 				Return:     semantic.Regexp,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument v")
@@ -48,7 +47,7 @@ func init() {
 				Required:   semantic.LabelSet{"v"},
 				Return:     semantic.String,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument v")
@@ -69,7 +68,7 @@ func init() {
 				Required:   semantic.LabelSet{"r", "v"},
 				Return:     semantic.String,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				r, okk := args.Get("r")
 				if !ok || !okk {
@@ -91,7 +90,7 @@ func init() {
 				Required:   semantic.LabelSet{"r", "v"},
 				Return:     semantic.Array,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				r, okk := args.Get("r")
 				if !ok || !okk {
@@ -117,7 +116,7 @@ func init() {
 				Required:   semantic.LabelSet{"r", "v"},
 				Return:     semantic.Bool,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				r, okk := args.Get("r")
 				if !ok || !okk {
@@ -139,7 +138,7 @@ func init() {
 				Required:   semantic.LabelSet{"r", "v", "t"},
 				Return:     semantic.String,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				r, ok := args.Get("r")
 				v, okk := args.Get("v")
 				t, okkk := args.Get("t")
@@ -162,7 +161,7 @@ func init() {
 				Required:   semantic.LabelSet{"r", "v", "i"},
 				Return:     semantic.Array,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				r, ok := args.Get("r")
 				v, okk := args.Get("v")
 				i, okkk := args.Get("i")
@@ -189,7 +188,7 @@ func init() {
 				Required:   semantic.LabelSet{"r"},
 				Return:     semantic.String,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				r, ok := args.Get("r")
 				if !ok {
 					return nil, errors.New(codes.Invalid, "missing argument")

--- a/stdlib/regexp/regexp_test.go
+++ b/stdlib/regexp/regexp_test.go
@@ -2,10 +2,10 @@ package regexp
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"regexp"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -16,7 +16,7 @@ func TestCompile(t *testing.T) {
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(v.Str())})
 	want, _ := regexp.Compile(v.Str())
 	realWant := values.NewRegexp(want)
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +30,7 @@ func TestQuoteMeta(t *testing.T) {
 	v := values.NewString("Escaping symbols like: .+*?()|[]{}^$")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(v.Str())})
 	want := regexp.QuoteMeta(v.Str())
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestFindString(t *testing.T) {
 	v := values.NewString("seafood fool")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str())})
 	want := r.Regexp().FindString(v.Str())
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestFindStringIndex(t *testing.T) {
 	v := values.NewString("tablett")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str())})
 	want := r.Regexp().FindStringIndex(v.Str())
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestMatchRegexpString(t *testing.T) {
 	v := values.NewString("gophergophergopher")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str())})
 	want := r.Regexp().MatchString(v.Str())
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestReplaceAllString(t *testing.T) {
 	tStr := values.NewString("T")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str()), "t": values.NewString(tStr.Str())})
 	want := re.ReplaceAllString(v.Str(), tStr.Str())
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestSplitRegexp(t *testing.T) {
 	i := values.NewInt(5)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str()), "i": values.NewInt(i.Int())})
 	want := r.Regexp().Split(v.Str(), int(i.Int()))
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestGetString(t *testing.T) {
 	r := values.NewRegexp(re)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp())})
 	want := re.String()
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stdlib/runtime/version.go
+++ b/stdlib/runtime/version.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"runtime/debug"
 
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/values"
 )
 
@@ -18,7 +17,7 @@ const modulePath = "github.com/influxdata/flux"
 var readBuildInfo = debug.ReadBuildInfo
 
 // Version returns the flux runtime version as a string.
-func Version(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func Version(ctx context.Context, args values.Object) (values.Value, error) {
 	bi, ok := readBuildInfo()
 	if !ok {
 		return nil, errBuildInfoNotPresent

--- a/stdlib/runtime/version_test.go
+++ b/stdlib/runtime/version_test.go
@@ -4,12 +4,12 @@ package runtime_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"runtime/debug"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/stdlib/runtime"
 	"github.com/influxdata/flux/values"
@@ -93,7 +93,7 @@ func TestVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			runtime.SetBuildInfo(tt.bi)
 
-			got, err := runtime.Version(context.Background(), dependenciestest.Default(), nil)
+			got, err := runtime.Version(dependenciestest.Default().Inject(context.Background()), nil)
 			if err != nil {
 				if tt.wantErr != nil {
 					if !cmp.Equal(tt.wantErr, err) {

--- a/stdlib/slack/slack.go
+++ b/stdlib/slack/slack.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -46,7 +45,7 @@ var validateColorStringFluxFn = values.NewFunction(
 		Required:   semantic.LabelSet{"color"},
 		Return:     semantic.String,
 	}),
-	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, ok := args.Get("color")
 
 		if !ok {

--- a/stdlib/slack/slack_test.go
+++ b/stdlib/slack/slack_test.go
@@ -10,9 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/flux/dependencies"
-	"github.com/influxdata/flux/execute"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	_ "github.com/influxdata/flux/builtin"
@@ -24,8 +21,8 @@ import (
 )
 
 func TestSlack(t *testing.T) {
-	ctx, deps := context.Background(), dependenciestest.Default()
-	_, scope, err := flux.Eval(ctx, deps, `
+	ctx := dependenciestest.Default().Inject(context.Background())
+	_, scope, err := flux.Eval(ctx, `
 import "csv"
 import "slack"
 
@@ -202,8 +199,8 @@ csv.from(csv:data) |> endpoint()`
 			if err != nil {
 				t.Fatal(err)
 			}
-			prog.SetExecutorDependencies(execute.Dependencies{dependencies.InterpreterDepsKey: dependencies.NewDefaults()})
-			query, err := prog.Start(context.Background(), &memory.Allocator{})
+			ctx := flux.NewDefaultDependencies().Inject(context.Background())
+			query, err := prog.Start(ctx, &memory.Allocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/sql/sql_test.go
+++ b/stdlib/sql/sql_test.go
@@ -88,10 +88,6 @@ func (a *MockAllocator) Parents() []execute.DatasetID {
 	return nil
 }
 
-func (a *MockAllocator) Dependencies() execute.Dependencies {
-	return nil
-}
-
 func TestFromRowReader(t *testing.T) {
 	t.Run("Mock RowReader", func(t *testing.T) {
 

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -8,7 +8,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -37,7 +36,7 @@ func generateSingleArgStringFunction(name string, stringFn func(string) string) 
 			Required:   semantic.LabelSet{stringArgV},
 			Return:     semantic.String,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var str string
 
 			v, ok := args.Get(stringArgV)
@@ -72,7 +71,7 @@ func generateDualArgStringFunction(name string, argNames []string, stringFn func
 			Required: semantic.LabelSet{argNames[0], argNames[1]},
 			Return:   semantic.String,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
 			for i, name := range argNames {
@@ -109,7 +108,7 @@ func generateDualArgStringFunctionReturnBool(name string, argNames []string, str
 			Required: semantic.LabelSet{argNames[0], argNames[1]},
 			Return:   semantic.Bool,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
 			for i, name := range argNames {
@@ -146,7 +145,7 @@ func generateDualArgStringFunctionReturnInt(name string, argNames []string, stri
 			Required: semantic.LabelSet{argNames[0], argNames[1]},
 			Return:   semantic.Int,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
 			for i, name := range argNames {
@@ -179,7 +178,7 @@ func generateSplit(name string, argNames []string, fn func(string, string) []str
 			Required: semantic.LabelSet{argNames[0], argNames[1]},
 			Return:   semantic.NewArrayPolyType(semantic.String),
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
 			for i, name := range argNames {
@@ -218,7 +217,7 @@ func generateSplitN(name string, argNames []string, fn func(string, string, int)
 			Required: semantic.LabelSet{argNames[0], argNames[1], argNames[2]},
 			Return:   semantic.Array,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 3)
 			var argTypes = []semantic.PolyType{semantic.String, semantic.String, semantic.Int}
 
@@ -257,7 +256,7 @@ func generateRepeat(name string, argNames []string, fn func(string, int) string)
 			Required: semantic.LabelSet{argNames[0], argNames[1]},
 			Return:   semantic.String,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 			var argType = []semantic.PolyType{semantic.String, semantic.Int}
 
@@ -293,7 +292,7 @@ func generateReplace(name string, argNames []string, fn func(string, string, str
 			Required: semantic.LabelSet{argNames[0], argNames[1], argNames[2], argNames[3]},
 			Return:   semantic.String,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 4)
 			var argType = []semantic.PolyType{semantic.String, semantic.String, semantic.String, semantic.Int}
 
@@ -328,7 +327,7 @@ func generateReplaceAll(name string, argNames []string, fn func(string, string, 
 			Required: semantic.LabelSet{argNames[0], argNames[1], argNames[2]},
 			Return:   semantic.String,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 3)
 
 			for i, name := range argNames {
@@ -358,7 +357,7 @@ func generateUnicodeIsFunction(name string, Fn func(rune) bool) values.Function 
 			Required:   semantic.LabelSet{stringArgV},
 			Return:     semantic.Bool,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var str string
 
 			v, ok := args.Get(stringArgV)
@@ -394,7 +393,7 @@ var strlen = values.NewFunction(
 		Required:   semantic.LabelSet{stringArgV},
 		Return:     semantic.Int,
 	}),
-	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, ok := args.Get(stringArgV)
 		if !ok {
 			return nil, fmt.Errorf("missing argument %q", stringArgV)
@@ -418,7 +417,7 @@ var substring = values.NewFunction(
 		Required: semantic.LabelSet{stringArgV, start, end},
 		Return:   semantic.String,
 	}),
-	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, vOk := args.Get(stringArgV)
 		a, aOk := args.Get(start)
 		b, bOk := args.Get(end)
@@ -534,7 +533,7 @@ func init() {
 				Required: semantic.LabelSet{"arr", "v"},
 				Return:   semantic.String,
 			}),
-			func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+			func(ctx context.Context, args values.Object) (values.Value, error) {
 				var argVals = make([]values.Value, 2)
 
 				val, ok := args.Get("arr")

--- a/stdlib/strings/strings_test.go
+++ b/stdlib/strings/strings_test.go
@@ -3,11 +3,11 @@ package strings
 import (
 	"context"
 	"errors"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"strings"
 	"testing"
 	"unicode"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -31,7 +31,7 @@ func TestTrim(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			trim := generateDualArgStringFunction("trim", []string{stringArgV, cutset}, strings.Trim)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "cutset": values.NewString(tc.cutset)})
-			result, err := trim.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := trim.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -71,7 +71,7 @@ func TestTrimPrefix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			trimPrefix := generateDualArgStringFunction("trimPrefix", []string{stringArgV, prefix}, strings.TrimPrefix)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "prefix": values.NewString(tc.prefix)})
-			result, err := trimPrefix.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := trimPrefix.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -111,7 +111,7 @@ func TestTrimSuffix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			trimSuffix := generateDualArgStringFunction("trimSuffix", []string{stringArgV, suffix}, strings.TrimSuffix)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "suffix": values.NewString(tc.suffix)})
-			result, err := trimSuffix.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := trimSuffix.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -142,7 +142,7 @@ func TestTrimSpace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			trimSpace := generateSingleArgStringFunction("trimSpace", strings.TrimSpace)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := trimSpace.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := trimSpace.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -174,7 +174,7 @@ func TestTitle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			title := generateSingleArgStringFunction("title", strings.Title)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := title.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := title.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -206,7 +206,7 @@ func TestToUpper(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			toUpper := generateSingleArgStringFunction("toUpper", strings.ToUpper)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := toUpper.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := toUpper.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -238,7 +238,7 @@ func TestToLower(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			toLower := generateSingleArgStringFunction("toLower", strings.ToLower)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := toLower.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := toLower.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -272,7 +272,7 @@ func TestTrimRight(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			trim := generateDualArgStringFunction("trimRight", []string{stringArgV, cutset}, strings.TrimRight)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "cutset": values.NewString(tc.cutset)})
-			result, err := trim.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := trim.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -306,7 +306,7 @@ func TestTrimLeft(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			trim := generateDualArgStringFunction("trimLeft", []string{stringArgV, cutset}, strings.TrimLeft)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "cutset": values.NewString(tc.cutset)})
-			result, err := trim.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := trim.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -338,7 +338,7 @@ func TestToTitle(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			title := generateSingleArgStringFunction("toTitle", strings.ToTitle)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := title.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := title.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -378,7 +378,7 @@ func TestHasSuffix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			hasSuffix := generateDualArgStringFunctionReturnBool("hasSuffix", []string{stringArgV, suffix}, strings.HasSuffix)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "suffix": values.NewString(tc.suffix)})
-			result, err := hasSuffix.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := hasSuffix.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -418,7 +418,7 @@ func TestHasPrefix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			hasPrefix := generateDualArgStringFunctionReturnBool("hasPrefix", []string{stringArgV, prefix}, strings.HasPrefix)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "prefix": values.NewString(tc.prefix)})
-			result, err := hasPrefix.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := hasPrefix.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -458,7 +458,7 @@ func TestContains(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			containsStr := generateDualArgStringFunctionReturnBool("containsStr", []string{stringArgV, substr}, strings.Contains)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "substr": values.NewString(tc.substr)})
-			result, err := containsStr.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := containsStr.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -498,7 +498,7 @@ func TestContainsAny(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			containsAny := generateDualArgStringFunctionReturnBool("containsAny", []string{stringArgV, chars}, strings.ContainsAny)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "chars": values.NewString(tc.chars)})
-			result, err := containsAny.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := containsAny.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -532,7 +532,7 @@ func TestEqualFold(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			equalFold := generateDualArgStringFunctionReturnBool("equalFold", []string{stringArgV, stringArgT}, strings.EqualFold)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "t": values.NewString(tc.t)})
-			result, err := equalFold.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := equalFold.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -578,7 +578,7 @@ func TestCompare(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			compare := generateDualArgStringFunctionReturnInt("compare", []string{stringArgV, stringArgT}, strings.Compare)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "t": values.NewString(tc.t)})
-			result, err := compare.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := compare.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Int()
 
 			if err != nil {
@@ -618,7 +618,7 @@ func TestCount(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			countStr := generateDualArgStringFunctionReturnInt("countStr", []string{stringArgV, substr}, strings.Count)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "substr": values.NewString(tc.substr)})
-			result, err := countStr.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := countStr.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Int()
 
 			if err != nil {
@@ -658,7 +658,7 @@ func TestIndex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			index := generateDualArgStringFunctionReturnInt("index", []string{stringArgV, substr}, strings.Index)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "substr": values.NewString(tc.substr)})
-			result, err := index.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := index.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Int()
 
 			if err != nil {
@@ -698,7 +698,7 @@ func TestIndexAny(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			indexAny := generateDualArgStringFunctionReturnInt("indexAny", []string{stringArgV, chars}, strings.IndexAny)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "chars": values.NewString(tc.chars)})
-			result, err := indexAny.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := indexAny.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Int()
 
 			if err != nil {
@@ -738,7 +738,7 @@ func TestLastIndex(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			lastIndex := generateDualArgStringFunctionReturnInt("lastIndex", []string{stringArgV, substr}, strings.LastIndex)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "substr": values.NewString(tc.substr)})
-			result, err := lastIndex.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := lastIndex.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Int()
 
 			if err != nil {
@@ -784,7 +784,7 @@ func TestLastIndexAny(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			lastIndexAny := generateDualArgStringFunctionReturnInt("lastIndexAny", []string{stringArgV, chars}, strings.LastIndexAny)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "chars": values.NewString(tc.chars)})
-			result, err := lastIndexAny.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := lastIndexAny.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Int()
 
 			if err != nil {
@@ -821,7 +821,7 @@ func TestIsDigit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			digit := generateUnicodeIsFunction("isDigit", unicode.IsDigit)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := digit.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := digit.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -863,7 +863,7 @@ func TestIsLetter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			is := generateUnicodeIsFunction("isLetter", unicode.IsLetter)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := is.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := is.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -905,7 +905,7 @@ func TestIsLower(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			is := generateUnicodeIsFunction("isLower", unicode.IsLower)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := is.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := is.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -947,7 +947,7 @@ func TestIsUpper(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			is := generateUnicodeIsFunction("isUpper", unicode.IsUpper)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := is.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := is.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Bool()
 
 			if err != nil {
@@ -981,7 +981,7 @@ func TestRepeat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testValue := generateRepeat("repeat", []string{stringArgV, integer}, strings.Repeat)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "i": values.NewInt(int64(tc.i))})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -1028,7 +1028,7 @@ func TestReplace(t *testing.T) {
 			testValue := generateReplace("replace", []string{stringArgV, stringArgT, stringArgU, integer}, strings.Replace)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v),
 				"t": values.NewString(tc.t), "u": values.NewString(tc.u), "i": values.NewInt(int64(tc.i))})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -1072,7 +1072,7 @@ func TestReplaceAll(t *testing.T) {
 			testValue := generateReplaceAll("replaceAll", []string{stringArgV, stringArgT, stringArgU}, strings.ReplaceAll)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v),
 				"t": values.NewString(tc.t), "u": values.NewString(tc.u)})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Str()
 
 			if err != nil {
@@ -1114,7 +1114,7 @@ func TestSplit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testValue := generateSplit("split", []string{stringArgV, stringArgT}, strings.Split)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "t": values.NewString(tc.t)})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Array()
 
 			if err != nil {
@@ -1149,7 +1149,7 @@ func TestSplitAfter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testValue := generateSplit("splitAfter", []string{stringArgV, stringArgT}, strings.SplitAfter)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "t": values.NewString(tc.t)})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Array()
 
 			if err != nil {
@@ -1186,7 +1186,7 @@ func TestSplitN(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testValue := generateSplitN("splitN", []string{stringArgV, stringArgT, integer}, strings.SplitN)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "t": values.NewString(tc.t), "i": values.NewInt(int64(tc.i))})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Array()
 
 			if err != nil {
@@ -1223,7 +1223,7 @@ func TestSplitAfterN(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testValue := generateSplitN("splitAfterN", []string{stringArgV, stringArgT, integer}, strings.SplitAfterN)
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v), "t": values.NewString(tc.t), "i": values.NewInt(int64(tc.i))})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := result.Array()
 
 			if err != nil {
@@ -1244,7 +1244,7 @@ func TestJoinStr(t *testing.T) {
 		values.NewString("a"), values.NewString("b"), values.NewString("c")})
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"arr": arr, "v": values.NewString(", ")})
 	want := strings.Join([]string{"a", "b", "c"}, ", ")
-	got, err := fluxFunc.Call(context.Background(), dependenciestest.Default(), fluxArg)
+	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1301,7 +1301,7 @@ func TestStrLength(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testValue := strlen
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v)})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 			res := int(result.Int())
 
 			if err != nil {
@@ -1387,7 +1387,7 @@ func TestSubstring(t *testing.T) {
 			testValue := substring
 			testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(tc.v),
 				"start": values.NewInt(int64(tc.start)), "end": values.NewInt(int64(tc.end))})
-			result, err := testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+			result, err := testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 
 			if err != nil {
 				if got, want := err.Error(), tc.expectErr.Error(); got != want {
@@ -1410,6 +1410,6 @@ func BenchmarkSubstring(b *testing.B) {
 	testCase := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString("townsendapplebeepancake"),
 		"start": values.NewInt(int64(0)), "end": values.NewInt(int64(5))})
 	for i := 0; i < b.N; i++ {
-		testValue.Call(context.Background(), dependenciestest.Default(), testCase)
+		testValue.Call(dependenciestest.Default().Inject(context.Background()), testCase)
 	}
 }

--- a/stdlib/system/time.go
+++ b/stdlib/system/time.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -18,7 +17,7 @@ func init() {
 		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
 			Return: semantic.Time,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			return values.NewTime(values.ConvertTime(time.Now().UTC())), nil
 		},
 		false,

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -25,7 +24,7 @@ func MakeContainsFunc() values.Function {
 			Required: semantic.LabelSet{"value", "set"},
 			Return:   semantic.Bool,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("value")
 			if !ok {
 				return nil, errors.New("missing argument value")

--- a/stdlib/universe/contains_test.go
+++ b/stdlib/universe/contains_test.go
@@ -2,9 +2,9 @@ package universe_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 )
@@ -107,7 +107,7 @@ func TestContains_NewQuery(t *testing.T) {
 func containsTestHelper(t *testing.T, tc containsCase) {
 	t.Helper()
 	contains := universe.MakeContainsFunc()
-	result, err := contains.Call(context.Background(), dependenciestest.Default(),
+	result, err := contains.Call(dependenciestest.Default().Inject(context.Background()),
 		values.NewObjectWithValues(map[string]values.Value{
 			"value": tc.value,
 			"set":   values.NewArrayWithBacking(tc.value.Type(), tc.set),

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -7,7 +7,6 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/compiler"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
@@ -107,7 +106,7 @@ func createFilterTransformation(id execute.DatasetID, mode execute.AccumulationM
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
-	t, err := NewFilterTransformation(a.Context(), a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Interface), s, d, cache)
+	t, err := NewFilterTransformation(a.Context(), s, d, cache)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -118,11 +117,10 @@ type filterTransformation struct {
 	d     execute.Dataset
 	cache execute.TableBuilderCache
 	ctx   context.Context
-	deps  dependencies.Interface
 	fn    *execute.RowPredicateFn
 }
 
-func NewFilterTransformation(ctx context.Context, deps dependencies.Interface, spec *FilterProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*filterTransformation, error) {
+func NewFilterTransformation(ctx context.Context, spec *FilterProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*filterTransformation, error) {
 	fn, err := execute.NewRowPredicateFn(spec.Fn.Fn, compiler.ToScope(spec.Fn.Scope))
 	if err != nil {
 		return nil, err
@@ -133,7 +131,6 @@ func NewFilterTransformation(ctx context.Context, deps dependencies.Interface, s
 		cache: cache,
 		fn:    fn,
 		ctx:   ctx,
-		deps:  deps,
 	}, nil
 }
 
@@ -161,7 +158,7 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			if pass, err := t.fn.Eval(t.ctx, t.deps, i, cr); err != nil {
+			if pass, err := t.fn.Eval(t.ctx, i, cr); err != nil {
 				return errors.Wrap(err, codes.Inherit, "failed to evaluate filter function")
 			} else if !pass {
 				// No match, skipping

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -2,13 +2,13 @@ package universe_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -1003,7 +1003,8 @@ func TestFilter_Process(t *testing.T) {
 				tc.want,
 				nil,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					f, err := universe.NewFilterTransformation(context.Background(), dependenciestest.Default(), tc.spec, d, c)
+					ctx := dependenciestest.Default().Inject(context.Background())
+					f, err := universe.NewFilterTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/histogram.go
+++ b/stdlib/universe/histogram.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
@@ -334,7 +333,7 @@ func (b linearBins) HasSideEffect() bool {
 	return false
 }
 
-func (b linearBins) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (b linearBins) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	startV, ok := args.Get("start")
 	if !ok {
 		return nil, errors.New("start is required")
@@ -469,7 +468,7 @@ func (b logarithmicBins) HasSideEffect() bool {
 	return false
 }
 
-func (b logarithmicBins) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (b logarithmicBins) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	startV, ok := args.Get("start")
 	if !ok {
 		return nil, errors.New("start is required")

--- a/stdlib/universe/length.go
+++ b/stdlib/universe/length.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -23,7 +22,7 @@ func MakeLengthFunc() values.Function {
 			Required: semantic.LabelSet{"arr"},
 			Return:   semantic.Int,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("arr")
 			if !ok {
 				return nil, errors.New("missing argument value")

--- a/stdlib/universe/length_test.go
+++ b/stdlib/universe/length_test.go
@@ -2,9 +2,9 @@ package universe_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
@@ -61,8 +61,7 @@ func lengthTestHelper(t *testing.T, tc lengthCase) {
 	t.Helper()
 	length := universe.MakeLengthFunc()
 	result, err := length.Call(
-		context.Background(),
-		dependenciestest.Default(),
+		dependenciestest.Default().Inject(context.Background()),
 		values.NewObjectWithValues(map[string]values.Value{
 			"arr": values.NewArrayWithBacking(semantic.Tvar(1).Nature(), tc.arr),
 		}),

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -1373,7 +1373,8 @@ func TestMap_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					f, err := universe.NewMapTransformation(context.Background(), dependenciestest.Default(), tc.spec, d, c)
+					ctx := dependenciestest.Default().Inject(context.Background())
+					f, err := universe.NewMapTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/reduce_test.go
+++ b/stdlib/universe/reduce_test.go
@@ -2,11 +2,11 @@ package universe_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"testing"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -166,7 +166,8 @@ func TestReduce_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					f, err := universe.NewReduceTransformation(context.Background(), dependenciestest.Default(), tc.spec, d, c)
+					ctx := dependenciestest.Default().Inject(context.Background())
+					f, err := universe.NewReduceTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
@@ -448,7 +447,6 @@ type schemaMutationTransformation struct {
 	d        execute.Dataset
 	cache    execute.TableBuilderCache
 	ctx      context.Context
-	deps     dependencies.Interface
 	mutators []SchemaMutator
 }
 
@@ -456,14 +454,14 @@ func createSchemaMutationTransformation(id execute.DatasetID, mode execute.Accum
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
 
-	t, err := NewSchemaMutationTransformation(a.Context(), a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Interface), spec, d, cache)
+	t, err := NewSchemaMutationTransformation(a.Context(), spec, d, cache)
 	if err != nil {
 		return nil, nil, err
 	}
 	return t, d, nil
 }
 
-func NewSchemaMutationTransformation(ctx context.Context, deps dependencies.Interface, spec plan.ProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*schemaMutationTransformation, error) {
+func NewSchemaMutationTransformation(ctx context.Context, spec plan.ProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*schemaMutationTransformation, error) {
 	s, ok := spec.(*SchemaMutationProcedureSpec)
 	if !ok {
 		return nil, fmt.Errorf("invalid spec type %T", spec)
@@ -483,14 +481,13 @@ func NewSchemaMutationTransformation(ctx context.Context, deps dependencies.Inte
 		cache:    cache,
 		mutators: mutators,
 		ctx:      ctx,
-		deps:     deps,
 	}, nil
 }
 
 func (t *schemaMutationTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	ctx := NewBuilderContext(tbl)
 	for _, m := range t.mutators {
-		err := m.Mutate(t.ctx, t.deps, ctx)
+		err := m.Mutate(t.ctx, ctx)
 		if err != nil {
 			return err
 		}

--- a/stdlib/universe/schema_functions_test.go
+++ b/stdlib/universe/schema_functions_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -1282,8 +1283,8 @@ func TestDropRenameKeep_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					// verify that ctx & deps should be nil here
-					tr, err := universe.NewSchemaMutationTransformation(context.Background(), nil, tc.spec, d, c)
+					ctx := dependenciestest.Default().Inject(context.Background())
+					tr, err := universe.NewSchemaMutationTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/sleep.go
+++ b/stdlib/universe/sleep.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -32,7 +31,7 @@ var sleepFunc = values.NewFunction(
 		Required:     semantic.LabelSet{vArg, durationArg},
 		Return:       semantic.Tvar(1),
 	}),
-	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	func(ctx context.Context, args values.Object) (values.Value, error) {
 		return interpreter.DoFunctionCallContext(sleep, ctx, args)
 	},
 	// sleeping is a side effect

--- a/stdlib/universe/sleep_test.go
+++ b/stdlib/universe/sleep_test.go
@@ -20,7 +20,7 @@ func TestSleep(t *testing.T) {
 				"duration": values.NewDuration(values.Duration(time.Microsecond)),
 			},
 		)
-		v, err := sleepFunc.Call(ctx, nil, args)
+		v, err := sleepFunc.Call(ctx, args)
 		if err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -41,7 +41,7 @@ func TestSleep(t *testing.T) {
 				"duration": values.NewDuration(values.Duration(200 * time.Millisecond)),
 			},
 		)
-		_, err := sleepFunc.Call(ctx, nil, args)
+		_, err := sleepFunc.Call(ctx, args)
 		if want, got := context.DeadlineExceeded, err; want != got {
 			t.Fatalf("unexpected error -want/+got:\n\t- %v\n\t+ %v", want, got)
 		}

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/compiler"
-
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/compiler"
-	"github.com/influxdata/flux/dependencies"
+
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
@@ -156,7 +156,7 @@ func createStateTrackingTransformation(id execute.DatasetID, mode execute.Accumu
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
-	t, err := NewStateTrackingTransformation(a.Context(), a.Dependencies()[dependencies.InterpreterDepsKey].(dependencies.Interface), s, d, cache)
+	t, err := NewStateTrackingTransformation(a.Context(), s, d, cache)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -167,9 +167,8 @@ type stateTrackingTransformation struct {
 	d     execute.Dataset
 	cache execute.TableBuilderCache
 
-	fn   *execute.RowPredicateFn
-	ctx  context.Context
-	deps dependencies.Interface
+	fn  *execute.RowPredicateFn
+	ctx context.Context
 	timeCol,
 	countColumn,
 	durationColumn string
@@ -177,7 +176,7 @@ type stateTrackingTransformation struct {
 	durationUnit int64
 }
 
-func NewStateTrackingTransformation(ctx context.Context, deps dependencies.Interface, spec *StateTrackingProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*stateTrackingTransformation, error) {
+func NewStateTrackingTransformation(ctx context.Context, spec *StateTrackingProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*stateTrackingTransformation, error) {
 	fn, err := execute.NewRowPredicateFn(spec.Fn.Fn, compiler.ToScope(spec.Fn.Scope))
 	if err != nil {
 		return nil, err
@@ -191,7 +190,6 @@ func NewStateTrackingTransformation(ctx context.Context, deps dependencies.Inter
 		durationUnit:   int64(spec.DurationUnit),
 		timeCol:        spec.TimeCol,
 		ctx:            ctx,
-		deps:           deps,
 	}, nil
 }
 
@@ -258,7 +256,7 @@ func (t *stateTrackingTransformation) Process(id execute.DatasetID, tbl flux.Tab
 	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			match, err := t.fn.Eval(t.ctx, t.deps, i, cr)
+			match, err := t.fn.Eval(t.ctx, i, cr)
 			if err != nil {
 				log.Printf("failed to evaluate state tracking expression: %v", err)
 				continue

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -376,7 +376,8 @@ func TestStateTracking_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					tx, err := universe.NewStateTrackingTransformation(context.Background(), dependenciestest.Default(), tc.spec, d, c)
+					ctx := dependenciestest.Default().Inject(context.Background())
+					tx, err := universe.NewStateTrackingTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -91,7 +90,7 @@ func (c *stringConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *stringConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *stringConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var str string
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -179,7 +178,7 @@ func (c *intConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *intConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *intConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var i int64
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -275,7 +274,7 @@ func (c *uintConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *uintConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *uintConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var i uint64
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -371,7 +370,7 @@ func (c *floatConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *floatConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *floatConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var float float64
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -463,7 +462,7 @@ func (c boolConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *boolConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *boolConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var b bool
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -575,7 +574,7 @@ func (c timeConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *timeConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *timeConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var t values.Time
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -661,7 +660,7 @@ func (c durationConv) HasSideEffect() bool {
 	return false
 }
 
-func (c *durationConv) Call(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+func (c *durationConv) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	var d values.Duration
 	v, ok := args.Get(conversionArg)
 	if !ok {
@@ -697,7 +696,7 @@ var bytes = values.NewFunction(
 		Required: []string{conversionArg},
 		Return:   semantic.Bytes,
 	}),
-	func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, ok := args.Get(conversionArg)
 		if !ok {
 			return nil, errMissingArg

--- a/stdlib/universe/typeconv_test.go
+++ b/stdlib/universe/typeconv_test.go
@@ -3,10 +3,10 @@ package universe
 import (
 	"context"
 	"errors"
-	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"math"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/values"
 )
 
@@ -71,7 +71,7 @@ func TestTypeconv_String(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &stringConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -156,7 +156,7 @@ func TestTypeconv_Int(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &intConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -241,7 +241,7 @@ func TestTypeconv_UInt(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &uintConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -331,7 +331,7 @@ func TestTypeconv_Bool(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &boolConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -427,7 +427,7 @@ func TestTypeconv_Float(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &floatConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -501,7 +501,7 @@ func TestTypeconv_Time(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &timeConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -571,7 +571,7 @@ func TestTypeconv_Duration(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := &durationConv{}
-			got, err := c.Call(context.Background(), dependenciestest.Default(), args)
+			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())

--- a/values/function.go
+++ b/values/function.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 )
 
@@ -13,11 +12,11 @@ import (
 type Function interface {
 	Value
 	HasSideEffect() bool
-	Call(ctx context.Context, deps dependencies.Interface, args Object) (Value, error)
+	Call(ctx context.Context, args Object) (Value, error)
 }
 
 // NewFunction returns a new function value
-func NewFunction(name string, typ semantic.PolyType, call func(ctx context.Context, deps dependencies.Interface, args Object) (Value, error), sideEffect bool) *function {
+func NewFunction(name string, typ semantic.PolyType, call func(ctx context.Context, args Object) (Value, error), sideEffect bool) *function {
 	return &function{
 		name:          name,
 		t:             typ,
@@ -30,7 +29,7 @@ func NewFunction(name string, typ semantic.PolyType, call func(ctx context.Conte
 type function struct {
 	name          string
 	t             semantic.PolyType
-	call          func(ctx context.Context, deps dependencies.Interface, args Object) (Value, error)
+	call          func(ctx context.Context, args Object) (Value, error)
 	hasSideEffect bool
 }
 
@@ -112,6 +111,6 @@ func (f *function) HasSideEffect() bool {
 	return f.hasSideEffect
 }
 
-func (f *function) Call(ctx context.Context, deps dependencies.Interface, args Object) (Value, error) {
-	return f.call(ctx, deps, args)
+func (f *function) Call(ctx context.Context, args Object) (Value, error) {
+	return f.call(ctx, args)
 }

--- a/values/valuestest/scope.go
+++ b/values/valuestest/scope.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -55,7 +54,7 @@ func NowScope() values.Scope {
 		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
 			Return: semantic.Time,
 		}),
-		func(ctx context.Context, deps dependencies.Interface, args values.Object) (values.Value, error) {
+		func(ctx context.Context, args values.Object) (values.Value, error) {
 			//Functions are only compared by type so the function body here is not important
 			return nil, errors.New("NowScope was called")
 		},


### PR DESCRIPTION
#1795 

 - No more `dependencies` package (moved to `flux`);
 - No more `execute.Dependencies`;
 - `Inject` pattern;
 - Fix to `Program` to make it inject `tableFind` dependencies;
 - Huge refactor to remove `dependencies.Interface` to function signatures.

I flattened the deps in a single object.