### PR TITLE
refactor(stdlib): add max and total allocations metrics to benchmarks

### DIFF
--- a/lang/query.go
+++ b/lang/query.go
@@ -26,6 +26,8 @@ func (q *query) Results() <-chan flux.Result {
 func (q *query) Done() {
 	q.cancel()
 	q.wg.Wait()
+	q.stats.MaxAllocated = q.alloc.MaxAllocated()
+	q.stats.TotalAllocated = q.alloc.TotalAllocated()
 	if q.span != nil {
 		q.span.Finish()
 		q.span = nil

--- a/query.go
+++ b/query.go
@@ -76,6 +76,9 @@ type Statistics struct {
 	Concurrency int `json:"concurrency"`
 	// MaxAllocated is the maximum number of bytes the query allocated.
 	MaxAllocated int64 `json:"max_allocated"`
+	// TotalAllocated is the total number of bytes allocated.
+	// The number includes memory that was freed and then used again.
+	TotalAllocated int64 `json:"total_allocated"`
 
 	// RuntimeErrors contains error messages that happened during the execution of the query.
 	RuntimeErrors []string `json:"runtime_errors"`
@@ -102,6 +105,7 @@ func (s Statistics) Add(other Statistics) Statistics {
 		Concurrency:     s.Concurrency + other.Concurrency,
 		RuntimeErrors:   errs,
 		MaxAllocated:    s.MaxAllocated + other.MaxAllocated,
+		TotalAllocated:  s.TotalAllocated + other.TotalAllocated,
 		Metadata:        md,
 	}
 }

--- a/stdlib/flux_bench_go112_test.go
+++ b/stdlib/flux_bench_go112_test.go
@@ -1,0 +1,13 @@
+// +build !go1.13
+
+package stdlib_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux"
+)
+
+func reportStatistics(b *testing.B, stats flux.Statistics) {
+	// Not supported in go 1.12.
+}

--- a/stdlib/flux_bench_test.go
+++ b/stdlib/flux_bench_test.go
@@ -1,0 +1,14 @@
+// +build go1.13
+
+package stdlib_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux"
+)
+
+func reportStatistics(b *testing.B, stats flux.Statistics) {
+	b.ReportMetric(float64(stats.TotalAllocated)/float64(b.N), "total_allocated/op")
+	b.ReportMetric(float64(stats.MaxAllocated)/float64(b.N), "max_allocated/op")
+}


### PR DESCRIPTION
This adds a custom metric for the max and total allocations as recorded
by the memory allocator to the flux end to end benchmarks.

It also adds a `total_allocated` to the statistics struct which records
a counter of all allocations without accounting for released memory.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written