### PR TITLE
fix(csv): return the EOF error when reading metadata

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -184,7 +184,9 @@ func newResultDecoder(cr *csv.Reader, c ResultDecoderConfig, extraMeta *tableMet
 	if extraMeta == nil {
 		tm, err := readMetadata(d.cr, c, nil)
 		if err != nil {
-			if sfe, ok := err.(*serializedFluxError); ok {
+			if err == io.EOF {
+				return nil, err
+			} else if sfe, ok := err.(*serializedFluxError); ok {
 				return nil, sfe.err
 			}
 			return nil, errors.Wrap(err, codes.Inherit, "failed to read metadata")


### PR DESCRIPTION
This EOF was read by another portion of the code and it was swallowed to
ensure that an EOF in the proper location did not result in an error.
This is readding code that was previously there in `v0.49.0`.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written