### PR TITLE
feat(stdlib): optimize filter to pass through tables when possible

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Func interface {
+	FunctionSignature() semantic.FunctionSignature
 	Type() semantic.Type
 	Eval(ctx context.Context, input values.Object) (values.Value, error)
 }
@@ -51,6 +52,10 @@ func (c compiledFn) buildScope(input values.Object) error {
 		c.inputScope.Set(k, v)
 	})
 	return nil
+}
+
+func (c compiledFn) FunctionSignature() semantic.FunctionSignature {
+	return c.fnType.FunctionSignature()
 }
 
 func (c compiledFn) Type() semantic.Type {

--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -10,7 +10,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"gonum.org/v1/gonum/floats"
 )
@@ -107,4 +110,141 @@ func ProcessTestHelper(
 	if !cmp.Equal(want, got, floatOptions) {
 		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
 	}
+}
+
+func ProcessTestHelper2(
+	t *testing.T,
+	data []flux.Table,
+	want []*Table,
+	wantErr error,
+	create func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset),
+) {
+	t.Helper()
+
+	defer func() {
+		if err := recover(); err != nil {
+			debug.PrintStack()
+			t.Fatalf("caught panic: %v", err)
+		}
+	}()
+
+	alloc := &memory.Allocator{}
+	store := newDataStore()
+	tx, d := create(RandomDatasetID(), alloc)
+	d.SetTriggerSpec(plan.DefaultTriggerSpec)
+	d.AddTransformation(store)
+
+	parentID := RandomDatasetID()
+	var gotErr error
+	for _, b := range data {
+		if err := tx.Process(parentID, b); err != nil {
+			gotErr = err
+			break
+		}
+	}
+
+	tx.Finish(parentID, gotErr)
+	if gotErr == nil {
+		gotErr = store.err
+	}
+
+	if gotErr == nil && wantErr != nil {
+		t.Fatalf("expected error %s, got none", wantErr.Error())
+	} else if gotErr != nil && wantErr == nil {
+		t.Fatalf("expected no error, got %s", gotErr.Error())
+	} else if gotErr != nil && wantErr != nil {
+		if wantErr.Error() != gotErr.Error() {
+			t.Fatalf("unexpected error -want/+got\n%s", cmp.Diff(wantErr.Error(), gotErr.Error()))
+		} else {
+			return
+		}
+	}
+
+	got, err := TablesFromCache(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	NormalizeTables(got)
+	NormalizeTables(want)
+
+	sort.Sort(SortedTables(got))
+	sort.Sort(SortedTables(want))
+
+	if !cmp.Equal(want, got, floatOptions) {
+		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
+	}
+}
+
+// dataStore will store the incoming tables from an upstream transformation or source.
+type dataStore struct {
+	tables *execute.GroupLookup
+	err    error
+}
+
+func newDataStore() *dataStore {
+	return &dataStore{
+		tables: execute.NewGroupLookup(),
+	}
+}
+
+func (d *dataStore) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	d.tables.Delete(key)
+	return nil
+}
+
+func (d *dataStore) Process(id execute.DatasetID, tbl flux.Table) error {
+	tbl, err := execute.CopyTable(tbl)
+	if err != nil {
+		return err
+	}
+	d.tables.Set(tbl.Key(), tbl)
+	return nil
+}
+
+func (d *dataStore) UpdateWatermark(id execute.DatasetID, t execute.Time) error {
+	return nil
+}
+
+func (d *dataStore) UpdateProcessingTime(id execute.DatasetID, t execute.Time) error {
+	return nil
+}
+
+func (d *dataStore) Finish(id execute.DatasetID, err error) {
+	if err != nil {
+		d.err = err
+	}
+}
+
+func (d *dataStore) Table(key flux.GroupKey) (flux.Table, error) {
+	data, ok := d.tables.Lookup(key)
+	if !ok {
+		return nil, errors.Newf(codes.Internal, "table with key %v not found", key)
+	}
+	return data.(flux.Table), nil
+}
+
+func (d *dataStore) ForEach(f func(key flux.GroupKey)) {
+	d.tables.Range(func(key flux.GroupKey, _ interface{}) {
+		f(key)
+	})
+}
+
+func (d *dataStore) ForEachWithContext(f func(flux.GroupKey, execute.Trigger, execute.TableContext)) {
+	d.tables.Range(func(key flux.GroupKey, _ interface{}) {
+		f(key, nil, execute.TableContext{
+			Key: key,
+		})
+	})
+}
+
+func (d *dataStore) DiscardTable(key flux.GroupKey) {
+	d.tables.Delete(key)
+}
+
+func (d *dataStore) ExpireTable(key flux.GroupKey) {
+	d.tables.Delete(key)
+}
+
+func (d *dataStore) SetTriggerSpec(t plan.TriggerSpec) {
 }

