### PR TITLE
feat(libflux): integrate libflux parser with the go parsing api

### DIFF
--- a/libflux/build.rs
+++ b/libflux/build.rs
@@ -28,6 +28,15 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
+    let ctypes = bindgen::Builder::default()
+        .header("include/influxdata/flux.h")
+        .generate()
+        .expect("Unable to generate c type bindings");
+
+    ctypes
+        .write_to_file(out_path.join("ctypes.rs"))
+        .expect("Couldn't write c type bindings!");
+
     // Run Ragel
     Command::new("ragel")
         .args(&[

--- a/libflux/go/libflux/parser_test.go
+++ b/libflux/go/libflux/parser_test.go
@@ -3,6 +3,7 @@
 package libflux_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/influxdata/flux/libflux/go/libflux"
@@ -17,5 +18,10 @@ from(bucket: "telegraf")
 	|> mean()
 `
 	ast := libflux.Parse(text)
+	buf, err := ast.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(buf))
 	ast.Free()
 }

--- a/libflux/include/influxdata/flux.h
+++ b/libflux/include/influxdata/flux.h
@@ -1,6 +1,8 @@
 #ifndef _INFLUXDATA_FLUX_H
 #define _INFLUXDATA_FLUX_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -8,12 +10,39 @@ extern "C" {
 // flux_ast_t is the AST representation of a flux query.
 struct flux_ast_t;
 
+// flux_buffer_t is a reference to a byte-slice.
+struct flux_buffer_t {
+	// data is a pointer to the data contained within the buffer.
+	void *data;
+
+	// len is the length of the buffer.
+	size_t len;
+};
+
+// flux_error_t represents a flux error.
+struct flux_error_t;
+
 // flux_parse will take in a string and return the AST representation
 // of the query.
 struct flux_ast_t *flux_parse(const char *);
 
-// flux_ast_free will free memory associated with an AST handle.
-void flux_ast_free(struct flux_ast_t *);
+// flux_ast_marshal_json will marshal json and fill in the given buffer
+// with the data. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_ast_marshal_json(struct flux_ast_t *, struct flux_buffer_t *);
+
+// flux_buffer_free will free the memory that was allocated for a buffer.
+// This should only be called if the caller is the one who owns the data.
+void flux_buffer_free(struct flux_buffer_t *);
+
+// flux_error_str will return a string representation of the error.
+// This will allocate memory for the returned string.
+const char *flux_error_str(struct flux_error_t *);
+
+// flux_free will free a resource.
+void flux_free(void *);
 
 #ifdef __cplusplus
 }

--- a/libflux/src/lib.rs
+++ b/libflux/src/lib.rs
@@ -9,24 +9,58 @@ pub mod scanner;
 pub mod semantic;
 
 use std::ffi::*;
-use std::os::raw::c_char;
+use std::error::Error;
+use std::os::raw::{c_void, c_char};
 
 use parser::Parser;
 
+pub mod ctypes {
+    include!(concat!(env!("OUT_DIR"), "/ctypes.rs"));
+}
+use ctypes::*;
+
+struct ErrorHandle {
+    err: Box<dyn Error>,
+}
+
 #[no_mangle]
-pub extern "C" fn flux_parse(cstr: *mut c_char) -> *mut ast::File {
+pub extern "C" fn flux_parse(cstr: *mut c_char) -> *mut flux_ast_t {
     let buf = unsafe {
         CStr::from_ptr(cstr).to_bytes()
     };
     let s = String::from_utf8(buf.to_vec()).unwrap();
     let mut p = Parser::new(&s);
     let file = p.parse_file(String::from(""));
-    return Box::into_raw(Box::new(file));
+    return Box::into_raw(Box::new(file)) as *mut flux_ast_t;
 }
 
 #[no_mangle]
-pub extern "C" fn flux_ast_free(ast: *mut ast::File) {
+pub extern "C" fn flux_ast_marshal_json(ast: *mut flux_ast_t, buf: *mut flux_buffer_t) -> *mut flux_error_t {
+    let self_ = unsafe { &*(ast as *mut ast::File) } as &ast::File;
+    let data = match serde_json::to_vec(self_) {
+        Ok(v) => v,
+        Err(err) => {
+            let errh = ErrorHandle{ err: Box::new(err) };
+            return Box::into_raw(Box::new(errh)) as *mut flux_error_t
+        },
+    };
+
+    let buffer = unsafe { &mut *buf };
+    buffer.len = data.len();
+    buffer.data = Box::into_raw(data.into_boxed_slice()) as *mut c_void;
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub extern "C" fn flux_error_str(err: *mut flux_error_t) -> *mut c_char {
+    let e = unsafe { &*(err as *mut ErrorHandle) };
+    let s = CString::new(e.err.description()).unwrap();
+    return s.into_raw();
+}
+
+#[no_mangle]
+pub extern "C" fn flux_free(err: *mut c_void) {
     unsafe {
-        let _ = Box::from_raw(ast);
+        let _ = Box::from_raw(err);
     }
 }

--- a/parser/go_parser.go
+++ b/parser/go_parser.go
@@ -1,0 +1,13 @@
+// +build !libflux
+
+package parser
+
+import (
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/internal/parser"
+	"github.com/influxdata/flux/internal/token"
+)
+
+func parseFile(f *token.File, src []byte) (*ast.File, error) {
+	return parser.ParseFile(f, src), nil
+}

--- a/parser/libflux_parser.go
+++ b/parser/libflux_parser.go
@@ -1,0 +1,34 @@
+// +build libflux
+
+package parser
+
+import (
+	"encoding/json"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/internal/token"
+	"github.com/influxdata/flux/libflux/go/libflux"
+)
+
+func parseFile(f *token.File, src []byte) (*ast.File, error) {
+	astFile := libflux.Parse(string(src))
+	defer astFile.Free()
+
+	data, err := astFile.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var file ast.File
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, err
+	}
+	file.Name = f.Name()
+
+	// The go parser will not fill in the imports if there are
+	// none so we remove them here to retain compatibility.
+	if len(file.Imports) == 0 {
+		file.Imports = nil
+	}
+	return &file, nil
+}


### PR DESCRIPTION
The libflux parser can be optionally enabled by using `-tags libflux`. If
that tag is used, the `libflux` go wrapper will be used to perform the
parsing which is written in Rust with a C ABI.

This adds a marshal json method to the Rust code as we are still working on
creating a flatbuffers API and using it within both Go and Rust.

This also updates the C API to generate bindings to the C types from the
header file so these types can be formally used instead of types that don't
match. The semantics are still the same. A pointer to a Rust type is cast
in an unsafe way to a mutable raw pointer that gets managed outside of
Rust, but the type names are more consistent which should lend itself to
readability.

Fixes #2009.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written