### PR TITLE
feat(memory): add a memory manager to the memory allocator

### DIFF
--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -133,9 +133,9 @@ func CreateAllocatingFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a
 }
 
 func (s *AllocatingFromProcedureSpec) Run(ctx context.Context) {
-	if err := s.alloc.Allocate(s.ByteCount); err != nil {
-		panic(err)
-	}
+	// Allocate the amount of memory as specified in the byte count.
+	// This memory is not used or returned.
+	_ = s.alloc.Allocate(s.ByteCount)
 }
 
 func (s *AllocatingFromProcedureSpec) AddTransformation(t execute.Transformation) {

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -717,7 +717,9 @@ func TestExecutor_Execute(t *testing.T) {
 					{0, 1},
 				},
 			},
-			allocator: &memory.Allocator{Limit: func(v int64) *int64 { return &v }(64)},
+			allocator: &memory.Allocator{
+				Limit: func(v int64) *int64 { return &v }(64),
+			},
 			wantErr: &flux.Error{
 				Code: codes.ResourceExhausted,
 				Err: memory.LimitExceededError{

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/apache/arrow/go/arrow/memory"
@@ -22,14 +23,22 @@ type Allocator struct {
 	// can assign. If this is null, there is no limit.
 	Limit *int64
 
+	// Manager holds the Manager for this Allocator.
+	// If this Allocator has a limit set and the limit is to be exceeded,
+	// it will attempt to use the Manager to request more memory.
+	// If this fails, then the Allocator will panic.
+	Manager Manager
+
 	// Allocator is the underlying memory allocator used to
 	// allocate and free memory.
 	// If this is unset, the DefaultAllocator is used.
 	Allocator memory.Allocator
 
-	bytesAllocated int64
-	maxAllocated   int64
-	totalAllocated int64
+	allocationLimit int64
+	bytesAllocated  int64
+	maxAllocated    int64
+	totalAllocated  int64
+	mu              sync.Mutex
 }
 
 // Allocate will ensure that the requested memory is available and
@@ -129,12 +138,12 @@ func (a *Allocator) count(size int) error {
 		// to modify the bytes allocated.
 		for {
 			allocated := atomic.LoadInt64(&a.bytesAllocated)
-			if want := allocated + int64(size); want > *a.Limit {
-				return errors.Wrap(LimitExceededError{
-					Limit:     *a.Limit,
-					Allocated: allocated,
-					Wanted:    want - allocated,
-				}, codes.ResourceExhausted)
+			limit := atomic.LoadInt64(&a.allocationLimit)
+			if want := allocated + int64(size); want > limit {
+				if err := a.requestMemory(allocated, want); err != nil {
+					return err
+				}
+				// The request for additional memory succeeded so try again.
 			} else if atomic.CompareAndSwapInt64(&a.bytesAllocated, allocated, want) {
 				c = want
 				break
@@ -162,12 +171,69 @@ func (a *Allocator) count(size int) error {
 	return nil
 }
 
+func (a *Allocator) requestMemory(allocated, want int64) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Confirm that we still need to request more memory.
+	// This is because we did the initial check outside of the lock.
+	// This also acts as the way to initialize the allocation limit.
+	if want <= *a.Limit {
+		atomic.StoreInt64(&a.allocationLimit, *a.Limit)
+		return nil
+	}
+
+	// If we do not have a memory manager, then there is no
+	// way to increase our allocation limit.
+	if a.Manager != nil {
+		// Request that additional memory is needed from the manager.
+		need := want - *a.Limit
+		n, err := a.Manager.RequestMemory(need)
+		if err == nil {
+			// Increase the limit by the amount the manager gave us.
+			*a.Limit += n
+			atomic.StoreInt64(&a.allocationLimit, *a.Limit)
+			return nil
+		}
+		// Ignore the error. We use our own custom one so we just
+		// needed to know it failed.
+	}
+	return errors.Wrap(LimitExceededError{
+		Limit:     *a.Limit,
+		Allocated: allocated,
+		Wanted:    want - allocated,
+	}, codes.ResourceExhausted)
+}
+
 // allocator returns the underlying memory.Allocator that should be used.
 func (a *Allocator) allocator() memory.Allocator {
 	if a.Allocator == nil {
 		return DefaultAllocator
 	}
 	return a.Allocator
+}
+
+// Manager will manage the memory allowed for the Allocator.
+// The Allocator may use the Manager to request additional memory or to
+// give back memory that is currently in use by the Allocator
+// when/if it is no longer needed.
+type Manager interface {
+	// RequestMemory will request that the given amount of memory
+	// be reserved for the caller. The manager will return the number
+	// of bytes that were successfully reserved. The n value will be
+	// either equal to or greater than the requested number of bytes.
+	// If the manager cannot reserve at least bytes in memory, then
+	// it will return an error with the details.
+	RequestMemory(want int64) (got int64, err error)
+
+	// FreeMemory will inform the memory manager that this memory
+	// is not being used anymore.
+	// It is not required for this to be called similar to how
+	// it is not necessary for a program to free the memory.
+	// It is the responsibility of the manager itself to identify
+	// when this allocator is not used anymore and to reclaim any
+	// unfreed memory when the resource is dead.
+	FreeMemory(bytes int64)
 }
 
 // LimitExceededError is an error when the allocation limit is exceeded.

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -1,9 +1,12 @@
 package memory_test
 
 import (
+	"sync"
 	"testing"
 
 	arrowmemory "github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 )
 
@@ -200,5 +203,141 @@ func TestAllocator_Free(t *testing.T) {
 	}
 	if want, got := int64(64), allocator.MaxAllocated(); want != got {
 		t.Fatalf("unexpected max allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+type MockMemoryManager struct {
+	Left      int64
+	RequestFn func(want int64) int64
+}
+
+func (m *MockMemoryManager) RequestMemory(want int64) (n int64, err error) {
+	if m.Left < want {
+		return 0, errors.New(codes.ResourceExhausted)
+	}
+	n = want
+	if m.RequestFn != nil {
+		n = m.RequestFn(want)
+	}
+	m.Left -= n
+	return n, nil
+}
+
+func (m *MockMemoryManager) FreeMemory(bytes int64) {
+	m.Left += bytes
+}
+
+func TestAllocator_RequestMemory(t *testing.T) {
+	// Allow the memory manager to allocate 64 bytes.
+	manager := &MockMemoryManager{
+		Left: 64,
+	}
+
+	// Set the Limit to 64 and allocate 32 bytes of it.
+	// This should not request more memory from the manager.
+	allocator := &memory.Allocator{
+		Limit:   func(v int64) *int64 { return &v }(64),
+		Manager: manager,
+	}
+	if err := allocator.Account(32); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(32), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), *allocator.Limit; want != got {
+		t.Fatalf("unexpected allocater limit -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(64), manager.Left; want != got {
+		t.Fatalf("unexpected memory left in the manager -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Now request more than would be normally allowed and see that the manager
+	// actually gives it more memory.
+	if err := allocator.Account(64); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(96), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(96), *allocator.Limit; want != got {
+		t.Fatalf("unexpected allocater limit -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(32), manager.Left; want != got {
+		t.Fatalf("unexpected memory left in the manager -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+
+	// Now request too much memory that the manager can't and won't give it.
+	if err := allocator.Account(64); err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Change the allocator so it will give double the amount of requested memory
+	// instead of the exact amount requested.
+	manager.RequestFn = func(want int64) int64 {
+		return want * 2
+	}
+
+	// Request 16 bytes of memory. The manager should give us 32 bytes.
+	// We now test that the allocator increases its limit by the amount
+	// the manager gives it rather than the request.
+	if err := allocator.Account(16); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if want, got := int64(112), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(128), *allocator.Limit; want != got {
+		t.Fatalf("unexpected allocater limit -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(0), manager.Left; want != got {
+		t.Fatalf("unexpected memory left in the manager -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+// This test makes a lot of small allocations and has the memory manager
+// only give small amounts of memory so that multiple goroutines are requesting
+// memory from the manager concurrently. This is to ensure that requesting
+// memory many times concurrently doesn't create a race condition.
+func TestAllocator_RequestMemory_Concurrently(t *testing.T) {
+	// Allow the memory manager to allocate 64 bytes.
+	manager := &MockMemoryManager{
+		Left: 128 * 128,
+	}
+
+	// Set the Limit to 64 and allocate 32 bytes of it.
+	// This should not request more memory from the manager.
+	allocator := &memory.Allocator{
+		Limit:   func(v int64) *int64 { return &v }(0),
+		Manager: manager,
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 128; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 128; i++ {
+				if err := allocator.Account(1); err != nil {
+					t.Errorf("unexpected error: %s", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Once we are finished, the allocator should have its limit set
+	// to the total amount of the memory manager.
+	if want, got := int64(128*128), allocator.Allocated(); want != got {
+		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(128*128), *allocator.Limit; want != got {
+		t.Fatalf("unexpected allocater limit -want/+got\n\t- %d\n\t+ %d", want, got)
+	}
+	if want, got := int64(0), manager.Left; want != got {
+		t.Fatalf("unexpected memory left in the manager -want/+got\n\t- %d\n\t+ %d", want, got)
 	}
 }


### PR DESCRIPTION
This adds a `memory.Manager` interface that will allow the
`memory.Allocator` to request more memory when more is needed. If this
value is not set, the previous behavior of failing instantaneously will
continue.

This is needed for influxdata/influxdb#15265.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written