--- a/execute/row_fn_test.go
+++ b/execute/row_fn_test.go
@@ -263,7 +263,7 @@ func TestRowMapFn_Eval(t *testing.T) {
 	}
 }
 
-func TestRowPredicateFn_Eval(t *testing.T) {
+func TestRowPredicateFn_EvalRow(t *testing.T) {
 	gt2F := func() (*execute.RowPredicateFn, error) {
 		return execute.NewRowPredicateFn(&semantic.FunctionExpression{
 			Block: &semantic.FunctionBlock{
@@ -356,7 +356,7 @@ func TestRowPredicateFn_Eval(t *testing.T) {
 			got := make([]bool, 0, len(tc.data.Data))
 			tc.data.Do(func(cr flux.ColReader) error {
 				for i := 0; i < cr.Len(); i++ {
-					b, err := f.Eval(ctx, i, cr)
+					b, err := f.EvalRow(ctx, i, cr)
 					if err == nil {
 						got = append(got, b)
 					}

--- a/execute/transformation.go
+++ b/execute/transformation.go
@@ -23,6 +23,65 @@ type Transformation interface {
 	Finish(id DatasetID, err error)
 }
 
+// TransformationSet is a group of transformations.
+type TransformationSet []Transformation
+
+func (ts TransformationSet) RetractTable(id DatasetID, key flux.GroupKey) error {
+	for _, t := range ts {
+		if err := t.RetractTable(id, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ts TransformationSet) Process(id DatasetID, tbl flux.Table) error {
+	if len(ts) == 0 {
+		return nil
+	} else if len(ts) == 1 {
+		return ts[0].Process(id, tbl)
+	}
+
+	// There is more than one transformation so we need to
+	// copy the table for each transformation.
+	bufTable, err := CopyTable(tbl)
+	if err != nil {
+		return err
+	}
+	defer bufTable.Done()
+
+	for _, t := range ts {
+		if err := t.Process(id, bufTable.Copy()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ts TransformationSet) UpdateWatermark(id DatasetID, time Time) error {
+	for _, t := range ts {
+		if err := t.UpdateWatermark(id, time); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ts TransformationSet) UpdateProcessingTime(id DatasetID, time Time) error {
+	for _, t := range ts {
+		if err := t.UpdateProcessingTime(id, time); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ts TransformationSet) Finish(id DatasetID, err error) {
+	for _, t := range ts {
+		t.Finish(id, err)
+	}
+}
+
 // StreamContext represents necessary context for a single stream of
 // query data.
 type StreamContext interface {

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
 	"github.com/influxdata/flux/querytest"
@@ -997,18 +998,18 @@ func TestFilter_Process(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			executetest.ProcessTestHelper(
+			executetest.ProcessTestHelper2(
 				t,
 				tc.data,
 				tc.want,
 				nil,
-				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
+				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
 					ctx := dependenciestest.Default().Inject(context.Background())
-					f, err := universe.NewFilterTransformation(ctx, tc.spec, d, c)
+					tx, d, err := universe.NewFilterTransformation(ctx, tc.spec, id, alloc)
 					if err != nil {
 						t.Fatal(err)
 					}
-					return f
+					return tx, d
 				},
 			)
 		})

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -255,7 +255,7 @@ func (t *stateTrackingTransformation) Process(id execute.DatasetID, tbl flux.Tab
 	return tbl.Do(func(cr flux.ColReader) error {
 		l := cr.Len()
 		for i := 0; i < l; i++ {
-			match, err := t.fn.Eval(t.ctx, i, cr)
+			match, err := t.fn.EvalRow(t.ctx, i, cr)
 			if err != nil {
 				log.Printf("failed to evaluate state tracking expression: %v", err)
 				continue


### PR DESCRIPTION
The filter transformation has been optimized to pass through the entire
table without copying when it is possible and, in other circumstances, pass
through the constructed table immediately to the next transformation rather
than to buffer it in memory until it receives a trigger.

First, the filter transformation uses type inference to know which
attributes from the record will be accessed. If all of these attributes are
part of the group key, it knows it can evaluate the function once to
determine if it the entire table should pass or if the table should be
cleared. This means we do not have to allocate any additional memory and we
can send an empty table to the next transformation when it is filtered.

If filter cannot make this optimization, it will now construct the table
and immediately send it off. If it receives a message to retract the table,
it will pass that on to the downstream dataset. This model means that
filter has less state and it is a 1-to-1 invariant for the group key which
is much easier to reason with and optimize. There is no regrouping logic
within filter which makes this safe to do.

#1903

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written