### PR TITLE
fix(stdlib/experimental/mqtt): Change usage of Topic for all messages

### DIFF
--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -84,11 +84,11 @@ func (o *ToMQTTOpSpec) ReadArgs(args flux.Arguments) error {
 		return err
 	}
 	var ok bool
-	o.Message, ok, err = args.GetString("message")
+	o.Message, _, err = args.GetString("message")
 	if err != nil {
 		return err
 	}
-	o.Topic, ok, err = args.GetString("topic")
+	o.Topic, _, err = args.GetString("topic")
 	if err != nil {
 		return err
 	}

--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -88,14 +88,9 @@ func (o *ToMQTTOpSpec) ReadArgs(args flux.Arguments) error {
 	if err != nil {
 		return err
 	}
-	if ok {
-		o.Topic, ok, err = args.GetString("topic")
-		if err != nil {
-			return err
-		}
-		if !ok {
-			return fmt.Errorf("topic required with message %s", o.Message)
-		}
+	o.Topic, ok, err = args.GetString("topic")
+	if err != nil {
+		return err
 	}
 
 	o.Name, ok, err = args.GetString("name")


### PR DESCRIPTION
Topic was only being used for fixed messages. Fixed it so it is always used.