### PR TITLE
feat(values): updated the duration value to include months and negative flag

### DIFF
--- a/internal/parser/strconv.go
+++ b/internal/parser/strconv.go
@@ -10,6 +10,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 // ParseTime will parse a time literal from a string.
@@ -48,6 +50,10 @@ func ParseDuration(lit string) ([]ast.Duration, error) {
 			n += size
 		}
 
+		if n == 0 {
+			return nil, errors.Newf(codes.Invalid, "invalid duration %s", lit)
+		}
+
 		magnitude, err := strconv.ParseInt(lit[:n], 10, 64)
 		if err != nil {
 			return nil, err
@@ -66,6 +72,11 @@ func ParseDuration(lit string) ([]ast.Duration, error) {
 			}
 			n += size
 		}
+
+		if n == 0 {
+			return nil, errors.Newf(codes.Invalid, "duration is missing a unit: %s", lit)
+		}
+
 		unit := lit[:n]
 		if unit == "µs" {
 			unit = "us"

--- a/stdlib/json/encode_test.go
+++ b/stdlib/json/encode_test.go
@@ -42,7 +42,7 @@ o = {
     e: /.*/,
 	f: 2019-08-14T10:03:12Z,
 }
-json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":\"1m0s\"},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\"}")  or fail()
+json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":\"1m\"},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\"}")  or fail()
 `
 	ctx := dependenciestest.Default().Inject(context.Background())
 	if _, _, err := flux.Eval(ctx, script, addFail); err != nil {

--- a/stdlib/universe/typeconv_test.go
+++ b/stdlib/universe/typeconv_test.go
@@ -556,7 +556,7 @@ func TestTypeconv_Duration(t *testing.T) {
 			name:      "duration(error)",
 			v:         "not_a_duration",
 			want:      values.ConvertDuration(0),
-			expectErr: errors.New("time: invalid duration not_a_duration"),
+			expectErr: errors.New("invalid duration not_a_duration"),
 		},
 		{
 			name:     "duration(v:nil)",

--- a/values/time.go
+++ b/values/time.go
@@ -1,15 +1,30 @@
 package values
 
 import (
+	"strconv"
+	"strings"
 	"time"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/parser"
 )
 
 type Time int64
 
 // Duration is a vector representing the duration unit components.
 type Duration struct {
+	// months is the number of months for the duration.
+	// This must be a positive value.
+	months int64
+
 	// nsecs is the number of nanoseconds for the duration.
+	// This must be a positive value.
 	nsecs int64
+
+	// negative indicates this duration is a negative value.
+	negative bool
 }
 
 const (
@@ -22,48 +37,56 @@ func ConvertTime(t time.Time) Time {
 
 // ConvertDuration takes a time.Duration and converts it into a Duration.
 func ConvertDuration(v time.Duration) Duration {
-	return Duration{nsecs: int64(v)}
+	negative := false
+	if v < 0 {
+		negative, v = true, -v
+	}
+	return Duration{
+		negative: negative,
+		nsecs:    int64(v),
+	}
 }
 
 func (t Time) Round(d Duration) Time {
-	if d.nsecs <= 0 {
+	if !d.IsPositive() {
 		return t
 	}
 	r := t.Remainder(d)
 	if lessThanHalf(r, d) {
-		return t - Time(r.nsecs)
+		return t - Time(r.Duration())
 	}
-	return t + Time(d.nsecs-r.nsecs)
+	return t + Time(d.Duration()-r.Duration())
 }
 
 func (t Time) Truncate(d Duration) Time {
-	if d.nsecs <= 0 {
+	if !d.IsPositive() {
 		return t
 	}
 	r := t.Remainder(d)
-	return t - Time(r.nsecs)
+	return t - Time(r.Duration())
 }
 
 func (t Time) Add(d Duration) Time {
-	return t + Time(d.nsecs)
+	return t + Time(d.Duration())
 }
 
 // Sub takes another time and returns a duration giving the duration
 // between the two times. A positive duration indicates that the receiver
 // occurs after the other time.
 func (t Time) Sub(other Time) Duration {
-	return Duration{nsecs: int64(t - other)}
+	return ConvertDuration(time.Duration(t - other))
 }
 
 // Remainder divides t by d and returns the remainder.
 func (t Time) Remainder(d Duration) (r Duration) {
-	return Duration{nsecs: int64(t) % int64(d.nsecs)}
+	return ConvertDuration(time.Duration(t) % d.Duration())
 }
 
 // lessThanHalf reports whether x+x < y but avoids overflow,
 // assuming x and y are both positive (Duration is signed).
 func lessThanHalf(x, y Duration) bool {
-	return uint64(x.nsecs)+uint64(x.nsecs) < uint64(y.nsecs)
+	xnsecs, ynsecs := x.Duration(), y.Duration()
+	return uint64(xnsecs)+uint64(xnsecs) < uint64(ynsecs)
 }
 
 func (t Time) String() string {
@@ -85,38 +108,44 @@ func (t Time) Time() time.Time {
 // Mul will multiply the Duration by a scalar.
 // This multiplies each component of the vector.
 func (d Duration) Mul(scale int) Duration {
-	return Duration{
-		nsecs: d.nsecs * int64(scale),
+	if scale < 0 {
+		scale = -scale
+		d.negative = !d.negative
 	}
+	d.months *= int64(scale)
+	d.nsecs *= int64(scale)
+	return d
 }
 
 // IsPositive returns true if this is a positive number.
 // It returns false if the number is zero.
 func (d Duration) IsPositive() bool {
-	return d.nsecs > 0
+	return !d.negative && !d.IsZero()
 }
 
 // IsZero returns true if this is a zero duration.
 func (d Duration) IsZero() bool {
-	return d.nsecs == 0
+	return d.months == 0 && d.nsecs == 0
 }
 
 // Normalize will normalize the duration within the interval.
 // It will ensure that the output duration is the smallest positive
 // duration that is the equivalent of the current duration.
 func (d Duration) Normalize(interval Duration) Duration {
-	offset, every := d.nsecs, interval.nsecs
+	offset, every := int64(d.Duration()), int64(interval.Duration())
 	if offset < 0 {
 		offset += every * ((offset / -every) + 1)
 	} else if offset > every {
 		offset -= every * (offset / every)
 	}
-	return Duration{nsecs: offset}
+	return ConvertDuration(time.Duration(offset))
 }
 
 // Equal returns true if the two durations are equal.
 func (d Duration) Equal(other Duration) bool {
-	return d.nsecs == other.nsecs
+	return d.negative == other.negative &&
+		d.months == other.months &&
+		d.nsecs == other.nsecs
 }
 
 // Duration will return the nanosecond equivalent
@@ -129,15 +158,90 @@ func (d Duration) Equal(other Duration) bool {
 // and it should only be used for interfacing with
 // outside code that is not month-aware.
 func (d Duration) Duration() time.Duration {
-	return time.Duration(d.nsecs)
+	months := d.months * 30 * 24 * int64(time.Hour)
+	dur := d.nsecs + months
+	if d.negative {
+		dur = -dur
+	}
+	return time.Duration(dur)
 }
+
 func (d Duration) String() string {
-	return time.Duration(d.nsecs).String()
+	if d.IsZero() {
+		return "0ns"
+	}
+
+	var buf []byte
+	writeInt := func(sb *strings.Builder, v int64, unit string) {
+		buf = strconv.AppendInt(buf, v, 10)
+		sb.Grow(len(buf) + len(unit))
+		sb.Write(buf)
+		sb.WriteString(unit)
+		buf = buf[:0]
+	}
+	var sb strings.Builder
+	if d.negative {
+		sb.WriteByte('-')
+	}
+
+	if d.months > 0 {
+		if years := d.months / 12; years > 0 {
+			writeInt(&sb, years, "y")
+		}
+		if months := d.months % 12; months > 0 {
+			writeInt(&sb, months, "mo")
+		}
+	}
+
+	if d.nsecs > 0 {
+		nsecs := d.nsecs % 1000
+		d.nsecs /= 1000
+		usecs := d.nsecs % 1000
+		d.nsecs /= 1000
+		msecs := d.nsecs % 1000
+		d.nsecs /= 1000
+		secs := d.nsecs % 60
+		d.nsecs /= 60
+		mins := d.nsecs % 60
+		d.nsecs /= 60
+		hours := d.nsecs % 24
+		d.nsecs /= 24
+		days := d.nsecs % 7
+		d.nsecs /= 7
+		weeks := d.nsecs
+
+		if weeks > 0 {
+			writeInt(&sb, weeks, "w")
+		}
+		if days > 0 {
+			writeInt(&sb, days, "d")
+		}
+		if hours > 0 {
+			writeInt(&sb, hours, "h")
+		}
+		if mins > 0 {
+			writeInt(&sb, mins, "m")
+		}
+		if secs > 0 {
+			writeInt(&sb, secs, "s")
+		}
+		if msecs > 0 {
+			writeInt(&sb, msecs, "ms")
+		}
+		if usecs > 0 {
+			writeInt(&sb, usecs, "us")
+		}
+		if nsecs > 0 {
+			writeInt(&sb, nsecs, "ns")
+		}
+	}
+	return sb.String()
 }
 
 func (d Duration) MarshalText() ([]byte, error) {
 	return []byte(d.String()), nil
 }
+
 func (d *Duration) UnmarshalText(data []byte) error {
 	dur, err := ParseDuration(string(data))
 	if err != nil {
@@ -148,11 +252,62 @@ func (d *Duration) UnmarshalText(data []byte) error {
 }
 
 func ParseDuration(s string) (Duration, error) {
-	// TODO(jsternberg): This should use the real duration parsing
-	// instead of time.ParseDuration.
-	d, err := time.ParseDuration(s)
+	dur, err := parser.ParseSignedDuration(s)
 	if err != nil {
 		return Duration{}, err
 	}
-	return Duration{nsecs: int64(d)}, nil
+	return DurationFromAST(dur)
+}
+
+// DurationFromAST creates a duration value from the AST DurationLiteral.
+func DurationFromAST(dur *ast.DurationLiteral) (d Duration, err error) {
+	if len(dur.Values) == 0 {
+		return d, nil
+	}
+
+	// Determine if this duration is negative. Every other value
+	// must be consistent with this.
+	d.negative = dur.Values[0].Magnitude < 0
+	for _, du := range dur.Values {
+		mag, unit := du.Magnitude, du.Unit
+		if (mag >= 0 && d.negative) || (mag < 0 && !d.negative) {
+			return Duration{}, errors.New(codes.Invalid, "duration magnitudes must be the same sign")
+		}
+
+		if d.negative {
+			mag = -mag
+		}
+
+		switch unit {
+		case "y":
+			mag *= 12
+			fallthrough
+		case "mo":
+			d.months += mag
+		case "w":
+			mag *= 7
+			fallthrough
+		case "d":
+			mag *= 24
+			fallthrough
+		case "h":
+			mag *= 60
+			fallthrough
+		case "m":
+			mag *= 60
+			fallthrough
+		case "s":
+			mag *= 1000
+			fallthrough
+		case "ms":
+			mag *= 1000
+			fallthrough
+		case "us", "µs":
+			mag *= 1000
+			fallthrough
+		case "ns":
+			d.nsecs += mag
+		}
+	}
+	return d, nil
 }

--- a/values/time_test.go
+++ b/values/time_test.go
@@ -1,37 +1,35 @@
-package values_test
+package values
 
 import (
 	"testing"
 	"time"
-
-	"github.com/influxdata/flux/values"
 )
 
 func TestTime_Round(t *testing.T) {
 	for _, tt := range []struct {
-		ts   values.Time
-		d    values.Duration
-		want values.Time
+		ts   Time
+		d    Duration
+		want Time
 	}{
 		{
-			ts:   values.Time(time.Second + 500*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(2 * time.Second),
+			ts:   Time(time.Second + 500*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(2 * time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 501*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(2 * time.Second),
+			ts:   Time(time.Second + 501*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(2 * time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 499*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 499*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 0*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 0*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 	} {
 		t.Run(tt.ts.String(), func(t *testing.T) {
@@ -44,39 +42,260 @@ func TestTime_Round(t *testing.T) {
 
 func TestTime_Truncate(t *testing.T) {
 	for _, tt := range []struct {
-		ts   values.Time
-		d    values.Duration
-		want values.Time
+		ts   Time
+		d    Duration
+		want Time
 	}{
 		{
-			ts:   values.Time(time.Second + 500*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 500*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 501*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 501*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 499*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 499*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 0*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 0*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 		{
-			ts:   values.Time(time.Second + 999*time.Millisecond),
-			d:    values.ConvertDuration(time.Second),
-			want: values.Time(time.Second),
+			ts:   Time(time.Second + 999*time.Millisecond),
+			d:    ConvertDuration(time.Second),
+			want: Time(time.Second),
 		},
 	} {
 		t.Run(tt.ts.String(), func(t *testing.T) {
 			if want, got := tt.want, tt.ts.Truncate(tt.d); want != got {
 				t.Fatalf("unexpected time -want/+got\n\t- %s\n\t%s", want, got)
+			}
+		})
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+	for _, tt := range []struct {
+		s    string
+		want Duration
+	}{
+		{
+			s: `1mo`,
+			want: Duration{
+				months: 1,
+			},
+		},
+		{
+			s: `1m`,
+			want: Duration{
+				nsecs: int64(time.Minute),
+			},
+		},
+		{
+			s: `1m30s`,
+			want: Duration{
+				nsecs: int64(time.Minute + 30*time.Second),
+			},
+		},
+		{
+			s: `1y`,
+			want: Duration{
+				months: 12,
+			},
+		},
+		{
+			s: `6mo`,
+			want: Duration{
+				months: 6,
+			},
+		},
+		{
+			s: `1y6mo`,
+			want: Duration{
+				months: 18,
+			},
+		},
+		{
+			s: `52w`,
+			want: Duration{
+				nsecs: int64(52 * 7 * 24 * time.Hour),
+			},
+		},
+		{
+			s: `-5m`,
+			want: Duration{
+				negative: true,
+				nsecs:    int64(5 * time.Minute),
+			},
+		},
+		{
+			s: `-1y`,
+			want: Duration{
+				negative: true,
+				months:   12,
+			},
+		},
+		{
+			s: `1d`,
+			want: Duration{
+				nsecs: int64(24 * time.Hour),
+			},
+		},
+		{
+			s: `1mo3d`,
+			want: Duration{
+				months: 1,
+				nsecs:  int64(3 * 24 * time.Hour),
+			},
+		},
+		{
+			s: `1d12h`,
+			want: Duration{
+				nsecs: int64(36 * time.Hour),
+			},
+		},
+		{
+			s:    `0ns`,
+			want: Duration{},
+		},
+		{
+			s: `500ms`,
+			want: Duration{
+				nsecs: int64(500 * time.Millisecond),
+			},
+		},
+		{
+			s: `300us`,
+			want: Duration{
+				nsecs: int64(300 * time.Microsecond),
+			},
+		},
+		{
+			s: `300µs`,
+			want: Duration{
+				nsecs: int64(300 * time.Microsecond),
+			},
+		},
+	} {
+		t.Run(tt.s, func(t *testing.T) {
+			got, err := ParseDuration(tt.s)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !got.Equal(tt.want) {
+				t.Fatalf("unexpected duration value -want/+got:\n\t- %s\n\t+ %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDuration_String(t *testing.T) {
+	for _, tt := range []struct {
+		d    Duration
+		want string
+	}{
+		{
+			d: Duration{
+				months: 1,
+			},
+			want: `1mo`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(time.Minute),
+			},
+			want: `1m`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(time.Minute + 30*time.Second),
+			},
+			want: `1m30s`,
+		},
+		{
+			d: Duration{
+				months: 12,
+			},
+			want: `1y`,
+		},
+		{
+			d: Duration{
+				months: 6,
+			},
+			want: `6mo`,
+		},
+		{
+			d: Duration{
+				months: 18,
+			},
+			want: `1y6mo`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(52 * 7 * 24 * time.Hour),
+			},
+			want: `52w`,
+		},
+		{
+			d: Duration{
+				negative: true,
+				nsecs:    int64(5 * time.Minute),
+			},
+			want: `-5m`,
+		},
+		{
+			d: Duration{
+				negative: true,
+				months:   12,
+			},
+			want: `-1y`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(24 * time.Hour),
+			},
+			want: `1d`,
+		},
+		{
+			d: Duration{
+				months: 1,
+				nsecs:  int64(3 * 24 * time.Hour),
+			},
+			want: `1mo3d`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(36 * time.Hour),
+			},
+			want: `1d12h`,
+		},
+		{
+			d:    Duration{},
+			want: `0ns`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(500 * time.Millisecond),
+			},
+			want: `500ms`,
+		},
+		{
+			d: Duration{
+				nsecs: int64(300 * time.Microsecond),
+			},
+			want: `300us`,
+		},
+	} {
+		t.Run(tt.want, func(t *testing.T) {
+			if got, want := tt.d.String(), tt.want; got != want {
+				t.Fatalf("unexpected duration string -want/+got:\n\t- %q\n\t+ %q", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
The duration value is now composed of the months, nanoseconds, and
whether the value is negative or not. This completes making the duration
value month-aware and moving negative into a flag makes it so that we
can ensure the sign of the entire value is the same as specified in the
spec.

This does not implement any of the month behavior. It modifies the
duration function, which returns a `time.Duration`, to treat each month
as 30 days. All of the time operations use `time.Duration` to compute
the final value.

BREAKING CHANGE: The string output of a duration has been modified to use the
flux representation of the value rather than the go representation.

Fixes #1985.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written