### PR TITLE
fix(libflux): correctly lex µs

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -915,7 +915,7 @@ func ResolveFunction(f values.Function) (ResolvedFunction, error) {
 // ResolvedFunction represents a function that can be passed down to the compiler.
 // Both the function expression and scope are captured.
 // The scope cannot be serialized, which is no longer a problem in the current design
-// with excpetion of the REPL which will not be able to correct pass through the scope.
+// with the exception of the REPL which will not be able to correctly pass through the scope.
 type ResolvedFunction struct {
 	Fn    *semantic.FunctionExpression `json:"fn"`
 	Scope values.Scope                 `json:"-"`

--- a/libflux/src/parser/tests.rs
+++ b/libflux/src/parser/tests.rs
@@ -9331,10 +9331,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
     )
 }
 
-// TODO(affo): the scanner fails in lexing µs.
-// There is a related test in the scanner.
 #[test]
-#[ignore] // See https://github.com/influxdata/flux/issues/1448
 fn duration_literal_all_units() {
     let mut p = Parser::new(r#"dur = 1y3mo2w1d4h1m30s1ms2µs70ns"#);
     let parsed = p.parse_file("".to_string());

--- a/libflux/src/scanner/mod.rs
+++ b/libflux/src/scanner/mod.rs
@@ -1,6 +1,6 @@
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-pub type CChar = i8;
+pub type CChar = u8;
 
 use std::ffi::CString;
 use std::str;
@@ -39,15 +39,15 @@ impl Scanner {
         let end = ((ptr as usize) + bytes.len()) as *const CChar;
         return Scanner {
             data: data,
-            ps: ptr,
-            p: ptr,
+            ps: ptr as *const CChar,
+            p: ptr as *const CChar,
             pe: end,
             eof: end,
             ts: 0,
             te: 0,
             lines: vec![0],
             token: TOK_ILLEGAL,
-            checkpoint: ptr,
+            checkpoint: ptr as *const CChar,
         };
     }
 

--- a/libflux/src/scanner/scanner.h
+++ b/libflux/src/scanner/scanner.h
@@ -69,4 +69,6 @@ enum TOK {
 #define WASM_EXPORT __attribute__ ((visibility("default")))
 
 // Scan reads the input and reports the next lexical token. Returns the execution state.
-WASM_EXPORT int scan(int mode, const char **p, const char *data, const char *pe, const char *eof, unsigned int *token, unsigned int *token_start, unsigned int *token_end, const unsigned int **newlines, unsigned int *newlines_len);
+WASM_EXPORT int scan(int mode, const unsigned char **p, const unsigned char *data, const unsigned char *pe,
+        const unsigned char *eof, unsigned int *token, unsigned int *token_start, unsigned int *token_end,
+        const unsigned int **newlines, unsigned int *newlines_len);

--- a/libflux/src/scanner/scanner.rl
+++ b/libflux/src/scanner/scanner.rl
@@ -158,7 +158,8 @@ unsigned int pop(node_t **head) {
     return retval;
 }
 
-int scan(int mode, const char **pp, const char *data, const char *pe, const char *eof, unsigned int *token, unsigned int *token_start, unsigned int *token_end, const unsigned int **newlines, unsigned int *newlines_len) {
+int scan(int mode, const unsigned char **pp, const unsigned char *data, const unsigned char *pe, const unsigned char *eof,
+        unsigned int *token, unsigned int *token_start, unsigned int *token_end, const unsigned int **newlines, unsigned int *newlines_len) {
     int cs;
     switch (mode) {
     case 0:
@@ -171,10 +172,10 @@ int scan(int mode, const char **pp, const char *data, const char *pe, const char
         cs = flux_en_string_expr;
         break;
     }
-    const char *p = *pp;
+    const unsigned char *p = *pp;
     int act;
-    const char *ts;
-    const char *te;
+    const unsigned char *ts;
+    const unsigned char *te;
     unsigned int tok = ILLEGAL;
     node_t* nls = NULL;
     unsigned int no_nls = 0;

--- a/libflux/src/scanner/tests.rs
+++ b/libflux/src/scanner/tests.rs
@@ -845,9 +845,7 @@ fn test_illegal() {
     );
 }
 
-// TODO(affo): this fails.
 #[test]
-#[ignore] // See https://github.com/influxdata/flux/issues/1448
 fn test_scan_duration() {
     let text = r#"dur = 1y3mo2w1d4h1m30s1ms2µs70ns"#;
     let cdata = CString::new(text).expect("CString::new failed");
@@ -881,7 +879,7 @@ fn test_scan_duration() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 32,
+            pos: 33,
         }
     );
 }

--- a/result.go
+++ b/result.go
@@ -37,7 +37,7 @@ type Table interface {
 	Do(f func(ColReader) error) error
 
 	// Done indicates that this table is no longer needed and that the
-	// underlying processer that produces the table may discard any
+	// underlying processor that produces the table may discard any
 	// buffers that need to be processed. If the table has already been
 	// read with Do, this happens automatically.
 	// This is also not required if the table is empty.


### PR DESCRIPTION
Using `unsigned char` instead of `char` in Ragel C generated function will fix this issue!!