### PR TITLE
feat(stdlib/sql): add sqlite3 support

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/influxdata/flux/cmd/flux/cmd"
+import (
+	"github.com/influxdata/flux/cmd/flux/cmd"
+	// Register the sqlite3 database driver.
+	_ "github.com/mattn/go-sqlite3"
+)
 
 func main() {
 	cmd.Execute()

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-runewidth v0.0.3 // indirect
+	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/opentracing/opentracing-go v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8BzLR4=
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
+github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 h1:d8RFOZ2IiFtFWBcKEHAFYJcPTf0wY5q0exFNJZVWa1U=
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/mattn/go-zglob v0.0.0-20171230104132-4959821b4817/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -49,19 +49,16 @@ func createFromSQLOpSpec(args flux.Arguments, administration *flux.Administratio
 	} else {
 		spec.DriverName = driverName
 	}
-
 	if dataSourceName, err := args.GetRequiredString("dataSourceName"); err != nil {
 		return nil, err
 	} else {
 		spec.DataSourceName = dataSourceName
 	}
-
 	if query, err := args.GetRequiredString("query"); err != nil {
 		return nil, err
 	} else {
 		spec.Query = query
 	}
-
 	return spec, nil
 }
 

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -126,6 +126,8 @@ func createFromSQLSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 	switch spec.DriverName {
 	case "mysql":
 		newRowReader = NewMySQLRowReader
+	case "sqlite3":
+		newRowReader = NewSqliteRowReader
 	case "postgres", "sqlmock":
 		newRowReader = NewPostgresRowReader
 	default:
@@ -198,7 +200,6 @@ func read(ctx context.Context, reader execute.RowReader, alloc *memory.Allocator
 			return nil, err
 		}
 	}
-
 	for reader.Next() {
 		row, err := reader.GetNextRow()
 		if err != nil {

--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -29,10 +29,18 @@ func TestFromSqlUrlValidation(t *testing.T) {
 			Name: "invalid driver",
 			Spec: &FromSQLProcedureSpec{
 				DriverName:     "voltdb",
-				DataSourceName: "",
+				DataSourceName: "blablabla",
 				Query:          "",
 			},
 			ErrMsg: "sql driver voltdb not supported",
+		}, {
+			Name: "invalid empty path",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "blabla",
+				DataSourceName: "",
+				Query:          "",
+			},
+			ErrMsg: "invalid data source url: empty path supplied",
 		}, {
 			Name: "invalid mysql",
 			Spec: &FromSQLProcedureSpec{

--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -73,3 +73,98 @@ func TestFromSqlUrlValidation(t *testing.T) {
 	}
 	testCases.Run(t, createFromSQLSource)
 }
+
+func TestFromSqliteUrlValidation(t *testing.T) {
+	testCases := executetest.SourceUrlValidationTestCases{
+		{
+			Name: "ok sqlite path1",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "file::memory:",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "ok sqlite path2",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: ":memory:",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "ok sqlite path3",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "bananas.db",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "ok sqlite path4",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "bananas?cool_pragma",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "ok sqlite path5",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "file:test.db?cache=shared&mode=memory",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "ok sqlite path6",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "bananas?cool_pragma&even_better=true",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "ok sqlite path7",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "file:test.db",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
+			Name: "bad sqlite driver",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite4",
+				DataSourceName: "bananas?cool_pragma",
+				Query:          "",
+			},
+			ErrMsg: "sql driver sqlite4 not supported",
+		}, {
+			Name: "bad sqlite path1",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: ":cool_pragma",
+				Query:          "",
+			},
+			ErrMsg: "invalid data source url: parse :cool_pragma: missing protocol scheme",
+		}, {
+			Name: "bad sqlite path2",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "",
+				Query:          "",
+			},
+			ErrMsg: "invalid data source url: empty path supplied",
+		}, {
+			Name: "bad sqlite path3",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "sqlite3",
+				DataSourceName: "    ",
+				Query:          "",
+			},
+			ErrMsg: "invalid data source url: empty path supplied",
+		},
+	}
+	testCases.Run(t, createFromSQLSource)
+}

--- a/stdlib/sql/postgres.go
+++ b/stdlib/sql/postgres.go
@@ -3,10 +3,13 @@ package sql
 import (
 	"database/sql"
 	"fmt"
-	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/execute"
-	"github.com/influxdata/flux/values"
 	"time"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/values"
 )
 
 type PostgresRowReader struct {
@@ -95,6 +98,8 @@ func (m *PostgresRowReader) InitColumnTypes(types []*sql.ColumnType) {
 			stringTypes[i] = flux.TTime
 		case "BOOL":
 			stringTypes[i] = flux.TBool
+		case "TEXT":
+			stringTypes[i] = flux.TString
 		default:
 			stringTypes[i] = flux.TString
 		}
@@ -137,4 +142,24 @@ func NewPostgresRowReader(r *sql.Rows) (execute.RowReader, error) {
 	}
 	reader.InitColumnTypes(types)
 	return reader, nil
+}
+
+// PostgresTranslateColumn translates flux colTypes into their corresponding postgres column type
+func PostgresColumnTranslateFunc() translationFunc {
+	c := map[string]string{
+		flux.TFloat.String():  "FLOAT",
+		flux.TInt.String():    "BIGINT",
+		flux.TUInt.String():   "BIGINT",
+		flux.TString.String(): "TEXT",
+		flux.TTime.String():   "TIMESTAMP",
+		flux.TBool.String():   "BOOL",
+	}
+	return func(f flux.ColType, colName string) (string, error) {
+		s, found := c[f.String()]
+		if !found {
+			return "", errors.Newf(codes.Internal, "PostgreSQL does not support column type %s", f.String())
+		}
+		return colName + " " + s, nil
+	}
+
 }

