### PR TITLE
refactor(internal/mutable): create mutable builders for all array types

### DIFF
--- a/internal/mutable/array.go
+++ b/internal/mutable/array.go
@@ -1,0 +1,78 @@
+package mutable
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
+)
+
+// Array specifies the common interface for all mutable arrays.
+type Array interface {
+	// AppendNull will append a null value to the array.
+	AppendNull()
+
+	// SetNull will set whether the value at the index is null.
+	SetNull(i int, v bool)
+
+	// IsNull will return if the value at the given index is null.
+	IsNull(i int) bool
+
+	// Cap returns the capacity of the array.
+	Cap() int
+
+	// Len returns the current length of the array.
+	Len() int
+
+	// NewArray will construct a new arrow array.
+	// Once the array is created, the mutable array will
+	// be reset.
+	NewArray() array.Interface
+
+	// Retain will retain a reference to the builder.
+	Retain()
+
+	// Release will release any reference to data buffers.
+	Release()
+
+	// Reserve will reserve additional capacity in the array for
+	// the number of elements to be appended.
+	//
+	// This does not change the length of the array, but only the capacity.
+	Reserve(n int)
+
+	// Resize will resize the array to the given size. It will potentially
+	// shrink the array if the requested size is less than the current size.
+	//
+	// This will change the length of the array.
+	Resize(n int)
+
+	// Swap will swap the values at i and j.
+	Swap(i, j int)
+}
+
+// arrayBase implements the common base for all mutable
+// array implementations.
+type arrayBase struct {
+	refCount int64
+	mem      memory.Allocator
+	length   int
+}
+
+// Len returns the length of the array.
+func (b *arrayBase) Len() int {
+	return b.length
+}
+
+// Retain will retain a reference to the builder.
+func (b *arrayBase) Retain() {
+	atomic.AddInt64(&b.refCount, 1)
+}
+
+func (b *arrayBase) SetNull(i int, v bool) {
+	panic("implement me")
+}
+
+func (b *arrayBase) IsNull(i int) bool {
+	return false
+}

--- a/internal/mutable/binaryarray.go
+++ b/internal/mutable/binaryarray.go
@@ -1,0 +1,109 @@
+package mutable
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/bitutil"
+	"github.com/apache/arrow/go/arrow/memory"
+)
+
+// BinaryArray implements a mutable array using arrow buffers.
+type BinaryArray struct {
+	arrayBase
+	dtype   arrow.BinaryDataType
+	rawData []string
+	size    int
+}
+
+// NewBinaryArray constructs a new BinaryArray.
+func NewBinaryArray(mem memory.Allocator, typ arrow.BinaryDataType) *BinaryArray {
+	return &BinaryArray{
+		arrayBase: arrayBase{
+			refCount: 1,
+			mem:      mem,
+		},
+		dtype: typ,
+	}
+}
+
+func (b *BinaryArray) AppendString(v string) {
+	b.rawData = append(b.rawData, v)
+	b.size += len(v)
+}
+
+func (b *BinaryArray) AppendStringValues(v []string) {
+	b.rawData = append(b.rawData, v...)
+	for i := range v {
+		b.size += len(b.rawData[i])
+	}
+}
+
+func (b *BinaryArray) AppendNull() {
+	panic("implement me")
+}
+
+func (b *BinaryArray) Cap() int { return cap(b.rawData) }
+func (b *BinaryArray) Len() int { return len(b.rawData) }
+
+func (b *BinaryArray) NewArray() array.Interface {
+	return b.NewBinaryArray()
+}
+
+func (b *BinaryArray) NewBinaryArray() *array.Binary {
+	builder := array.NewBinaryBuilder(b.mem, b.dtype)
+	builder.Reserve(len(b.rawData))
+	builder.ReserveData(b.size)
+	for _, v := range b.rawData {
+		builder.AppendString(v)
+	}
+	b.reset()
+	return builder.NewBinaryArray()
+}
+
+func (b *BinaryArray) reset() {
+	b.rawData = b.rawData[0:0]
+	b.length = 0
+	b.size = 0
+}
+
+func (b *BinaryArray) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		b.reset()
+	}
+}
+
+func (b *BinaryArray) Reserve(n int) {
+	if len(b.rawData)+n > cap(b.rawData) {
+		capacity := bitutil.NextPowerOf2(len(b.rawData) + n)
+		newB := make([]string, len(b.rawData), capacity)
+		copy(newB, b.rawData)
+		b.rawData = newB
+	}
+}
+
+func (b *BinaryArray) Resize(n int) {
+	if n > cap(b.rawData) {
+		capacity := bitutil.NextPowerOf2(n)
+		newB := make([]string, n, capacity)
+		copy(newB, b.rawData)
+		b.rawData = newB
+	} else {
+		b.rawData = b.rawData[:n:cap(b.rawData)]
+	}
+}
+
+func (b *BinaryArray) ValueString(i int) string {
+	return b.rawData[i]
+}
+
+func (b *BinaryArray) SetString(i int, v string) {
+	old := b.rawData[i]
+	b.rawData[i] = v
+	b.size += len(v) - len(old)
+}
+
+func (b *BinaryArray) Swap(i, j int) {
+	b.rawData[i], b.rawData[j] = b.rawData[j], b.rawData[i]
+}

