### PR TITLE
ci: download and install flatbuffers in Dockerfile_build

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     ruby \
     ca-certificates curl file \
-    build-essential \
+    build-essential cmake \
     autoconf automake autotools-dev libtool xutils-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -21,6 +21,14 @@ RUN curl http://www.colm.net/files/ragel/ragel-${RAGEL_VERSION}.tar.gz -O && \
     make install && \
     cd .. && rm -rf ragel-${RAGEL_VERSION}*
 ENV PATH="/usr/local/bin:${PATH}"
+
+ENV FLATBUFFERS_VERSION=1.11.0
+RUN curl -LS https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.tar.gz | gunzip -c | tar x && \
+    mkdir flatbuffers-${FLATBUFFERS_VERSION}/build && \
+    cd flatbuffers-${FLATBUFFERS_VERSION}/build && \
+    cmake -G "Unix Makefiles" .. && \
+    make && make install && \
+    cd ../.. && rm -rf flatbuffers-${FLATBUFFERS_VERSION}
 
 # Install and configure openssl - needed for proper Rust install
 ENV SSL_VERSION=1.0.2q


### PR DESCRIPTION
We need to run `flatc` as part of the `checkgenerate` target in CI.  This adds commands to get and install the FlatBuffers package in `Dockerfile_build`.