### PR TITLE
fix(stdlib): make keep/drop throw an error if merging tables with different schemas

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2424,7 +2424,7 @@ from(bucket: "telegraf/autogen")
 
 Drop excludes specified columns from a table. Columns to exclude can be specified either through a list, or a predicate function.
 When a dropped column is part of the group key it will also be dropped from the key.
-If a specified column is not present in a table an error will be thrown.
+If dropping a column in the group key would result in merging two tables with different schemas, an error will be thrown.
 
 Drop has the following properties:
 
@@ -2458,7 +2458,8 @@ from(bucket: "telegraf/autogen")
 Keep is the inverse of drop. It returns a table containing only columns that are specified,
 ignoring all others.
 Only columns in the group key that are also specified in `keep` will be kept in the resulting group key.
-If a specified column is not present in a table an error will be thrown.
+If not all columns in the group key are kept, this can result in merging tables that will have the same group key.
+If this would result in merging two tables with different schemas, an error will be thrown.
 
 Keep has the following properties:
 

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"

--- a/stdlib/universe/schema_functions_test.go
+++ b/stdlib/universe/schema_functions_test.go
@@ -671,6 +671,43 @@ func TestDropRenameKeep_Process(t *testing.T) {
 			wantErr: errors.New("requested operation merges tables with different numbers of columns for group key {a=one}"),
 		},
 		{
+			name: "keep one key col merge error column type",
+			spec: &universe.SchemaMutationProcedureSpec{
+				Mutations: []universe.SchemaMutation{
+					&universe.KeepOpSpec{
+						Columns: []string{"a", "c"},
+					},
+				},
+			},
+			data: []flux.Table{
+				&executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "a", Type: flux.TString},
+						{Label: "b", Type: flux.TString},
+						{Label: "c", Type: flux.TFloat},
+					},
+					KeyCols: []string{"a", "b"},
+					Data: [][]interface{}{
+						{"one", "two", 3.0},
+						{"one", "two", 13.0},
+					},
+				},
+				&executetest.Table{
+					ColMeta: []flux.ColMeta{
+						{Label: "a", Type: flux.TString},
+						{Label: "b", Type: flux.TString},
+						{Label: "c", Type: flux.TString},
+					},
+					KeyCols: []string{"a", "b"},
+					Data: [][]interface{}{
+						{"one", "three", "foo"},
+						{"one", "three", "bar"},
+					},
+				},
+			},
+			wantErr: errors.New("requested operation merges tables with different schemas for group key {a=one}"),
+		},
+		{
 			name: "duplicate single col",
 			spec: &universe.SchemaMutationProcedureSpec{
 				Mutations: []universe.SchemaMutation{


### PR DESCRIPTION
This fixes an issue that happens when we are keeping or dropping columns such that we lose a column in the group key.  When this happens we may need to merge separate tables that now have the same group key.

Previously we would not detect if the tables had different schemas and an internal error would be thrown in `AppendMappedRecordWithNulls`.  The fix here is to throw a more user-friendly error.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
