### PR TITLE
refactor(plan): add a WithDetails() option to plan.Formatted

### DIFF
--- a/plan/format.go
+++ b/plan/format.go
@@ -1,10 +1,16 @@
 package plan
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+)
 
 type FormatOption func(*formatter)
 
-// TODO(cwolff): enhance the this output to make it more useful
+// Formatted accepts a plan.Spec and options, and returns a Formatter
+// that can be used with the standard fmt package, e.g.,
+//   fmt.Println(Formatted(plan, WithDetails())
 func Formatted(p *Spec, opts ...FormatOption) fmt.Formatter {
 	f := formatter{
 		p: p,
@@ -15,24 +21,57 @@ func Formatted(p *Spec, opts ...FormatOption) fmt.Formatter {
 	return f
 }
 
+// WithDetails returns a FormatOption that can be used to provide extra details
+// in a formatted plan.
+func WithDetails() FormatOption {
+	return func(f *formatter) {
+		f.withDetails = true
+	}
+}
+
+// Detailer provides an optional interface that ProcedureSpecs can implement.
+// Implementors of this interface will have their details appear in the
+// formatted output for a plan if the WithDetails() option is set.
+type Detailer interface {
+	PlanDetails() string
+}
+
 type formatter struct {
-	p *Spec
+	withDetails bool
+	p           *Spec
 }
 
 func (f formatter) Format(fs fmt.State, c rune) {
-	fmt.Fprintf(fs, "\ndigraph {\n")
+	// Panicking while producing debug output is frustrating, so catch any panics and
+	// continue if that happens.
+	defer func() {
+		if e := recover(); e != nil {
+			_, _ = fmt.Fprintf(fs, "panic while formatting plan: %v\n", e)
+			_, _ = fmt.Fprintf(fs, "stack: %s\n", string(debug.Stack()))
+		}
+	}()
+
+	_, _ = fmt.Fprintf(fs, "digraph {\n")
 	var edges []string
-	f.p.BottomUpWalk(func(pn Node) error {
-		fmt.Fprintf(fs, "  %v\n", pn.ID())
+	_ = f.p.BottomUpWalk(func(pn Node) error {
+		_, _ = fmt.Fprintf(fs, "  %v\n", pn.ID())
+		if f.withDetails {
+			if d, ok := pn.ProcedureSpec().(Detailer); ok {
+				lines := strings.Split(strings.TrimSpace(d.PlanDetails()), "\n")
+				for _, line := range lines {
+					_, _ = fmt.Fprintf(fs, "  // %s\n", line)
+				}
+			}
+		}
 		for _, pred := range pn.Predecessors() {
 			edges = append(edges, fmt.Sprintf("  %v -> %v", pred.ID(), pn.ID()))
 		}
 		return nil
 	})
 
-	fmt.Fprintf(fs, "\n")
+	_, _ = fmt.Fprintf(fs, "\n")
 	for _, e := range edges {
-		fmt.Fprintf(fs, "%v\n", e)
+		_, _ = fmt.Fprintf(fs, "%v\n", e)
 	}
-	fmt.Fprintf(fs, "}\n")
+	_, _ = fmt.Fprintf(fs, "}\n")
 }

--- a/plan/format_test.go
+++ b/plan/format_test.go
@@ -1,0 +1,84 @@
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/andreyvit/diff"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
+	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values/valuestest"
+)
+
+func TestFormatted(t *testing.T) {
+	fromSpec := &influxdb.FromProcedureSpec{
+		Bucket: "my-bucket",
+	}
+
+	// (r) => r._value > 5.0
+	filterSpec := &universe.FilterProcedureSpec{
+		Fn: interpreter.ResolvedFunction{
+			Fn: &semantic.FunctionExpression{
+				Block: &semantic.FunctionBlock{
+					Parameters: &semantic.FunctionParameters{
+						List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+					},
+					Body: &semantic.BinaryExpression{
+						Operator: ast.GreaterThanOperator,
+						Left: &semantic.MemberExpression{
+							Object:   &semantic.IdentifierExpression{Name: "r"},
+							Property: "_value",
+						},
+						Right: &semantic.FloatLiteral{Value: 5},
+					},
+				},
+			},
+			Scope: valuestest.NowScope(),
+		},
+	}
+
+	type testcase struct {
+		name string
+		plan *plantest.PlanSpec
+		want string
+	}
+
+	tcs := []testcase{
+		{
+			name: "from |> filter",
+			plan: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", fromSpec),
+					plan.CreateLogicalNode("filter", filterSpec),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			want: `digraph {
+  from
+  filter
+  // r._value > 5.000000
+
+  from -> filter
+}
+`,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ps := plantest.CreatePlanSpec(tc.plan)
+			got := fmt.Sprintf("%v", plan.Formatted(ps, plan.WithDetails()))
+			if tc.want != got {
+				t.Fatalf("unexpected output: -want/+got:\n%v", diff.LineDiff(tc.want, got))
+			}
+		})
+	}
+}

--- a/semantic/format.go
+++ b/semantic/format.go
@@ -1,0 +1,108 @@
+package semantic
+
+import (
+	"fmt"
+	"strings"
+)
+
+type FormatOption func(*formatter)
+
+// Formatted produces a Formatter object suitable for printing
+// using the standard fmt package.
+// Currently only works for some expressions.
+func Formatted(n Node, opts ...FormatOption) fmt.Formatter {
+	f := formatter{
+		n: n,
+	}
+	for _, o := range opts {
+		o(&f)
+	}
+	return f
+}
+
+type formatter struct {
+	n Node
+}
+
+func (f formatter) Format(fs fmt.State, c rune) {
+	v := &formattingVisitor{}
+	Walk(v, f.n)
+	var result string
+	if len(v.stack) == 0 {
+		result = "<semantic format error, empty stack>"
+	} else if len(v.stack) > 1 {
+		var sb strings.Builder
+		sb.WriteString("<semantic format error, big stack:")
+		for _, s := range v.stack {
+			sb.WriteString(" " + s)
+		}
+		sb.WriteString(">")
+		result = sb.String()
+	} else {
+		result = v.stack[0]
+	}
+	fmt.Fprintf(fs, "%v", result)
+}
+
+type formattingVisitor struct {
+	stack []string
+}
+
+func (v *formattingVisitor) push(s string) {
+	v.stack = append(v.stack, s)
+}
+
+func (v *formattingVisitor) pop() string {
+	l := len(v.stack)
+	if l == 0 {
+		return "<semantic format error, pop empty>"
+	}
+	s := v.stack[l-1]
+	v.stack = v.stack[:l-1]
+	return s
+}
+
+func (v *formattingVisitor) Visit(node Node) Visitor {
+	switch n := node.(type) {
+	case *LogicalExpression:
+	case *BinaryExpression:
+	case *MemberExpression:
+	case *StringLiteral:
+	case *FloatLiteral:
+	case *IntegerLiteral:
+	case *IdentifierExpression:
+	default:
+		// Do not recurse into unknown nodes, just push an error string
+		// onto the stack
+		v.push(fmt.Sprintf("<semantic format error, unknown node %T>", n))
+		return nil
+	}
+
+	return v
+}
+
+func (v *formattingVisitor) Done(node Node) {
+	switch n := node.(type) {
+	case *LogicalExpression:
+		rhs := v.pop()
+		lhs := v.pop()
+		v.push(lhs + " " + n.Operator.String() + " " + rhs)
+	case *BinaryExpression:
+		rhs := v.pop()
+		lhs := v.pop()
+		v.push(lhs + " " + n.Operator.String() + " " + rhs)
+	case *MemberExpression:
+		o := v.pop()
+		v.push(o + "." + n.Property)
+	case *StringLiteral:
+		v.push("\"" + n.Value + "\"")
+	case *FloatLiteral:
+		// %f will add zeros even for whole numbers, it's possible to easily tell
+		// the difference between integers and floats in output.
+		v.push(fmt.Sprintf("%f", n.Value))
+	case *IntegerLiteral:
+		v.push(fmt.Sprintf("%v", n.Value))
+	case *IdentifierExpression:
+		v.push(n.Name)
+	}
+}

--- a/semantic/format_test.go
+++ b/semantic/format_test.go
@@ -1,0 +1,53 @@
+package semantic_test
+
+import (
+	"fmt"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
+	"testing"
+)
+
+func TestFormatted(t *testing.T) {
+	type testcase struct {
+		name string
+		flux string
+		want string
+	}
+
+	tcs := []testcase{
+		{
+			name: "filter expression",
+			flux: `r._measurement == "cpu" and r._field != "usage_system"`,
+			want: `r._measurement == "cpu" and r._field != "usage_system"`,
+		},
+		{
+			name: "arithmetic expression multiply/divide",
+			flux: `i * 3 > 0 and j / 7.0 >= 0`,
+			want: `i * 3 > 0 and j / 7.000000 >= 0`,
+		},
+		{
+			name: "arithmetic expression plus/minus",
+			flux: `i + 3 < 0 and j - 7 <= 37`,
+			want: `i + 3 < 0 and j - 7 <= 37`,
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ast, err := flux.Parse(tc.flux)
+			if err != nil {
+				t.Fatal(err)
+			}
+			semPkg, err := semantic.New(ast)
+			if err != nil {
+				t.Fatal(err)
+			}
+			semExpr := semPkg.Files[0].Body[0].(*semantic.ExpressionStatement).Expression
+			got := fmt.Sprintf("%v", semantic.Formatted(semExpr))
+			if tc.want != got {
+				t.Fatalf("unexpected output: -want/+got:\n- %v\n+ %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -113,6 +113,14 @@ func createFilterTransformation(id execute.DatasetID, mode execute.AccumulationM
 	return t, d, nil
 }
 
+func (s *FilterProcedureSpec) PlanDetails() string {
+	body := s.Fn.Fn.Block.Body
+	if expr, ok := body.(semantic.Expression); ok {
+		return fmt.Sprintf("%v", semantic.Formatted(expr))
+	}
+	return "<non-Expression>"
+}
+
 type filterTransformation struct {
 	d     *execute.PassthroughDataset
 	ctx   context.Context


### PR DESCRIPTION
This provides a way for ProcedureSpecs to add details to debug output.
E.g., for showing the filters that have been pushed into a source.
