### PR TITLE
Type inference plumbing

### DIFF
--- a/libflux/src/semantic/infer.rs
+++ b/libflux/src/semantic/infer.rs
@@ -1,0 +1,56 @@
+use crate::semantic::types::{Kind, MonoType};
+use std::ops;
+
+// Type constraints are produced during type inference and come
+// in two flavors.
+//
+// A kind constraint asserts that a particular type is of a
+// particular kind or family of types.
+//
+// An equality contraint asserts that two types are equivalent
+// and will be unified at some point.
+//
+#[derive(Debug, PartialEq)]
+enum Constraint {
+    Kind(MonoType, Kind),
+    Equal(MonoType, MonoType),
+}
+
+#[derive(Debug, PartialEq)]
+struct Constraints(Vec<Constraint>);
+
+// Constraints can be added using the '+' operator
+impl ops::Add for Constraints {
+    type Output = Constraints;
+
+    fn add(self, cons: Constraints) -> Self::Output {
+        Constraints(self.0.into_iter().chain(cons.0.into_iter()).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::semantic::types::Tvar;
+
+    #[test]
+    fn add_constraints() {
+        let c0 = Constraints(vec![
+            Constraint::Equal(MonoType::Var(Tvar(0)), MonoType::Var(Tvar(1))),
+            Constraint::Kind(MonoType::Var(Tvar(1)), Kind::Addable),
+        ]);
+        let c1 = Constraints(vec![
+            Constraint::Equal(MonoType::Var(Tvar(2)), MonoType::Var(Tvar(3))),
+            Constraint::Kind(MonoType::Var(Tvar(3)), Kind::Divisible),
+        ]);
+        assert_eq!(
+            c0 + c1,
+            Constraints(vec![
+                Constraint::Equal(MonoType::Var(Tvar(0)), MonoType::Var(Tvar(1))),
+                Constraint::Kind(MonoType::Var(Tvar(1)), Kind::Addable),
+                Constraint::Equal(MonoType::Var(Tvar(2)), MonoType::Var(Tvar(3))),
+                Constraint::Kind(MonoType::Var(Tvar(3)), Kind::Divisible),
+            ])
+        );
+    }
+}

--- a/libflux/src/semantic/mod.rs
+++ b/libflux/src/semantic/mod.rs
@@ -1,3 +1,5 @@
 mod analyze;
+mod infer;
 mod nodes;
+mod sub;
 mod types;

--- a/libflux/src/semantic/sub.rs
+++ b/libflux/src/semantic/sub.rs
@@ -1,0 +1,50 @@
+use crate::semantic::types::{MonoType, Tvar};
+use std::{collections::HashMap, fmt};
+
+// A substitution defines a function that takes a monotype as input
+// and returns a monotype as output. The output type is interpreted
+// as being equivalent to the input type.
+//
+// Substitutions are idempotent. Given a substitution s and an input
+// type x, we have s(s(x)) = s(x).
+//
+#[derive(Debug, PartialEq)]
+pub struct Subst(HashMap<Tvar, MonoType>);
+
+impl fmt::Display for Subst {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("substitution:\n")?;
+        for (k, v) in &self.0 {
+            write!(f, "\t{}: {}\n", k, v)?;
+        }
+        Ok(())
+    }
+}
+
+impl Subst {
+    pub fn empty() -> Subst {
+        Subst(HashMap::new())
+    }
+
+    pub fn init(values: HashMap<Tvar, MonoType>) -> Subst {
+        Subst(values)
+    }
+
+    pub fn lookup(&self, tv: Tvar) -> Option<&MonoType> {
+        self.0.get(&tv)
+    }
+
+    pub fn merge(self, with: Subst) -> Subst {
+        let applied: HashMap<Tvar, MonoType> = self
+            .0
+            .into_iter()
+            .map(|(k, v)| (k, v.apply(&with)))
+            .collect();
+        Subst(applied.into_iter().chain(with.0.into_iter()).collect())
+    }
+}
+
+// A type is substitutable if a substitution can be applied to it.
+pub trait Substitutable {
+    fn apply(self, sub: &Subst) -> Self;
+}


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

#1953 .

This PR does several things.

1. It defines empty structs for each of the basic types. Previously each of the basic types (int, float, string, ...) were just variants of the `MonoType` enum.

2. Defines the data structure for type substitutions as well as the `Substitutable` trait.

3. Defines the data structure for mapping type variables to their kind constraints.

4. Defines the `Constraint` enum which represents either a type constraint or a kind constraint. Type inference will produce a set of these constraints for each expression.
