### PR TITLE
ci: include required libtinfo dependency in Dockerfile_build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: nathanielc/flux-build:latest
+      - image: quay.io/influxdb/flux-build:latest
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: -p=8
@@ -60,7 +60,7 @@ jobs:
           when: always
   test-race:
     docker:
-      - image: nathanielc/flux-build:latest
+      - image: quay.io/influxdb/flux-build:latest
     environment:
       GOPATH: /tmp/go
       GOFLAGS: -p=8
@@ -78,7 +78,7 @@ jobs:
       # No need to save the pkg/mod cache since the other job does it
   test-bench:
     docker:
-      - image: nathanielc/flux-build:latest
+      - image: quay.io/influxdb/flux-build:latest
     environment:
       GOPATH: /tmp/go
       GOFLAGS: -p=8

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -5,6 +5,7 @@ FROM golang:1.12
 # Install common packages
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
+    libtinfo5 \
     ruby \
     ca-certificates curl file \
     build-essential cmake \
@@ -31,7 +32,7 @@ RUN curl -LS https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSIO
     cd ../.. && rm -rf flatbuffers-${FLATBUFFERS_VERSION}
 
 # Install and configure openssl - needed for proper Rust install
-ENV SSL_VERSION=1.0.2q
+ENV SSL_VERSION=1.0.2t
 
 RUN curl https://www.openssl.org/source/openssl-$SSL_VERSION.tar.gz -O && \
     tar -xzf openssl-$SSL_VERSION.tar.gz && \


### PR DESCRIPTION

Also made CircleCI config point at quay.io instead of nathanielc's Docker hub.

