### PR TITLE
feat(stdlib/sql): add sqlite3 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-runewidth v0.0.3 // indirect
+	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/opentracing/opentracing-go v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
+github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 h1:d8RFOZ2IiFtFWBcKEHAFYJcPTf0wY5q0exFNJZVWa1U=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/mattn/go-zglob v0.0.0-20171230104132-4959821b4817/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 const FromSQLKind = "fromSQL"
@@ -117,6 +118,8 @@ func createFromSQLSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 	switch spec.DriverName {
 	case "mysql":
 		newRowReader = NewMySQLRowReader
+	case "sqlite3":
+		newRowReader = NewSqliteRowReader
 	case "postgres", "sqlmock":
 		newRowReader = NewPostgresRowReader
 	default:
@@ -189,7 +192,6 @@ func read(ctx context.Context, reader execute.RowReader, alloc *memory.Allocator
 			return nil, err
 		}
 	}
-
 	for reader.Next() {
 		row, err := reader.GetNextRow()
 		if err != nil {

--- a/stdlib/sql/sqlite.go
+++ b/stdlib/sql/sqlite.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"database/sql"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/influxdata/flux"
@@ -13,7 +12,7 @@ import (
 	"github.com/influxdata/flux/values"
 )
 
-type MySQLRowReader struct {
+type SqliteRowReader struct {
 	Cursor      *sql.Rows
 	columns     []interface{}
 	columnTypes []flux.ColType
@@ -22,8 +21,7 @@ type MySQLRowReader struct {
 	CloseFunc   func() error
 }
 
-// Next prepares MySQLRowReader to return rows
-func (m *MySQLRowReader) Next() bool {
+func (m *SqliteRowReader) Next() bool {
 	if m.NextFunc != nil {
 		return m.NextFunc()
 	}
@@ -45,16 +43,14 @@ func (m *MySQLRowReader) Next() bool {
 	return next
 }
 
-func (m *MySQLRowReader) GetNextRow() ([]values.Value, error) {
+func (m *SqliteRowReader) GetNextRow() ([]values.Value, error) {
 	row := make([]values.Value, len(m.columns))
 	for i, col := range m.columns {
 		switch col := col.(type) {
 		case bool, int64, uint64, float64, string:
 			row[i] = values.New(col)
 		case []uint8:
-			// Hack for MySQL, might need to work with charset?
-			// Can't do boolean with MySQL - stores BOOLEANs as TINYINTs (0 or 1)
-			// No way to distinguish if intended int or bool
+			// this allows easier testing using existing methods
 			switch m.columnTypes[i] {
 			case flux.TInt:
 				newInt, err := UInt8ToInt64(col)
@@ -68,7 +64,6 @@ func (m *MySQLRowReader) GetNextRow() ([]values.Value, error) {
 					return nil, err
 				}
 				row[i] = values.NewFloat(newFloat)
-			// This works, but you can also just just add the DSN parameter parseTime=true (see line 136)
 			case flux.TTime:
 				t, err := time.Parse(layout, string(col))
 				if err != nil {
@@ -89,20 +84,24 @@ func (m *MySQLRowReader) GetNextRow() ([]values.Value, error) {
 	return row, nil
 }
 
-func (m *MySQLRowReader) InitColumnNames(names []string) {
-	m.columnNames = names
+func (m *SqliteRowReader) InitColumnNames(n []string) {
+	m.columnNames = n
 }
 
-func (m *MySQLRowReader) InitColumnTypes(types []*sql.ColumnType) {
+func (m *SqliteRowReader) InitColumnTypes(types []*sql.ColumnType) {
 	stringTypes := make([]flux.ColType, len(types))
 	for i := 0; i < len(types); i++ {
 		switch types[i].DatabaseTypeName() {
-		case "INT", "BIGINT", "SMALLINT", "TINYINT":
+		case "INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT":
 			stringTypes[i] = flux.TInt
 		case "FLOAT", "DOUBLE":
 			stringTypes[i] = flux.TFloat
-		case "DATETIME":
+		case "DATETIME", "TIMESTAMP", "DATE":
 			stringTypes[i] = flux.TTime
+		case "TEXT":
+			stringTypes[i] = flux.TString
+		case "BOOL", "BOOLEAN":
+			stringTypes[i] = flux.TInt
 		default:
 			stringTypes[i] = flux.TString
 		}
@@ -110,52 +109,31 @@ func (m *MySQLRowReader) InitColumnTypes(types []*sql.ColumnType) {
 	m.columnTypes = stringTypes
 }
 
-func (m *MySQLRowReader) ColumnNames() []string {
+func (m *SqliteRowReader) ColumnNames() []string {
 	return m.columnNames
 }
 
-func (m *MySQLRowReader) ColumnTypes() []flux.ColType {
+func (m *SqliteRowReader) ColumnTypes() []flux.ColType {
 	return m.columnTypes
 }
 
-func (m *MySQLRowReader) SetColumnTypes(types []flux.ColType) {
+func (m *SqliteRowReader) SetColumnTypes(types []flux.ColType) {
 	m.columnTypes = types
 }
 
-func (m *MySQLRowReader) SetColumns(i []interface{}) {
+func (m *SqliteRowReader) SetColumns(i []interface{}) {
 	m.columns = i
 }
 
-func (m *MySQLRowReader) Close() error {
-	if m.CloseFunc != nil {
-		return m.CloseFunc()
-	}
+func (m *SqliteRowReader) Close() error {
 	if err := m.Cursor.Err(); err != nil {
 		return err
 	}
 	return m.Cursor.Close()
 }
 
-func UInt8ToFloat(a []uint8) (float64, error) {
-	str := string(a)
-	s, err := strconv.ParseFloat(str, 64)
-	if err != nil {
-		return s, err
-	}
-	return s, nil
-}
-
-func UInt8ToInt64(a []uint8) (int64, error) {
-	str := string(a)
-	s, err := strconv.ParseInt(str, 0, 64)
-	if err != nil {
-		return s, err
-	}
-	return s, nil
-}
-
-func NewMySQLRowReader(r *sql.Rows) (execute.RowReader, error) {
-	reader := &MySQLRowReader{
+func NewSqliteRowReader(r *sql.Rows) (execute.RowReader, error) {
+	reader := &SqliteRowReader{
 		Cursor: r,
 	}
 	cols, err := r.Columns()
@@ -169,21 +147,17 @@ func NewMySQLRowReader(r *sql.Rows) (execute.RowReader, error) {
 		return nil, err
 	}
 	reader.InitColumnTypes(types)
-
 	return reader, nil
 }
 
-// MysqlTranslateColumn translates flux colTypes into their corresponding MySQL column type
-func MysqlTranslateColumn() translationFunc {
+// SqliteTranslateColumn translates flux colTypes into their corresponding SQLite column type
+func SqliteTranslateColumn() translationFunc {
 	c := map[string]string{
 		flux.TFloat.String():  "FLOAT",
-		flux.TInt.String():    "BIGINT",
-		flux.TUInt.String():   "BIGINT",
-		flux.TString.String(): "TEXT(16383)",
+		flux.TInt.String():    "INT",
+		flux.TUInt.String():   "INT",
+		flux.TString.String(): "TEXT",
 		flux.TTime.String():   "DATETIME",
-		flux.TBool.String():   "BOOL",
-		// BOOL is a synonym supplied by MySQL for "convenience", and MYSQL turns this into a TINYINT type under the hood
-		// which means that looking at the schema afterwards shows the columntype as TINYINT, and not bool!
 	}
 	return func(f flux.ColType, colname string) (string, error) {
 		s, found := c[f.String()]

--- a/stdlib/sql/sqlite_test.go
+++ b/stdlib/sql/sqlite_test.go
@@ -1,0 +1,136 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/values"
+)
+
+func TestBoolTranslation(t *testing.T) {
+	// write values to "DB" - as would be done by sql.to() - using sqlite3 as it allows maximum levels of type abuse, and therefore likely the largest
+	// potential for issues
+	db, err := sql.Open("sqlite3", ":memory:")
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// create table - column type can be anything
+	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS bools (name TEXT, age INT, employed BOOL)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert first row - BOOL as BOOL, which sqlite WILL accept as a write - and silently store true as 1
+	q = fmt.Sprintf("INSERT INTO bools (name, age, employed) VALUES (\"albert\",110,true)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert second row - BOOL as INT - again, will accept ok
+	q = fmt.Sprintf("INSERT INTO bools (name, age, employed) VALUES (\"mary\",10,1)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	q = fmt.Sprintf("SELECT * FROM bools")
+	results, err := db.Query(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// read the data back out and check that Flux fails here - we should not be doing magic type casts
+	TestReader := &SqliteRowReader{
+		Cursor: results,
+	}
+
+	TestReader.columnNames = []string{"name", "age", "employed"}
+	TestReader.columnTypes = []flux.ColType{flux.TString, flux.TInt, flux.TInt}
+
+	// all rows should fail to parse into Flux types becuase there is no SQLite boolean type, regardless of what the column "type" is
+	for TestReader.Next() {
+		row, _ := TestReader.GetNextRow()
+		// fail as BOOL
+		if cmp.Equal(values.NewBool(true), row[2]) {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(values.NewBool(true), row[2]))
+		}
+		// succeed as INT, which is what it actually is
+		if !cmp.Equal(values.NewInt(1), row[2]) {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(values.NewInt(1), row[2]))
+		}
+
+	}
+
+}
+
+func TestNulTranslation(t *testing.T) {
+	// write values to "DB" - as would be done by sql.to() - using sqlite3 as it allows maximum levels of type abuse, and therefore likely the largest
+	// potential for issues
+	db, err := sql.Open("sqlite3", ":memory:")
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// create table
+	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS magic (name TEXT, age INT, employed BADINTBOOL)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert first row - null string
+	q = fmt.Sprintf("INSERT INTO magic (age, employed) VALUES (11,true)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert second row - null int
+	q = fmt.Sprintf("INSERT INTO magic (name, employed) VALUES (\"mary\",true)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert third row - null bool
+	q = fmt.Sprintf("INSERT INTO magic (name, age) VALUES (\"casper\",10)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	q = fmt.Sprintf("SELECT * FROM magic")
+	results, err := db.Query(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// read the data back out and check
+	TestReader := &SqliteRowReader{
+		Cursor: results,
+	}
+
+	TestReader.columnNames = []string{"name", "age", "employed"}
+	TestReader.columnTypes = []flux.ColType{flux.TString, flux.TInt, flux.TBool}
+
+	// number of columns == number of rows - and Nill goes left -> right. otherwise the following loop will fail
+	i := 0
+	for TestReader.Next() {
+		row, err := TestReader.GetNextRow()
+		// none should throw errors - expect them all to handle Nulls from DB correctly
+		if !cmp.Equal(err, nil) {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+		}
+		if !row[i].IsNull() {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(true, row[i].IsNull()))
+		}
+		i++
+	}
+
+}

--- a/stdlib/sql/to_privates_test.go
+++ b/stdlib/sql/to_privates_test.go
@@ -1,0 +1,252 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// additional and seperate tests that can be run without needing functions to be Exported in sql, just to be testable
+func TestCorrectBatchSize(t *testing.T) {
+	// given the combination of row width and supplied batchSize argument from user, verify that it is modified as required
+	userBatchSize := 1000
+	rowWidth := 10
+	correctedSize := correctBatchSize(userBatchSize, rowWidth)
+	if !cmp.Equal(99, correctedSize) {
+		t.Log(cmp.Diff(90, correctedSize))
+		t.Fail()
+	}
+
+	// verify that the batchSoze is not lower than the width of a single row - if it ever is, we have a big problem
+	userBatchSize = 1
+	correctedSize = correctBatchSize(userBatchSize, rowWidth)
+	if !cmp.Equal(10, correctedSize) {
+		t.Log(cmp.Diff(10, correctedSize))
+		t.Fail()
+	}
+
+	userBatchSize = -1
+	correctedSize = correctBatchSize(userBatchSize, rowWidth)
+	if !cmp.Equal(10, correctedSize) {
+		t.Log(cmp.Diff(10, correctedSize))
+		t.Fail()
+	}
+}
+
+func TestTranslation(t *testing.T) {
+	// verify that this works as it should - used here to avoid exporting this functionality
+	columnLabel := "apples"
+	// verify invalid return error
+	_, err := getTranslationFunc("bananas")
+	if !cmp.Equal(errors.New(codes.Internal, "invalid driverName: bananas").Error(), err.Error()) {
+		t.Log(cmp.Diff(errors.New(codes.Internal, "invalid driverName: bananas").Error(), err.Error()))
+		t.Fail()
+	}
+
+	// verify that valid returns expected hapiness for SQLITE
+	sqlT, err := getTranslationFunc("sqlite3")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	// float
+	v, err := sqlT()(flux.TFloat, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" FLOAT", v) {
+		t.Log(cmp.Diff(columnLabel+" FLOAT", v))
+		t.Fail()
+	}
+	// int
+	v, err = sqlT()(flux.TInt, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" INT", v) {
+		t.Log(cmp.Diff(columnLabel+" INT", v))
+		t.Fail()
+	}
+	// uint
+	v, err = sqlT()(flux.TUInt, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" INT", v) {
+		t.Log(cmp.Diff(columnLabel+" INT", v))
+		t.Fail()
+	}
+	// string
+	v, err = sqlT()(flux.TString, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" TEXT", v) {
+		t.Log(cmp.Diff(columnLabel+" TEXT", v))
+		t.Fail()
+	}
+	// time
+	v, err = sqlT()(flux.TTime, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" DATETIME", v) {
+		t.Log(cmp.Diff(columnLabel+" DATETIME", v))
+		t.Fail()
+	}
+	// as SQLITE has NO BOOLEAN column type, we need to return an error rather than doing implicit conversions
+	_, err = sqlT()(flux.TBool, columnLabel)
+	if cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal("DB does not support column type bool", err.Error()) {
+		t.Log(cmp.Diff("DB does not support column type bool", err.Error()))
+		t.Fail()
+	}
+
+	// verify that valid returns expected hapiness for postgres
+	sqlT, err = getTranslationFunc("postgres")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	// float
+	v, err = sqlT()(flux.TFloat, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" FLOAT", v) {
+		t.Log(cmp.Diff(columnLabel+" FLOAT", v))
+		t.Fail()
+	}
+	// int
+	v, err = sqlT()(flux.TInt, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" BIGINT", v) {
+		t.Log(cmp.Diff(columnLabel+" BIGINT", v))
+		t.Fail()
+	}
+	// uint
+	v, err = sqlT()(flux.TUInt, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" BIGINT", v) {
+		t.Log(cmp.Diff(columnLabel+" BIGINT", v))
+		t.Fail()
+	}
+	// string
+	v, err = sqlT()(flux.TString, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" text", v) {
+		t.Log(cmp.Diff(columnLabel+" text", v))
+		t.Fail()
+	}
+	// time
+	v, err = sqlT()(flux.TTime, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" TIMESTAMP", v) {
+		t.Log(cmp.Diff(columnLabel+" TIMESTAMP", v))
+		t.Fail()
+	}
+	// bool
+	v, err = sqlT()(flux.TBool, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" BOOL", v) {
+		t.Log(cmp.Diff(columnLabel+" BOOL", v))
+		t.Fail()
+	}
+
+	// verify that valid returns expected hapiness for MySQL
+	sqlT, err = getTranslationFunc("mysql")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	// float
+	v, err = sqlT()(flux.TFloat, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" FLOAT", v) {
+		t.Log(cmp.Diff(columnLabel+" FLOAT", v))
+		t.Fail()
+	}
+	// int
+	v, err = sqlT()(flux.TInt, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" BIGINT", v) {
+		t.Log(cmp.Diff(columnLabel+" BIGINT", v))
+		t.Fail()
+	}
+	// uint
+	v, err = sqlT()(flux.TUInt, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" BIGINT", v) {
+		t.Log(cmp.Diff(columnLabel+" BIGINT", v))
+		t.Fail()
+	}
+	// string
+	v, err = sqlT()(flux.TString, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" TEXT(16383)", v) {
+		t.Log(cmp.Diff(columnLabel+" TEXT(16383)", v))
+		t.Fail()
+	}
+	// time
+	v, err = sqlT()(flux.TTime, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" DATETIME", v) {
+		t.Log(cmp.Diff(columnLabel+" DATETIME", v))
+		t.Fail()
+	}
+	// bool
+	v, err = sqlT()(flux.TBool, columnLabel)
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal(columnLabel+" BOOL", v) {
+		t.Log(cmp.Diff(columnLabel+" BOOL", v))
+		t.Fail()
+	}
+
+}

--- a/stdlib/sql/to_test.go
+++ b/stdlib/sql/to_test.go
@@ -1,8 +1,9 @@
 package sql_test
 
 import (
-	"github.com/influxdata/flux/plan"
 	"testing"
+
+	"github.com/influxdata/flux/plan"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/go-cmp/cmp"
@@ -21,7 +22,7 @@ func TestSqlTo(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
 			Name: "from with database",
-			Raw:  `import "sql" from(bucket: "mybucket") |> sql.to(driverName:"sqlmock", dataSourceName:"root@/db", table:"TestTable")`,
+			Raw:  `import "sql" from(bucket: "mybucket") |> sql.to(driverName:"sqlmock", dataSourceName:"root@/db", table:"TestTable", batchSize:10000)`,
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
@@ -36,6 +37,45 @@ func TestSqlTo(t *testing.T) {
 							DriverName:     "sqlmock",
 							DataSourceName: "root@/db",
 							Table:          "TestTable",
+							BatchSize:      10000,
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "toSQL1"},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			querytest.NewQueryTestHelper(t, tc)
+		})
+	}
+}
+
+func TestSqlite3To(t *testing.T) {
+	tests := []querytest.NewQueryTestCase{
+		{
+			Name: "from with database",
+			Raw:  `import "sql" from(bucket: "mybucket") |> sql.to(driverName:"sqlite3", dataSourceName:"file::memory:", table:"TestTable", batchSize:10000)`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: "mybucket",
+						},
+					},
+					{
+						ID: "toSQL1",
+						Spec: &fsql.ToSQLOpSpec{
+							DriverName:     "sqlite3",
+							DataSourceName: "file::memory:",
+							Table:          "TestTable",
+							BatchSize:      10000,
 						},
 					},
 				},
@@ -77,6 +117,7 @@ func TestToSQL_Process(t *testing.T) {
 					DriverName:     driverName,
 					DataSourceName: dsn,
 					Table:          "TestTable2",
+					BatchSize:      1,
 				},
 			},
 			data: executetest.MustCopyTable(&executetest.Table{
@@ -127,6 +168,7 @@ func TestToSQL_Process(t *testing.T) {
 					DriverName:     driverName,
 					DataSourceName: dsn,
 					Table:          "TestTable2",
+					BatchSize:      1,
 				},
 			},
 			data: executetest.MustCopyTable(&executetest.Table{
@@ -177,6 +219,7 @@ func TestToSQL_Process(t *testing.T) {
 					DriverName:     driverName,
 					DataSourceName: dsn,
 					Table:          "TestTable2",
+					BatchSize:      1,
 				},
 			},
 			data: executetest.MustCopyTable(&executetest.Table{
@@ -227,6 +270,7 @@ func TestToSQL_Process(t *testing.T) {
 					DriverName:     driverName,
 					DataSourceName: dsn,
 					Table:          "TestTable2",
+					BatchSize:      1,
 				},
 			},
 			data: executetest.MustCopyTable(&executetest.Table{
@@ -300,6 +344,272 @@ func TestToSQL_Process(t *testing.T) {
 			if !cmp.Equal(tc.want.ValueArgs, valArgs, cmpopts.EquateNaNs()) {
 				t.Log(cmp.Diff(tc.want.ValueArgs, valArgs))
 				t.Fail()
+			}
+		})
+	}
+}
+
+func TestToSQLite3_Process(t *testing.T) {
+	driverName := "sqlite3"
+	// use the in-memory mode - so we can test the functionality of the "type interactions" between driver and flux without needing an underlying FS
+	dsn := "file::memory:"
+	_, _, _ = sqlmock.NewWithDSN(dsn)
+	type wanted struct {
+		Table        []*executetest.Table
+		ColumnNames  []string
+		ValueStrings [][]string
+		ValueArgs    [][]interface{}
+	}
+	testCases := []struct {
+		name string
+		spec *fsql.ToSQLProcedureSpec
+		data flux.Table
+		want wanted
+	}{
+		{
+			name: "coltable with name in _measurement",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", 2.0, "one"},
+					{execute.Time(21), "a", 2.0, "one"},
+					{execute.Time(21), "b", 1.0, "seven"},
+					{execute.Time(31), "a", 3.0, "nine"},
+					{execute.Time(41), "c", 4.0, "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", 2.0, "one"},
+						{execute.Time(21), "a", 2.0, "one"},
+						{execute.Time(21), "b", 1.0, "seven"},
+						{execute.Time(31), "a", 3.0, "nine"},
+						{execute.Time(41), "c", 4.0, "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", 2.0, "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", 2.0, "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", 1.0, "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", 3.0, "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", 4.0, "elevendyone"}},
+			},
+		},
+		{
+			name: "coltable with ints",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", int64(2), "one"},
+					{execute.Time(21), "a", int64(2), "one"},
+					{execute.Time(21), "b", int64(1), "seven"},
+					{execute.Time(31), "a", int64(3), "nine"},
+					{execute.Time(41), "c", int64(4), "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TInt},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", int64(2), "one"},
+						{execute.Time(21), "a", int64(2), "one"},
+						{execute.Time(21), "b", int64(1), "seven"},
+						{execute.Time(31), "a", int64(3), "nine"},
+						{execute.Time(41), "c", int64(4), "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", int64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", int64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", int64(1), "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", int64(3), "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", int64(4), "elevendyone"}},
+			},
+		},
+		{
+			name: "coltable with uints",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TUInt},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", uint64(2), "one"},
+					{execute.Time(21), "a", uint64(2), "one"},
+					{execute.Time(21), "b", uint64(1), "seven"},
+					{execute.Time(31), "a", uint64(3), "nine"},
+					{execute.Time(41), "c", uint64(4), "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TUInt},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", uint64(2), "one"},
+						{execute.Time(21), "a", uint64(2), "one"},
+						{execute.Time(21), "b", uint64(1), "seven"},
+						{execute.Time(31), "a", uint64(3), "nine"},
+						{execute.Time(41), "c", uint64(4), "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", uint64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", uint64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", uint64(1), "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", uint64(3), "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", uint64(4), "elevendyone"}},
+			},
+		},
+		{
+			name: "coltable with bool",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TBool},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", true, "one"},
+					{execute.Time(21), "a", true, "one"},
+					{execute.Time(21), "b", false, "seven"},
+					{execute.Time(31), "a", true, "nine"},
+					{execute.Time(41), "c", false, "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TBool},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", true, "one"},
+						{execute.Time(21), "a", true, "one"},
+						{execute.Time(21), "b", false, "seven"},
+						{execute.Time(31), "a", true, "nine"},
+						{execute.Time(41), "c", false, "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", true, "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", true, "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", false, "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", true, "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", false, "elevendyone"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			d := executetest.NewDataset(executetest.RandomDatasetID())
+			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
+
+			transformation, err := fsql.NewToSQLTransformation(d, c, tc.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a := tc.data
+			colNames, valStrings, valArgs, err := fsql.CreateInsertComponents(transformation, a)
+			if tc.name == "coltable with bool" {
+				// sqlite doesn't have a BOOL type, so let user know, do not perform implicit type conversion
+				if err == nil {
+					t.Fatal(err)
+				}
+				if err.Error() != "DB does not support column type bool" {
+					t.Fatal(err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(tc.want.ColumnNames, colNames, cmpopts.EquateNaNs()) {
+					t.Log(cmp.Diff(tc.want.ColumnNames, colNames))
+					t.Fail()
+				}
+				if !cmp.Equal(tc.want.ValueStrings, valStrings, cmpopts.EquateNaNs()) {
+					t.Log(cmp.Diff(tc.want.ValueStrings, valStrings))
+					t.Fail()
+				}
+				if !cmp.Equal(tc.want.ValueArgs, valArgs, cmpopts.EquateNaNs()) {
+					t.Log(cmp.Diff(tc.want.ValueArgs, valArgs))
+					t.Fail()
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Adds support for SQLite3 to the stdlib/sql package. SQLite is a fully SQL compliant relational DB, in a file (or in memory, if preferred). Adding this to flux would allow it to interact with this DB, and present a lot of opportunity to extract information from many 3rd party "infrastructure tools", and combine this with Influxdb, or other data sources.

- SQLite3 to() and from() are both supported.

- Slight refactor of common sql stuff (specifically from CreateInsertComponents() column types) to allow for easier addition of other flavours of SQL DB. Main area is move of "type logic" into the driver files themselves, as these are often very specific to any given DB. This also allows for returning driver-specific type errors (i.e. when you try to create a column of an unsupported type)

- SQL errors are now returned to the user to allow for troubleshooting failures.

- Added new (optional) “batchSize” argument to sql.to() that allows us to set limits on the batch size at runtime, thereby allowing for throttling. This simply allows us to override the already set (via const var) size at runtime.

Closes #1933
Fixes #1938 

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
