### PR TITLE
feat(arrow): add an arrow backed version of the table buffer

### DIFF
--- a/arrow/table_buffer.go
+++ b/arrow/table_buffer.go
@@ -1,0 +1,89 @@
+package arrow
+
+import (
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// TableBuffer represents the buffered component of an arrow table.
+//
+// TableBuffer is a low-level structure for creating
+// a table that implements the flux.ColReader interface.
+// It does not have very many guiding blocks to ensure it is
+// used correctly.
+//
+// A valid TableBuffer will have a number of columns that
+// is equal in length to the number of values arrays.
+// All of the values arrays will have the same length.
+type TableBuffer struct {
+	GroupKey flux.GroupKey
+	Columns  []flux.ColMeta
+	Values   []array.Interface
+}
+
+var _ flux.ColReader = (*TableBuffer)(nil)
+
+func (t *TableBuffer) Len() int {
+	return t.Values[0].Len()
+}
+
+func (t *TableBuffer) Bools(j int) *array.Boolean {
+	return t.Values[j].(*array.Boolean)
+}
+func (t *TableBuffer) Ints(j int) *array.Int64 {
+	return t.Values[j].(*array.Int64)
+}
+func (t *TableBuffer) UInts(j int) *array.Uint64 {
+	return t.Values[j].(*array.Uint64)
+}
+func (t *TableBuffer) Floats(j int) *array.Float64 {
+	return t.Values[j].(*array.Float64)
+}
+func (t *TableBuffer) Strings(j int) *array.Binary {
+	return t.Values[j].(*array.Binary)
+}
+func (t *TableBuffer) Times(j int) *array.Int64 {
+	return t.Values[j].(*array.Int64)
+}
+
+func (t *TableBuffer) Retain() {
+	for _, vs := range t.Values {
+		vs.Retain()
+	}
+}
+
+func (t *TableBuffer) Release() {
+	for _, vs := range t.Values {
+		vs.Release()
+	}
+}
+
+func (t *TableBuffer) Key() flux.GroupKey {
+	return t.GroupKey
+}
+
+func (t *TableBuffer) Cols() []flux.ColMeta {
+	return t.Columns
+}
+
+// Validate will validate that this TableBuffer has the
+// proper structure.
+func (t *TableBuffer) Validate() error {
+	if len(t.Columns) != len(t.Values) {
+		return errors.Newf(codes.Internal, "mismatched number of columns and arrays: %d != %d", len(t.Columns), len(t.Values))
+	}
+
+	if len(t.Columns) == 0 {
+		return errors.New(codes.Internal, "table must have at least one column")
+	}
+
+	sz := t.Values[0].Len()
+	for i := 1; i < len(t.Values); i++ {
+		if t.Values[i].Len() != sz {
+			return errors.New(codes.Internal, "column size mismatch")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The `arrow.TableBuffer` can be used as a building block for other tools
that are directly building out tables using the underlying arrow
utilities. It has compatibility with the `flux.ColReader` interface and
mostly follows the same criteria that already existing tables use to
construct their own column readers. It can likely replace those usages
with one common usage.

It does not provide much in terms of safety mechanisms. It is expected
that table building utilities will build safety mechanisms to prevent
programming error on top of it and it does provide a simple mechanism
that can be triggered by those building blocks to ensure the generated
buffers are correct.

The intention behind this is to start building the libraries so that we
can directly produce arrow arrays in the construction of tables instead
of utilizing the `ColListTableBuilder` which does not allow direct
access to the arrow builders it uses.

It is not intended to replace the `ColListTableBuilder`, but to act as
an additional option when constructing tables for transformations that
benefit from direct access to the arrow arrays and to allow us to
further build other libraries on top of it as we experiment with the
most efficient way to build tables.

### Done checklist
- [x] docs/SPEC.md updated
- [ ] Test cases written