### PR TITLE
fix(memory): reorder variables in the allocator for atomic operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go v0.43.0
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
-	github.com/apache/arrow/go/arrow v0.0.0-20190809133625-b98a560fc561
+	github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db
 	github.com/c-bata/go-prompt v0.2.2
 	github.com/cespare/xxhash v1.1.0
 	github.com/dave/jennifer v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNg
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/apache/arrow/go/arrow v0.0.0-20190809133625-b98a560fc561 h1:KV3aFGTnXs2V1/5p2mspoWEXFFHAp1U2+ZgW4eTUc2g=
-github.com/apache/arrow/go/arrow v0.0.0-20190809133625-b98a560fc561/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
+github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db h1:nxAtV4VajJDhKysp2kdcJZsq8Ss1xSA0vZTkVHHJd0E=
+github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/apex/log v1.1.0 h1:J5rld6WVFi6NxA6m8GJ1LJqu3+GiTFIt3mYv27gdQWI=
 github.com/apex/log v1.1.0/go.mod h1:yA770aXIDQrhVOIGurT/pVdfCpSq1GQV/auzMN5fzvY=
 github.com/aws/aws-sdk-go v1.15.64 h1:xI5HhxebTF+jVqVOraUDqI3kr24n+yTvslwZCo3OhGA=

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -19,6 +19,15 @@ var _ memory.Allocator = (*Allocator)(nil)
 
 // Allocator tracks the amount of memory being consumed by a query.
 type Allocator struct {
+	// Variables accessed with atomic operations should be at
+	// the beginning of the struct to ensure byte alignment is correct.
+	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	allocationLimit int64
+	bytesAllocated  int64
+	maxAllocated    int64
+	totalAllocated  int64
+	mu              sync.Mutex
+
 	// Limit is the limit on the amount of memory that this allocator
 	// can assign. If this is null, there is no limit.
 	Limit *int64
@@ -33,12 +42,6 @@ type Allocator struct {
 	// allocate and free memory.
 	// If this is unset, the DefaultAllocator is used.
 	Allocator memory.Allocator
-
-	allocationLimit int64
-	bytesAllocated  int64
-	maxAllocated    int64
-	totalAllocated  int64
-	mu              sync.Mutex
 }
 
 // Allocate will ensure that the requested memory is available and


### PR DESCRIPTION
The variables used by atomic operations have to be byte aligned for
these operations to succeed. The easiest way to ensure this happens is
to put these variables at the top of the struct.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written