### PR TITLE
fix(execute): add annotated errors to the execute package where it effects normal usage

### DIFF
--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -2,12 +2,12 @@ package execute
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"regexp"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/compiler"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -138,7 +138,7 @@ func (f *TablePredicateFn) Prepare(tbl flux.Table) error {
 		return err
 	}
 	if f.preparedFn.Type() != semantic.Bool {
-		return errors.New("table predicate function does not evaluate to a boolean")
+		return errors.New(codes.Invalid, "table predicate function does not evaluate to a boolean")
 	}
 	return nil
 }
@@ -192,7 +192,7 @@ func (f *RowPredicateFn) Prepare(cols []flux.ColMeta) error {
 		return err
 	}
 	if f.preparedFn.Type() != semantic.Bool {
-		return errors.New("row predicate function does not evaluate to a boolean")
+		return errors.New(codes.Invalid, "row predicate function does not evaluate to a boolean")
 	}
 	return nil
 }
@@ -240,7 +240,7 @@ func (f *RowMapFn) Prepare(cols []flux.ColMeta) error {
 	}
 	k := f.preparedFn.Type().Nature()
 	if k != semantic.Object {
-		return fmt.Errorf("map function must return an object, got %s", k.String())
+		return errors.Newf(codes.Invalid, "map function must return an object, got %s", k.String())
 	}
 	return nil
 }

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -1,10 +1,10 @@
 package execute
 
 import (
-	"fmt"
-
 	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
@@ -109,7 +109,7 @@ func (t *selectorTransformation) Finish(id DatasetID, err error) {
 func (t *selectorTransformation) setupBuilder(tbl flux.Table) (TableBuilder, int, error) {
 	builder, created := t.cache.TableBuilder(tbl.Key())
 	if !created {
-		return nil, 0, fmt.Errorf("found duplicate table with key: %v", tbl.Key())
+		return nil, 0, errors.Newf(codes.FailedPrecondition, "found duplicate table with key: %v", tbl.Key())
 	}
 	if err := AddTableCols(tbl, builder); err != nil {
 		return nil, 0, err
@@ -118,7 +118,7 @@ func (t *selectorTransformation) setupBuilder(tbl flux.Table) (TableBuilder, int
 	cols := builder.Cols()
 	valueIdx := ColIdx(t.config.Column, cols)
 	if valueIdx < 0 {
-		return nil, 0, fmt.Errorf("no column %q exists", t.config.Column)
+		return nil, 0, errors.Newf(codes.FailedPrecondition, "no column %q exists", t.config.Column)
 	}
 	return builder, valueIdx, nil
 }
@@ -145,7 +145,7 @@ func (t *indexSelectorTransformation) Process(id DatasetID, tbl flux.Table) erro
 	case flux.TString:
 		s = t.selector.NewStringSelector()
 	default:
-		return fmt.Errorf("unsupported selector type %v", valueCol.Type)
+		return errors.Newf(codes.Invalid, "unsupported selector type %v", valueCol.Type)
 	}
 
 	return tbl.Do(func(cr flux.ColReader) error {
@@ -169,7 +169,7 @@ func (t *indexSelectorTransformation) Process(id DatasetID, tbl flux.Table) erro
 			selected := s.(DoStringIndexSelector).DoString(cr.Strings(valueIdx))
 			return t.appendSelected(selected, builder, cr)
 		default:
-			return fmt.Errorf("unsupported selector type %v", valueCol.Type)
+			return errors.Newf(codes.Invalid, "unsupported selector type %v", valueCol.Type)
 		}
 	})
 }
@@ -197,14 +197,14 @@ func (t *rowSelectorTransformation) Process(id DatasetID, tbl flux.Table) error 
 	case flux.TString:
 		rower = t.selector.NewStringSelector()
 	default:
-		return fmt.Errorf("unsupported selector type %v", valueCol.Type)
+		return errors.Newf(codes.Invalid, "unsupported selector type %v", valueCol.Type)
 	}
 
 	// if rower has a nil value, this means that the row selector doesn't
 	// yet have an implementation
 
 	if rower == nil {
-		return fmt.Errorf("invalid use of function: %T has no implementation for type %v", t.selector, valueCol.Type)
+		return errors.Newf(codes.FailedPrecondition, "invalid use of function: %T has no implementation for type %v", t.selector, valueCol.Type)
 	}
 
 	if err := tbl.Do(func(cr flux.ColReader) error {
@@ -222,7 +222,7 @@ func (t *rowSelectorTransformation) Process(id DatasetID, tbl flux.Table) error 
 		case flux.TString:
 			rower.(DoStringRowSelector).DoString(cr.Strings(valueIdx), cr)
 		default:
-			return fmt.Errorf("unsupported selector type %v", valueCol.Type)
+			return errors.Newf(codes.Invalid, "unsupported selector type %v", valueCol.Type)
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
The aggregate, selector, and row functions get used within the universe
package. While we annotated the errors in universe, this didn't effect
transformations that had the bulk of their implementation within the
execute package.

This specifically targets very common errors that could occur so that
they don't show up as internal errors in InfluxDB.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written