--- a/stdlib/sql/source_validator.go
+++ b/stdlib/sql/source_validator.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	neturl "net/url"
+	"strings"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/influxdata/flux/codes"
@@ -33,13 +34,35 @@ func validateDataSource(validator url.Validator, driverName string, dataSourceNa
 		if err != nil {
 			return errors.Newf(codes.Invalid, "invalid data source url: %v", err)
 		}
+	case "sqlite3":
+		/*
+			example SQLite is: file:test.db?cache=shared&mode=memory
+			SQLite supports a superset of DSNs, including several special cases that net/url will flag as errors:
+			:memory:
+			file::memory:
+
+			so we need to check for these, otherwise will flag as an error
+		*/
+		if dataSourceName == ":memory:" || dataSourceName == "file::memory:" {
+			return nil
+		}
+		// we have a dsn that MIGHT be valid, so need to parse it - if it fails here, it is likely to be invalid
+		u, err = neturl.Parse(dataSourceName)
+		if err != nil {
+			return errors.Newf(codes.Invalid, "invalid data source url: %v", err)
+		}
+		// NOTE: parser doesn't return an error for an empty path, or a path consisting of only whitespace - not an error as such, but here we rely on the driver implementation "doing the right thing"
+		// better not to, and flag this as an error
+		if strings.TrimSpace(dataSourceName) == "" {
+			return errors.Newf(codes.Invalid, "invalid data source url: %v", "empty path supplied")
+		}
 	default:
 		return errors.Newf(codes.Invalid, "sql driver %s not supported", driverName)
 	}
 
 	if err = validator.Validate(u); err != nil {
 		return errors.Newf(codes.Invalid, "data source did not pass url validation: %v", err)
-	} else {
-		return nil
 	}
+	return nil
+
 }

--- a/stdlib/sql/sql_test.go
+++ b/stdlib/sql/sql_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
@@ -133,57 +134,44 @@ func TestFromRowReader(t *testing.T) {
 	})
 }
 
-func TestMySQLParsing(t *testing.T) {
+func TestMySqlParsing(t *testing.T) {
+	// here we want to build a mocked representation of what's in our MySql db, and then run our RowReader over it, then verify that the results
+	// are as expected.
+	// NOTE: no meaningful test for reading bools, because the DB doesn't support them, and we already know that we can read INT types
 	testCases := []struct {
 		name       string
 		columnName string
-		columnType flux.ColType
-		data       [][]uint8
+		data       *sql.Rows
 		want       [][]values.Value
 	}{
 		{
 			name:       "ints",
 			columnName: "_int",
-			columnType: flux.TInt,
-			data:       stringSliceToByteArrays([]string{"6", "1", "643", "42", "1283", "4", "0", "18"}),
-			want:       [][]values.Value{{values.NewInt(6)}, {values.NewInt(1)}, {values.NewInt(643)}, {values.NewInt(42)}, {values.NewInt(1283)}, {values.NewInt(4)}, {values.NewInt(0)}, {values.NewInt(18)}},
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(int64(6)).AddRow(int64(1)).AddRow(int64(643)).AddRow(int64(42)).AddRow(int64(1283))),
+			want:       [][]values.Value{{values.NewInt(6)}, {values.NewInt(1)}, {values.NewInt(643)}, {values.NewInt(42)}, {values.NewInt(1283)}},
 		},
 		{
 			name:       "floats",
 			columnName: "_float",
-			columnType: flux.TFloat,
-			data:       stringSliceToByteArrays([]string{"6", "1", "643", "42", "1283", "4", "0", "18"}),
-			want:       [][]values.Value{{values.NewFloat(6)}, {values.NewFloat(1)}, {values.NewFloat(643)}, {values.NewFloat(42)}, {values.NewFloat(1283)}, {values.NewFloat(4)}, {values.NewFloat(0)}, {values.NewFloat(18)}},
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(float64(6)).AddRow(float64(1)).AddRow(float64(643)).AddRow(float64(42)).AddRow(float64(1283))),
+			want:       [][]values.Value{{values.NewFloat(6)}, {values.NewFloat(1)}, {values.NewFloat(643)}, {values.NewFloat(42)}, {values.NewFloat(1283)}},
 		},
 		{
 			name:       "strings",
 			columnName: "_string",
-			columnType: flux.TString,
-			data:       stringSliceToByteArrays([]string{"6", "1", "643", "42", "1283", "4", "0", "18"}),
-			want:       [][]values.Value{{values.NewString("6")}, {values.NewString("1")}, {values.NewString("643")}, {values.NewString("42")}, {values.NewString("1283")}, {values.NewString("4")}, {values.NewString("0")}, {values.NewString("18")}},
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(string("6")).AddRow(string("1")).AddRow(string("643")).AddRow(string("42")).AddRow(string("1283"))),
+			want:       [][]values.Value{{values.NewString("6")}, {values.NewString("1")}, {values.NewString("643")}, {values.NewString("42")}, {values.NewString("1283")}},
 		},
 		{
 			name:       "datetime",
 			columnName: "_datetime",
-			columnType: flux.TTime,
-			data: stringSliceToByteArrays([]string{
-				"2019-06-03 13:59:00",
-				"2019-06-03 13:59:01",
-				"2019-06-03 13:59:02",
-				"2019-06-03 13:59:03",
-				"2019-06-03 13:59:04",
-				"2019-06-03 13:59:05",
-				"2019-06-03 13:59:06",
-				"2019-06-03 13:59:07"}),
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(createTestTimes()[0].(time.Time)).AddRow(createTestTimes()[1].(time.Time)).AddRow(createTestTimes()[2].(time.Time)).AddRow(createTestTimes()[3].(time.Time)).AddRow(createTestTimes()[4].(time.Time))),
 			want: [][]values.Value{
 				{values.NewTime(values.ConvertTime(createTestTimes()[0].(time.Time)))},
 				{values.NewTime(values.ConvertTime(createTestTimes()[1].(time.Time)))},
 				{values.NewTime(values.ConvertTime(createTestTimes()[2].(time.Time)))},
 				{values.NewTime(values.ConvertTime(createTestTimes()[3].(time.Time)))},
 				{values.NewTime(values.ConvertTime(createTestTimes()[4].(time.Time)))},
-				{values.NewTime(values.ConvertTime(createTestTimes()[5].(time.Time)))},
-				{values.NewTime(values.ConvertTime(createTestTimes()[6].(time.Time)))},
-				{values.NewTime(values.ConvertTime(createTestTimes()[7].(time.Time)))},
 			},
 		},
 	}
