### PR TITLE
refactor(values): use the duration methods throughout flux

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -382,7 +382,7 @@ func (e *unaryEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, e
 		case semantic.Bool:
 			return values.NewBool(!v.Bool()), nil
 		case semantic.Duration:
-			return values.NewDuration(-v.Duration()), nil
+			return values.NewDuration(v.Duration().Mul(-1)), nil
 		default:
 			panic(values.UnexpectedKind(e.t.Nature(), v.Type().Nature()))
 		}

--- a/execute/bounds.go
+++ b/execute/bounds.go
@@ -80,7 +80,7 @@ func (b Bounds) Duration() Duration {
 	if b.IsEmpty() {
 		return values.ConvertDuration(0)
 	}
-	return Duration(b.Stop - b.Start)
+	return b.Stop.Sub(b.Start)
 }
 
 func Now() Time {

--- a/execute/trigger.go
+++ b/execute/trigger.go
@@ -86,7 +86,7 @@ func (t *afterWatermarkTrigger) Triggered(c TriggerContext) bool {
 		return false
 	}
 	stop := c.Table.Key.ValueTime(timeIdx)
-	if c.Watermark >= stop+Time(t.allowedLateness) {
+	if c.Watermark >= stop.Add(t.allowedLateness) {
 		t.finished = true
 	}
 	return c.Watermark >= stop
@@ -125,7 +125,7 @@ type afterProcessingTimeTrigger struct {
 func (t *afterProcessingTimeTrigger) Triggered(c TriggerContext) bool {
 	if !t.triggerTimeSet {
 		t.triggerTimeSet = true
-		t.triggerTime = c.CurrentProcessingTime + Time(t.duration)
+		t.triggerTime = c.CurrentProcessingTime.Add(t.duration)
 	}
 	t.current = c.CurrentProcessingTime
 	return t.current >= t.triggerTime

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -347,7 +347,6 @@ func groupBy(keys []flux.GroupKey, by []string) []seriesGroup {
 type dataGenerator struct {
 	Start     values.Time
 	Period    values.Duration
-	Jitter    values.Duration
 	Nulls     float64
 	NumPoints int
 	Allocator *memory.Allocator
@@ -458,12 +457,7 @@ func (dg *dataGenerator) Generate(tb execute.TableBuilder, r *rand.Rand, typ flu
 	})
 
 	start, stop = dg.Start, dg.Start
-	for i := 0; i < dg.NumPoints; i++ {
-		ts := dg.Start.Add(values.ConvertDuration(time.Duration(i)) * dg.Period)
-		if dg.Jitter != 0 {
-			jitter := r.Intn(int(dg.Jitter)*2 + 1)
-			ts = ts.Add(values.ConvertDuration(time.Duration(jitter)))
-		}
+	for i, ts := 0, dg.Start; i < dg.NumPoints; i, ts = i+1, ts.Add(dg.Period) {
 		_ = tb.AppendTime(timeIdx, ts)
 		_ = tb.AppendValue(valueIdx, next())
 		_ = tb.AppendValue(valueIdx, next())

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -368,7 +368,7 @@ func (itrp *Interpreter) doExpression(ctx context.Context, expr semantic.Express
 			case semantic.Float:
 				return values.NewFloat(-v.Float()), nil
 			case semantic.Duration:
-				return values.NewDuration(-v.Duration()), nil
+				return values.NewDuration(v.Duration().Mul(-1)), nil
 			default:
 				return nil, errors.Newf(codes.Invalid, "operand to unary expression is not a number value, got %v", v.Type())
 			}

--- a/stdlib/experimental/durations.go
+++ b/stdlib/experimental/durations.go
@@ -60,7 +60,7 @@ func subDuration(name string) values.Value {
 		if !ok {
 			return nil, fmt.Errorf("%s requires 'from' parameter", name)
 		}
-		return values.NewTime(t.Time().Add(-d.Duration())), nil
+		return values.NewTime(t.Time().Add(d.Duration().Mul(-1))), nil
 	}
 	return values.NewFunction(name, tp, fn, false)
 }

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -93,7 +93,7 @@ func createStateTrackingOpSpec(args flux.Arguments, a *flux.Administration) (flu
 		spec.TimeColumn = execute.DefaultTimeColLabel
 	}
 
-	if spec.DurationColumn != "" && spec.DurationUnit <= 0 {
+	if spec.DurationColumn != "" && !values.Duration(spec.DurationUnit).IsPositive() {
 		return nil, errors.New(codes.Invalid, "state tracking duration unit must be greater than zero")
 	}
 	return spec, nil

--- a/values/binary.go
+++ b/values/binary.go
@@ -76,7 +76,8 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.AdditionOperator, Left: semantic.Duration, Right: semantic.Duration}: func(lv, rv Value) (Value, error) {
 		l := lv.Duration()
 		r := rv.Duration()
-		return NewDuration(l + r), nil
+		d := ConvertDuration(l.Duration() + r.Duration())
+		return NewDuration(d), nil
 	},
 	{Operator: ast.AdditionOperator, Left: semantic.Nil, Right: semantic.Nil}: nil,
 	{Operator: ast.SubtractionOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) (Value, error) {
@@ -97,7 +98,8 @@ var binaryFuncLookup = map[BinaryFuncSignature]BinaryFunction{
 	{Operator: ast.SubtractionOperator, Left: semantic.Duration, Right: semantic.Duration}: func(lv, rv Value) (Value, error) {
 		l := lv.Duration()
 		r := rv.Duration()
-		return NewDuration(l - r), nil
+		d := ConvertDuration(l.Duration() - r.Duration())
+		return NewDuration(d), nil
 	},
 	{Operator: ast.SubtractionOperator, Left: semantic.Nil, Right: semantic.Nil}: nil,
 	{Operator: ast.MultiplicationOperator, Left: semantic.Int, Right: semantic.Int}: func(lv, rv Value) (Value, error) {

--- a/values/time.go
+++ b/values/time.go
@@ -94,6 +94,19 @@ func (d Duration) IsZero() bool {
 	return d == 0
 }
 
+// Normalize will normalize the duration within the interval.
+// It will ensure that the output duration is the smallest positive
+// duration that is the equivalent of the current duration.
+func (d Duration) Normalize(interval Duration) Duration {
+	offset := d
+	if offset < 0 {
+		offset += interval * ((offset / -interval) + 1)
+	} else if offset > interval {
+		offset -= interval * (offset / interval)
+	}
+	return offset
+}
+
 // Duration will return the nanosecond equivalent
 // of this duration. It will assume that months are
 // the equivalent of 30 days.


### PR DESCRIPTION
This changes everywhere inside of flux to use duration methods instead
of math on the duration value itself.

This also moves the offset normalization code to a utility in
`values.Duration` so that there aren't any sections of code that rely on
`values.Duration` being a `time.Duration` for them to function.

Fixes #1982.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written