### PR TITLE
fix(stdlib/universe): update the universe package to use flux errors throughout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	go.uber.org/zap v1.9.1
 	golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
+	golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0
 	gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca
 	google.golang.org/api v0.7.0
 	honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a

--- a/internal/cmd/errcheck/errcheck.go
+++ b/internal/cmd/errcheck/errcheck.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func analyzePackage(pkg *packages.Package) (count int) {
+	for _, f := range pkg.Syntax {
+		count += analyzeFile(f, pkg)
+	}
+	return count
+}
+
+type callVisitor struct {
+	Fset     *token.FileSet
+	TypeInfo *types.Info
+	Errors   []error
+}
+
+func (c *callVisitor) Visit(node ast.Node) (w ast.Visitor) {
+	switch node := node.(type) {
+	case *ast.CallExpr:
+		var ident *ast.Ident
+		switch fun := node.Fun.(type) {
+		case *ast.SelectorExpr:
+			ident = fun.Sel
+		case *ast.Ident:
+			ident = fun
+		}
+
+		if obj := c.TypeInfo.ObjectOf(ident); obj != nil {
+			if fn, ok := obj.(*types.Func); ok {
+				c.check(node, fn)
+			}
+		}
+		return nil
+	}
+	return c
+}
+
+func (c *callVisitor) check(node ast.Node, fn *types.Func) {
+	if fn.Pkg() == nil {
+		return
+	}
+
+	pos := c.Fset.Position(node.Pos())
+	if cwd, err := os.Getwd(); err == nil {
+		if filename, err := filepath.Rel(cwd, pos.Filename); err == nil {
+			pos.Filename = filename
+		}
+	}
+	if fn.Pkg().Path() == "errors" && fn.Name() == "New" {
+		c.Errors = append(c.Errors, fmt.Errorf("%s: found usage of errors.New", pos))
+	}
+	if fn.Pkg().Path() == "fmt" && fn.Name() == "Errorf" {
+		c.Errors = append(c.Errors, fmt.Errorf("%s: found usage of fmt.Errorf", pos))
+	}
+}
+
+func analyzeFile(file *ast.File, pkg *packages.Package) int {
+	v := callVisitor{
+		Fset:     pkg.Fset,
+		TypeInfo: pkg.TypesInfo,
+	}
+	ast.Walk(&v, file)
+
+	if len(v.Errors) > 0 {
+		for _, err := range v.Errors {
+			fmt.Println(err)
+		}
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	cfg := packages.Config{
+		Mode: packages.NeedName |
+			packages.NeedFiles |
+			packages.NeedCompiledGoFiles |
+			packages.NeedImports |
+			packages.NeedDeps |
+			packages.NeedSyntax |
+			packages.NeedTypes |
+			packages.NeedTypesInfo,
+		Env: os.Environ(),
+	}
+	pkgs, err := packages.Load(&cfg, os.Args[1:]...)
+	if err != nil {
+		panic(err)
+	}
+
+	count := 0
+	for _, pkg := range pkgs {
+		count += analyzePackage(pkg)
+	}
+	os.Exit(count)
+}

--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -2,9 +2,6 @@ package csv
 
 import (
 	"context"
-	stderrors "errors"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/influxdata/flux"
@@ -56,17 +53,11 @@ func createFromCSVOpSpec(args flux.Arguments, a *flux.Administration) (flux.Oper
 	}
 
 	if spec.CSV == "" && spec.File == "" {
-		return nil, stderrors.New("must provide csv raw text or filename")
+		return nil, errors.New(codes.Invalid, "must provide csv raw text or filename")
 	}
 
 	if spec.CSV != "" && spec.File != "" {
-		return nil, stderrors.New("must provide exactly one of the parameters csv or file")
-	}
-
-	if spec.File != "" {
-		if _, err := os.Stat(spec.File); err != nil {
-			return nil, errors.Wrap(err, codes.Inherit, "failed to stat csv file: ")
-		}
+		return nil, errors.New(codes.Invalid, "must provide exactly one of the parameters csv or file")
 	}
 
 	return spec, nil
@@ -89,7 +80,7 @@ type FromCSVProcedureSpec struct {
 func newFromCSVProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*FromCSVOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &FromCSVProcedureSpec{
@@ -112,7 +103,7 @@ func (s *FromCSVProcedureSpec) Copy() plan.ProcedureSpec {
 func createFromCSVSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
 	spec, ok := prSpec.(*FromCSVProcedureSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", prSpec)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", prSpec)
 	}
 
 	csvText := spec.CSV

--- a/stdlib/csv/from_test.go
+++ b/stdlib/csv/from_test.go
@@ -74,11 +74,6 @@ func TestFromCSV_NewQuery(t *testing.T) {
 				},
 			},
 		},
-		{
-			Name:    "fromCSV File",
-			Raw:     `import "csv" csv.from(file: "f.txt") |> range(start:-4h, stop:-2h) |> sum()`,
-			WantErr: true,
-		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/stdlib/influxdata/influxdb/buckets.go
+++ b/stdlib/influxdata/influxdb/buckets.go
@@ -1,9 +1,9 @@
 package influxdb
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -43,7 +43,7 @@ type BucketsProcedureSpec struct {
 func newBucketsProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	_, ok := qs.(*BucketsOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &BucketsProcedureSpec{}, nil

--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -4,8 +4,9 @@
 package influxdb
 
 import (
-	"fmt"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -56,7 +57,7 @@ type FromProcedureSpec struct {
 func newFromProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*FromOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &FromProcedureSpec{

--- a/stdlib/socket/from.go
+++ b/stdlib/socket/from.go
@@ -5,7 +5,6 @@ package socket
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	neturl "net/url"
@@ -85,7 +84,7 @@ func createFromSocketOpSpec(args flux.Arguments, a *flux.Administration) (flux.O
 	}
 
 	if !contains(decoders, spec.Decoder) {
-		return nil, fmt.Errorf("invalid decoder %s, must be one of %v", spec.Decoder, decoders)
+		return nil, errors.Newf(codes.Invalid, "invalid decoder %s, must be one of %v", spec.Decoder, decoders)
 	}
 
 	return spec, nil
@@ -108,7 +107,7 @@ type FromSocketProcedureSpec struct {
 func newFromSocketProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*FromSocketOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &FromSocketProcedureSpec{
@@ -131,7 +130,7 @@ func (s *FromSocketProcedureSpec) Copy() plan.ProcedureSpec {
 func createFromSocketSource(s plan.ProcedureSpec, dsid execute.DatasetID, a execute.Administration) (execute.Source, error) {
 	spec, ok := s.(*FromSocketProcedureSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", s)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", s)
 	}
 
 	// known issue with url.Parse for detecting the presence of a scheme: https://github.com/golang/go/issues/19779
@@ -149,7 +148,7 @@ func createFromSocketSource(s plan.ProcedureSpec, dsid execute.DatasetID, a exec
 		scheme = url.Scheme
 		address = url.Host
 		if !contains(schemes, scheme) {
-			return nil, fmt.Errorf("invalid scheme %s, must be one of %v", scheme, schemes)
+			return nil, errors.Newf(codes.Invalid, "invalid scheme %s, must be one of %v", scheme, schemes)
 		}
 	}
 
@@ -174,7 +173,7 @@ func NewSocketSource(spec *FromSocketProcedureSpec, rc io.ReadCloser, tp line.Ti
 	}
 
 	if decoder == nil {
-		return nil, fmt.Errorf("unknown decoder type: %v", spec.Decoder)
+		return nil, errors.Newf(codes.Invalid, "unknown decoder type: %v", spec.Decoder)
 	}
 
 	return &socketSource{

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -312,7 +312,7 @@ func CreateInsertComponents(t *ToSQLTransformation, tbl flux.Table) (colNames []
 					}
 					valueArgs = append(valueArgs, er.Bools(j).Value(i))
 				default:
-					return fmt.Errorf("invalid type for column %s", col.Label)
+					return errors.Newf(codes.FailedPrecondition, "invalid type for column %s", col.Label)
 				}
 			}
 
@@ -354,7 +354,7 @@ func ExecuteQueries(tx *sql.Tx, s *ToSQLOpSpec, colNames []string, valueStrings 
 		_, err := tx.Exec(query, *valueArgs...)
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				return fmt.Errorf("transaction failed (%s) while recovering from %s", err, rbErr)
+				return errors.Newf(codes.Aborted, "transaction failed (%s) while recovering from %s", err, rbErr)
 			}
 			return err
 		}

--- a/stdlib/testing/assert_empty.go
+++ b/stdlib/testing/assert_empty.go
@@ -1,10 +1,10 @@
 package testing
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -51,7 +51,7 @@ func (s *AssertEmptyProcedureSpec) Copy() plan.ProcedureSpec {
 
 func newAssertEmptyProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	if _, ok := qs.(*AssertEmptyOpSpec); !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &AssertEmptyProcedureSpec{}, nil
 }
@@ -67,7 +67,7 @@ func createAssertEmptyTransformation(id execute.DatasetID, mode execute.Accumula
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	dataset := execute.NewDataset(id, mode, cache)
 	if _, ok := spec.(*AssertEmptyProcedureSpec); !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 
 	transform := NewAssertEmptyTransformation(dataset, cache)
@@ -105,7 +105,7 @@ func (t *AssertEmptyTransformation) UpdateProcessingTime(id execute.DatasetID, m
 
 func (t *AssertEmptyTransformation) Finish(id execute.DatasetID, err error) {
 	if err == nil && t.failures > 0 {
-		err = fmt.Errorf("found %d tables that were not empty", t.failures)
+		err = errors.Newf(codes.Aborted, "found %d tables that were not empty", t.failures)
 	}
 	t.d.Finish(err)
 }

--- a/stdlib/testing/assert_equals.go
+++ b/stdlib/testing/assert_equals.go
@@ -1,12 +1,13 @@
 package testing
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -47,7 +48,7 @@ func createAssertEqualsOpSpec(args flux.Arguments, a *flux.Administration) (flux
 	}
 	p, ok := t.(*flux.TableObject)
 	if !ok {
-		return nil, errors.New("got input to assertEquals is not a table object")
+		return nil, errors.New(codes.Invalid, "got input to assertEquals is not a table object")
 	}
 	a.AddParent(p)
 
@@ -57,7 +58,7 @@ func createAssertEqualsOpSpec(args flux.Arguments, a *flux.Administration) (flux
 	}
 	p, ok = t.(*flux.TableObject)
 	if !ok {
-		return nil, errors.New("want input to assertEquals is not a table object")
+		return nil, errors.New(codes.Invalid, "want input to assertEquals is not a table object")
 	}
 	a.AddParent(p)
 
@@ -90,7 +91,7 @@ func (s *AssertEqualsProcedureSpec) Copy() plan.ProcedureSpec {
 func newAssertEqualsProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*AssertEqualsOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &AssertEqualsProcedureSpec{Name: spec.Name}, nil
 }
@@ -133,14 +134,14 @@ type assertEqualsParentState struct {
 
 func createAssertEqualsTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	if len(a.Parents()) != 2 {
-		return nil, nil, errors.New("assertEquals should have exactly 2 parents")
+		return nil, nil, errors.New(codes.Internal, "assertEquals should have exactly 2 parents")
 	}
 
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	dataset := execute.NewDataset(id, mode, cache)
 	pspec, ok := spec.(*AssertEqualsProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 
 	transform := NewAssertEqualsTransformation(dataset, cache, pspec, a.Parents()[0], a.Parents()[1], a.Allocator())
@@ -176,7 +177,7 @@ func (t *AssertEqualsTransformation) Process(id execute.DatasetID, tbl flux.Tabl
 	} else if id == t.gotParent.id {
 		t.gotParent.ntables++
 	} else {
-		return fmt.Errorf("unexpected dataset id: %v", id)
+		return errors.Newf(codes.Internal, "unexpected dataset id: %v", id)
 	}
 	if created {
 		colMap, err = execute.AddNewTableCols(tbl, builder, colMap)
@@ -219,7 +220,7 @@ func (t *AssertEqualsTransformation) UpdateWatermark(id execute.DatasetID, mark 
 			min = t.gotParent.mark
 		}
 	} else {
-		return fmt.Errorf("unexpected dataset id: %v", id)
+		return errors.Newf(codes.Internal, "unexpected dataset id: %v", id)
 	}
 
 	return t.d.UpdateWatermark(min)
@@ -241,7 +242,7 @@ func (t *AssertEqualsTransformation) UpdateProcessingTime(id execute.DatasetID, 
 			min = t.gotParent.processing
 		}
 	} else {
-		return fmt.Errorf("unexpected dataset id: %v", id)
+		return errors.Newf(codes.Internal, "unexpected dataset id: %v", id)
 	}
 	return t.d.UpdateProcessingTime(min)
 }
@@ -255,7 +256,7 @@ func (t *AssertEqualsTransformation) Finish(id execute.DatasetID, err error) {
 	} else if t.wantParent.id == id {
 		t.wantParent.finished = true
 	} else {
-		t.d.Finish(fmt.Errorf("unexpected dataset id: %v", id))
+		t.d.Finish(errors.Newf(codes.Internal, "unexpected dataset id: %v", id))
 	}
 
 	if err != nil {

--- a/stdlib/testing/diff.go
+++ b/stdlib/testing/diff.go
@@ -2,15 +2,15 @@ package testing
 
 import (
 	"bytes"
-	"errors"
-	"fmt"
 	"sort"
 	"sync"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -51,7 +51,7 @@ func createDiffOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	}
 	p, ok := t.(*flux.TableObject)
 	if !ok {
-		return nil, errors.New("want input to diff is not a table object")
+		return nil, errors.New(codes.Invalid, "want input to diff is not a table object")
 	}
 	a.AddParent(p)
 
@@ -61,7 +61,7 @@ func createDiffOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	}
 	p, ok = t.(*flux.TableObject)
 	if !ok {
-		return nil, errors.New("got input to diff is not a table object")
+		return nil, errors.New(codes.Invalid, "got input to diff is not a table object")
 	}
 	a.AddParent(p)
 
@@ -96,7 +96,7 @@ func (s *DiffProcedureSpec) Copy() plan.ProcedureSpec {
 func newDiffProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*DiffOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &DiffProcedureSpec{Verbose: spec.Verbose}, nil
 }
@@ -159,7 +159,7 @@ func copyTable(id execute.DatasetID, tbl flux.Table, alloc *memory.Allocator) (*
 		case flux.TTime:
 			bc.Builder = arrow.NewIntBuilder(alloc)
 		default:
-			return nil, errors.New("implement me")
+			return nil, errors.New(codes.Unimplemented)
 		}
 		builders[col.Label] = bc
 	}
@@ -246,7 +246,7 @@ func copyTable(id execute.DatasetID, tbl flux.Table, alloc *memory.Allocator) (*
 					}
 				}
 			default:
-				return errors.New("implement me")
+				return errors.New(codes.Unimplemented)
 			}
 		}
 		return nil
@@ -272,14 +272,14 @@ func copyTable(id execute.DatasetID, tbl flux.Table, alloc *memory.Allocator) (*
 
 func createDiffTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	if len(a.Parents()) != 2 {
-		return nil, nil, errors.New("diff should have exactly 2 parents")
+		return nil, nil, errors.New(codes.Internal, "diff should have exactly 2 parents")
 	}
 
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	dataset := execute.NewDataset(id, mode, cache)
 	pspec, ok := spec.(*DiffProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", pspec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", pspec)
 	}
 
 	transform := NewDiffTransformation(dataset, cache, pspec, a.Parents()[0], a.Parents()[1], a.Allocator())
@@ -375,7 +375,7 @@ func (t *DiffTransformation) createSchema(builder execute.TableBuilder, want, go
 	}
 	for label, col := range got.columns {
 		if typ, ok := colTypes[label]; ok && typ != col.Type {
-			return 0, nil, fmt.Errorf("column types differ: want=%s got=%s", typ, col.Type)
+			return 0, nil, errors.Newf(codes.FailedPrecondition, "column types differ: want=%s got=%s", typ, col.Type)
 		} else if !ok {
 			colTypes[label] = col.Type
 		}
@@ -436,7 +436,7 @@ func (t *DiffTransformation) diff(key flux.GroupKey, want, got *tableBuffer) err
 	// First, construct an output table.
 	builder, created := t.cache.TableBuilder(key)
 	if !created {
-		return errors.New("duplicate table key")
+		return errors.New(codes.FailedPrecondition, "duplicate table key")
 	}
 
 	diffIdx, columnIdxs, err := t.createSchema(builder, want, got)

--- a/stdlib/universe/chande_momentum_oscillator.go
+++ b/stdlib/universe/chande_momentum_oscillator.go
@@ -1,9 +1,10 @@
 package universe
 
 import (
-	"fmt"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -76,7 +77,7 @@ type ChandeMomentumOscillatorProcedureSpec struct {
 func newChandeMomentumOscillatorProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*ChandeMomentumOscillatorOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &ChandeMomentumOscillatorProcedureSpec{
@@ -107,7 +108,7 @@ func (s *ChandeMomentumOscillatorProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createChandeMomentumOscillatorTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*ChandeMomentumOscillatorProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -139,7 +140,7 @@ func (t *chandeMomentumOscillatorTransformation) RetractTable(id execute.Dataset
 func (t *chandeMomentumOscillatorTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if !created {
-		return fmt.Errorf("chande momentum oscillator found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "chande momentum oscillator found duplicate table with key: %v", tbl.Key())
 	}
 	cols := tbl.Cols()
 	doChandeMomentumOscillator := make([]bool, len(cols))
@@ -148,7 +149,7 @@ func (t *chandeMomentumOscillatorTransformation) Process(id execute.DatasetID, t
 		for _, label := range t.columns {
 			if c.Label == label {
 				if c.Type != flux.TInt && c.Type != flux.TUInt && c.Type != flux.TFloat {
-					return fmt.Errorf("cannot take chande momentum oscillator of column %s (type %s)", c.Label, c.Type.String())
+					return errors.Newf(codes.Invalid, "cannot take chande momentum oscillator of column %s (type %s)", c.Label, c.Type.String())
 				}
 				found = true
 				break

--- a/stdlib/universe/columns.go
+++ b/stdlib/universe/columns.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -61,7 +61,7 @@ type ColumnsProcedureSpec struct {
 func newColumnsProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*ColumnsOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &ColumnsProcedureSpec{
@@ -82,7 +82,7 @@ func (s *ColumnsProcedureSpec) Copy() plan.ProcedureSpec {
 func createColumnsTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*ColumnsProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -112,7 +112,7 @@ func (t *columnsTransformation) RetractTable(id execute.DatasetID, key flux.Grou
 func (t *columnsTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if !created {
-		return fmt.Errorf("columns found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "columns found duplicate table with key: %v", tbl.Key())
 	}
 
 	labels := make([]string, len(tbl.Cols()))

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -2,10 +2,11 @@ package universe
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -25,22 +26,22 @@ func MakeContainsFunc() values.Function {
 			Return:   semantic.Bool,
 		}),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
-			v, ok := args.Get("value")
-			if !ok {
-				return nil, errors.New("missing argument value")
+			a := interpreter.NewArguments(args)
+			v, err := a.GetRequired("value")
+			if err != nil {
+				return nil, err
 			}
 
-			setarg, ok := args.Get("set")
-			if !ok {
-				return nil, errors.New("missing argument set")
+			setarg, err := a.GetRequiredArray("set", v.Type().Nature())
+			if err != nil {
+				return nil, err
 			}
 
 			set := setarg.Array()
 			found := false
-			var err error
 			if set.Len() > 0 {
 				if set.Get(0).Type() != v.Type() {
-					err = fmt.Errorf("value type %T does not match set type %T", v.Type(), set.Get(0).Type())
+					err = errors.Newf(codes.Invalid, "value type %T does not match set type %T", v.Type(), set.Get(0).Type())
 				} else {
 					for i := 0; i < set.Len(); i++ {
 						if set.Get(i).Equal(v) {

--- a/stdlib/universe/count.go
+++ b/stdlib/universe/count.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -49,7 +49,7 @@ type CountProcedureSpec struct {
 func newCountProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*CountOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &CountProcedureSpec{
 		AggregateConfig: spec.AggregateConfig,
@@ -85,7 +85,7 @@ type CountAgg struct {
 func createCountTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*CountProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(CountAgg), s.AggregateConfig, a.Allocator())

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -2,7 +2,6 @@ package universe
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
@@ -79,7 +78,7 @@ type FilterProcedureSpec struct {
 func newFilterProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*FilterOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &FilterProcedureSpec{
@@ -104,7 +103,7 @@ func (s *FilterProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createFilterTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*FilterProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	t, d, err := NewFilterTransformation(a.Context(), s, id, a.Allocator())
 	if err != nil {

--- a/stdlib/universe/first.go
+++ b/stdlib/universe/first.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -52,7 +52,7 @@ type FirstProcedureSpec struct {
 func newFirstProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*FirstOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &FirstProcedureSpec{
 		SelectorConfig: spec.SelectorConfig,
@@ -82,7 +82,7 @@ type FirstSelector struct {
 func createFirstTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	ps, ok := spec.(*FirstProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
 	t, d := execute.NewIndexSelectorTransformationAndDataset(id, mode, new(FirstSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/histogram.go
+++ b/stdlib/universe/histogram.go
@@ -2,14 +2,15 @@ package universe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"regexp"
 	"sort"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -107,7 +108,7 @@ type HistogramProcedureSpec struct {
 func newHistogramProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*HistogramOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &HistogramProcedureSpec{
@@ -131,7 +132,7 @@ func (s *HistogramProcedureSpec) Copy() plan.ProcedureSpec {
 func createHistogramTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*HistogramProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -162,14 +163,14 @@ func (t *histogramTransformation) RetractTable(id execute.DatasetID, key flux.Gr
 func (t *histogramTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if !created {
-		return fmt.Errorf("histogram found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "histogram found duplicate table with key: %v", tbl.Key())
 	}
 	valueIdx := execute.ColIdx(t.spec.Column, tbl.Cols())
 	if valueIdx < 0 {
-		return fmt.Errorf("column %q is missing", t.spec.Column)
+		return errors.Newf(codes.FailedPrecondition, "column %q is missing", t.spec.Column)
 	}
 	if col := tbl.Cols()[valueIdx]; col.Type != flux.TFloat {
-		return fmt.Errorf("column %q must be a float got %v", t.spec.Column, col.Type)
+		return errors.Newf(codes.FailedPrecondition, "column %q must be a float got %v", t.spec.Column, col.Type)
 	}
 
 	err := execute.AddTableKeyCols(tbl.Key(), builder)
@@ -336,31 +337,31 @@ func (b linearBins) HasSideEffect() bool {
 func (b linearBins) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	startV, ok := args.Get("start")
 	if !ok {
-		return nil, errors.New("start is required")
+		return nil, errors.New(codes.Invalid, "start is required")
 	}
 	if startV.Type() != semantic.Float {
-		return nil, errors.New("start must be a float")
+		return nil, errors.New(codes.Invalid, "start must be a float")
 	}
 	widthV, ok := args.Get("width")
 	if !ok {
-		return nil, errors.New("width is required")
+		return nil, errors.New(codes.Invalid, "width is required")
 	}
 	if widthV.Type() != semantic.Float {
-		return nil, errors.New("width must be a float")
+		return nil, errors.New(codes.Invalid, "width must be a float")
 	}
 	countV, ok := args.Get("count")
 	if !ok {
-		return nil, errors.New("count is required")
+		return nil, errors.New(codes.Invalid, "count is required")
 	}
 	if countV.Type() != semantic.Int {
-		return nil, errors.New("count must be an int")
+		return nil, errors.New(codes.Invalid, "count must be an int")
 	}
 	infV, ok := args.Get("infinity")
 	if !ok {
 		infV = values.NewBool(true)
 	}
 	if infV.Type() != semantic.Bool {
-		return nil, errors.New("infinity must be a bool")
+		return nil, errors.New(codes.Invalid, "infinity must be a bool")
 	}
 	start := startV.Float()
 	width := widthV.Float()
@@ -471,31 +472,31 @@ func (b logarithmicBins) HasSideEffect() bool {
 func (b logarithmicBins) Call(ctx context.Context, args values.Object) (values.Value, error) {
 	startV, ok := args.Get("start")
 	if !ok {
-		return nil, errors.New("start is required")
+		return nil, errors.New(codes.Invalid, "start is required")
 	}
 	if startV.Type() != semantic.Float {
-		return nil, errors.New("start must be a float")
+		return nil, errors.New(codes.Invalid, "start must be a float")
 	}
 	factorV, ok := args.Get("factor")
 	if !ok {
-		return nil, errors.New("factor is required")
+		return nil, errors.New(codes.Invalid, "factor is required")
 	}
 	if factorV.Type() != semantic.Float {
-		return nil, errors.New("factor must be a float")
+		return nil, errors.New(codes.Invalid, "factor must be a float")
 	}
 	countV, ok := args.Get("count")
 	if !ok {
-		return nil, errors.New("count is required")
+		return nil, errors.New(codes.Invalid, "count is required")
 	}
 	if countV.Type() != semantic.Int {
-		return nil, errors.New("count must be an int")
+		return nil, errors.New(codes.Invalid, "count must be an int")
 	}
 	infV, ok := args.Get("infinity")
 	if !ok {
 		infV = values.NewBool(true)
 	}
 	if infV.Type() != semantic.Bool {
-		return nil, errors.New("infinity must be a bool")
+		return nil, errors.New(codes.Invalid, "infinity must be a bool")
 	}
 	start := startV.Float()
 	factor := factorV.Float()

--- a/stdlib/universe/holt_winters.go
+++ b/stdlib/universe/holt_winters.go
@@ -2,16 +2,18 @@ package universe
 
 import (
 	"fmt"
-	"github.com/influxdata/flux/values"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
 	fluxarrow "github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	fluxmemory "github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe/holt_winters"
+	"github.com/influxdata/flux/values"
 )
 
 const HoltWintersKind = "holtWinters"
@@ -108,7 +110,7 @@ type HoltWintersProcedureSpec struct {
 func newHoltWintersProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*HoltWintersOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &HoltWintersProcedureSpec{
 		WithFit:    spec.WithFit,
@@ -137,7 +139,7 @@ func (s *HoltWintersProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createHoltWintersTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*HoltWintersProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -176,22 +178,22 @@ func (hwt *holtWintersTransformation) Process(id execute.DatasetID, tbl flux.Tab
 	// Sanity checks.
 	builder, created := hwt.cache.TableBuilder(tbl.Key())
 	if !created {
-		return fmt.Errorf("holtWinters found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "holtWinters found duplicate table with key: %v", tbl.Key())
 	}
 	cols := tbl.Cols()
 	timeIdx := execute.ColIdx(hwt.timeColumn, cols)
 	if timeIdx < 0 {
-		return fmt.Errorf("cannot find time column %s", hwt.timeColumn)
+		return errors.Newf(codes.FailedPrecondition, "cannot find time column %s", hwt.timeColumn)
 	}
 	colIdx := execute.ColIdx(hwt.column, cols)
 	if colIdx < 0 {
-		return fmt.Errorf("cannot find column %s", hwt.column)
+		return errors.Newf(codes.FailedPrecondition, "cannot find column %s", hwt.column)
 	}
 	typ := cols[colIdx].Type
 	if typ != flux.TInt &&
 		typ != flux.TUInt &&
 		typ != flux.TFloat {
-		return fmt.Errorf("holtWinters can work only on numerical types, got %s", typ.String())
+		return errors.Newf(codes.FailedPrecondition, "holtWinters can work only on numerical types, got %s", typ.String())
 	}
 
 	// Building schema.

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -1,14 +1,15 @@
 package universe
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"sort"
 	"sync"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
@@ -87,7 +88,7 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	if array, err := args.GetRequiredArray("on", semantic.String); err != nil {
 		return nil, err
 	} else if array.Len() == 0 {
-		return nil, errors.New("at least one column in 'on' column list is required")
+		return nil, errors.New(codes.Invalid, "at least one column in 'on' column list is required")
 	} else {
 		spec.On, err = interpreter.ToStringArray(array)
 		if err != nil {
@@ -100,7 +101,7 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	if joinType, ok, err := args.GetString("method"); err != nil {
 		return nil, err
 	} else if ok && !methods[joinType] {
-		return nil, fmt.Errorf("%s is not a valid join type", joinType)
+		return nil, errors.Newf(codes.Invalid, "%s is not a valid join type", joinType)
 	} else if ok && methods[joinType] {
 		spec.Method = joinType
 	} else {
@@ -109,7 +110,7 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 
 	// It is not valid to specify a list of 'on' columns for a cross product
 	if spec.Method == "cross" && spec.On != nil {
-		return nil, errors.New("cross product and 'on' are mutually exclusive")
+		return nil, errors.New(codes.Invalid, "cross product and 'on' are mutually exclusive")
 	}
 
 	tables, err := args.GetRequiredObject("tables")
@@ -124,13 +125,13 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 			return
 		}
 		if operation.PolyType().Nature() != semantic.Object {
-			err = fmt.Errorf("expected %q to be object type; instead got %v",
+			err = errors.Newf(codes.Invalid, "expected %q to be object type; instead got %v",
 				name, operation.PolyType().Nature())
 			return
 		}
 		table, ok := operation.(*flux.TableObject)
 		if !ok {
-			err = fmt.Errorf("expected %q to be TableObject type, instead got %v", name, operation.Type())
+			err = errors.Newf(codes.Invalid, "expected %q to be TableObject type, instead got %v", name, operation.Type())
 			return
 		}
 		spec.params.names = append(spec.params.names, name)
@@ -176,7 +177,7 @@ func newMergeJoinProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.
 	var ok bool
 
 	if spec, ok = qs.(*JoinOpSpec); !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	tableNames := make([]string, len(spec.TableNames))
@@ -213,12 +214,12 @@ func (s *MergeJoinProcedureSpec) Copy() plan.ProcedureSpec {
 func createMergeJoinTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*MergeJoinProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	parents := a.Parents()
 	if len(parents) != 2 {
 		//TODO(nathanielc): Support n-way joins
-		return nil, nil, errors.New("joins currently must only have two parents")
+		return nil, nil, errors.New(codes.Unimplemented, "joins currently must only have two parents")
 	}
 
 	tableNames := make(map[execute.DatasetID]string, len(s.TableNames))
@@ -560,24 +561,24 @@ func (c *MergeJoinCache) Table(key flux.GroupKey) (flux.Table, error) {
 	preJoinGroupKeys, ok := c.reverseLookup[key]
 
 	if !ok {
-		return nil, fmt.Errorf("no table exists with group key: %v", key)
+		return nil, errors.Newf(codes.FailedPrecondition, "no table exists with group key: %v", key)
 	}
 
 	if _, ok := c.tables[key]; !ok {
 
 		left := c.buffers[c.leftID].table(preJoinGroupKeys.left)
 		if left == nil {
-			return nil, fmt.Errorf("no table in left join buffer with key: %v", key)
+			return nil, errors.Newf(codes.FailedPrecondition, "no table in left join buffer with key: %v", key)
 		}
 
 		right := c.buffers[c.rightID].table(preJoinGroupKeys.right)
-		if left == nil {
-			return nil, fmt.Errorf("no table in right join buffer with key: %v", key)
+		if right == nil {
+			return nil, errors.Newf(codes.FailedPrecondition, "no table in right join buffer with key: %v", key)
 		}
 
 		table, err := c.join(left, right)
 		if err != nil {
-			return nil, fmt.Errorf("table with group key (%v) could not be fetched", key)
+			return nil, errors.Newf(codes.NotFound, "table with group key (%v) could not be fetched", key)
 		}
 
 		c.tables[key] = table

--- a/stdlib/universe/key_values.go
+++ b/stdlib/universe/key_values.go
@@ -1,8 +1,6 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
@@ -88,7 +86,7 @@ type KeyValuesProcedureSpec struct {
 func newKeyValuesProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*KeyValuesOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &KeyValuesProcedureSpec{

--- a/stdlib/universe/last.go
+++ b/stdlib/universe/last.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -51,7 +51,7 @@ type LastProcedureSpec struct {
 func newLastProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*LastOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &LastProcedureSpec{
 		SelectorConfig: spec.SelectorConfig,
@@ -86,7 +86,7 @@ type LastSelector struct {
 func createLastTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	ps, ok := spec.(*LastProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
 	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(LastSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/length.go
+++ b/stdlib/universe/length.go
@@ -2,9 +2,11 @@ package universe
 
 import (
 	"context"
-	"errors"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -23,9 +25,12 @@ func MakeLengthFunc() values.Function {
 			Return:   semantic.Int,
 		}),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
-			v, ok := args.Get("arr")
-			if !ok {
-				return nil, errors.New("missing argument value")
+			a := interpreter.NewArguments(args)
+			v, err := a.GetRequired("arr")
+			if err != nil {
+				return nil, err
+			} else if got := v.Type().Nature(); got != semantic.Array {
+				return nil, errors.Newf(codes.Invalid, "arr must be an array, got %s", got)
 			}
 			l := v.Array().Len()
 			return values.NewInt(int64(l)), nil

--- a/stdlib/universe/max.go
+++ b/stdlib/universe/max.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -52,7 +52,7 @@ type MaxProcedureSpec struct {
 func newMaxProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*MaxOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &MaxProcedureSpec{
 		SelectorConfig: spec.SelectorConfig,
@@ -81,7 +81,7 @@ type MaxSelector struct {
 func createMaxTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	ps, ok := spec.(*MaxProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
 	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(MaxSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/mean.go
+++ b/stdlib/universe/mean.go
@@ -1,13 +1,14 @@
 package universe
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/apache/arrow/go/arrow/array"
 	arrowmath "github.com/apache/arrow/go/arrow/math"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -52,7 +53,7 @@ type MeanProcedureSpec struct {
 func newMeanProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*MeanOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &MeanProcedureSpec{
 		AggregateConfig: spec.AggregateConfig,
@@ -81,7 +82,7 @@ type MeanAgg struct {
 func createMeanTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*MeanProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(MeanAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/min.go
+++ b/stdlib/universe/min.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -52,7 +52,7 @@ type MinProcedureSpec struct {
 func newMinProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*MinOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &MinProcedureSpec{
 		SelectorConfig: spec.SelectorConfig,
@@ -81,7 +81,7 @@ type MinSelector struct {
 func createMinTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	ps, ok := spec.(*MinProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
 	t, d := execute.NewRowSelectorTransformationAndDataset(id, mode, new(MinSelector), ps.SelectorConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/mode.go
+++ b/stdlib/universe/mode.go
@@ -1,11 +1,12 @@
 package universe
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -64,7 +65,7 @@ type ModeProcedureSpec struct {
 func newModeProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*ModeOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &ModeProcedureSpec{
@@ -91,7 +92,7 @@ func (s *ModeProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createModeTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*ModeProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -121,7 +122,7 @@ func (t *modeTransformation) RetractTable(id execute.DatasetID, key flux.GroupKe
 func (t *modeTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if !created {
-		return fmt.Errorf("mode found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "mode found duplicate table with key: %v", tbl.Key())
 	}
 
 	colIdx := execute.ColIdx(t.column, tbl.Cols())

--- a/stdlib/universe/moving_average.go
+++ b/stdlib/universe/moving_average.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/moving_average"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -64,7 +64,7 @@ type MovingAverageProcedureSpec struct {
 func newMovingAverageProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*MovingAverageOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &MovingAverageProcedureSpec{
@@ -90,7 +90,7 @@ func (s *MovingAverageProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createMovingAverageTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*MovingAverageProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -128,17 +128,17 @@ func (t *movingAverageTransformation) RetractTable(id execute.DatasetID, key flu
 func (t *movingAverageTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if !created {
-		return fmt.Errorf("moving average found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "moving average found duplicate table with key: %v", tbl.Key())
 	}
 	if t.n <= 0 {
-		return fmt.Errorf("cannot take moving average with a period of %v (must be greater than 0)", t.n)
+		return errors.Newf(codes.Invalid, "cannot take moving average with a period of %v (must be greater than 0)", t.n)
 	}
 	cols := tbl.Cols()
 	valueIdx := -1
 	for j, c := range cols {
 		if c.Label == execute.DefaultValueColLabel {
 			if c.Type != flux.TInt && c.Type != flux.TUInt && c.Type != flux.TFloat {
-				return fmt.Errorf("cannot take moving average of column %s (type %s)", c.Label, c.Type.String())
+				return errors.Newf(codes.FailedPrecondition, "cannot take moving average of column %s (type %s)", c.Label, c.Type.String())
 			}
 			valueIdx = j
 			mac := c
@@ -155,7 +155,7 @@ func (t *movingAverageTransformation) Process(id execute.DatasetID, tbl flux.Tab
 		}
 	}
 	if valueIdx == -1 {
-		return fmt.Errorf("cannot find _value column")
+		return errors.Newf(codes.FailedPrecondition, "cannot find _value column")
 	}
 
 	t.i = make([]int, len(cols))

--- a/stdlib/universe/sample.go
+++ b/stdlib/universe/sample.go
@@ -1,13 +1,13 @@
 package universe
 
 import (
-	"fmt"
-
 	"math/rand"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -46,7 +46,7 @@ func createSampleOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 	if err != nil {
 		return nil, err
 	} else if n <= 0 {
-		return nil, fmt.Errorf("n must be a positive integer, but was %d", n)
+		return nil, errors.Newf(codes.Invalid, "n must be a positive integer, but was %d", n)
 	}
 	spec.N = n
 
@@ -54,7 +54,7 @@ func createSampleOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 		return nil, err
 	} else if ok {
 		if pos >= spec.N {
-			return nil, fmt.Errorf("pos must be less than n, but %d >= %d", pos, spec.N)
+			return nil, errors.Newf(codes.Invalid, "pos must be less than n, but %d >= %d", pos, spec.N)
 		}
 		spec.Pos = pos
 	} else {
@@ -85,7 +85,7 @@ type SampleProcedureSpec struct {
 func newSampleProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*SampleOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &SampleProcedureSpec{
 		N:              spec.N,
@@ -121,7 +121,7 @@ type SampleSelector struct {
 func createSampleTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	ps, ok := spec.(*SampleProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", ps)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
 
 	ss := &SampleSelector{

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -2,11 +2,11 @@ package universe
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -160,11 +160,11 @@ func createRenameOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 	}
 
 	if cols == nil && renameFn.Fn == nil {
-		return nil, errors.New("rename error: neither column list nor map function provided")
+		return nil, errors.New(codes.Invalid, "rename error: neither column list nor map function provided")
 	}
 
 	if cols != nil && renameFn.Fn != nil {
-		return nil, errors.New("rename error: both column list and map function provided")
+		return nil, errors.New(codes.Invalid, "rename error: both column list and map function provided")
 	}
 
 	spec := &RenameOpSpec{
@@ -180,7 +180,7 @@ func createRenameOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 				return
 			}
 			if v.Type() != semantic.String {
-				err = fmt.Errorf("rename error: columns object contains non-string value of type %s", v.Type())
+				err = errors.Newf(codes.Invalid, "rename error: columns object contains non-string value of type %s", v.Type())
 				return
 			}
 			renameCols[name] = v.Str()
@@ -219,11 +219,11 @@ func createDropOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	}
 
 	if cols == nil && dropPredicate.Fn == nil {
-		return nil, errors.New("drop error: neither column list nor predicate function provided")
+		return nil, errors.New(codes.Invalid, "drop error: neither column list nor predicate function provided")
 	}
 
 	if cols != nil && dropPredicate.Fn != nil {
-		return nil, errors.New("drop error: both column list and predicate provided")
+		return nil, errors.New(codes.Invalid, "drop error: both column list and predicate provided")
 	}
 
 	var dropCols []string
@@ -266,11 +266,11 @@ func createKeepOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	}
 
 	if cols == nil && keepPredicate.Fn == nil {
-		return nil, errors.New("keep error: neither column list nor predicate function provided")
+		return nil, errors.New(codes.Invalid, "keep error: neither column list nor predicate function provided")
 	}
 
 	if cols != nil && keepPredicate.Fn != nil {
-		return nil, errors.New("keep error: both column list and predicate provided")
+		return nil, errors.New(codes.Invalid, "keep error: both column list and predicate provided")
 	}
 
 	var keepCols []string
@@ -435,7 +435,7 @@ func (s *SchemaMutationProcedureSpec) Copy() plan.ProcedureSpec {
 func newSchemaMutationProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	s, ok := qs.(SchemaMutation)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T doesn't implement SchemaMutation", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T doesn't implement SchemaMutation", qs)
 	}
 
 	return &SchemaMutationProcedureSpec{
@@ -464,7 +464,7 @@ func createSchemaMutationTransformation(id execute.DatasetID, mode execute.Accum
 func NewSchemaMutationTransformation(ctx context.Context, spec plan.ProcedureSpec, d execute.Dataset, cache execute.TableBuilderCache) (*schemaMutationTransformation, error) {
 	s, ok := spec.(*SchemaMutationProcedureSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 
 	mutators := make([]SchemaMutator, len(s.Mutations))

--- a/stdlib/universe/set.go
+++ b/stdlib/universe/set.go
@@ -1,10 +1,10 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -69,7 +69,7 @@ type SetProcedureSpec struct {
 func newSetProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	s, ok := qs.(*SetOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	p := &SetProcedureSpec{
 		Key:   s.Key,
@@ -91,7 +91,7 @@ func (s *SetProcedureSpec) Copy() plan.ProcedureSpec {
 func createSetTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SetProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)

--- a/stdlib/universe/skew.go
+++ b/stdlib/universe/skew.go
@@ -1,12 +1,13 @@
 package universe
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -52,7 +53,7 @@ type SkewProcedureSpec struct {
 func newSkewProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*SkewOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &SkewProcedureSpec{
 		AggregateConfig: spec.AggregateConfig,
@@ -80,7 +81,7 @@ type SkewAgg struct {
 func createSkewTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SkewProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(SkewAgg), s.AggregateConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/sleep.go
+++ b/stdlib/universe/sleep.go
@@ -2,10 +2,11 @@ package universe
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -53,7 +54,7 @@ func sleep(ctx context.Context, args interpreter.Arguments) (values.Value, error
 	if err != nil {
 		return nil, err
 	} else if d.Type().Nature() != semantic.Duration {
-		return nil, fmt.Errorf("keyword argument %q should be of kind %v, but got %v", durationArg, semantic.Duration, v.PolyType().Nature())
+		return nil, errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", durationArg, semantic.Duration, v.PolyType().Nature())
 	}
 
 	timer := time.NewTimer(d.Duration().Duration())

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -1,10 +1,10 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -78,7 +78,7 @@ type SortProcedureSpec struct {
 func newSortProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*SortOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 
 	return &SortProcedureSpec{
@@ -108,7 +108,7 @@ func (s *SortProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createSortTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SortProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	cache := execute.NewTableBuilderCache(a.Allocator())
 	d := execute.NewDataset(id, mode, cache)
@@ -148,7 +148,7 @@ func (t *sortTransformation) Process(id execute.DatasetID, tbl flux.Table) error
 
 	builder, created := t.cache.TableBuilder(key)
 	if !created {
-		return fmt.Errorf("sort found duplicate table with key: %v", tbl.Key())
+		return errors.Newf(codes.FailedPrecondition, "sort found duplicate table with key: %v", tbl.Key())
 	}
 	if err := execute.AddTableCols(tbl, builder); err != nil {
 		return err

--- a/stdlib/universe/spread.go
+++ b/stdlib/universe/spread.go
@@ -1,11 +1,11 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -51,7 +51,7 @@ func (s *SpreadOpSpec) Kind() flux.OperationKind {
 func newSpreadProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*SpreadOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &SpreadProcedureSpec{
 		AggregateConfig: spec.AggregateConfig,
@@ -82,7 +82,7 @@ func (s *SpreadProcedureSpec) TriggerSpec() plan.TriggerSpec {
 func createSpreadTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SpreadProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(SpreadAgg), s.AggregateConfig, a.Allocator())

--- a/stdlib/universe/stddev.go
+++ b/stdlib/universe/stddev.go
@@ -1,12 +1,13 @@
 package universe
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -47,7 +48,7 @@ func createStddevOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 		return nil, err
 	} else if ok {
 		if mode != modePopulation && mode != modeSample {
-			return nil, fmt.Errorf("%q is not a valid standard deviation mode", mode)
+			return nil, errors.Newf(codes.Invalid, "%q is not a valid standard deviation mode", mode)
 		}
 		s.Mode = mode
 	} else {
@@ -76,7 +77,7 @@ type StddevProcedureSpec struct {
 func newStddevProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*StddevOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &StddevProcedureSpec{
 		Mode:            spec.Mode,
@@ -107,7 +108,7 @@ type StddevAgg struct {
 func createStddevTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*StddevProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, &StddevAgg{Mode: s.Mode}, s.AggregateConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/sum.go
+++ b/stdlib/universe/sum.go
@@ -1,12 +1,12 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/apache/arrow/go/arrow/math"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -51,7 +51,7 @@ type SumProcedureSpec struct {
 func newSumProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*SumOpSpec)
 	if !ok {
-		return nil, fmt.Errorf("invalid spec type %T", qs)
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 	}
 	return &SumProcedureSpec{
 		AggregateConfig: spec.AggregateConfig,
@@ -85,7 +85,7 @@ type SumAgg struct{}
 func createSumTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SumProcedureSpec)
 	if !ok {
-		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
 
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, new(SumAgg), s.AggregateConfig, a.Allocator())

--- a/stdlib/universe/transformations.go
+++ b/stdlib/universe/transformations.go
@@ -1,2 +1,2 @@
-// Package transformations contains the implementations for the builtin transformation functions.
+// Package universe contains the implementations for the builtin transformation functions.
 package universe

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -2,11 +2,12 @@ package universe
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strconv"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -27,7 +28,7 @@ const (
 	conversionArg = "v"
 )
 
-var errMissingArg = fmt.Errorf("missing argument %q", conversionArg)
+var errMissingArg = errors.Newf(codes.Invalid, "missing argument %q", conversionArg)
 
 type stringConv struct{}
 
@@ -114,7 +115,7 @@ func (c *stringConv) Call(ctx context.Context, args values.Object) (values.Value
 	case semantic.Duration:
 		str = v.Duration().String()
 	default:
-		return nil, fmt.Errorf("cannot convert %v to string", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to string", v.Type())
 	}
 	return values.NewString(str), nil
 }
@@ -210,7 +211,7 @@ func (c *intConv) Call(ctx context.Context, args values.Object) (values.Value, e
 	case semantic.Duration:
 		i = int64(v.Duration())
 	default:
-		return nil, fmt.Errorf("cannot convert %v to int", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to int", v.Type())
 	}
 	return values.NewInt(i), nil
 }
@@ -306,7 +307,7 @@ func (c *uintConv) Call(ctx context.Context, args values.Object) (values.Value, 
 	case semantic.Duration:
 		i = uint64(v.Duration())
 	default:
-		return nil, fmt.Errorf("cannot convert %v to uint", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to uint", v.Type())
 	}
 	return values.NewUInt(i), nil
 }
@@ -398,7 +399,7 @@ func (c *floatConv) Call(ctx context.Context, args values.Object) (values.Value,
 			float = 0
 		}
 	default:
-		return nil, fmt.Errorf("cannot convert %v to float", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to float", v.Type())
 	}
 	return values.NewFloat(float), nil
 }
@@ -478,7 +479,7 @@ func (c *boolConv) Call(ctx context.Context, args values.Object) (values.Value, 
 		case "false":
 			b = false
 		default:
-			return nil, fmt.Errorf("cannot convert string %q to bool", s)
+			return nil, errors.Newf(codes.Invalid, "cannot convert string %q to bool", s)
 		}
 	case semantic.Int:
 		switch n := v.Int(); n {
@@ -487,7 +488,7 @@ func (c *boolConv) Call(ctx context.Context, args values.Object) (values.Value, 
 		case 1:
 			b = true
 		default:
-			return nil, fmt.Errorf("cannot convert int %d to bool, must be 0 or 1", n)
+			return nil, errors.Newf(codes.Invalid, "cannot convert int %d to bool, must be 0 or 1", n)
 		}
 	case semantic.UInt:
 		switch n := v.UInt(); n {
@@ -496,7 +497,7 @@ func (c *boolConv) Call(ctx context.Context, args values.Object) (values.Value, 
 		case 1:
 			b = true
 		default:
-			return nil, fmt.Errorf("cannot convert uint %d to bool, must be 0 or 1", n)
+			return nil, errors.Newf(codes.Invalid, "cannot convert uint %d to bool, must be 0 or 1", n)
 		}
 	case semantic.Float:
 		switch n := v.Float(); n {
@@ -505,12 +506,12 @@ func (c *boolConv) Call(ctx context.Context, args values.Object) (values.Value, 
 		case 1:
 			b = true
 		default:
-			return nil, fmt.Errorf("cannot convert float %f to bool, must be 0 or 1", n)
+			return nil, errors.Newf(codes.Invalid, "cannot convert float %f to bool, must be 0 or 1", n)
 		}
 	case semantic.Bool:
 		b = v.Bool()
 	default:
-		return nil, fmt.Errorf("cannot convert %v to bool", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to bool", v.Type())
 	}
 	return values.NewBool(b), nil
 }
@@ -596,7 +597,7 @@ func (c *timeConv) Call(ctx context.Context, args values.Object) (values.Value, 
 	case semantic.Time:
 		t = v.Time()
 	default:
-		return nil, fmt.Errorf("cannot convert %v to time", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to time", v.Type())
 	}
 	return values.NewTime(t), nil
 }
@@ -682,7 +683,7 @@ func (c *durationConv) Call(ctx context.Context, args values.Object) (values.Val
 	case semantic.Duration:
 		d = v.Duration()
 	default:
-		return nil, fmt.Errorf("cannot convert %v to duration", v.Type())
+		return nil, errors.Newf(codes.Invalid, "cannot convert %v to duration", v.Type())
 	}
 	return values.NewDuration(d), nil
 }
@@ -705,7 +706,7 @@ var bytes = values.NewFunction(
 		case semantic.String:
 			return values.NewBytes([]byte(v.Str())), nil
 		default:
-			return nil, fmt.Errorf("cannot convert %v to bytes", v.Type())
+			return nil, errors.Newf(codes.Invalid, "cannot convert %v to bytes", v.Type())
 		}
 	},
 	false,

--- a/stdlib/universe/yield.go
+++ b/stdlib/universe/yield.go
@@ -1,9 +1,9 @@
 package universe
 
 import (
-	"fmt"
-
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 )
@@ -64,7 +64,7 @@ func newYieldProcedure(qs flux.OperationSpec, _ plan.Administration) (plan.Proce
 		return &YieldProcedureSpec{Name: spec.Name}, nil
 	}
 
-	return nil, fmt.Errorf("invalid spec type %T", qs)
+	return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
 }
 
 func (s *YieldProcedureSpec) Kind() plan.ProcedureKind {


### PR DESCRIPTION
The universe package now only uses annotated flux errors throughtout the
entire package. A utility has also been included in the `internal/cmd`
directory to check a package to ensure it does not use `errors.New` or
`fmt.Errorf`.

#1897

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written