### PR TITLE
feat(rust/parser): demonstrate building Rust from Go

### DIFF
--- a/internal/rust/main.go
+++ b/internal/rust/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/influxdata/flux/internal/rust/parser"
+)
+
+func main() {
+	for _, arg := range os.Args[1:] {
+		buf, err := ioutil.ReadFile(arg)
+		if err != nil {
+			panic(err)
+		}
+
+		content := string(buf)
+		parser.Parse(content)
+	}
+}

--- a/internal/rust/parser/Cargo.lock
+++ b/internal/rust/parser/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "scanner 0.1.0",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/internal/rust/parser/Cargo.toml
+++ b/internal/rust/parser/Cargo.toml
@@ -13,11 +13,12 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 scanner = {path = "../scanner" }
 ast = {path = "../ast" }
+serde_json = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
 
 # https://rustwasm.github.io/docs/book/reference/code-size.html#optimizing-builds-for-code-size
 [profile.release]
-lto = true
+lto = false
 opt-level = 'z'

--- a/internal/rust/parser/parser.go
+++ b/internal/rust/parser/parser.go
@@ -1,0 +1,19 @@
+package parser
+
+//go:generate cargo build --release
+
+// #cgo LDFLAGS: -L${SRCDIR}/target/release -ldl -Wl,-Bstatic -lflux_parser -Wl,-Bdynamic
+// #include <stdlib.h>
+// void flux_parse_json(const char*);
+import "C"
+
+import (
+	"unsafe"
+)
+
+func Parse(input string) {
+	cstr := C.CString(input)
+	defer C.free(unsafe.Pointer(cstr))
+
+	C.flux_parse_json(cstr)
+}

--- a/internal/rust/parser/src/lib.rs
+++ b/internal/rust/parser/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 use std::str;
 
 use ast::*;
@@ -18,15 +19,19 @@ pub fn parse(s: &str) -> JsValue {
     return JsValue::from_serde(&file).unwrap();
 }
 
-// TODO uncomment when we get back to the Go build side.
-//#[no_mangle]
-//pub fn go_parse(s: *const c_char) {
-//    let buf = unsafe {
-//        CStr::from_ptr(s).to_bytes()
-//    };
-//    let str = String::from_utf8(buf.to_vec()).unwrap();
-//    println!("Parse in Rust {}", str);
-//}
+#[no_mangle]
+pub fn flux_parse_json(s: *const c_char) {
+    let buf = unsafe { CStr::from_ptr(s).to_bytes() };
+    let str = String::from_utf8(buf.to_vec()).unwrap();
+    let mut p = Parser::new(&str);
+    let file = p.parse_file(String::from(""));
+
+    let j = serde_json::to_string(&file);
+    match j {
+        Ok(v) => println!("{}", v),
+        Err(e) => println!("{}", e),
+    }
+}
 
 fn format_token(t: T) -> &'static str {
     match t {


### PR DESCRIPTION
DO NOT MERGE this is just an example of how the pieces fit together.

The Go binary can be built and run using:
```
go generate ./internal/rust/...
go run ./internal/rust/ <path to Flux file>
```

