### PR TITLE
feat(compile): add EvalOptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ use only the standard libraries, or the third-party packages we have decided to 
 For rationale, check out the post [The Case Against Third Party Libraries](http://blog.gopheracademy.com/advent-2014/case-against-3pl/).
 
 ## Useful links
-- [Useful techniques in Go](http://arslan.io/ten-useful-techniques-in-go)
+- [Useful techniques in Go](https://arslan.io/2015/10/08/ten-useful-techniques-in-go/) 
 - [Go in production](http://peter.bourgon.org/go-in-production/)
 - [Principles of designing Go APIs with channels](https://inconshreveable.com/07-08-2014/principles-of-designing-go-apis-with-channels/)
 - [Common mistakes in Golang](http://soryy.com/blog/2014/common-mistakes-with-go-lang/).

--- a/compile_internal_test.go
+++ b/compile_internal_test.go
@@ -95,3 +95,26 @@ func TestValidatePackageBuiltins(t *testing.T) {
 		})
 	}
 }
+
+func Test_options(t *testing.T) {
+	pkg := &ast.Package{
+		Files: []*ast.File{
+			{
+				Body: []ast.Statement{
+					&ast.VariableAssignment{},
+					&ast.OptionStatement{},
+				},
+			},
+			{
+				Body: []ast.Statement{
+					&ast.VariableAssignment{},
+				},
+			},
+		},
+	}
+
+	actual := options(pkg)
+	if len(actual.Files) != 1 || len(actual.Files[0].Body) != 1 {
+		t.Fail()
+	}
+}

--- a/semantic/analyze.go
+++ b/semantic/analyze.go
@@ -37,6 +37,7 @@ func analyzePackage(pkg *ast.Package) (*Package, error) {
 	}
 	return p, nil
 }
+
 func analyzeFile(file *ast.File) (*File, error) {
 	f := &File{
 		loc:  loc(file.Location()),


### PR DESCRIPTION
A naive implementation to satisy #2051, this PR adds a new `EvalOptions` function that calls `EvalAST` with a filtered deep copy of the AST that excludes all statement types except options. This will allow options to be extracted and inspected without evaluating the full AST. A simple test is included to validate the option filtering logic.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
