### PR TITLE
feat(test_rewriter): create a tool for updating .flux tests in-place

### DIFF
--- a/internal/cmd/test_rewriter/add_measurement.go
+++ b/internal/cmd/test_rewriter/add_measurement.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+var addMeasurementCmd = &cobra.Command{
+	Use:   "add-measurement [test files...]",
+	Short: "Update test inData and outData to have a _measurement column",
+	RunE:  addMeasurementE,
+	Args:  cobra.MinimumNArgs(1),
+}
+
+func init() {
+	rootCmd.AddCommand(addMeasurementCmd)
+	addMeasurementCmd.Flags().StringVar(&flagMeasurementName, "measurement-name", "m", "value to populate new column")
+}
+
+var (
+	flagMeasurementName string
+)
+
+func addMeasurementE(cmd *cobra.Command, args []string) error {
+	return doSubCommand(addMeasurementColumn, args)
+}
+
+func addMeasurementColumn(fileName string) error {
+	astPkg, err := getFileAST(fileName)
+	if err != nil {
+		return err
+	}
+
+	df := &dataFinder{
+		dataStmts: make(map[string]*ast.VariableAssignment),
+	}
+	ast.Walk(df, astPkg)
+
+	if _, ok := df.dataStmts["inData"]; !ok {
+		fmt.Printf("  No inData; skipping\n")
+		return nil
+	}
+
+	for _, a := range df.dataStmts {
+		lack, err := csvLacksMeasurementColumn(a)
+		if err != nil {
+			return err
+		}
+		if !lack {
+			fmt.Printf("  %v has _measurement, skipping\n", a.ID.Name)
+			return nil
+		}
+	}
+
+	var q string
+	{
+		var sb strings.Builder
+		sb.WriteString(`
+import "csv"
+import "experimental"
+`)
+		for _, a := range df.dataStmts {
+			sb.WriteString(ast.Format(a) + "\n")
+			sb.WriteString(fmt.Sprintf(`
+csv.from(csv: %v)
+  |> experimental.set(o: {_measurement: "%v"})
+  |> experimental.group(mode: "extend", columns: ["_measurement"])
+  |> yield(name: "%v")
+`, a.ID.Name, flagMeasurementName, a.ID.Name))
+		}
+		q = sb.String()
+	}
+
+	ri, err := runQuery(q)
+	if err != nil {
+		return err
+	}
+	defer ri.Release()
+
+	for ri.More() {
+		r := ri.Next()
+
+		var bb bytes.Buffer
+		enc := csv.NewResultEncoder(csv.DefaultEncoderConfig())
+		if _, err := enc.Encode(&bb, r); err != nil {
+			return err
+		}
+		if err := replaceStringLitRHS(df.dataStmts[r.Name()], "\n"+bb.String()); err != nil {
+			return err
+		}
+	}
+	if ri.Err() != nil {
+		return ri.Err()
+	}
+
+	if err := rewriteFile(fileName, astPkg); err != nil {
+		return nil
+	}
+	fmt.Printf("  Rewrote %s with measurement columns added.\n", fileName)
+	return nil
+}
+
+func csvLacksMeasurementColumn(a *ast.VariableAssignment) (bool, error) {
+	bb := bytes.NewBuffer([]byte(a.Init.(*ast.StringLiteral).Value))
+	dec := csv.NewResultDecoder(csv.ResultDecoderConfig{})
+	r, err := dec.Decode(bb)
+	if err != nil {
+		return false, err
+	}
+	lacks := true
+	if err := r.Tables().Do(func(t flux.Table) error {
+		for _, c := range t.Cols() {
+			if c.Label == "_measurement" {
+				lacks = false
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	return lacks, nil
+}
+
+func replaceStringLitRHS(va *ast.VariableAssignment, v string) error {
+	sl, ok := va.Init.(*ast.StringLiteral)
+	if !ok {
+		return errors.New(codes.Invalid, "funky assignment")
+	}
+	sl.Value = v
+	sl.Loc = nil
+	return nil
+}
+
+type dataFinder struct {
+	dataStmts map[string]*ast.VariableAssignment
+}
+
+func (d *dataFinder) Visit(node ast.Node) ast.Visitor {
+	return d
+}
+
+func (d *dataFinder) Done(node ast.Node) {
+	switch n := node.(type) {
+	case *ast.VariableAssignment:
+		if n.ID.Name == "inData" || n.ID.Name == "outData" {
+			d.dataStmts[n.ID.Name] = n
+		}
+	}
+}

--- a/internal/cmd/test_rewriter/add_range.go
+++ b/internal/cmd/test_rewriter/add_range.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/spf13/cobra"
+)
+
+var addRangeCmd = &cobra.Command{
+	Use:   "add-range [test files...]",
+	Short: "Update tests that lack a call to range()",
+	RunE:  addRangeE,
+	Args:  cobra.MinimumNArgs(1),
+}
+
+func init() {
+	rootCmd.AddCommand(addRangeCmd)
+}
+
+func addRangeE(cmd *cobra.Command, args []string) error {
+	return doSubCommand(addRangeCall, args)
+}
+
+func addRangeCall(fileName string) error {
+	astPkg, err := getFileAST(fileName)
+	if err != nil {
+		return err
+	}
+
+	var rf rangeFinder
+	ast.Walk(&rf, astPkg)
+
+	if rf.found {
+		fmt.Printf("  range found, nothing to do.\n")
+		return nil
+	}
+
+	// add call to range to the leafiest |> we found
+	pe := rf.pipeExpr
+	if pe == nil {
+		fmt.Println("  no pipe expression found")
+		return nil
+	}
+
+	if err := addRangeToPipeline(pe); err != nil {
+		return err
+	}
+	if err := addDropToPipeline(pe); err != nil {
+		return err
+	}
+
+	if err := rewriteFile(fileName, astPkg); err != nil {
+		return nil
+	}
+	fmt.Printf("  Rewrote %s with a call to range() added.\n", fileName)
+	return nil
+}
+
+func addRangeToPipeline(pe *ast.PipeExpression) error {
+	startTime, err := time.Parse(time.RFC3339, "1980-01-01T00:00:00.000Z")
+	if err != nil {
+		return err
+	}
+
+	oldArg := pe.Argument
+	pe.Argument = &ast.PipeExpression{
+		Argument: oldArg,
+		Call: &ast.CallExpression{
+			Callee: &ast.Identifier{Name: "range"},
+			Arguments: []ast.Expression{
+				&ast.ObjectExpression{
+					Properties: []*ast.Property{
+						{
+							Key:   &ast.Identifier{Name: "start"},
+							Value: &ast.DateTimeLiteral{Value: startTime},
+						},
+					},
+				},
+			},
+		},
+	}
+	return nil
+}
+
+func addDropToPipeline(pe *ast.PipeExpression) error {
+	oldArg := pe.Argument
+	pe.Argument = &ast.PipeExpression{
+		Argument: oldArg,
+		Call: &ast.CallExpression{
+			Callee: &ast.Identifier{Name: "drop"},
+			Arguments: []ast.Expression{
+				&ast.ObjectExpression{
+					Properties: []*ast.Property{
+						{
+							Key: &ast.Identifier{Name: "columns"},
+							Value: &ast.ArrayExpression{
+								Elements: []ast.Expression{
+									&ast.StringLiteral{Value: "_start"},
+									&ast.StringLiteral{Value: "_stop"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return nil
+}
+
+type rangeFinder struct {
+	found    bool
+	pipeExpr *ast.PipeExpression
+}
+
+func (r *rangeFinder) Visit(node ast.Node) ast.Visitor {
+	if r.found {
+		return nil
+	}
+	switch n := node.(type) {
+	case *ast.CallExpression:
+		if id, ok := n.Callee.(*ast.Identifier); ok {
+			if id.Name == "range" {
+				r.found = true
+				return nil
+			}
+		}
+	}
+	return r
+}
+
+func (r *rangeFinder) Done(node ast.Node) {
+	switch n := node.(type) {
+	case *ast.PipeExpression:
+		if r.pipeExpr == nil {
+			r.pipeExpr = n
+		}
+	}
+
+}

--- a/internal/cmd/test_rewriter/main.go
+++ b/internal/cmd/test_rewriter/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	_ "github.com/influxdata/flux/builtin"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependencies/filesystem"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/parser"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "test_rewriter",
+	Short: "A tool for fixing common problems with Flux tests by rewriting them in-place.",
+	Long:  "A tool for fixing common problems with Flux tests by rewriting them in-place.",
+}
+
+func init() {
+	rootCmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "do nothing, but show what would be done")
+}
+
+var (
+	flagDryRun = false
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		_, _ = fmt.Fprint(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func doSubCommand(f func(fileName string) error, args []string) error {
+	for _, arg := range args {
+		fmt.Printf("%v:\n", arg)
+		if err := f(arg); err != nil {
+			return errors.Wrap(err, codes.Inherit, arg)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func getFileAST(fileName string) (*ast.Package, error) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	script, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	astPkg := parser.ParseSource(string(script))
+	return astPkg, nil
+
+}
+
+func runQuery(query string) (flux.ResultIterator, error) {
+	c := lang.FluxCompiler{
+		Extern: nil,
+		Query:  query,
+	}
+	deps := flux.NewDefaultDependencies()
+	deps.Deps.FilesystemService = filesystem.SystemFS
+
+	ctx := deps.Inject(context.Background())
+	program, err := c.Compile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = deps.Inject(ctx)
+	alloc := &memory.Allocator{}
+	qry, err := program.Start(ctx, alloc)
+	if err != nil {
+		return nil, err
+	}
+	return flux.NewResultIteratorFromQuery(qry), nil
+}
+
+func rewriteFile(fileName string, astPkg *ast.Package) error {
+	newScript := ast.Format(astPkg) + "\n"
+	if !flagDryRun {
+		if err := ioutil.WriteFile(fileName, []byte(newScript), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
I had to update several `.flux` tests for this issue:
https://github.com/influxdata/flux/pull/2013

I found it useful to write a tool to automate the changes that I needed to make.  This is that tool.

It has two subcommands:
- Add `_measurement` column to tests that need them
- Add a call to `range()` to tests that need it