### PR TITLE
feat(execute): switch to using discarding mode for the transformations

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -207,7 +207,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 			return fmt.Errorf("unsupported procedure %v", kind)
 		}
 
-		tr, ds, err := createTransformationFn(id, AccumulatingMode, spec, ec)
+		tr, ds, err := createTransformationFn(id, DiscardingMode, spec, ec)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
This switches to using discarding mode with the transformations. The
intention of discarding mode was that it would discard the data after it
had been processed. For the current query engine, we do not have any
other stream primitives that would cause us to need the data after it
had been completed because we have no other triggers that actually
function.

But this hadn't caused a problem mostly because accumulating mode, the
previous method that was used, didn't actually accumulate anything.
Since tables will automatically release any memory they are using after
being processed, accumulating mode was essentially the same as
discarding mode, but didn't bother to remove anything from the group
lookup cache.

This change makes it clear that accumulating mode does not function as
it is stated to function and switches to using discarding mode because
it is the only method we actually support anyway.

#1904

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written