@@ -191,26 +179,137 @@ func TestMySQLParsing(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 
-			TestReader := &MySQLRowReader{}
-
-			TestReader.NextFunc = func() func() bool {
-				i := 0
-				vals := make([]interface{}, len(tc.data))
-				for i, v := range tc.data {
-					vals[i] = v
+			TestReader, err := NewMySQLRowReader(tc.data)
+			if !cmp.Equal(nil, err) {
+				t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+			}
+			i := 0
+			for TestReader.Next() {
+				row, _ := TestReader.GetNextRow()
+				if !cmp.Equal(tc.want[i], row) {
+					t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(tc.want[i], row))
 				}
-				return func() bool {
-					if i < len(tc.data) {
-						TestReader.SetColumns([]interface{}{vals[i]})
-						i++
-						return true
-					}
-					return false
-				}
-			}()
-			TestReader.InitColumnNames([]string{tc.columnName})
-			TestReader.SetColumnTypes([]flux.ColType{tc.columnType})
+				i++
+			}
+		})
+	}
+}
 
+func TestPostgresParsing(t *testing.T) {
+	// here we want to build a mocked representation of what's in our Postgres db, and then run our RowReader over it, then verify that the results
+	// are as expected
+	testCases := []struct {
+		name       string
+		columnName string
+		data       *sql.Rows
+		want       [][]values.Value
+	}{
+		{
+			name:       "ints",
+			columnName: "_int",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(int64(6)).AddRow(int64(1)).AddRow(int64(643)).AddRow(int64(42)).AddRow(int64(1283))),
+			want:       [][]values.Value{{values.NewInt(6)}, {values.NewInt(1)}, {values.NewInt(643)}, {values.NewInt(42)}, {values.NewInt(1283)}},
+		},
+		{
+			name:       "floats",
+			columnName: "_float",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(float64(6)).AddRow(float64(1)).AddRow(float64(643)).AddRow(float64(42)).AddRow(float64(1283))),
+			want:       [][]values.Value{{values.NewFloat(6)}, {values.NewFloat(1)}, {values.NewFloat(643)}, {values.NewFloat(42)}, {values.NewFloat(1283)}},
+		},
+		{
+			name:       "strings",
+			columnName: "_string",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(string("6")).AddRow(string("1")).AddRow(string("643")).AddRow(string("42")).AddRow(string("1283"))),
+			want:       [][]values.Value{{values.NewString("6")}, {values.NewString("1")}, {values.NewString("643")}, {values.NewString("42")}, {values.NewString("1283")}},
+		},
+		{
+			name:       "bools",
+			columnName: "_bools",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(bool(true)).AddRow(bool(false)).AddRow(bool(true)).AddRow(bool(false)).AddRow(bool(true))),
+			want:       [][]values.Value{{values.NewBool(true)}, {values.NewBool(false)}, {values.NewBool(true)}, {values.NewBool(false)}, {values.NewBool(true)}},
+		},
+		{
+			name:       "datetime",
+			columnName: "_datetime",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(createTestTimes()[0].(time.Time)).AddRow(createTestTimes()[1].(time.Time)).AddRow(createTestTimes()[2].(time.Time)).AddRow(createTestTimes()[3].(time.Time)).AddRow(createTestTimes()[4].(time.Time))),
+			want: [][]values.Value{
+				{values.NewTime(values.ConvertTime(createTestTimes()[0].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[1].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[2].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[3].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[4].(time.Time)))},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			TestReader, err := NewPostgresRowReader(tc.data)
+			if !cmp.Equal(nil, err) {
+				t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+			}
+			i := 0
+			for TestReader.Next() {
+				row, _ := TestReader.GetNextRow()
+				if !cmp.Equal(tc.want[i], row) {
+					t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(tc.want[i], row))
+				}
+				i++
+			}
+		})
+	}
+}
+
+func TestSQLiteParsing(t *testing.T) {
+	// here we want to build a mocked representation of what's in our SQLite db, and then run our RowReader over it, then verify that the results
+	// are as expected.
+	// NOTE: no meaningful test for reading bools, because the DB doesn't support them, and we already know that we can read INT types
+	testCases := []struct {
+		name       string
+		columnName string
+		data       *sql.Rows
+		want       [][]values.Value
+	}{
+		{
+			name:       "ints",
+			columnName: "_int",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(int64(6)).AddRow(int64(1)).AddRow(int64(643)).AddRow(int64(42)).AddRow(int64(1283))),
+			want:       [][]values.Value{{values.NewInt(6)}, {values.NewInt(1)}, {values.NewInt(643)}, {values.NewInt(42)}, {values.NewInt(1283)}},
+		},
+		{
+			name:       "floats",
+			columnName: "_float",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(float64(6)).AddRow(float64(1)).AddRow(float64(643)).AddRow(float64(42)).AddRow(float64(1283))),
+			want:       [][]values.Value{{values.NewFloat(6)}, {values.NewFloat(1)}, {values.NewFloat(643)}, {values.NewFloat(42)}, {values.NewFloat(1283)}},
+		},
+		{
+			name:       "strings",
+			columnName: "_string",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(string("6")).AddRow(string("1")).AddRow(string("643")).AddRow(string("42")).AddRow(string("1283"))),
+			want:       [][]values.Value{{values.NewString("6")}, {values.NewString("1")}, {values.NewString("643")}, {values.NewString("42")}, {values.NewString("1283")}},
+		},
+		{
+			name:       "datetime",
+			columnName: "_datetime",
+			data:       mockRowsToSQLRows(sqlmock.NewRows([]string{"column"}).AddRow(createTestTimes()[0].(time.Time)).AddRow(createTestTimes()[1].(time.Time)).AddRow(createTestTimes()[2].(time.Time)).AddRow(createTestTimes()[3].(time.Time)).AddRow(createTestTimes()[4].(time.Time))),
+			want: [][]values.Value{
+				{values.NewTime(values.ConvertTime(createTestTimes()[0].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[1].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[2].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[3].(time.Time)))},
+				{values.NewTime(values.ConvertTime(createTestTimes()[4].(time.Time)))},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			TestReader, err := NewSqliteRowReader(tc.data)
+			if !cmp.Equal(nil, err) {
+				t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+			}
 			i := 0
 			for TestReader.Next() {
 				row, _ := TestReader.GetNextRow()
@@ -241,13 +340,11 @@ func createTestTimes() []interface{} {
 	return a
 }
 
-func stringSliceToByteArrays(s []string) [][]byte {
-	array := make([][]byte, len(s))
-
-	for i := range s {
-		b := []byte(s[i])
-		array[i] = b
-	}
-
-	return array
+// kind of abusing the functionality here, but it works well for our purpose
+func mockRowsToSQLRows(mockedRows *sqlmock.Rows) *sql.Rows {
+	db, mock, _ := sqlmock.New()
+	mock.ExpectQuery("select").WillReturnRows(mockedRows)
+	// the following basically does a type cast to what we need
+	rows, _ := db.Query("select")
+	return rows
 }

--- a/stdlib/sql/sqlite_test.go
+++ b/stdlib/sql/sqlite_test.go
@@ -1,0 +1,137 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/values"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestBoolTranslation(t *testing.T) {
+	// write values to "DB" - as would be done by sql.to() - using sqlite3 as it allows maximum levels of type abuse, and therefore likely the largest
+	// potential for issues
+	db, err := sql.Open("sqlite3", ":memory:")
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// create table - column type can be anything
+	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS bools (name TEXT, age INT, employed BOOL)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert first row - BOOL as BOOL, which sqlite WILL accept as a write - and silently store true as 1
+	q = fmt.Sprintf("INSERT INTO bools (name, age, employed) VALUES (\"albert\",110,true)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert second row - BOOL as INT - again, will accept ok
+	q = fmt.Sprintf("INSERT INTO bools (name, age, employed) VALUES (\"mary\",10,1)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	q = fmt.Sprintf("SELECT * FROM bools")
+	results, err := db.Query(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// read the data back out and check that Flux fails here - we should not be doing magic type casts
+	TestReader := &SqliteRowReader{
+		Cursor: results,
+	}
+
+	TestReader.columnNames = []string{"name", "age", "employed"}
+	TestReader.columnTypes = []flux.ColType{flux.TString, flux.TInt, flux.TInt}
+
+	// all rows should fail to parse into Flux types becuase there is no SQLite boolean type, regardless of what the column "type" is
+	for TestReader.Next() {
+		row, _ := TestReader.GetNextRow()
+		// fail as BOOL
+		if cmp.Equal(values.NewBool(true), row[2]) {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(values.NewBool(true), row[2]))
+		}
+		// succeed as INT, which is what it actually is
+		if !cmp.Equal(values.NewInt(1), row[2]) {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(values.NewInt(1), row[2]))
+		}
+
+	}
+
+}
+
+func TestNulTranslation(t *testing.T) {
+	// write values to "DB" - as would be done by sql.to() - using sqlite3 as it allows maximum levels of type abuse, and therefore likely the largest
+	// potential for issues
+	db, err := sql.Open("sqlite3", ":memory:")
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// create table
+	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS magic (name TEXT, age INT, employed BADINTBOOL)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert first row - null string
+	q = fmt.Sprintf("INSERT INTO magic (age, employed) VALUES (11,true)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert second row - null int
+	q = fmt.Sprintf("INSERT INTO magic (name, employed) VALUES (\"mary\",true)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// insert third row - null bool
+	q = fmt.Sprintf("INSERT INTO magic (name, age) VALUES (\"casper\",10)")
+	_, err = db.Exec(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	q = fmt.Sprintf("SELECT * FROM magic")
+	results, err := db.Query(q)
+	if !cmp.Equal(err, nil) {
+		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+	}
+
+	// read the data back out and check
+	TestReader := &SqliteRowReader{
+		Cursor: results,
+	}
+
+	TestReader.columnNames = []string{"name", "age", "employed"}
+	TestReader.columnTypes = []flux.ColType{flux.TString, flux.TInt, flux.TBool}
+
+	// number of columns == number of rows - and Nill goes left -> right. otherwise the following loop will fail
+	i := 0
+	for TestReader.Next() {
+		row, err := TestReader.GetNextRow()
+		// none should throw errors - expect them all to handle Nulls from DB correctly
+		if !cmp.Equal(err, nil) {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
+		}
+		if !row[i].IsNull() {
+			t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(true, row[i].IsNull()))
+		}
+		i++
+	}
+
+}

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -296,38 +296,10 @@ func CreateInsertComponents(t *ToSQLTransformation, tbl flux.Table) (colNames []
 		if err != nil {
 			return nil, nil, nil, err
 		}
+
 		switch col.Type {
-		case flux.TFloat:
-			v, err := translateColumn()(col.Type, col.Label)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			newSQLTableCols = append(newSQLTableCols, v)
-		case flux.TInt:
-			v, err := translateColumn()(col.Type, col.Label)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			newSQLTableCols = append(newSQLTableCols, v)
-		case flux.TUInt:
-			v, err := translateColumn()(col.Type, col.Label)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			newSQLTableCols = append(newSQLTableCols, v)
-		case flux.TString:
-			v, err := translateColumn()(col.Type, col.Label)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			newSQLTableCols = append(newSQLTableCols, v)
-		case flux.TTime:
-			v, err := translateColumn()(col.Type, col.Label)
-			if err != nil {
-				return nil, nil, nil, err
-			}
-			newSQLTableCols = append(newSQLTableCols, v)
-		case flux.TBool:
+		case flux.TFloat, flux.TInt, flux.TUInt, flux.TString, flux.TBool, flux.TTime:
+			// each type is handled within the function - precise mapping is handled within each driver's implementation
 			v, err := translateColumn()(col.Type, col.Label)
 			if err != nil {
 				return nil, nil, nil, err

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	ToSQLKind = "toSQL"
-	BatchSize = 10000
+	ToSQLKind        = "toSQL"
+	DefaultBatchSize = 10000 //TODO: decide if this should be kept low enough for the lowest (SQLite), or not.
 )
 
 type ToSQLOpSpec struct {
 	DriverName     string `json:"driverName,omitempty"`
 	DataSourceName string `json:"dataSourcename,omitempty"`
 	Table          string `json:"table,omitempty"`
+	BatchSize      int    `json:"batchSize,omitempty"`
 }
 
 func init() {
@@ -31,6 +32,7 @@ func init() {
 			"driverName":     semantic.String,
 			"dataSourceName": semantic.String,
 			"table":          semantic.String,
+			"batchSize":      semantic.Int,
 		},
 		[]string{"driverName", "dataSourceName", "table"},
 	)
@@ -67,6 +69,17 @@ func (o *ToSQLOpSpec) ReadArgs(args flux.Arguments) error {
 		return errors.New(codes.Invalid, "invalid table name")
 	}
 
+	b, _, err := args.GetInt("batchSize")
+	if err != nil {
+		return err
+	}
+	if b <= 0 {
+		// set default as argument we not supplied
+		o.BatchSize = DefaultBatchSize
+	} else {
+		o.BatchSize = int(b)
+	}
+
 	return err
 }
 
@@ -101,6 +114,7 @@ func (o *ToSQLProcedureSpec) Copy() plan.ProcedureSpec {
 			DriverName:     s.DriverName,
 			DataSourceName: s.DataSourceName,
 			Table:          s.Table,
+			BatchSize:      s.BatchSize,
 		},
 	}
 	return res
@@ -183,7 +197,7 @@ func (t *ToSQLTransformation) Process(id execute.DatasetID, tbl flux.Table) (err
 	}
 	for i := range valStrings {
 		if err := ExecuteQueries(t.tx, t.spec.Spec, colNames, &valStrings[i], &valArgs[i]); err != nil {
-			return nil
+			return err
 		}
 	}
 
@@ -216,38 +230,109 @@ func (t *ToSQLTransformation) Finish(id execute.DatasetID, err error) {
 	t.d.Finish(err)
 }
 
+type translationFunc func(f flux.ColType, colname string) (string, error)
+
+func correctBatchSize(batchSize, numberCols int) int {
+	/*
+		BatchSize for the DB is the number of parameters that can be queued within each call to Exec.
+		As each row you send has a parameter count equal to the number of columns (i.e. the number of "?" used in the insert statement), and some DBs
+		have a default limit on the number of parameters which can be queued before calling Exec; SQLite, for example, has a default of 999 (can only be changed
+		at compile time).
+
+		So if the row width is 10 columns, the maximum Batchsize would be:
+
+		(999 - row_width) / row_width = 98 rows. (with 0.9 of a row unused)
+
+		and,
+
+		(1000 - row_width) / row_width = 99 rows. (no remainder)
+
+		NOTE: Given a statement like:
+
+		INSERT INTO data_table (now,values,difference) VALUES(?,?,?)
+
+		each iteration of EXEC() would add 3 new values (one for each of the '?' placeholders) - but the final "parameter count" includes the initial 3 column names.
+		this is why the calculation subracts an initial "column width" from the supplied Batchsize.
+
+		Sending more would result in the call to Exec returning a "too many SQL variables" error, and the transaction would be rolled-back / aborted
+	*/
+
+	if batchSize < numberCols {
+		// if this is because the width of a single row is very large, pass to DB driver, and if this exceeds the number of allowed parameters
+		// this will be fed back to the user to handle - possibly by reducing the row width
+		return numberCols
+	}
+	return (batchSize - numberCols) / numberCols
+}
+
+func getTranslationFunc(driverName string) (func() translationFunc, error) {
+	// simply return the translationFunc that corresponds to the driver type
+	switch driverName {
+	case "sqlite3":
+		return SqliteColumnTranslateFunc, nil
+	case "postgres", "sqlmock":
+		return PostgresColumnTranslateFunc, nil
+	case "mysql":
+		return MysqlColumnTranslateFunc, nil
+	default:
+		return nil, errors.Newf(codes.Internal, "invalid driverName: %s", driverName)
+	}
+
+}
+
 func CreateInsertComponents(t *ToSQLTransformation, tbl flux.Table) (colNames []string, valStringArray [][]string, valArgsArray [][]interface{}, err error) {
 	cols := tbl.Cols()
+	batchSize := correctBatchSize(t.spec.Spec.BatchSize, len(cols))
+
 	labels := make(map[string]idxType, len(cols))
 	var questionMarks, newSQLTableCols []string
 	for i, col := range cols {
 		labels[col.Label] = idxType{Idx: i, Type: col.Type}
 		questionMarks = append(questionMarks, "?")
 		colNames = append(colNames, col.Label)
-
+		driverName := t.spec.Spec.DriverName
+		// the following allows driver-specific type errors (of which there can be MANY) to be returned, rather than the default of invalid type
+		translateColumn, err := getTranslationFunc(driverName)
+		if err != nil {
+			return nil, nil, nil, err
+		}
 		switch col.Type {
 		case flux.TFloat:
-			newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s FLOAT", col.Label))
+			v, err := translateColumn()(col.Type, col.Label)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			newSQLTableCols = append(newSQLTableCols, v)
 		case flux.TInt:
-			newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s BIGINT", col.Label))
+			v, err := translateColumn()(col.Type, col.Label)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			newSQLTableCols = append(newSQLTableCols, v)
 		case flux.TUInt:
-			newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s BIGINT", col.Label))
+			v, err := translateColumn()(col.Type, col.Label)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			newSQLTableCols = append(newSQLTableCols, v)
 		case flux.TString:
-			switch t.spec.Spec.DriverName {
-			case "mysql":
-				newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s TEXT(16383)", col.Label))
-			case "postgres":
-				newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s text", col.Label))
+			v, err := translateColumn()(col.Type, col.Label)
+			if err != nil {
+				return nil, nil, nil, err
 			}
+			newSQLTableCols = append(newSQLTableCols, v)
 		case flux.TTime:
-			switch t.spec.Spec.DriverName {
-			case "mysql":
-				newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s DATETIME", col.Label))
-			case "postgres":
-				newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s TIMESTAMP", col.Label))
+			v, err := translateColumn()(col.Type, col.Label)
+			if err != nil {
+				return nil, nil, nil, err
 			}
+			newSQLTableCols = append(newSQLTableCols, v)
 		case flux.TBool:
-			newSQLTableCols = append(newSQLTableCols, fmt.Sprintf("%s BOOL", col.Label))
+			v, err := translateColumn()(col.Type, col.Label)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			newSQLTableCols = append(newSQLTableCols, v)
 		default:
 			return nil, nil, nil, errors.Newf(codes.Internal, "invalid type for column %s", col.Label)
 		}
@@ -329,7 +414,8 @@ func CreateInsertComponents(t *ToSQLTransformation, tbl flux.Table) (colNames []
 				return err
 			}
 
-			if i != 0 && i%BatchSize == 0 {
+			if i != 0 && i%batchSize == 0 {
+				// create "mini batches" of values - each one represents a single db.Exec to SQL
 				valArgsArray = append(valArgsArray, valueArgs)
 				valStringArray = append(valStringArray, valueStrings)
 				valueArgs = make([]interface{}, 0)
@@ -362,6 +448,8 @@ func ExecuteQueries(tx *sql.Tx, s *ToSQLOpSpec, colNames []string, valueStrings 
 	if s.DriverName != "sqlmock" {
 		_, err := tx.Exec(query, *valueArgs...)
 		if err != nil {
+			// this err which is extremely helpful as it comes from the SQL driver should be
+			// bubbled up further up the stack so user can see the issue
 			if rbErr := tx.Rollback(); rbErr != nil {
 				return errors.Newf(codes.Aborted, "transaction failed (%s) while recovering from %s", err, rbErr)
 			}

--- a/stdlib/sql/to_privates_test.go
+++ b/stdlib/sql/to_privates_test.go
@@ -1,0 +1,168 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	flux "github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// additional and seperate tests that can be run without needing functions to be Exported in sql, just to be testable
+func TestCorrectBatchSize(t *testing.T) {
+	// given the combination of row width and supplied batchSize argument from user, verify that it is modified as required
+	userBatchSize := 1000
+	rowWidth := 10
+	correctedSize := correctBatchSize(userBatchSize, rowWidth)
+	if !cmp.Equal(99, correctedSize) {
+		t.Log(cmp.Diff(90, correctedSize))
+		t.Fail()
+	}
+
+	// verify that the batchSoze is not lower than the width of a single row - if it ever is, we have a big problem
+	userBatchSize = 1
+	correctedSize = correctBatchSize(userBatchSize, rowWidth)
+	if !cmp.Equal(10, correctedSize) {
+		t.Log(cmp.Diff(10, correctedSize))
+		t.Fail()
+	}
+
+	userBatchSize = -1
+	correctedSize = correctBatchSize(userBatchSize, rowWidth)
+	if !cmp.Equal(10, correctedSize) {
+		t.Log(cmp.Diff(10, correctedSize))
+		t.Fail()
+	}
+}
+
+func TestTranslationDriverReturn(t *testing.T) {
+
+	// verify invalid return error
+	_, err := getTranslationFunc("bananas")
+	if !cmp.Equal(errors.New(codes.Internal, "invalid driverName: bananas").Error(), err.Error()) {
+		t.Log(cmp.Diff(errors.New(codes.Internal, "invalid driverName: bananas").Error(), err.Error()))
+		t.Fail()
+	}
+
+	// verify that valid returns expected happiness for SQLITE
+	_, err = getTranslationFunc("sqlite3")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	// verify that valid returns expected happiness for Postgres
+	_, err = getTranslationFunc("postgres")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	// verify that valid returns expected happiness for MySQL
+	_, err = getTranslationFunc("mysql")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+}
+
+func TestSqliteTranslation(t *testing.T) {
+	sqliteTypeTranslations := map[string]flux.ColType{
+		"FLOAT":    flux.TFloat,
+		"INT":      flux.TInt,
+		"TEXT":     flux.TString,
+		"DATETIME": flux.TTime,
+	}
+	columnLabel := "apples"
+	sqlT, err := getTranslationFunc("sqlite3")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	for dbTypeString, fluxType := range sqliteTypeTranslations {
+		v, err := sqlT()(fluxType, columnLabel)
+		if !cmp.Equal(nil, err) {
+			t.Log(cmp.Diff(nil, err))
+			t.Fail()
+		}
+		if !cmp.Equal(columnLabel+" "+dbTypeString, v) {
+			t.Log(cmp.Diff(columnLabel+" "+dbTypeString, v))
+			t.Fail()
+		}
+	}
+
+	// as SQLITE has NO BOOLEAN column type, we need to return an error rather than doing implicit conversions
+	_, err = sqlT()(flux.TBool, columnLabel)
+	if cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+	if !cmp.Equal("SQLite does not support column type bool", err.Error()) {
+		t.Log(cmp.Diff("SQLite does not support column type bool", err.Error()))
+		t.Fail()
+	}
+
+}
+
+func TestPostgresTranslation(t *testing.T) {
+	postgresTypeTranslations := map[string]flux.ColType{
+		"FLOAT":     flux.TFloat,
+		"TEXT":      flux.TString,
+		"BIGINT":    flux.TInt,
+		"TIMESTAMP": flux.TTime,
+		"BOOL":      flux.TBool,
+	}
+
+	columnLabel := "apples"
+	// verify that valid returns expected happiness for postgres
+	sqlT, err := getTranslationFunc("postgres")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	for dbTypeString, fluxType := range postgresTypeTranslations {
+		v, err := sqlT()(fluxType, columnLabel)
+		if !cmp.Equal(nil, err) {
+			t.Log(cmp.Diff(nil, err))
+			t.Fail()
+		}
+		if !cmp.Equal(columnLabel+" "+dbTypeString, v) {
+			t.Log(cmp.Diff(columnLabel+" "+dbTypeString, v))
+			t.Fail()
+		}
+	}
+}
+
+func TestMysqlTranslation(t *testing.T) {
+	mysqlTypeTranslations := map[string]flux.ColType{
+		"FLOAT":       flux.TFloat,
+		"BIGINT":      flux.TInt,
+		"TEXT(16383)": flux.TString,
+		"DATETIME":    flux.TTime,
+		"BOOL":        flux.TBool,
+	}
+
+	columnLabel := "apples"
+	// verify that valid returns expected happiness for postgres
+	sqlT, err := getTranslationFunc("mysql")
+	if !cmp.Equal(nil, err) {
+		t.Log(cmp.Diff(nil, err))
+		t.Fail()
+	}
+
+	for dbTypeString, fluxType := range mysqlTypeTranslations {
+		v, err := sqlT()(fluxType, columnLabel)
+		if !cmp.Equal(nil, err) {
+			t.Log(cmp.Diff(nil, err))
+			t.Fail()
+		}
+		if !cmp.Equal(columnLabel+" "+dbTypeString, v) {
+			t.Log(cmp.Diff(columnLabel+" "+dbTypeString, v))
+			t.Fail()
+		}
+	}
+}

--- a/stdlib/sql/to_test.go
+++ b/stdlib/sql/to_test.go
@@ -3,9 +3,12 @@ package sql_test
 import (
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin" // We need to import the builtins for the tests to work.
 	"github.com/influxdata/flux/dependencies/dependenciestest"
@@ -38,6 +41,7 @@ func TestSqlTo(t *testing.T) {
 							DriverName:     "sqlmock",
 							DataSourceName: "root@/db",
 							Table:          "TestTable",
+							BatchSize:      fsql.DefaultBatchSize,
 						},
 					},
 				},
@@ -364,4 +368,307 @@ func TestToSql_NewTransformation(t *testing.T) {
 		},
 	}
 	test.Run(t)
+}
+func TestSqlite3To(t *testing.T) {
+	tests := []querytest.NewQueryTestCase{
+		{
+			Name: "from with database",
+			Raw:  `import "sql" from(bucket: "mybucket") |> sql.to(driverName:"sqlite3", dataSourceName:"file::memory:", table:"TestTable", batchSize:10000)`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: "mybucket",
+						},
+					},
+					{
+						ID: "toSQL1",
+						Spec: &fsql.ToSQLOpSpec{
+							DriverName:     "sqlite3",
+							DataSourceName: "file::memory:",
+							Table:          "TestTable",
+							BatchSize:      10000,
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "toSQL1"},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			querytest.NewQueryTestHelper(t, tc)
+		})
+	}
+}
+
+func TestToSQLite3_Process(t *testing.T) {
+	driverName := "sqlite3"
+	// use the in-memory mode - so we can test the functionality of the "type interactions" between driver and flux without needing an underlying FS
+	dsn := "file::memory:"
+	_, _, _ = sqlmock.NewWithDSN(dsn)
+	type wanted struct {
+		Table        []*executetest.Table
+		ColumnNames  []string
+		ValueStrings [][]string
+		ValueArgs    [][]interface{}
+	}
+	testCases := []struct {
+		name string
+		spec *fsql.ToSQLProcedureSpec
+		data flux.Table
+		want wanted
+	}{
+		{
+			name: "coltable with name in _measurement",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", 2.0, "one"},
+					{execute.Time(21), "a", 2.0, "one"},
+					{execute.Time(21), "b", 1.0, "seven"},
+					{execute.Time(31), "a", 3.0, "nine"},
+					{execute.Time(41), "c", 4.0, "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", 2.0, "one"},
+						{execute.Time(21), "a", 2.0, "one"},
+						{execute.Time(21), "b", 1.0, "seven"},
+						{execute.Time(31), "a", 3.0, "nine"},
+						{execute.Time(41), "c", 4.0, "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", 2.0, "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", 2.0, "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", 1.0, "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", 3.0, "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", 4.0, "elevendyone"}},
+			},
+		},
+		{
+			name: "coltable with ints",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", int64(2), "one"},
+					{execute.Time(21), "a", int64(2), "one"},
+					{execute.Time(21), "b", int64(1), "seven"},
+					{execute.Time(31), "a", int64(3), "nine"},
+					{execute.Time(41), "c", int64(4), "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TInt},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", int64(2), "one"},
+						{execute.Time(21), "a", int64(2), "one"},
+						{execute.Time(21), "b", int64(1), "seven"},
+						{execute.Time(31), "a", int64(3), "nine"},
+						{execute.Time(41), "c", int64(4), "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", int64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", int64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", int64(1), "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", int64(3), "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", int64(4), "elevendyone"}},
+			},
+		},
+		{
+			name: "coltable with uints",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TUInt},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", uint64(2), "one"},
+					{execute.Time(21), "a", uint64(2), "one"},
+					{execute.Time(21), "b", uint64(1), "seven"},
+					{execute.Time(31), "a", uint64(3), "nine"},
+					{execute.Time(41), "c", uint64(4), "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TUInt},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", uint64(2), "one"},
+						{execute.Time(21), "a", uint64(2), "one"},
+						{execute.Time(21), "b", uint64(1), "seven"},
+						{execute.Time(31), "a", uint64(3), "nine"},
+						{execute.Time(41), "c", uint64(4), "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", uint64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", uint64(2), "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", uint64(1), "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", uint64(3), "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", uint64(4), "elevendyone"}},
+			},
+		},
+		{
+			name: "coltable with bool",
+			spec: &fsql.ToSQLProcedureSpec{
+				Spec: &fsql.ToSQLOpSpec{
+					DriverName:     driverName,
+					DataSourceName: dsn,
+					Table:          "TestTable2",
+					BatchSize:      10000,
+				},
+			},
+			data: executetest.MustCopyTable(&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_measurement", Type: flux.TString},
+					{Label: "_value", Type: flux.TBool},
+					{Label: "fred", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(11), "a", true, "one"},
+					{execute.Time(21), "a", true, "one"},
+					{execute.Time(21), "b", false, "seven"},
+					{execute.Time(31), "a", true, "nine"},
+					{execute.Time(41), "c", false, "elevendyone"},
+				},
+			}),
+			want: wanted{
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "_value", Type: flux.TBool},
+						{Label: "fred", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(11), "a", true, "one"},
+						{execute.Time(21), "a", true, "one"},
+						{execute.Time(21), "b", false, "seven"},
+						{execute.Time(31), "a", true, "nine"},
+						{execute.Time(41), "c", false, "elevendyone"},
+					},
+				}},
+				ColumnNames:  []string{"_time", "_measurement", "_value", "fred"},
+				ValueStrings: [][]string{{"(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)", "(?,?,?,?)"}},
+				ValueArgs: [][]interface{}{{
+					values.Time(int64(execute.Time(11))).Time(), "a", true, "one",
+					values.Time(int64(execute.Time(21))).Time(), "a", true, "one",
+					values.Time(int64(execute.Time(21))).Time(), "b", false, "seven",
+					values.Time(int64(execute.Time(31))).Time(), "a", true, "nine",
+					values.Time(int64(execute.Time(41))).Time(), "c", false, "elevendyone"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			d := executetest.NewDataset(executetest.RandomDatasetID())
+			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
+			c.SetTriggerSpec(plan.DefaultTriggerSpec)
+
+			transformation, err := fsql.NewToSQLTransformation(d, dependenciestest.Default(), c, tc.spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			a := tc.data
+			colNames, valStrings, valArgs, err := fsql.CreateInsertComponents(transformation, a)
+			if tc.name == "coltable with bool" {
+				// sqlite doesn't have a BOOL type, so let user know, do not perform implicit type conversion
+				if err == nil {
+					t.Fatal(err)
+				}
+				if err.Error() != "SQLite does not support column type bool" {
+					t.Fatal(err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !cmp.Equal(tc.want.ColumnNames, colNames, cmpopts.EquateNaNs()) {
+					t.Log(cmp.Diff(tc.want.ColumnNames, colNames))
+					t.Fail()
+				}
+				if !cmp.Equal(tc.want.ValueStrings, valStrings, cmpopts.EquateNaNs()) {
+					t.Log(cmp.Diff(tc.want.ValueStrings, valStrings))
+					t.Fail()
+				}
+				if !cmp.Equal(tc.want.ValueArgs, valArgs, cmpopts.EquateNaNs()) {
+					t.Log(cmp.Diff(tc.want.ValueArgs, valArgs))
+					t.Fail()
+				}
+			}
+		})
+	}
 }

--- a/stdlib/sql/to_test.go
+++ b/stdlib/sql/to_test.go
@@ -3,12 +3,9 @@ package sql_test
 import (
 	"testing"
 
-	_ "github.com/mattn/go-sqlite3"
-
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin" // We need to import the builtins for the tests to work.
 	"github.com/influxdata/flux/dependencies/dependenciestest"
@@ -20,6 +17,7 @@ import (
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	fsql "github.com/influxdata/flux/stdlib/sql"
 	"github.com/influxdata/flux/values"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestSqlTo(t *testing.T) {


### PR DESCRIPTION
Adds support for SQLite3 to the stdlib/sql package. SQLite is a fully SQL compliant relational DB, in a file (or in memory, if preferred). Adding this to flux would allow it to interact with this DB, and present a lot of opportunity to extract information from many 3rd party "infrastructure tools", and combine this with Influxdb, or other data sources.

- SQLite3 to() and from() are both supported.

- Slight refactor of common sql stuff (specifically from CreateInsertComponents() column types) to allow for easier addition of other flavours of SQL DB. Main area is move of "type logic" into the driver files themselves, as these are often very specific to any given DB. This also allows for returning driver-specific type errors (i.e. when you try to create a column of an unsupported type)

- SQL errors are now returned to the user to allow for troubleshooting failures.

- Added new (optional) “batchSize” argument to sql.to() that allows us to set limits on the batch size at runtime, thereby allowing for throttling. This simply allows us to override the already set (via const var) size at runtime.

Closes #1933
Fixes #1938
#2006

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written