--- a/internal/mutable/binaryarray_test.go
+++ b/internal/mutable/binaryarray_test.go
@@ -1,0 +1,258 @@
+package mutable_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux/internal/mutable"
+)
+
+func TestBinaryArray_Append(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Appending will change the length to 1.
+	b.AppendString("a")
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Appending again changes the length to 2.
+	b.AppendString("b")
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewBinaryArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.ValueString(0), "a"; got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	if got, want := a.ValueString(1), "b"; got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestBinaryArray_AppendValues(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	b.AppendStringValues([]string{"a", "b"})
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewBinaryArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.ValueString(0), "a"; got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	if got, want := a.ValueString(1), "b"; got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestBinaryArray_Reserve(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Reserve will increase the capacity, but not the length.
+	// We do not verify the exact capacity because that doesn't matter,
+	// just that it is greater than or equal to 2.
+	b.Reserve(2)
+	if got, want := b.Len(), 0; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := b.Cap(); got < 2 {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %s\n\t+ %d", "at least 2", got)
+	}
+
+	// If we append a value, the capacity should not change.
+	want := b.Cap()
+	b.AppendString("a")
+	if got := b.Cap(); got != want {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestBinaryArray_Resize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Resize to 2 for 2 elements.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with default values.
+	a := b.NewBinaryArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.ValueString(0), ""; got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	if got, want := a.ValueString(1), ""; got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	a.Release()
+}
+
+func TestBinaryArray_Set(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	// Resize the array to two values and set each of the values.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Set the values.
+	b.SetString(0, "a")
+	b.SetString(1, "b")
+
+	// Verify the values using Value.
+	if got, want := b.ValueString(0), "a"; got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	if got, want := b.ValueString(1), "b"; got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewBinaryArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.ValueString(0), "a"; got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	if got, want := a.ValueString(1), "b"; got != want {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	a.Release()
+}
+
+func TestBinaryArray_NewArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append a value.
+	b.AppendString("a")
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Construct an array. This should reset the builder.
+	b.NewArray().Release()
+
+	// Append a value to the builder again.
+	b.AppendString("b")
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 1 with the same value.
+	a := b.NewBinaryArray()
+	if got, want := a.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := a.ValueString(0), "b"; got != want {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+	a.Release()
+}
+
+func TestBinaryArray_MixReserveResize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBinaryArray(mem, arrow.BinaryTypes.String)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	s1 := 10
+	s2 := 15
+	total := s1 + s2
+
+	// Mix resize and reserve.
+	b.Resize(s1)
+	b.Reserve(s2)
+	if got, want := b.Len(), s1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := b.Cap(), total; got < want {
+		t.Fatalf("unexpected capacity got < want: %d < %d", got, want)
+	}
+
+	for i := 0; i < total; i++ {
+		ch := byte('a') + byte(i)
+		if i < s1 {
+			b.SetString(i, string([]byte{ch}))
+		} else {
+			b.AppendString(string([]byte{ch}))
+		}
+	}
+	if got, want := b.Len(), total; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	for i := 0; i < total; i++ {
+		ch := byte('a') + byte(i)
+		if got, want := b.ValueString(i), string([]byte{ch}); got != want {
+			t.Fatalf("unexpected value at index %d: %v != %v", i, want, got)
+		}
+	}
+}

--- a/internal/mutable/booleanarray.go
+++ b/internal/mutable/booleanarray.go
@@ -1,0 +1,123 @@
+package mutable
+
+import (
+	"sync/atomic"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/bitutil"
+	"github.com/apache/arrow/go/arrow/memory"
+)
+
+// BooleanArray is an array of bool values.
+type BooleanArray struct {
+	arrayBase
+	data     *memory.Buffer
+	capacity int
+}
+
+// NewBooleanArray constructs a new BooleanArray.
+func NewBooleanArray(mem memory.Allocator) *BooleanArray {
+	return &BooleanArray{
+		arrayBase: arrayBase{
+			refCount: 1,
+			mem:      mem,
+		},
+	}
+}
+
+func (b *BooleanArray) Append(v bool) {
+	b.Reserve(1)
+	i := b.length
+	b.length++
+	b.Set(i, v)
+}
+
+func (b *BooleanArray) AppendNull() {
+	panic("implement me")
+}
+
+func (b *BooleanArray) AppendValues(v []bool) {
+	b.Reserve(len(v))
+	offset := b.length
+	b.length += len(v)
+	for i := range v {
+		b.Set(offset+i, v[i])
+	}
+}
+
+func (b *BooleanArray) Cap() int { return b.capacity }
+
+func (b *BooleanArray) NewArray() array.Interface {
+	return b.NewBooleanArray()
+}
+
+func (b *BooleanArray) NewBooleanArray() *array.Boolean {
+	data := array.NewData(
+		arrow.FixedWidthTypes.Boolean,
+		b.length,
+		[]*memory.Buffer{nil, b.data},
+		nil, 0, 0,
+	)
+	b.reset()
+
+	a := array.NewBooleanData(data)
+	data.Release()
+	return a
+}
+
+func (b *BooleanArray) init() {
+	b.data = memory.NewResizableBuffer(b.mem)
+}
+
+func (b *BooleanArray) reset() {
+	b.data.Release()
+	b.data = nil
+	b.length = 0
+	b.capacity = 0
+}
+
+// Release will release any reference to data buffers.
+func (b *BooleanArray) Release() {
+	if atomic.AddInt64(&b.refCount, -1) == 0 {
+		if b.data != nil {
+			b.reset()
+		}
+	}
+}
+
+func (b *BooleanArray) Reserve(n int) {
+	if b.length+n > b.capacity {
+		b.resize(b.length + n)
+	}
+}
+
+func (b *BooleanArray) Resize(n int) {
+	if n > b.capacity {
+		b.resize(n)
+	}
+	b.length = n
+}
+
+func (b *BooleanArray) resize(n int) {
+	if b.data == nil {
+		b.init()
+	}
+	capacity := bitutil.CeilByte(n)
+	b.data.Resize(capacity / 8)
+	b.capacity = b.data.Cap() * 8
+}
+
+func (b *BooleanArray) Value(i int) bool {
+	return bitutil.BitIsSet(b.data.Buf(), i)
+}
+
+func (b *BooleanArray) Set(i int, v bool) {
+	bitutil.SetBitTo(b.data.Buf(), i, v)
+}
+
+func (b *BooleanArray) Swap(i, j int) {
+	v := b.Value(i)
+	b.Set(i, b.Value(j))
+	b.Set(j, v)
+}

--- a/internal/mutable/booleanarray_test.go
+++ b/internal/mutable/booleanarray_test.go
@@ -1,0 +1,256 @@
+package mutable_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux/internal/mutable"
+)
+
+func TestBooleanArray_Append(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Appending will change the length to 1.
+	b.Append(true)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Appending again changes the length to 2.
+	b.Append(false)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewBooleanArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := a.Value(0); !got {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", true, got)
+	}
+	if got := a.Value(1); got {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestBooleanArray_AppendValues(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	b.AppendValues([]bool{true, false})
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2.
+	a := b.NewBooleanArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := a.Value(0); !got {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", true, got)
+	}
+	if got := a.Value(1); got {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+
+	// IsNull should not fail.
+	if got := a.IsNull(0); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.IsNull(1); got {
+		t.Fatalf("unexpected null check -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestBooleanArray_Reserve(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Reserve will increase the capacity, but not the length.
+	// We do not verify the exact capacity because that doesn't matter,
+	// just that it is greater than or equal to 2.
+	b.Reserve(2)
+	if got, want := b.Len(), 0; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := b.Cap(); got < 2 {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %s\n\t+ %d", "at least 2", got)
+	}
+
+	// If we append a value, the capacity should not change.
+	want := b.Cap()
+	b.Append(true)
+	if got := b.Cap(); got != want {
+		t.Fatalf("unexpected capacity -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func TestBooleanArray_Resize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Resize to 2 for 2 elements.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with default values.
+	a := b.NewBooleanArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := a.Value(0); got {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	if got := a.Value(1); got {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestBooleanArray_Set(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append two values.
+	// Resize the array to two values and set each of the values.
+	b.Resize(2)
+	if got, want := b.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Set the values.
+	b.Set(0, true)
+	b.Set(1, false)
+
+	// Verify the values using Value.
+	if got := b.Value(0); !got {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", true, got)
+	}
+	if got := b.Value(1); got {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+
+	// Constructing the array creates an arrow array of length 2 with the same values.
+	a := b.NewBooleanArray()
+	if got, want := a.Len(), 2; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := a.Value(0); !got {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", true, got)
+	}
+	if got := a.Value(1); got {
+		t.Fatalf("unexpected value at index 1 -want/+got:\n\t- %v\n\t+ %v", false, got)
+	}
+	a.Release()
+}
+
+func TestBooleanArray_NewArray(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	// Append a value.
+	b.Append(true)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Construct an array. This should reset the builder.
+	b.NewArray().Release()
+
+	// Append a value to the builder again.
+	b.Append(true)
+	if got, want := b.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Constructing the array creates an arrow array of length 1 with the same value.
+	a := b.NewBooleanArray()
+	if got, want := a.Len(), 1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got := a.Value(0); !got {
+		t.Fatalf("unexpected value at index 0 -want/+got:\n\t- %v\n\t+ %v", true, got)
+	}
+	a.Release()
+}
+
+func TestBooleanArray_MixReserveResize(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.NewGoAllocator())
+	defer mem.AssertSize(t, 0)
+
+	b := mutable.NewBooleanArray(mem)
+	defer b.Release()
+	mem.AssertSize(t, 0)
+
+	s1 := 10
+	s2 := 15
+	total := s1 + s2
+
+	// Mix resize and reserve.
+	b.Resize(s1)
+	b.Reserve(s2)
+	if got, want := b.Len(), s1; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	if got, want := b.Cap(), total; got < want {
+		t.Fatalf("unexpected capacity got < want: %d < %d", got, want)
+	}
+
+	for i := 0; i < total; i++ {
+		v := i%2 == 0
+		if i < s1 {
+			b.Set(i, v)
+		} else {
+			b.Append(v)
+		}
+	}
+	if got, want := b.Len(), total; got != want {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+	for i := 0; i < total; i++ {
+		if got, want := b.Value(i), i%2 == 0; got != want {
+			t.Fatalf("unexpected value at index %d: %v != %v", i, want, got)
+		}
+	}
+}

--- a/internal/mutable/numericarray.go
+++ b/internal/mutable/numericarray.go
@@ -10,18 +10,18 @@ import (
 
 // Int64Array is an array of int64 values.
 type Int64Array struct {
-	refCount int64
-	mem      memory.Allocator
-	data     *memory.Buffer
-	rawData  []int64
-	length   int
+	arrayBase
+	data    *memory.Buffer
+	rawData []int64
 }
 
 // NewInt64Array constructs a new Int64Array.
 func NewInt64Array(mem memory.Allocator) *Int64Array {
 	return &Int64Array{
-		refCount: 1,
-		mem:      mem,
+		arrayBase: arrayBase{
+			refCount: 1,
+			mem:      mem,
+		},
 	}
 }
 
@@ -32,6 +32,10 @@ func (b *Int64Array) Append(v int64) {
 	b.Reserve(1)
 	b.rawData = append(b.rawData, v)
 	b.length = len(b.rawData)
+}
+
+func (b *Int64Array) AppendNull() {
+	panic("implement me")
 }
 
 // AppendValues will append the given values to the array.
@@ -46,9 +50,6 @@ func (b *Int64Array) AppendValues(v []int64) {
 
 // Cap returns the capacity of the array.
 func (b *Int64Array) Cap() int { return cap(b.rawData) }
-
-// Len returns the length of the array.
-func (b *Int64Array) Len() int { return len(b.rawData) }
 
 // NewArray returns a new array from the data using NewInt64Array.
 func (b *Int64Array) NewArray() array.Interface {
@@ -82,11 +83,6 @@ func (b *Int64Array) reset() {
 	b.data = nil
 	b.rawData = nil
 	b.length = 0
-}
-
-// Retain will retain a reference to the builder.
-func (b *Int64Array) Retain() {
-	atomic.AddInt64(&b.refCount, 1)
 }
 
 // Release will release any reference to data buffers.
@@ -138,20 +134,25 @@ func (b *Int64Array) Set(i int, v int64) {
 	b.rawData[i] = v
 }
 
+// Swap will swap the values at i and j.
+func (b *Int64Array) Swap(i, j int) {
+	b.rawData[i], b.rawData[j] = b.rawData[j], b.rawData[i]
+}
+
 // Uint64Array is an array of uint64 values.
 type Uint64Array struct {
-	refCount int64
-	mem      memory.Allocator
-	data     *memory.Buffer
-	rawData  []uint64
-	length   int
+	arrayBase
+	data    *memory.Buffer
+	rawData []uint64
 }
 
 // NewUint64Array constructs a new Uint64Array.
 func NewUint64Array(mem memory.Allocator) *Uint64Array {
 	return &Uint64Array{
-		refCount: 1,
-		mem:      mem,
+		arrayBase: arrayBase{
+			refCount: 1,
+			mem:      mem,
+		},
 	}
 }
 
@@ -162,6 +163,10 @@ func (b *Uint64Array) Append(v uint64) {
 	b.Reserve(1)
 	b.rawData = append(b.rawData, v)
 	b.length = len(b.rawData)
+}
+
+func (b *Uint64Array) AppendNull() {
+	panic("implement me")
 }
 
 // AppendValues will append the given values to the array.
@@ -176,9 +181,6 @@ func (b *Uint64Array) AppendValues(v []uint64) {
 
 // Cap returns the capacity of the array.
 func (b *Uint64Array) Cap() int { return cap(b.rawData) }
-
-// Len returns the length of the array.
-func (b *Uint64Array) Len() int { return len(b.rawData) }
 
 // NewArray returns a new array from the data using NewUint64Array.
 func (b *Uint64Array) NewArray() array.Interface {
@@ -212,11 +214,6 @@ func (b *Uint64Array) reset() {
 	b.data = nil
 	b.rawData = nil
 	b.length = 0
-}
-
-// Retain will retain a reference to the builder.
-func (b *Uint64Array) Retain() {
-	atomic.AddInt64(&b.refCount, 1)
 }
 
 // Release will release any reference to data buffers.
@@ -268,20 +265,25 @@ func (b *Uint64Array) Set(i int, v uint64) {
 	b.rawData[i] = v
 }
 
+// Swap will swap the values at i and j.
+func (b *Uint64Array) Swap(i, j int) {
+	b.rawData[i], b.rawData[j] = b.rawData[j], b.rawData[i]
+}
+
 // Float64Array is an array of float64 values.
 type Float64Array struct {
-	refCount int64
-	mem      memory.Allocator
-	data     *memory.Buffer
-	rawData  []float64
-	length   int
+	arrayBase
+	data    *memory.Buffer
+	rawData []float64
 }
 
 // NewFloat64Array constructs a new Float64Array.
 func NewFloat64Array(mem memory.Allocator) *Float64Array {
 	return &Float64Array{
-		refCount: 1,
-		mem:      mem,
+		arrayBase: arrayBase{
+			refCount: 1,
+			mem:      mem,
+		},
 	}
 }
 
@@ -292,6 +294,10 @@ func (b *Float64Array) Append(v float64) {
 	b.Reserve(1)
 	b.rawData = append(b.rawData, v)
 	b.length = len(b.rawData)
+}
+
+func (b *Float64Array) AppendNull() {
+	panic("implement me")
 }
 
 // AppendValues will append the given values to the array.
@@ -306,9 +312,6 @@ func (b *Float64Array) AppendValues(v []float64) {
 
 // Cap returns the capacity of the array.
 func (b *Float64Array) Cap() int { return cap(b.rawData) }
-
-// Len returns the length of the array.
-func (b *Float64Array) Len() int { return len(b.rawData) }
 
 // NewArray returns a new array from the data using NewFloat64Array.
 func (b *Float64Array) NewArray() array.Interface {
@@ -344,11 +347,6 @@ func (b *Float64Array) reset() {
 	}
 	b.rawData = nil
 	b.length = 0
-}
-
-// Retain will retain a reference to the builder.
-func (b *Float64Array) Retain() {
-	atomic.AddInt64(&b.refCount, 1)
 }
 
 // Release will release any reference to data buffers.
@@ -398,4 +396,9 @@ func (b *Float64Array) Value(i int) float64 {
 // Set will set the value at index i.
 func (b *Float64Array) Set(i int, v float64) {
 	b.rawData[i] = v
+}
+
+// Swap will swap the values at i and j.
+func (b *Float64Array) Swap(i, j int) {
+	b.rawData[i], b.rawData[j] = b.rawData[j], b.rawData[i]
 }


### PR DESCRIPTION
This creates mutable builders for all of the array types that we use.
This also adds a common interface for all of the mutable builders.

It adds a boolean and string array. The boolean array is complete, but
the string array does not implement the contract correctly. It does not
use the allocator for the mutable memory and will instead construct the
array using an untracked slice and only consume the memory once it
constructs an array.

The intention of this is that we would be able to remove our custom
allocator code and use only the allocator interface. This would allow us
to create different allocator implementations instead of being tied to
the single `*memory.Allocator` struct.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written