### PR TITLE
feat(values): turn duration value into a vector

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -730,7 +730,7 @@ func (a Arguments) GetDuration(name string) (Duration, bool, error) {
 	if !ok {
 		return ConvertDuration(0), false, nil
 	}
-	return Duration(v.Duration()), true, nil
+	return v.Duration(), true, nil
 }
 
 func (a Arguments) GetRequiredDuration(name string) (Duration, error) {

--- a/stdlib/json/encode_test.go
+++ b/stdlib/json/encode_test.go
@@ -42,7 +42,7 @@ o = {
     e: /.*/,
 	f: 2019-08-14T10:03:12Z,
 }
-json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":60000000000},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\"}")  or fail()
+json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":\"1m0s\"},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\"}")  or fail()
 `
 	ctx := dependenciestest.Default().Inject(context.Background())
 	if _, _, err := flux.Eval(ctx, script, addFail); err != nil {

--- a/stdlib/universe/derivative_test.go
+++ b/stdlib/universe/derivative_test.go
@@ -48,7 +48,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{execute.DefaultValueColLabel},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -102,7 +102,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{execute.DefaultValueColLabel},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -156,7 +156,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:     []string{execute.DefaultValueColLabel},
 				TimeColumn:  execute.DefaultTimeColLabel,
-				Unit:        1,
+				Unit:        flux.ConvertDuration(1),
 				NonNegative: true,
 			},
 			data: []flux.Table{&executetest.Table{
@@ -186,7 +186,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{execute.DefaultValueColLabel},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -213,7 +213,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{execute.DefaultValueColLabel},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -240,7 +240,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:     []string{execute.DefaultValueColLabel},
 				TimeColumn:  execute.DefaultTimeColLabel,
-				Unit:        1,
+				Unit:        flux.ConvertDuration(1),
 				NonNegative: true,
 			},
 			data: []flux.Table{&executetest.Table{
@@ -297,7 +297,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:     []string{execute.DefaultValueColLabel},
 				TimeColumn:  execute.DefaultTimeColLabel,
-				Unit:        1,
+				Unit:        flux.ConvertDuration(1),
 				NonNegative: true,
 			},
 			data: []flux.Table{&executetest.Table{
@@ -327,7 +327,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{execute.DefaultValueColLabel},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -356,7 +356,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{"x", "y"},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -385,7 +385,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:     []string{"x", "y"},
 				TimeColumn:  execute.DefaultTimeColLabel,
-				Unit:        1,
+				Unit:        flux.ConvertDuration(1),
 				NonNegative: true,
 			},
 			data: []flux.Table{&executetest.Table{
@@ -417,7 +417,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{"x", "y"},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -448,7 +448,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{"x", "y"},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -473,7 +473,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{"x", "y"},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{
@@ -498,7 +498,7 @@ func TestDerivative_Process(t *testing.T) {
 			spec: &universe.DerivativeProcedureSpec{
 				Columns:    []string{"x"},
 				TimeColumn: execute.DefaultTimeColLabel,
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 			},
 			data: []flux.Table{&executetest.Table{
 				ColMeta: []flux.ColMeta{

--- a/stdlib/universe/integral_test.go
+++ b/stdlib/universe/integral_test.go
@@ -45,7 +45,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -77,7 +77,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "int",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -109,7 +109,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "uint",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -173,7 +173,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float with tags",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -206,7 +206,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float with multiple values",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 				TimeColumn: execute.DefaultTimeColLabel,
 				AggregateConfig: execute.AggregateConfig{
 					Columns: []string{"x", "y"},
@@ -244,7 +244,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float with null timestamps",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -268,7 +268,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float with null values",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -303,7 +303,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float with out-of-order timestamps",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},
@@ -327,7 +327,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "integral over string",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:       1,
+				Unit:       flux.ConvertDuration(1),
 				TimeColumn: execute.DefaultTimeColLabel,
 				AggregateConfig: execute.AggregateConfig{
 					Columns: []string{"t"},
@@ -352,7 +352,7 @@ func TestIntegral_Process(t *testing.T) {
 		{
 			name: "float repeated times",
 			spec: &universe.IntegralProcedureSpec{
-				Unit:            1,
+				Unit:            flux.ConvertDuration(1),
 				TimeColumn:      execute.DefaultTimeColLabel,
 				AggregateConfig: execute.DefaultAggregateConfig,
 			},

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -170,7 +170,7 @@ func TestStateTracking_Process(t *testing.T) {
 			name: "only duration",
 			spec: &universe.StateTrackingProcedureSpec{
 				DurationColumn: "duration",
-				DurationUnit:   1,
+				DurationUnit:   flux.ConvertDuration(1),
 				Fn:             gt5,
 				TimeCol:        "_time",
 			},
@@ -208,7 +208,7 @@ func TestStateTracking_Process(t *testing.T) {
 			name: "only duration, null timestamps",
 			spec: &universe.StateTrackingProcedureSpec{
 				DurationColumn: "duration",
-				DurationUnit:   1,
+				DurationUnit:   flux.ConvertDuration(1),
 				Fn:             gt5,
 				TimeCol:        "_time",
 			},
@@ -232,7 +232,7 @@ func TestStateTracking_Process(t *testing.T) {
 			name: "only duration, out of order timestamps",
 			spec: &universe.StateTrackingProcedureSpec{
 				DurationColumn: "duration",
-				DurationUnit:   1,
+				DurationUnit:   flux.ConvertDuration(1),
 				Fn:             gt5,
 				TimeCol:        "_time",
 			},
@@ -331,7 +331,7 @@ func TestStateTracking_Process(t *testing.T) {
 			spec: &universe.StateTrackingProcedureSpec{
 				CountColumn:    "count",
 				DurationColumn: "duration",
-				DurationUnit:   1,
+				DurationUnit:   flux.ConvertDuration(1),
 				Fn:             gt5,
 				TimeCol:        "_time",
 			},

--- a/time.go
+++ b/time.go
@@ -83,22 +83,9 @@ func (t Time) MarshalText() ([]byte, error) {
 }
 
 // Duration is a marshalable duration type.
-type Duration values.Duration
+type Duration = values.Duration
 
 // ConvertDuration will convert a time.Duration into a flux.Duration.
 func ConvertDuration(v time.Duration) Duration {
-	return Duration(values.ConvertDuration(v))
-}
-
-func (d *Duration) UnmarshalText(data []byte) error {
-	dur, err := values.ParseDuration(string(data))
-	if err != nil {
-		return err
-	}
-	*d = Duration(dur)
-	return nil
-}
-
-func (d Duration) MarshalText() ([]byte, error) {
-	return []byte(values.Duration(d).String()), nil
+	return values.ConvertDuration(v)
 }

--- a/values/time.go
+++ b/values/time.go
@@ -5,7 +5,12 @@ import (
 )
 
 type Time int64
-type Duration int64
+
+// Duration is a vector representing the duration unit components.
+type Duration struct {
+	// nsecs is the number of nanoseconds for the duration.
+	nsecs int64
+}
 
 const (
 	fixedWidthTimeFmt = "2006-01-02T15:04:05.000000000Z"
@@ -17,48 +22,48 @@ func ConvertTime(t time.Time) Time {
 
 // ConvertDuration takes a time.Duration and converts it into a Duration.
 func ConvertDuration(v time.Duration) Duration {
-	return Duration(v)
+	return Duration{nsecs: int64(v)}
 }
 
 func (t Time) Round(d Duration) Time {
-	if d <= 0 {
+	if d.nsecs <= 0 {
 		return t
 	}
 	r := t.Remainder(d)
 	if lessThanHalf(r, d) {
-		return t - Time(r)
+		return t - Time(r.nsecs)
 	}
-	return t + Time(d-r)
+	return t + Time(d.nsecs-r.nsecs)
 }
 
 func (t Time) Truncate(d Duration) Time {
-	if d <= 0 {
+	if d.nsecs <= 0 {
 		return t
 	}
 	r := t.Remainder(d)
-	return t - Time(r)
+	return t - Time(r.nsecs)
 }
 
 func (t Time) Add(d Duration) Time {
-	return t + Time(d)
+	return t + Time(d.nsecs)
 }
 
 // Sub takes another time and returns a duration giving the duration
 // between the two times. A positive duration indicates that the receiver
 // occurs after the other time.
 func (t Time) Sub(other Time) Duration {
-	return Duration(t - other)
+	return Duration{nsecs: int64(t - other)}
 }
 
 // Remainder divides t by d and returns the remainder.
 func (t Time) Remainder(d Duration) (r Duration) {
-	return Duration(int64(t) % int64(d))
+	return Duration{nsecs: int64(t) % int64(d.nsecs)}
 }
 
 // lessThanHalf reports whether x+x < y but avoids overflow,
 // assuming x and y are both positive (Duration is signed).
 func lessThanHalf(x, y Duration) bool {
-	return uint64(x)+uint64(x) < uint64(y)
+	return uint64(x.nsecs)+uint64(x.nsecs) < uint64(y.nsecs)
 }
 
 func (t Time) String() string {
@@ -80,31 +85,38 @@ func (t Time) Time() time.Time {
 // Mul will multiply the Duration by a scalar.
 // This multiplies each component of the vector.
 func (d Duration) Mul(scale int) Duration {
-	return d * Duration(scale)
+	return Duration{
+		nsecs: d.nsecs * int64(scale),
+	}
 }
 
 // IsPositive returns true if this is a positive number.
 // It returns false if the number is zero.
 func (d Duration) IsPositive() bool {
-	return d > 0
+	return d.nsecs > 0
 }
 
 // IsZero returns true if this is a zero duration.
 func (d Duration) IsZero() bool {
-	return d == 0
+	return d.nsecs == 0
 }
 
 // Normalize will normalize the duration within the interval.
 // It will ensure that the output duration is the smallest positive
 // duration that is the equivalent of the current duration.
 func (d Duration) Normalize(interval Duration) Duration {
-	offset := d
+	offset, every := d.nsecs, interval.nsecs
 	if offset < 0 {
-		offset += interval * ((offset / -interval) + 1)
-	} else if offset > interval {
-		offset -= interval * (offset / interval)
+		offset += every * ((offset / -every) + 1)
+	} else if offset > every {
+		offset -= every * (offset / every)
 	}
-	return offset
+	return Duration{nsecs: offset}
+}
+
+// Equal returns true if the two durations are equal.
+func (d Duration) Equal(other Duration) bool {
+	return d.nsecs == other.nsecs
 }
 
 // Duration will return the nanosecond equivalent
@@ -117,17 +129,30 @@ func (d Duration) Normalize(interval Duration) Duration {
 // and it should only be used for interfacing with
 // outside code that is not month-aware.
 func (d Duration) Duration() time.Duration {
-	return time.Duration(d)
+	return time.Duration(d.nsecs)
 }
 func (d Duration) String() string {
-	return time.Duration(d).String()
+	return time.Duration(d.nsecs).String()
 }
+
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+func (d *Duration) UnmarshalText(data []byte) error {
+	dur, err := ParseDuration(string(data))
+	if err != nil {
+		return err
+	}
+	*d = dur
+	return nil
+}
+
 func ParseDuration(s string) (Duration, error) {
 	// TODO(jsternberg): This should use the real duration parsing
 	// instead of time.ParseDuration.
 	d, err := time.ParseDuration(s)
 	if err != nil {
-		return 0, err
+		return Duration{}, err
 	}
-	return Duration(d), nil
+	return Duration{nsecs: int64(d)}, nil
 }


### PR DESCRIPTION
The duration value is meant to be a vector of the necessary components
for implementing a duration. This changes `values.Duration` into a
struct which will be that vector.

The only attribute implemented is nanoseconds because we have not
implemented any other dimension of the vector.

BREAKING CHANGE: JSON encoding of duration values will now be output as
string instead of an integer.

Fixes #1981.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written