### PR TITLE
fix(stdlib/universe): add back missing import

### DIFF
--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"


### PR DESCRIPTION
It looks like f6fa52a removed the fmt import, and then 843bb95 was
merged and included a call to fmt.Sprintf, but unfortunately the
resultant merge left the file with a missing import. Duly noted as
another case of outdated PRs causing a broken master branch.