### PR TITLE
feat(semantic): type environment

### DIFF
--- a/libflux/src/semantic/env.rs
+++ b/libflux/src/semantic/env.rs
@@ -1,0 +1,100 @@
+use crate::semantic::sub::{Substitutable, Substitution};
+use crate::semantic::types::{union, PolyType, Tvar};
+use std::collections::HashMap;
+
+// A type environment maps program identifiers to their polymorphic types.
+//
+// A type environment is implemented as a stack of frames where each
+// frame holds the bindings for the identifiers declared in a particular
+// lexical block.
+//
+#[derive(Debug, Clone, PartialEq)]
+pub struct Environment {
+    pub parent: Option<Box<Environment>>,
+    pub values: HashMap<String, PolyType>,
+}
+
+impl Substitutable for Environment {
+    fn apply(self, sub: &Substitution) -> Self {
+        Environment {
+            parent: match self.parent {
+                Some(env) => Some(Box::new(env.apply(sub))),
+                None => None,
+            },
+            values: self.values.apply(sub),
+        }
+    }
+    fn free_vars(&self) -> Vec<Tvar> {
+        match &self.parent {
+            Some(env) => union(env.free_vars(), self.values.free_vars()),
+            None => self.values.free_vars(),
+        }
+    }
+}
+
+// Derive a type environment from a hash map
+impl From<HashMap<String, PolyType>> for Environment {
+    fn from(bindings: HashMap<String, PolyType>) -> Environment {
+        Environment {
+            parent: None,
+            values: bindings,
+        }
+    }
+}
+
+impl Environment {
+    pub fn empty() -> Environment {
+        Environment {
+            parent: None,
+            values: HashMap::new(),
+        }
+    }
+    pub fn new(from: Self) -> Environment {
+        Environment {
+            parent: Some(Box::new(from)),
+            values: HashMap::new(),
+        }
+    }
+    pub fn lookup(&self, v: &str) -> Option<&PolyType> {
+        if let Some(t) = self.values.get(v) {
+            Some(t)
+        } else {
+            if let Some(env) = &self.parent {
+                env.lookup(v)
+            } else {
+                None
+            }
+        }
+    }
+    // Add a new variable binding to the current stack frame
+    pub fn add(&mut self, name: String, t: PolyType) {
+        self.values.insert(name, t);
+    }
+    // Remove a variable binding from the current stack frame
+    pub fn remove(&mut self, name: &str) {
+        self.values.remove(name);
+    }
+    // A type environment is a stack where each frame corresponds to a lexical
+    // block inside a Flux program.
+    //
+    // After inferring the types in each lexical block, the frame at the top
+    // of the stack will be popped, returning the type environment for the
+    // enclosing block.
+    //
+    // Note that 'pop' must be paired with a corresponding call to 'new'. In
+    // particular when inferring the type of a function expression, a new
+    // frame must be added to the top of the stack by calling 'new'. Then the
+    // bindings for the function arguments must be added to the new frame. At
+    // that point the type of the function body is inferred and the last frame
+    // is popped from the stack and returned to the calling function.
+    //
+    // It is invalid to call pop on a type environment with only one stack
+    // frame. This will result in a panic.
+    //
+    pub fn pop(self) -> Environment {
+        match self.parent {
+            Some(env) => *env,
+            None => panic!("cannot pop final stack frame from type environment"),
+        }
+    }
+}

--- a/libflux/src/semantic/fresh.rs
+++ b/libflux/src/semantic/fresh.rs
@@ -1,0 +1,23 @@
+use crate::semantic::types::Tvar;
+
+// Fresher returns incrementing type variables
+pub struct Fresher(u64);
+
+// Create a tvar fresher from a u64
+impl From<u64> for Fresher {
+    fn from(u: u64) -> Fresher {
+        Fresher(u)
+    }
+}
+
+impl Fresher {
+    pub fn new() -> Fresher {
+        Fresher(0)
+    }
+
+    pub fn fresh(&mut self) -> Tvar {
+        let u = self.0;
+        self.0 += 1;
+        Tvar(u)
+    }
+}

--- a/libflux/src/semantic/infer.rs
+++ b/libflux/src/semantic/infer.rs
@@ -1,4 +1,8 @@
-use crate::semantic::types::{Kind, MonoType};
+use crate::semantic::env::Environment;
+use crate::semantic::fresh::Fresher;
+use crate::semantic::sub::{Substitutable, Substitution};
+use crate::semantic::types::{minus, Error, Kind, MonoType, PolyType, Tvar};
+use std::collections::HashMap;
 use std::ops;
 
 // Type constraints are produced during type inference and come
@@ -11,21 +15,113 @@ use std::ops;
 // and will be unified at some point.
 //
 #[derive(Debug, PartialEq)]
-enum Constraint {
+pub enum Constraint {
     Kind(MonoType, Kind),
     Equal(MonoType, MonoType),
 }
 
 #[derive(Debug, PartialEq)]
-struct Constraints(Vec<Constraint>);
+pub struct Constraints(Vec<Constraint>);
+
+impl Constraints {
+    pub fn empty() -> Constraints {
+        Constraints(Vec::new())
+    }
+}
 
 // Constraints can be added using the '+' operator
 impl ops::Add for Constraints {
     type Output = Constraints;
 
-    fn add(self, cons: Constraints) -> Self::Output {
-        Constraints(self.0.into_iter().chain(cons.0.into_iter()).collect())
+    fn add(mut self, mut cons: Constraints) -> Self::Output {
+        self.0.append(&mut cons.0);
+        self
     }
+}
+
+impl From<Vec<Constraint>> for Constraints {
+    fn from(constraints: Vec<Constraint>) -> Constraints {
+        Constraints(constraints)
+    }
+}
+
+impl From<Constraints> for Vec<Constraint> {
+    fn from(constraints: Constraints) -> Vec<Constraint> {
+        constraints.0
+    }
+}
+
+// Solve a set of type constraints
+pub fn solve(
+    cons: &Constraints,
+    with: &mut HashMap<Tvar, Vec<Kind>>,
+) -> Result<Substitution, Error> {
+    cons.0
+        .iter()
+        .try_fold(Substitution::empty(), |sub, constraint| match constraint {
+            Constraint::Kind(t, kind) => {
+                // Apply the current substitution to the type, then constrain
+                let s = t.clone().apply(&sub).constrain(*kind, with)?;
+                Ok(sub.merge(s))
+            }
+            Constraint::Equal(t, other) => {
+                // Apply the current substitution to the constraint, then unify
+                let s = t.clone().apply(&sub).unify(other.clone(), with)?;
+                Ok(sub.merge(s))
+            }
+        })
+}
+
+// Create a parametric type from a monotype by universally quantifying
+// all of its free type variables.
+//
+// A type variable is free in a monotype if it is **free** in the global
+// type environment. Equivalently a type variable is free and can be
+// quantified if has not already been quantified another type in the
+// type environment.
+//
+pub fn generalize(env: &Environment, with: &HashMap<Tvar, Vec<Kind>>, t: MonoType) -> PolyType {
+    let vars = minus(&env.free_vars(), t.free_vars());
+    let mut cons = HashMap::new();
+    for (tv, kinds) in with {
+        if vars.contains(tv) {
+            cons.insert(*tv, kinds.to_owned());
+        }
+    }
+    PolyType {
+        free: vars,
+        cons: cons,
+        expr: t,
+    }
+}
+
+// Instantiate a new monotype from a polytype by assigning all universally
+// quantified type variables new fresh variables that do not exist in the
+// current type environment.
+//
+// Instantiation is what allows for polymorphic function specialization
+// based on the context in which a function is called.
+pub fn instantiate(poly: PolyType, f: &mut Fresher) -> (MonoType, Constraints) {
+    // Substitute fresh type variables for all quantified variables
+    let sub: Substitution = poly
+        .free_vars()
+        .into_iter()
+        .map(|tv| (tv, MonoType::Var(f.fresh())))
+        .collect::<HashMap<Tvar, MonoType>>()
+        .into();
+    // Generate constraints for the new fresh type variables
+    let constraints = poly
+        .cons
+        .into_iter()
+        .fold(Constraints::empty(), |cons, (tv, kinds)| {
+            cons + kinds
+                .into_iter()
+                .map(|kind| Constraint::Kind(sub.apply(tv), kind))
+                .collect::<Vec<Constraint>>()
+                .into()
+        });
+    // Instantiate monotype using new fresh type variables
+    (poly.expr.apply(&sub), constraints)
 }
 
 #[cfg(test)]

--- a/libflux/src/semantic/mod.rs
+++ b/libflux/src/semantic/mod.rs
@@ -1,4 +1,6 @@
 mod analyze;
+mod env;
+mod fresh;
 mod infer;
 mod nodes;
 mod sub;

--- a/libflux/src/semantic/nodes.rs
+++ b/libflux/src/semantic/nodes.rs
@@ -8,14 +8,60 @@
 
 extern crate chrono;
 extern crate derivative;
+
 use crate::ast;
+use crate::semantic::infer;
 use crate::semantic::types;
+use crate::semantic::{
+    env::Environment,
+    fresh::Fresher,
+    infer::{Constraint, Constraints},
+    sub::{Substitutable, Substitution},
+    types::{Kind, MonoType, PolyType, Tvar},
+};
 
 use chrono::prelude::DateTime;
 use chrono::Duration;
 use chrono::FixedOffset;
 use derivative::Derivative;
+use std::collections::HashMap;
+use std::fmt;
 use std::vec::Vec;
+
+// Result returned from the various 'infer' methods defined in this
+// module. The result of inferring an expression or statment is an
+// updated type environment and a set of type constraints to be solved.
+type Result = std::result::Result<(Environment, Constraints), Error>;
+
+#[derive(Debug)]
+pub struct Error {
+    msg: String,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl From<types::Error> for Error {
+    fn from(err: types::Error) -> Error {
+        Error {
+            msg: err.to_string(),
+        }
+    }
+}
+
+impl Error {
+    fn undeclared_variable(name: String) -> Error {
+        Error {
+            msg: format!("undeclared variable {}", name),
+        }
+    }
+    fn invalid_statement(msg: String) -> Error {
+        Error { msg }
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Statement {
@@ -58,12 +104,84 @@ pub enum Expression {
     Regexp(RegexpLit),
 }
 
+impl Expression {
+    pub fn type_of(&self) -> &MonoType {
+        match self {
+            Expression::Identifier(e) => &e.typ,
+            Expression::Array(e) => &e.typ,
+            Expression::Function(e) => &e.typ,
+            Expression::Logical(e) => &e.typ,
+            Expression::Object(e) => &e.typ,
+            Expression::Member(e) => &e.typ,
+            Expression::Index(e) => &e.typ,
+            Expression::Binary(e) => &e.typ,
+            Expression::Unary(e) => &e.typ,
+            Expression::Call(e) => &e.typ,
+            Expression::Conditional(e) => &e.typ,
+            Expression::StringExpr(e) => &e.typ,
+            Expression::Integer(lit) => &lit.typ,
+            Expression::Float(lit) => &lit.typ,
+            Expression::StringLit(lit) => &lit.typ,
+            Expression::Duration(lit) => &lit.typ,
+            Expression::Uint(lit) => &lit.typ,
+            Expression::Boolean(lit) => &lit.typ,
+            Expression::DateTime(lit) => &lit.typ,
+            Expression::Regexp(lit) => &lit.typ,
+        }
+    }
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        match self {
+            Expression::Identifier(e) => e.infer(env, f),
+            Expression::Array(e) => e.infer(env, f),
+            Expression::Function(e) => e.infer(env, f),
+            Expression::Logical(e) => e.infer(env, f),
+            Expression::Object(e) => e.infer(env, f),
+            Expression::Member(e) => e.infer(env, f),
+            Expression::Index(e) => e.infer(env, f),
+            Expression::Binary(e) => e.infer(env, f),
+            Expression::Unary(e) => e.infer(env, f),
+            Expression::Call(e) => e.infer(env, f),
+            Expression::Conditional(e) => e.infer(env, f),
+            Expression::StringExpr(e) => e.infer(env, f),
+            Expression::Integer(lit) => lit.infer(env, f),
+            Expression::Float(lit) => lit.infer(env, f),
+            Expression::StringLit(lit) => lit.infer(env, f),
+            Expression::Duration(lit) => lit.infer(env, f),
+            Expression::Uint(lit) => lit.infer(env, f),
+            Expression::Boolean(lit) => lit.infer(env, f),
+            Expression::DateTime(lit) => lit.infer(env, f),
+            Expression::Regexp(lit) => lit.infer(env, f),
+        }
+    }
+}
+
+// Infer the types of a flux package
+pub fn infer_pkg_types(
+    pkg: &mut Package,
+    env: Environment,
+    f: &mut Fresher,
+) -> std::result::Result<(Environment, Substitution), Error> {
+    let (env, cons) = pkg.infer(env, f)?;
+    Ok((env, infer::solve(&cons, &mut HashMap::new())?))
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Package {
     pub loc: ast::SourceLocation,
 
     pub package: String,
     pub files: Vec<File>,
+}
+
+impl Package {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        self.files
+            .iter_mut()
+            .try_fold((env, Constraints::empty()), |(env, rest), file| {
+                let (env, cons) = file.infer(env, f)?;
+                Ok((env, cons + rest))
+            })
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -73,6 +191,41 @@ pub struct File {
     pub package: Option<PackageClause>,
     pub imports: Vec<ImportDeclaration>,
     pub body: Vec<Statement>,
+}
+
+impl File {
+    fn infer(&mut self, mut env: Environment, f: &mut Fresher) -> Result {
+        // TODO: add imported types to the type environment
+        self.body.iter_mut().try_fold(
+            (env, Constraints::empty()),
+            |(env, rest), node| match node {
+                Statement::Builtin(stmt) => {
+                    let (env, cons) = stmt.infer(env, f)?;
+                    Ok((env, cons + rest))
+                }
+                Statement::Variable(stmt) => {
+                    let (env, cons) = stmt.infer(env, f)?;
+                    Ok((env, cons + rest))
+                }
+                Statement::Option(stmt) => {
+                    let (env, cons) = stmt.infer(env, f)?;
+                    Ok((env, cons + rest))
+                }
+                Statement::Expr(stmt) => {
+                    let (env, cons) = stmt.infer(env, f)?;
+                    Ok((env, cons + rest))
+                }
+                Statement::Test(stmt) => {
+                    let (env, cons) = stmt.infer(env, f)?;
+                    Ok((env, cons + rest))
+                }
+                Statement::Return(_) => Err(Error::invalid_statement(String::from(
+                    "cannot have return statement in file block",
+                ))),
+            },
+        )
+        // TODO: remove imported names from the type environment
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -91,32 +244,27 @@ pub struct ImportDeclaration {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct Block {
-    pub loc: ast::SourceLocation,
-
-    pub body: Vec<Statement>,
-}
-
-impl Block {
-    fn return_statement(&self) -> &ReturnStmt {
-        let len = self.body.len();
-        let last = self
-            .body
-            .get(len - 1)
-            .expect("body must have at least one statement");
-        let last: Option<&ReturnStmt> = match last {
-            Statement::Return(rs) => Some(rs),
-            _ => None,
-        };
-        last.expect("last statement must be a return statement")
-    }
-}
-
-#[derive(Debug, PartialEq, Clone)]
 pub struct OptionStmt {
     pub loc: ast::SourceLocation,
 
     pub assignment: Assignment,
+}
+
+impl OptionStmt {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        match &mut self.assignment {
+            Assignment::Member(stmt) => {
+                let (env, cons) = stmt.init.infer(env, f)?;
+                let (env, rest) = stmt.member.infer(env, f)?;
+
+                let l = stmt.member.typ.clone();
+                let r = stmt.init.type_of().clone();
+
+                Ok((env, cons + rest + vec![Constraint::Equal(l, r)].into()))
+            }
+            Assignment::Variable(stmt) => stmt.infer(env, f),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -126,11 +274,23 @@ pub struct BuiltinStmt {
     pub id: Identifier,
 }
 
+impl BuiltinStmt {
+    fn infer(&self, _: Environment, _: &mut Fresher) -> Result {
+        unimplemented!();
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct TestStmt {
     pub loc: ast::SourceLocation,
 
     pub assignment: VariableAssgn,
+}
+
+impl TestStmt {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        self.assignment.infer(env, f)
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -140,6 +300,14 @@ pub struct ExprStmt {
     pub expression: Expression,
 }
 
+impl ExprStmt {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        let (env, cons) = self.expression.infer(env, f)?;
+        let sub = infer::solve(&cons, &mut HashMap::new())?;
+        Ok((env.apply(&sub), cons))
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct ReturnStmt {
     pub loc: ast::SourceLocation,
@@ -147,12 +315,76 @@ pub struct ReturnStmt {
     pub argument: Expression,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+impl ReturnStmt {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        self.argument.infer(env, f)
+    }
+}
+
+#[derive(Debug, Derivative, PartialEq, Clone)]
 pub struct VariableAssgn {
+    #[derivative(PartialEq = "ignore")]
+    free: Vec<Tvar>,
+
+    #[derivative(PartialEq = "ignore")]
+    cons: HashMap<Tvar, Vec<Kind>>,
+
     pub loc: ast::SourceLocation,
 
     pub id: Identifier,
     pub init: Expression,
+}
+
+impl VariableAssgn {
+    pub fn new(id: Identifier, init: Expression, loc: ast::SourceLocation) -> VariableAssgn {
+        VariableAssgn {
+            free: Vec::new(),
+            cons: HashMap::new(),
+            loc,
+            id,
+            init,
+        }
+    }
+    pub fn poly_type_of(&self) -> PolyType {
+        PolyType {
+            free: self.free.clone(),
+            cons: self.cons.clone(),
+            expr: self.init.type_of().clone(),
+        }
+    }
+    // Polymorphic generalization, necessary for let-polymorphism, is
+    // implemented here.
+    //
+    // In particular, for every variable assignment we infer the type of
+    // its corresponding expression. We then generalize that type by
+    // quantifying over all of its free type variables. Finally we bind
+    // the variable to its newly generalized type in the type environment
+    // before inferring the rest of the program.
+    //
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        let (env, constraints) = self.init.infer(env, f)?;
+
+        let mut kinds = HashMap::new();
+        let sub = infer::solve(&constraints, &mut kinds)?;
+
+        // Apply substitution to the type environment
+        let mut env = env.apply(&sub);
+
+        let t = self.init.type_of().clone().apply(&sub);
+        let p = infer::generalize(&env, &kinds, t);
+
+        // Update variable assignment nodes with the free vars
+        // and kind constraints obtained from generalization.
+        //
+        // Note these variables are fixed after generalization
+        // and so it is safe to update these nodes in place.
+        self.free = p.free.clone();
+        self.cons = p.cons.clone();
+
+        // Update the type environment
+        &mut env.add(String::from(&self.id.name), p);
+        Ok((env, constraints))
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -168,9 +400,15 @@ pub struct MemberAssgn {
 pub struct StringExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub parts: Vec<StringExprPart>,
+}
+
+impl StringExpr {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -198,9 +436,15 @@ pub struct InterpolatedPart {
 pub struct ArrayExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub elements: Vec<Expression>,
+}
+
+impl ArrayExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 // FunctionExpr represents the definition of a function
@@ -209,13 +453,17 @@ pub struct ArrayExpr {
 pub struct FunctionExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub params: Vec<FunctionParameter>,
     pub body: Block,
 }
 
 impl FunctionExpr {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
+
     pub fn pipe(&self) -> Option<&FunctionParameter> {
         for p in &self.params {
             if p.is_pipe {
@@ -237,6 +485,40 @@ impl FunctionExpr {
     }
 }
 
+// Block represents a function block and is equivalent to a let-expression
+// in other functional languages.
+//
+// Functions must evaluate to a value in Flux. In other words, a function
+// must always have a return value. This means a function block is by
+// definition an expression.
+//
+#[derive(Debug, PartialEq, Clone)]
+pub enum Block {
+    Variable(VariableAssgn, Box<Block>),
+    Expr(ExprStmt, Box<Block>),
+    Return(Expression),
+}
+
+impl Block {
+    fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
+        match self {
+            Block::Variable(stmt, block) => {
+                let (env, cons) = stmt.infer(env, f)?;
+                let (env, rest) = block.infer(env, f)?;
+
+                Ok((env, cons + rest))
+            }
+            Block::Expr(stmt, block) => {
+                let (env, cons) = stmt.infer(env, f)?;
+                let (env, rest) = block.infer(env, f)?;
+
+                Ok((env, cons + rest))
+            }
+            Block::Return(e) => e.infer(env, f),
+        }
+    }
+}
+
 // FunctionParameter represents a function parameter.
 #[derive(Debug, PartialEq, Clone)]
 pub struct FunctionParameter {
@@ -252,11 +534,17 @@ pub struct FunctionParameter {
 pub struct BinaryExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub operator: ast::Operator,
     pub left: Expression,
     pub right: Expression,
+}
+
+impl BinaryExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -264,11 +552,17 @@ pub struct BinaryExpr {
 pub struct CallExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub callee: Expression,
     pub arguments: Vec<Property>,
     pub pipe: Option<Expression>,
+}
+
+impl CallExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -276,11 +570,17 @@ pub struct CallExpr {
 pub struct ConditionalExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub test: Expression,
     pub consequent: Expression,
     pub alternate: Expression,
+}
+
+impl ConditionalExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -288,11 +588,17 @@ pub struct ConditionalExpr {
 pub struct LogicalExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub operator: ast::LogicalOperator,
     pub left: Expression,
     pub right: Expression,
+}
+
+impl LogicalExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -300,10 +606,16 @@ pub struct LogicalExpr {
 pub struct MemberExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub object: Expression,
     pub property: String,
+}
+
+impl MemberExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -311,10 +623,16 @@ pub struct MemberExpr {
 pub struct IndexExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub array: Expression,
     pub index: Expression,
+}
+
+impl IndexExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -322,10 +640,16 @@ pub struct IndexExpr {
 pub struct ObjectExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub with: Option<IdentifierExpr>,
     pub properties: Vec<Property>,
+}
+
+impl ObjectExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -333,10 +657,16 @@ pub struct ObjectExpr {
 pub struct UnaryExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub operator: ast::Operator,
     pub argument: Expression,
+}
+
+impl UnaryExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -352,9 +682,24 @@ pub struct Property {
 pub struct IdentifierExpr {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub name: String,
+}
+
+impl IdentifierExpr {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        match env.lookup(&self.name) {
+            Some(poly) => {
+                let (t, cons) = infer::instantiate(poly.clone(), f);
+                Ok((
+                    env,
+                    cons + Constraints::from(vec![Constraint::Equal(t, self.typ.clone())]),
+                ))
+            }
+            None => Err(Error::undeclared_variable(self.name.to_string())),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -369,9 +714,15 @@ pub struct Identifier {
 pub struct BooleanLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: bool,
+}
+
+impl BooleanLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -379,9 +730,15 @@ pub struct BooleanLit {
 pub struct IntegerLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: i64,
+}
+
+impl IntegerLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -389,9 +746,15 @@ pub struct IntegerLit {
 pub struct FloatLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: f64,
+}
+
+impl FloatLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -399,10 +762,16 @@ pub struct FloatLit {
 pub struct RegexpLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     // TODO(affo): should this be a compiled regexp?
     pub value: String,
+}
+
+impl RegexpLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -410,9 +779,15 @@ pub struct RegexpLit {
 pub struct StringLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: String,
+}
+
+impl StringLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -420,9 +795,15 @@ pub struct StringLit {
 pub struct UintLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: u64,
+}
+
+impl UintLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -430,9 +811,15 @@ pub struct UintLit {
 pub struct DateTimeLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: DateTime<FixedOffset>,
+}
+
+impl DateTimeLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 #[derive(Derivative)]
@@ -440,9 +827,15 @@ pub struct DateTimeLit {
 pub struct DurationLit {
     pub loc: ast::SourceLocation,
     #[derivative(PartialEq = "ignore")]
-    pub typ: types::MonoType,
+    pub typ: MonoType,
 
     pub value: Duration,
+}
+
+impl DurationLit {
+    fn infer(&self, env: Environment, f: &mut Fresher) -> Result {
+        unimplemented!();
+    }
 }
 
 const NANOS: i64 = 1;
@@ -459,7 +852,7 @@ const YEARS: f64 = MONTHS * 12.0;
 // TODO(affo): this is not accurate, a duration value depends on the time in which it is calculated.
 // 1 month is different if now is the 1st of January, or the 1st of February.
 // Some days do not last 24 hours because of light savings.
-pub fn convert_duration(duration: &Vec<ast::Duration>) -> Result<Duration, String> {
+pub fn convert_duration(duration: &Vec<ast::Duration>) -> std::result::Result<Duration, String> {
     let d = duration
         .iter()
         .try_fold(0 as i64, |acc, d| match d.unit.as_str() {
@@ -481,6 +874,121 @@ pub fn convert_duration(duration: &Vec<ast::Duration>) -> Result<Duration, Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::parse_string;
+    use crate::semantic::analyze::analyze;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_infer_instantiation() {
+        let src = r#"
+            x = f
+            y = f
+            z = a
+        "#;
+
+        // This environment represents our prelude
+        //
+        //     a = 5
+        //     f = (a, b) => 2 * (a + b)
+        //
+        let env = Environment::from(maplit::hashmap! {
+            // a = 5
+            String::from("a") => PolyType {
+                free: Vec::new(),
+                cons: HashMap::new(),
+                expr: MonoType::Int,
+            },
+            // f = (a, b) => 2 * (a + b)
+            String::from("f") => PolyType {
+                free: vec![Tvar(0)],
+                cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
+                expr: MonoType::Fun(Box::new(types::Function {
+                    req: maplit::hashmap! {
+                        String::from("a") => MonoType::Var(Tvar(0)),
+                        String::from("b") => MonoType::Var(Tvar(0)),
+                    },
+                    opt: HashMap::new(),
+                    pipe: None,
+                    retn: MonoType::Var(Tvar(0)),
+                })),
+            },
+        });
+
+        let file = parse_string("file", src);
+
+        let ast = ast::Package {
+            base: file.base.clone(),
+            path: "path/to/pkg".to_string(),
+            package: "main".to_string(),
+            files: vec![file],
+        };
+
+        let mut f: Fresher = 1.into();
+        let mut pkg = analyze(ast, &mut f).unwrap();
+
+        let (env, _) = infer_pkg_types(&mut pkg, env, &mut f).unwrap();
+
+        let normalized: HashMap<String, PolyType> = env
+            .values
+            .into_iter()
+            .map(|(k, v)| (k, v.normalize()))
+            .collect();
+
+        assert_eq!(
+            normalized,
+            maplit::hashmap! {
+                String::from("f") => PolyType {
+                    free: vec![Tvar(0)],
+                    cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
+                    expr: MonoType::Fun(Box::new(types::Function {
+                        req: maplit::hashmap! {
+                            String::from("a") => MonoType::Var(Tvar(0)),
+                            String::from("b") => MonoType::Var(Tvar(0)),
+                        },
+                        opt: HashMap::new(),
+                        pipe: None,
+                        retn: MonoType::Var(Tvar(0)),
+                    })),
+                },
+                String::from("a") => PolyType {
+                    free: Vec::new(),
+                    cons: HashMap::new(),
+                    expr: MonoType::Int,
+                },
+                String::from("x") => PolyType {
+                    free: vec![Tvar(0)],
+                    cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
+                    expr: MonoType::Fun(Box::new(types::Function {
+                        req: maplit::hashmap! {
+                            String::from("a") => MonoType::Var(Tvar(0)),
+                            String::from("b") => MonoType::Var(Tvar(0)),
+                        },
+                        opt: HashMap::new(),
+                        pipe: None,
+                        retn: MonoType::Var(Tvar(0)),
+                    })),
+                },
+                String::from("y") => PolyType {
+                    free: vec![Tvar(0)],
+                    cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
+                    expr: MonoType::Fun(Box::new(types::Function {
+                        req: maplit::hashmap! {
+                            String::from("a") => MonoType::Var(Tvar(0)),
+                            String::from("b") => MonoType::Var(Tvar(0)),
+                        },
+                        opt: HashMap::new(),
+                        pipe: None,
+                        retn: MonoType::Var(Tvar(0)),
+                    })),
+                },
+                String::from("z") => PolyType {
+                    free: Vec::new(),
+                    cons: HashMap::new(),
+                    expr: MonoType::Int,
+                },
+            }
+        );
+    }
 
     #[test]
     fn duration_conversion_ok() {

--- a/libflux/src/semantic/parser/mod.rs
+++ b/libflux/src/semantic/parser/mod.rs
@@ -1,9 +1,14 @@
-use std::{ str::Chars, iter::Peekable, slice::Iter, collections::{ HashMap, HashSet } };
+use std::{
+    collections::{HashMap, HashSet},
+    iter::Peekable,
+    slice::Iter,
+    str::Chars,
+};
 
-use crate::semantic::types::{ PolyType, MonoType, Tvar, Kind, TvarKinds, Row, Array, Function, Property };
+use crate::semantic::types::{Array, Function, Kind, MonoType, PolyType, Property, Row, Tvar};
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-// TokenType holds all possible TokenType values 
+// TokenType holds all possible TokenType values
 pub enum TokenType {
     ERROR,
     EOF,
@@ -18,7 +23,7 @@ pub enum TokenType {
     FLOAT,
     STRING,
     BOOL,
-    DURATION, 
+    DURATION,
     TIME,
     REGEXP,
 
@@ -30,55 +35,55 @@ pub enum TokenType {
     LEFTPAREN,
     RIGHTPAREN,
     QUESTIONMARK,
-    COLON, 
-    COMMA, 
-    PIPE, 
-    ARROW, 
+    COLON,
+    COMMA,
+    PIPE,
+    ARROW,
     PLUS,
-    WITH
+    WITH,
 }
 
 // Lexer holds the iterator for the source string, the list of output tokens and keeps track of
 // the current string value of any identifier or keyword to append the the Token.
 struct Lexer<'a> {
-    source: Peekable<Chars<'a>>, 
-    tokens: Vec<Token>, 
+    source: Peekable<Chars<'a>>,
+    tokens: Vec<Token>,
     current_string: String,
 }
 
 #[derive(Debug, PartialEq, Clone)]
-// Token holds the token's type and the text value for any keyword or identifier to be used later 
-// by the parser. 
+// Token holds the token's type and the text value for any keyword or identifier to be used later
+// by the parser.
 pub struct Token {
     token_type: TokenType,
     text: Option<String>,
 }
 
-// Lex instantiates the Lexer with default values and initializes lexing. 
-// This function is not meant to be used directly. The user should pass 
-// source into Parse(), which in turn calls this function. 
+// Lex instantiates the Lexer with default values and initializes lexing.
+// This function is not meant to be used directly. The user should pass
+// source into Parse(), which in turn calls this function.
 pub fn Lex(source: &str) -> Vec<Token> {
-    let mut lexer = Lexer { 
+    let mut lexer = Lexer {
         source: source.chars().peekable(),
         tokens: Vec::new(),
         current_string: String::new(),
-        };
-    lexer.lex_tokens(); 
+    };
+    lexer.lex_tokens();
     lexer.tokens
 }
 
 impl Lexer<'_> {
     // lex_tokens calls lex_token while there are still characters to lex
-    fn lex_tokens(&mut self){
+    fn lex_tokens(&mut self) {
         while let Some(token_type) = lex_token(self) {
             if token_type == TokenType::WHITESPACE {
-                self.ignore(); 
+                self.ignore();
             } else {
-                self.emit(token_type); 
+                self.emit(token_type);
             }
 
             if token_type == TokenType::EOF {
-                break; 
+                break;
             }
         }
     }
@@ -86,7 +91,7 @@ impl Lexer<'_> {
     // next grabs the next character from the string while there are still characters to lex
     fn next(&mut self) -> Option<char> {
         match self.source.next() {
-            None => None, 
+            None => None,
             Some(letter) => {
                 if letter.is_alphanumeric() {
                     self.current_string.push(letter);
@@ -101,9 +106,15 @@ impl Lexer<'_> {
     fn emit(&mut self, token: TokenType) {
         if !self.current_string.is_empty() {
             let text = self.current_string.clone();
-            self.tokens.push(Token{ token_type: token, text: Some(text) })
+            self.tokens.push(Token {
+                token_type: token,
+                text: Some(text),
+            })
         } else {
-            self.tokens.push(Token{ token_type: token, text: None })
+            self.tokens.push(Token {
+                token_type: token,
+                text: None,
+            })
         }
         self.current_string = String::new();
     }
@@ -118,24 +129,24 @@ impl Lexer<'_> {
         while let Some(letter) = self.source.peek() {
             if letter.is_alphanumeric() {
                 self.next();
-                continue; 
+                continue;
             }
             break;
         }
 
-        let current: &str = &self.current_string; 
+        let current: &str = &self.current_string;
         match current {
-            "forall" => TokenType::FORALL, 
-            "where" => TokenType::WHERE, 
-            "int" => TokenType::INT, 
-            "float" => TokenType::FLOAT, 
-            "string" => TokenType::STRING, 
-            "bool" => TokenType::BOOL, 
-            "uint" => TokenType::UINT, 
-            "duration" => TokenType::DURATION, 
-            "time" => TokenType::TIME, 
-            "regexp" => TokenType::REGEXP, 
-            _ => TokenType::IDENTIFIER
+            "forall" => TokenType::FORALL,
+            "where" => TokenType::WHERE,
+            "int" => TokenType::INT,
+            "float" => TokenType::FLOAT,
+            "string" => TokenType::STRING,
+            "bool" => TokenType::BOOL,
+            "uint" => TokenType::UINT,
+            "duration" => TokenType::DURATION,
+            "time" => TokenType::TIME,
+            "regexp" => TokenType::REGEXP,
+            _ => TokenType::IDENTIFIER,
         }
     }
 }
@@ -143,33 +154,29 @@ impl Lexer<'_> {
 // lex_token lexes and returns a single token
 fn lex_token(lexer: &mut Lexer) -> Option<TokenType> {
     match lexer.next() {
-        Some(letter) if letter.is_alphanumeric() =>  Some(lexer.keyword_or_ident()), 
-        Some(letter) if letter.is_whitespace() => Some(TokenType::WHITESPACE), 
-        Some(letter) if letter == '{' => Some(TokenType::LEFTCURLYBRAC), 
-        Some(letter) if letter == '}' => Some(TokenType::RIGHTCURLYBRAC), 
-        Some(letter) if letter == '[' => Some(TokenType::LEFTSQUAREBRAC), 
-        Some(letter) if letter == ']' => Some(TokenType::RIGHTSQUAREBRAC), 
-        Some(letter) if letter == '(' => Some(TokenType::LEFTPAREN), 
-        Some(letter) if letter == ')' => Some(TokenType::RIGHTPAREN), 
-        Some(letter) if letter == '?' => Some(TokenType::QUESTIONMARK), 
-        Some(letter) if letter == ':' => Some(TokenType::COLON), 
-        Some(letter) if letter == ',' => Some(TokenType::COMMA), 
-        Some(letter) if letter == '+' => Some(TokenType::PLUS), 
+        Some(letter) if letter.is_alphanumeric() => Some(lexer.keyword_or_ident()),
+        Some(letter) if letter.is_whitespace() => Some(TokenType::WHITESPACE),
+        Some(letter) if letter == '{' => Some(TokenType::LEFTCURLYBRAC),
+        Some(letter) if letter == '}' => Some(TokenType::RIGHTCURLYBRAC),
+        Some(letter) if letter == '[' => Some(TokenType::LEFTSQUAREBRAC),
+        Some(letter) if letter == ']' => Some(TokenType::RIGHTSQUAREBRAC),
+        Some(letter) if letter == '(' => Some(TokenType::LEFTPAREN),
+        Some(letter) if letter == ')' => Some(TokenType::RIGHTPAREN),
+        Some(letter) if letter == '?' => Some(TokenType::QUESTIONMARK),
+        Some(letter) if letter == ':' => Some(TokenType::COLON),
+        Some(letter) if letter == ',' => Some(TokenType::COMMA),
+        Some(letter) if letter == '+' => Some(TokenType::PLUS),
         Some(letter) if letter == '|' => Some(TokenType::WITH),
-        Some(letter) if letter == '<' => {
-            match lexer.next() {
-                Some('-') => Some(TokenType::PIPE),
-                _ => Some(TokenType::ERROR), 
-            }
+        Some(letter) if letter == '<' => match lexer.next() {
+            Some('-') => Some(TokenType::PIPE),
+            _ => Some(TokenType::ERROR),
         },
-        Some(letter) if letter == '-' => {
-            match lexer.next() {
-                Some('>') => Some(TokenType::ARROW), 
-                _ => Some(TokenType::ERROR), 
-            }
+        Some(letter) if letter == '-' => match lexer.next() {
+            Some('>') => Some(TokenType::ARROW),
+            _ => Some(TokenType::ERROR),
         },
-        Some(_) => Some(TokenType::ERROR), 
-        _ => Some(TokenType::EOF), 
+        Some(_) => Some(TokenType::ERROR),
+        _ => Some(TokenType::EOF),
     }
 }
 
@@ -177,194 +184,188 @@ struct Parser<'a> {
     tokens: Peekable<Iter<'a, Token>>,
 }
 
-// Parse passes the source text through the Lexer, It then initializes parsing 
+// Parse passes the source text through the Lexer, It then initializes parsing
 // and returns a PolyType representation.
 
-// This is the only function meant to be accessed by the end user. It handles 
-// both lexing and parsing of string polytypes. 
+// This is the only function meant to be accessed by the end user. It handles
+// both lexing and parsing of string polytypes.
 pub fn Parse(source: &str) -> Result<PolyType, &'static str> {
-    let tokens = Lex(source); 
-    let mut parser = Parser{ tokens: tokens.iter().peekable() }; 
+    let tokens = Lex(source);
+    let mut parser = Parser {
+        tokens: tokens.iter().peekable(),
+    };
     parser.parse_polytype()
 }
 
 impl Parser<'_> {
     // next grabs the next token using the Iter()'s next method and unpacks
     // the value if there are still tokens to parse
-    fn next(& mut self) -> Token {
+    fn next(&mut self) -> Token {
         match self.tokens.next() {
             Some(token) => (*token).clone(),
             None => Token {
                 token_type: TokenType::EOF,
-                text: None
+                text: None,
             },
         }
     }
-    
     // peek returns a preview of the next Token using Iter()'s peek method
     // and unpacks the value if there are still tokens to parse
-    fn peek(& mut self) -> Token {
+    fn peek(&mut self) -> Token {
         match self.tokens.peek() {
             Some(token) => (**token).clone(),
             None => Token {
                 token_type: TokenType::EOF,
-                text: None
+                text: None,
             },
         }
     }
 
-    // Production rules for each of the following methods can be found in the accompanying grammar.md file. 
+    // Production rules for each of the following methods can be found in the accompanying grammar.md file.
     // Each function name corresponds to the production rule or rules that it implements.
 
-    // TODO: Error handling for Parser's methods needs to be improved so that more 
-    // helpful messages are returned when parsing fails. 
+    // TODO: Error handling for Parser's methods needs to be improved so that more
+    // helpful messages are returned when parsing fails.
 
-    // parse_polytype steps through the token list and checks that each 
-    // token is in the correct order. 
-    fn parse_polytype(& mut self) -> Result<PolyType, &'static str> {
+    // parse_polytype steps through the token list and checks that each
+    // token is in the correct order.
+    fn parse_polytype(&mut self) -> Result<PolyType, &'static str> {
         if self.next().token_type != TokenType::FORALL {
-            return Err("Missing forall")
+            return Err("Missing forall");
         }
         if self.next().token_type != TokenType::LEFTSQUAREBRAC {
-            return Err("Missing left square bracket")
+            return Err("Missing left square bracket");
         }
 
-        let free_vars = self.parse_vars()?; 
+        let free_vars = self.parse_vars()?;
 
         if self.next().token_type != TokenType::RIGHTSQUAREBRAC {
-            return Err("Missing right square bracket")
+            return Err("Missing right square bracket");
         }
 
-        let mut cons = None; 
+        let mut cons = HashMap::new();
         if self.peek().token_type == TokenType::WHERE {
             self.next(); // move to where
-            cons = self.parse_constraints();
+            cons = self.parse_constraints()?;
         }
 
         Ok(PolyType {
             free: free_vars,
             cons: cons,
             expr: self.parse_monotype()?,
-        })  
+        })
     }
 
     // parse_vars parses a list of type_vars
-    fn parse_vars(& mut self) -> Result<Vec<Tvar>, &'static str>{
+    fn parse_vars(&mut self) -> Result<Vec<Tvar>, &'static str> {
         let mut type_vars = Vec::new();
 
         loop {
-            let next_token = self.peek(); 
+            let next_token = self.peek();
             if next_token.token_type == TokenType::IDENTIFIER {
                 let tvar = self.parse_type_var(&next_token);
                 match tvar {
-                    Err(e) => { return Err(e) }
-                    Ok(tvar) => { type_vars.push(tvar); }
+                    Err(e) => return Err(e),
+                    Ok(tvar) => {
+                        type_vars.push(tvar);
+                    }
                 }
             }
             if self.peek().token_type != TokenType::COMMA {
                 break;
             }
-            self.next(); // skip to comma 
+            self.next(); // skip to comma
         }
         Ok(type_vars)
     }
-    
     // parse_var parses a single type_var
-    fn parse_type_var(& mut self, token: &Token) -> Result<Tvar, &'static str>{
+    fn parse_type_var(&mut self, token: &Token) -> Result<Tvar, &'static str> {
         match &token.text {
-            Some(text) => { 
-                let num = text.trim_start_matches("t").parse::<i64>();
+            Some(text) => {
+                let num = text.trim_start_matches("t").parse::<u64>();
                 match num {
-                    Err(_e) => Err("Not a valid type variable"), 
-                    Ok (num) => {
+                    Err(_e) => Err("Not a valid type variable"),
+                    Ok(num) => {
                         self.next();
                         Ok(Tvar(num))
                     }
                 }
             }
-            None => Err("Type variable must have text")
+            None => Err("Type variable must have text"),
         }
     }
 
     // parse_contraints parses a list of constraints for each type_var that has contraints
-    fn parse_constraints(& mut self) -> Option<TvarKinds> {
+    fn parse_constraints(&mut self) -> Result<HashMap<Tvar, Vec<Kind>>, &'static str> {
         let mut cons_map = HashMap::new();
 
         loop {
-            let mut next_token = self.peek(); 
+            let mut next_token = self.peek();
 
             if next_token.token_type == TokenType::COMMA {
                 self.next(); // skip to comma
                 next_token = self.peek(); // look at identifier next
-            } 
+            }
 
             if next_token.token_type == TokenType::IDENTIFIER {
-                let type_var = self.parse_type_var(&next_token);
-                let kinds = self.parse_kinds(); 
-                match type_var {
-                    Err(_e) => return { None } , 
-                    Ok(var) => 
-                    match kinds {
-                        Err(_e) => return { None } , 
-                        Ok(kinds) => cons_map.insert(var, kinds), 
-                    }
-                };
+                let type_var = self.parse_type_var(&next_token)?;
+                let kinds = self.parse_kinds()?;
+                cons_map.insert(type_var, kinds);
             } else {
                 break;
             }
         }
-        Some(TvarKinds(cons_map))
+        Ok(cons_map)
     }
 
     // parse_kinds parses a list of kinds to associate with a type_var for a constraint
-    fn parse_kinds(& mut self) -> Result<HashSet<Kind>, &'static str>{
-        let mut kinds_set = HashSet::new(); 
-        
+    fn parse_kinds(&mut self) -> Result<Vec<Kind>, &'static str> {
+        let mut kinds = Vec::new();
         loop {
-            let next_token = self.peek(); 
+            let next_token = self.peek();
             if next_token.token_type != TokenType::COLON {
                 if next_token.token_type != TokenType::PLUS {
-                    break; 
-                }  
+                    break;
+                }
             }
-            self.next(); 
+            self.next();
             let kind = self.parse_kind();
 
             match kind {
                 Err(e) => return Err(e),
                 Ok(kind) => {
-                    kinds_set.insert(kind);
-                } 
+                    kinds.push(kind);
+                }
             }
         }
-        Ok(kinds_set)
+        Ok(kinds)
     }
 
     // parse_kind parses a single kind for a constraint
-    fn parse_kind(& mut self) -> Result<Kind, &'static str> {
+    fn parse_kind(&mut self) -> Result<Kind, &'static str> {
         let token = self.next();
 
         if token.text.is_none() {
-            return Err("Constraints must have a valid Kind")
+            return Err("Constraints must have a valid Kind");
         }
 
-        let text: &str = &token.text.unwrap(); 
+        let text: &str = &token.text.unwrap();
 
         match text {
             "Addable" => Ok(Kind::Addable),
             "Subtractable" => Ok(Kind::Subtractable),
-            "Divisible" => Ok(Kind::Divisible), 
+            "Divisible" => Ok(Kind::Divisible),
             "Comparable" => Ok(Kind::Comparable),
             "Nullable" => Ok(Kind::Nullable),
             "Equatable" => Ok(Kind::Equatable),
-            _ => Err("Constraints must have a valid Kind")
+            _ => Err("Constraints must have a valid Kind"),
         }
     }
 
     // parse_monotype parses a monotype
-    fn parse_monotype(& mut self) -> Result<MonoType, &'static str> {
-        let next_token = self.peek(); 
-        if let Ok(primitive) = self.parse_primitives(&next_token){
+    fn parse_monotype(&mut self) -> Result<MonoType, &'static str> {
+        let next_token = self.peek();
+        if let Ok(primitive) = self.parse_primitives(&next_token) {
             Ok(primitive)
         } else if let Ok(type_var) = self.parse_type_var(&next_token) {
             Ok(MonoType::Var(type_var))
@@ -377,214 +378,210 @@ impl Parser<'_> {
         } else {
             Err("Monotype was not in valid format")
         }
-
     }
 
     // parse_primitives a single primitive monotype
     fn parse_primitives(&mut self, token: &Token) -> Result<MonoType, &'static str> {
         match token.token_type {
-            TokenType::BOOL => { 
-                self.next(); 
-                Ok(MonoType::Bool) 
+            TokenType::BOOL => {
+                self.next();
+                Ok(MonoType::Bool)
             }
-            TokenType::INT => { 
-                self.next(); 
-                Ok(MonoType::Int) 
+            TokenType::INT => {
+                self.next();
+                Ok(MonoType::Int)
             }
-            TokenType::UINT => { 
-                self.next(); 
-                Ok(MonoType::Uint) 
+            TokenType::UINT => {
+                self.next();
+                Ok(MonoType::Uint)
             }
-            TokenType::FLOAT => { 
-                self.next(); 
-                Ok(MonoType::Float) 
+            TokenType::FLOAT => {
+                self.next();
+                Ok(MonoType::Float)
             }
-            TokenType::STRING => { 
-                self.next(); 
-                Ok(MonoType::String) 
+            TokenType::STRING => {
+                self.next();
+                Ok(MonoType::String)
             }
-            TokenType::DURATION => { 
-                self.next(); 
-                Ok(MonoType::Duration) 
+            TokenType::DURATION => {
+                self.next();
+                Ok(MonoType::Duration)
             }
-            TokenType::TIME => { 
-                self.next(); 
-                Ok(MonoType::Time) 
+            TokenType::TIME => {
+                self.next();
+                Ok(MonoType::Time)
             }
-            TokenType::REGEXP => { 
-                self.next(); 
-                Ok(MonoType::Regexp) 
+            TokenType::REGEXP => {
+                self.next();
+                Ok(MonoType::Regexp)
             }
-            _ => Err("Not a valid basic type")
+            _ => Err("Not a valid basic type"),
         }
     }
 
     // parse_array parses an array monotype
-    fn parse_array(& mut self, token: &Token) -> Result<MonoType, &'static str> {
+    fn parse_array(&mut self, token: &Token) -> Result<MonoType, &'static str> {
         if token.token_type != TokenType::LEFTSQUAREBRAC {
             Err("Not a valid array monotype")
         } else {
-            let mut token = self.next(); 
+            let mut token = self.next();
 
             // recursively parse the array's monotype
             let monotype = self.parse_monotype();
             match monotype {
                 Ok(monotype) => {
-                    token = self.next(); 
+                    token = self.next();
                     if token.token_type == TokenType::RIGHTSQUAREBRAC {
                         Ok(MonoType::Arr(Box::new(Array(monotype))))
                     } else {
                         Err("Array monotype must have right square bracket")
                     }
                 }
-                Err(e) => Err(e)
+                Err(e) => Err(e),
             }
         }
     }
 
-    // parse_function parses a single function monotype 
-    fn parse_function(& mut self, token: &Token) -> Result<MonoType, &'static str> {
+    // parse_function parses a single function monotype
+    fn parse_function(&mut self, token: &Token) -> Result<MonoType, &'static str> {
         if token.token_type != TokenType::LEFTPAREN {
-            return Err("Function must start with a left paren")
+            return Err("Function must start with a left paren");
         }
 
-        self.next(); 
-        let mut token = self.next(); 
+        self.next();
+        let mut token = self.next();
 
-        let mut req_args = HashMap::new(); 
-        let mut opt_args = HashMap::new(); 
-        let mut pipe_arg = None; 
-        
+        let mut req_args = HashMap::new();
+        let mut opt_args = HashMap::new();
+        let mut pipe_arg = None;
         loop {
             if token.token_type == TokenType::IDENTIFIER {
                 if let Ok(arg) = self.parse_required_optional(&token) {
                     req_args.insert(arg.0, arg.1);
                 } else {
-                    return Err("Must have valid required arguments")
+                    return Err("Must have valid required arguments");
                 }
             } else if token.token_type == TokenType::QUESTIONMARK {
-                token = self.next(); // skip question mark 
-                
-                // now we can parse this optional argument the same way 
-                // that we parse required arguments 
-                if let Ok(arg) = self.parse_required_optional(&token){
+                token = self.next(); // skip question mark
+
+                // now we can parse this optional argument the same way
+                // that we parse required arguments
+                if let Ok(arg) = self.parse_required_optional(&token) {
                     opt_args.insert(arg.0, arg.1);
                 } else {
-                    return Err("Invalid format for optional arguments")
-                } 
+                    return Err("Invalid format for optional arguments");
+                }
             } else if token.token_type == TokenType::PIPE {
-                let arg = self.parse_pipe(); 
+                let arg = self.parse_pipe();
                 if arg.is_none() {
-                    return Err("Invalid format for pipe arguments")
+                    return Err("Invalid format for pipe arguments");
                 } else {
-                    pipe_arg = arg; 
+                    pipe_arg = arg;
                 }
             } else {
-                return Err("Invalid arguments for this function.")
+                return Err("Invalid arguments for this function.");
             }
-            
             token = self.next(); // check if next is right paren or comma
             if token.token_type != TokenType::COMMA {
                 // if the next token is not comma, must be right paren
                 break;
-            } 
+            }
             token = self.next(); // if its a comma, then there are more args to parse
         }
-        
 
         if token.token_type != TokenType::RIGHTPAREN {
-            return Err("Function arguments must be follow by a right paren")
+            return Err("Function arguments must be follow by a right paren");
         }
 
         token = self.next(); // move to arrow
 
         if token.token_type != TokenType::ARROW {
-            return Err("Function must have an arrow before return monotype")
+            return Err("Function must have an arrow before return monotype");
         }
 
         // recursively parse the function's return type
-        let return_type = self.parse_monotype(); 
+        let return_type = self.parse_monotype();
 
         if let Ok(return_val) = return_type {
-            Ok(MonoType::Fun(Box::new(Function{
+            Ok(MonoType::Fun(Box::new(Function {
                 req: req_args,
                 opt: opt_args,
                 pipe: pipe_arg,
                 retn: return_val,
-            }))) 
+            })))
         } else {
-            return Err("Function must have a valid return type")
+            return Err("Function must have a valid return type");
         }
     }
 
     // parse_required_optional parses a single required or optional argument for the function monotype
-    fn parse_required_optional(& mut self, token: &Token) -> Result<(String, MonoType), &'static str> {
-        let mut arg_var = String::new(); 
+    fn parse_required_optional(
+        &mut self,
+        token: &Token,
+    ) -> Result<(String, MonoType), &'static str> {
+        let mut arg_var = String::new();
 
         match &token.text {
-            None => {
-                return Err("Invalid format for required arguments")
-            },
+            None => return Err("Invalid format for required arguments"),
             Some(var) => {
                 arg_var = var.to_string();
             }
         }
 
-        let token = self.next(); 
+        let token = self.next();
         if token.token_type != TokenType::COLON {
-            return Err("Invalid format for required arguments")
+            return Err("Invalid format for required arguments");
         }
 
-        let monotype = self.parse_monotype(); 
+        let monotype = self.parse_monotype();
 
         match monotype {
-            Err(e) => Err(e), 
-            Ok(monotype) => Ok((arg_var, monotype))
+            Err(e) => Err(e),
+            Ok(monotype) => Ok((arg_var, monotype)),
         }
     }
 
     // parse_pipe parses a single pipe argument for the function monotype
-    fn parse_pipe(& mut self) -> Option<Property> {
-        let mut token = self.peek(); 
+    fn parse_pipe(&mut self) -> Option<Property> {
+        let mut token = self.peek();
 
-        let mut string = None;  
-        let mut monotype = Err("No monotype found"); 
+        let mut string = None;
+        let mut monotype = Err("No monotype found");
         if token.token_type == TokenType::IDENTIFIER {
-            token = self.next(); 
+            token = self.next();
 
-            string = token.text; 
+            string = token.text;
         }
 
         let next_token = self.peek();
         if next_token.token_type == TokenType::COLON {
-            self.next(); 
-            monotype = self.parse_monotype(); 
+            self.next();
+            monotype = self.parse_monotype();
         }
 
         match monotype {
-            // if there's no monotype, there's no pipe argument 
-            Err(_e) => None, 
+            // if there's no monotype, there's no pipe argument
+            Err(_e) => None,
             Ok(monotype) => {
                 // string is optional, so still return Property
                 match string {
                     None => Some(Property {
                         k: "<-".to_string(),
                         v: monotype,
-                    }), 
-                    Some(string) => {Some(Property{
-                        k: string, 
-                        v: monotype
-                        })
-                    }
+                    }),
+                    Some(string) => Some(Property {
+                        k: string,
+                        v: monotype,
+                    }),
                 }
             }
         }
     }
 
     // parse_row parses a row monotype as a series of nested row extensions
-    fn parse_row(& mut self, token: &Token) -> Result<MonoType, &'static str> {
+    fn parse_row(&mut self, token: &Token) -> Result<MonoType, &'static str> {
         if token.token_type != TokenType::LEFTCURLYBRAC {
-            return Err("Not a valid row monotype")
+            return Err("Not a valid row monotype");
         }
         self.next(); // move to left curly brac
 
@@ -592,73 +589,72 @@ impl Parser<'_> {
 
         if token.token_type != TokenType::IDENTIFIER {
             if token.token_type == TokenType::RIGHTCURLYBRAC {
-                return Ok(MonoType::Row(Box::new(Row::Empty)))
+                return Ok(MonoType::Row(Box::new(Row::Empty)));
             } else {
-                return Err("Row monotype must start with row name or contain a type variable")
+                return Err("Row monotype must start with row name or contain a type variable");
             }
         }
-        
-        let mut row_stack = vec![]; 
 
+        let mut row_stack = vec![];
         while token.token_type != TokenType::RIGHTCURLYBRAC {
-            if token.token_type != TokenType::IDENTIFIER{
-                return Err("Row variable names must have text")
+            if token.token_type != TokenType::IDENTIFIER {
+                return Err("Row variable names must have text");
             }
 
-            let variable = token.text.clone(); 
+            let variable = token.text.clone();
             if variable.is_none() {
-                return Err("Row variable names must have text")
+                return Err("Row variable names must have text");
             }
-            token = self.next(); 
+            token = self.next();
 
-            if token.token_type != TokenType::COLON{
-                return Err("Invalid row syntax: no colon after variable name")
+            if token.token_type != TokenType::COLON {
+                return Err("Invalid row syntax: no colon after variable name");
             }
 
             if let Ok(monotype) = self.parse_monotype() {
-                let property = Property{
-                    k: variable.unwrap(), 
-                    v: monotype
+                let property = Property {
+                    k: variable.unwrap(),
+                    v: monotype,
                 };
 
                 row_stack.push(property);
             } else {
-                return Err("Row monotypes must be valid")
-            }  
+                return Err("Row monotypes must be valid");
+            }
 
-            token = self.next(); 
+            token = self.next();
             if token.token_type == TokenType::WITH {
-                token = self.next(); 
+                token = self.next();
             }
         }
 
-        let mut inner_prop = None; 
+        let mut inner_prop = None;
         while let Some(outer_prop) = row_stack.pop() {
             if inner_prop.is_none() {
                 inner_prop = Some(MonoType::Row(Box::new(Row::Extension {
-                    head: outer_prop, 
+                    head: outer_prop,
                     tail: MonoType::Row(Box::new(Row::Empty)),
-                }))); 
-                continue; 
+                })));
+                continue;
             }
 
             inner_prop = Some(MonoType::Row(Box::new(Row::Extension {
-                head: outer_prop, 
+                head: outer_prop,
                 tail: inner_prop.unwrap(),
-            }))); 
+            })));
         }
         match inner_prop {
-            None => Err("Unable to parse row MonoType"), 
-            Some(rows) => Ok(rows)
+            None => Err("Unable to parse row MonoType"),
+            Some(rows) => Ok(rows),
         }
     }
 }
 
 #[cfg(test)]
-mod tests { 
+mod tests {
     use super::*;
 
-    #[test] 
+    #[test]
     fn parse_primitives_test() {
         let parse_text = "forall [t0] (x: t0, y: float) -> t0";
 
@@ -668,127 +664,127 @@ mod tests {
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: None, 
-            expr: MonoType::Fun(Box::new(Function{
+            cons: HashMap::new(),
+            expr: MonoType::Fun(Box::new(Function {
                 req: req_args,
                 opt: HashMap::new(),
                 pipe: None,
-                retn: MonoType::Var(Tvar(0))
+                retn: MonoType::Var(Tvar(0)),
             })),
         };
-        assert_eq!(Ok(output), Parse(parse_text)); 
+        assert_eq!(Ok(output), Parse(parse_text));
 
         let parse_text = "forall [t0] where t0: Comparable bool";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Comparable);
+        bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Bool,
         };
-        assert_eq!(Ok(output), Parse(parse_text)); 
+        assert_eq!(Ok(output), Parse(parse_text));
 
-        let parse_text = "forall [t1] where t1: Addable + Subtractable + Comparable + Divisible float"; 
+        let parse_text =
+            "forall [t1] where t1: Addable + Subtractable + Comparable + Divisible float";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new();
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Addable);
-        kinds.insert(Kind::Subtractable);
-        kinds.insert(Kind::Comparable);
-        kinds.insert(Kind::Divisible);
+        kinds.push(Kind::Addable);
+        kinds.push(Kind::Subtractable);
+        kinds.push(Kind::Comparable);
+        kinds.push(Kind::Divisible);
 
-        bounds.insert(Tvar(1), kinds); 
+        bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
             free: vec![Tvar(1)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Float,
         };
-        assert_eq!(Ok(output), Parse(parse_text)); 
+        assert_eq!(Ok(output), Parse(parse_text));
 
-        let parse_text = "forall [t10] where t10: Comparable + Nullable regexp"; 
+        let parse_text = "forall [t10] where t10: Comparable + Nullable regexp";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new();
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable);
-        kinds.insert(Kind::Nullable);
+        kinds.push(Kind::Comparable);
+        kinds.push(Kind::Nullable);
 
-        bounds.insert(Tvar(10), kinds); 
+        bounds.insert(Tvar(10), kinds);
 
         let output = PolyType {
             free: vec![Tvar(10)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Regexp,
         };
-        assert_eq!(Ok(output), Parse(parse_text)); 
+        assert_eq!(Ok(output), Parse(parse_text));
 
-        let text = "forall [t0] uint"; 
-     
+        let text = "forall [t0] uint";
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: None, 
+            cons: HashMap::new(),
             expr: MonoType::Uint,
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text = "forall [t0] where t0: Comparable bool"; 
+        let text = "forall [t0] where t0: Comparable bool";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Comparable);
+        bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Bool,
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text = "forall [t1] where t1: Addable + Subtractable int"; 
+        let text = "forall [t1] where t1: Addable + Subtractable int";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Addable); 
-        kinds.insert(Kind::Subtractable);
-        bounds.insert(Tvar(1),kinds);
+        kinds.push(Kind::Addable);
+        kinds.push(Kind::Subtractable);
+        bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
             free: vec![Tvar(1)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Int,
         };
 
         assert_eq!(Ok(output), Parse(text));
-        
-        let text = "forall [t0, t1] where t0: Equatable + Nullable, t1: Addable + Subtractable string"; 
 
+        let text =
+            "forall [t0, t1] where t0: Equatable + Nullable, t1: Addable + Subtractable string";
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Equatable); 
-        kinds.insert(Kind::Nullable);
-        bounds.insert(Tvar(0),kinds); 
+        kinds.push(Kind::Equatable);
+        kinds.push(Kind::Nullable);
+        bounds.insert(Tvar(0), kinds);
 
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Addable); 
-        kinds.insert(Kind::Subtractable);
-        bounds.insert(Tvar(1),kinds);
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Addable);
+        kinds.push(Kind::Subtractable);
+        bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0), Tvar(1)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::String,
         };
 
@@ -797,88 +793,92 @@ mod tests {
 
     #[test]
     fn parse_array_test() {
-        let parse_text = "forall [t0, t1] where t0: Comparable + Equatable + Nullable, t1: Comparable + Equatable + Nullable [uint]"; 
+        let parse_text = "forall [t0, t1] where t0: Comparable + Equatable + Nullable, t1: Comparable + Equatable + Nullable [uint]";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        kinds.insert(Kind::Equatable);
-        kinds.insert(Kind::Nullable);  
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Comparable);
+        kinds.push(Kind::Equatable);
+        kinds.push(Kind::Nullable);
+        bounds.insert(Tvar(0), kinds);
 
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        kinds.insert(Kind::Equatable);
-        kinds.insert(Kind::Nullable);  
-        bounds.insert(Tvar(1),kinds);        
+        kinds.push(Kind::Comparable);
+        kinds.push(Kind::Equatable);
+        kinds.push(Kind::Nullable);
+        bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0), Tvar(1)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Arr(Box::new(Array(MonoType::Uint))),
         };
-        assert_eq!(Ok(output), Parse(parse_text)); 
+        assert_eq!(Ok(output), Parse(parse_text));
 
-        let parse_text = "forall [t0, t1, t2, t3, t4] where t0: Addable, t1: Addable + Subtractable, t2: Addable + Subtractable + Divisible [[time]]"; 
+        let parse_text = "forall [t0, t1, t2, t3, t4] where t0: Addable, t1: Addable + Subtractable, t2: Addable + Subtractable + Divisible [[time]]";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Addable);  
-        bounds.insert(Tvar(0),kinds);  
+        kinds.push(Kind::Addable);
+        bounds.insert(Tvar(0), kinds);
 
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Addable);  
-        kinds.insert(Kind::Subtractable);  
-        bounds.insert(Tvar(1),kinds);       
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Addable);
+        kinds.push(Kind::Subtractable);
+        bounds.insert(Tvar(1), kinds);
 
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Addable);  
-        kinds.insert(Kind::Subtractable);
-        kinds.insert(Kind::Divisible);  
-        bounds.insert(Tvar(2),kinds);   
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Addable);
+        kinds.push(Kind::Subtractable);
+        kinds.push(Kind::Divisible);
+        bounds.insert(Tvar(2), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0), Tvar(1), Tvar(2), Tvar(3), Tvar(4)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Arr(Box::new(Array(MonoType::Arr(Box::new(Array(MonoType::Time)))))),
+            cons: bounds,
+            expr: MonoType::Arr(Box::new(Array(MonoType::Arr(Box::new(Array(
+                MonoType::Time,
+            )))))),
         };
 
-        assert_eq!(Ok(output), Parse(parse_text)); 
+        assert_eq!(Ok(output), Parse(parse_text));
 
-        let text = "forall [t0] where t0: Comparable + Equatable [uint]"; 
+        let text = "forall [t0] where t0: Comparable + Equatable [uint]";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        kinds.insert(Kind::Equatable);
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Comparable);
+        kinds.push(Kind::Equatable);
+        bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             expr: MonoType::Arr(Box::new(Array(MonoType::Uint))),
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text = "forall [t0] where t0: Addable + Divisible [[duration]]"; 
+        let text = "forall [t0] where t0: Addable + Divisible [[duration]]";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Addable); 
-        kinds.insert(Kind::Divisible);
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Addable);
+        kinds.push(Kind::Divisible);
+        bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
+            cons: bounds,
             // An Array of type Array of type Duration
-            expr: MonoType::Arr(Box::new(Array(MonoType::Arr(Box::new(Array(MonoType::Duration)))))),
+            expr: MonoType::Arr(Box::new(Array(MonoType::Arr(Box::new(Array(
+                MonoType::Duration,
+            )))))),
         };
 
         assert_eq!(Ok(output), Parse(text));
@@ -886,13 +886,14 @@ mod tests {
 
     #[test]
     fn parse_function_test() {
-        let parse_text = "forall [t12] where t12: Subtractable (x: t12, ?y: int, <-var: float) -> t12"; 
+        let parse_text =
+            "forall [t12] where t12: Subtractable (x: t12, ?y: int, <-var: float) -> t12";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Subtractable); 
-        bounds.insert(Tvar(12),kinds);
+        kinds.push(Kind::Subtractable);
+        bounds.insert(Tvar(12), kinds);
 
         let mut req_arg = HashMap::new();
         req_arg.insert("x".to_string(), MonoType::Var(Tvar(12)));
@@ -900,127 +901,128 @@ mod tests {
         let mut opt_arg = HashMap::new();
         opt_arg.insert("y".to_string(), MonoType::Int);
 
-        let pipe_arg = Some(Property{
+        let pipe_arg = Some(Property {
             k: "var".to_string(),
             v: MonoType::Float,
         });
 
         let output = PolyType {
             free: vec![Tvar(12)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Fun(Box::new(Function{
+            cons: bounds,
+            expr: MonoType::Fun(Box::new(Function {
                 req: req_arg,
                 opt: opt_arg,
                 pipe: pipe_arg,
-                retn: MonoType::Var(Tvar(12))
-            }))
+                retn: MonoType::Var(Tvar(12)),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(parse_text));
 
-        let text = "forall [t0] where t0: Subtractable (x: t0) -> t0"; 
+        let text = "forall [t0] where t0: Subtractable (x: t0) -> t0";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Subtractable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Subtractable);
+        bounds.insert(Tvar(0), kinds);
 
         let mut req_arg = HashMap::new();
         req_arg.insert("x".to_string(), MonoType::Var(Tvar(0)));
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Fun(Box::new(Function{
+            cons: bounds,
+            expr: MonoType::Fun(Box::new(Function {
                 req: req_arg,
                 opt: HashMap::new(),
                 pipe: None,
-                retn: MonoType::Var(Tvar(0))
-            }))
+                retn: MonoType::Var(Tvar(0)),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text = "forall [t1, t10, t100] where t1: Addable, t10: Subtractable (x: t1, ?y: t10) -> t100"; 
+        let text =
+            "forall [t1, t10, t100] where t1: Addable, t10: Subtractable (x: t1, ?y: t10) -> t100";
 
         let mut bounds = HashMap::new();
 
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Addable); 
-        bounds.insert(Tvar(1),kinds);
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Addable);
+        bounds.insert(Tvar(1), kinds);
 
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Subtractable); 
-        bounds.insert(Tvar(10),kinds);
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Subtractable);
+        bounds.insert(Tvar(10), kinds);
 
         let mut req_args = HashMap::new();
         req_args.insert("x".to_string(), MonoType::Var(Tvar(1)));
 
-        let mut opt_args = HashMap::new(); 
+        let mut opt_args = HashMap::new();
         opt_args.insert("y".to_string(), MonoType::Var(Tvar(10)));
 
         let output = PolyType {
             free: vec![Tvar(1), Tvar(10), Tvar(100)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Fun(Box::new(Function{
+            cons: bounds,
+            expr: MonoType::Fun(Box::new(Function {
                 req: req_args,
                 opt: opt_args,
                 pipe: None,
-                retn: MonoType::Var(Tvar(100))
-            }))
+                retn: MonoType::Var(Tvar(100)),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text =  "forall [t0] where t0: Nullable (<-x: t0) -> t0"; 
+        let text = "forall [t0] where t0: Nullable (<-x: t0) -> t0";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Nullable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Nullable);
+        bounds.insert(Tvar(0), kinds);
 
-        let pipe_arg = Some(Property{
+        let pipe_arg = Some(Property {
             k: "x".to_string(),
             v: MonoType::Var(Tvar(0)),
         });
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Fun(Box::new(Function{
+            cons: bounds,
+            expr: MonoType::Fun(Box::new(Function {
                 req: HashMap::new(),
                 opt: HashMap::new(),
                 pipe: pipe_arg,
-                retn: MonoType::Var(Tvar(0))
-            }))
+                retn: MonoType::Var(Tvar(0)),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text = "forall [t0, t1] where t0: Comparable (<-: t0) -> t0"; 
+        let text = "forall [t0, t1] where t0: Comparable (<-: t0) -> t0";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Comparable);
+        bounds.insert(Tvar(0), kinds);
 
-        let pipe_arg = Some(Property{
+        let pipe_arg = Some(Property {
             k: "<-".to_string(),
             v: MonoType::Var(Tvar(0)),
         });
 
         let output = PolyType {
             free: vec![Tvar(0), Tvar(1)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Fun(Box::new(Function{
+            cons: bounds,
+            expr: MonoType::Fun(Box::new(Function {
                 req: HashMap::new(),
                 opt: HashMap::new(),
                 pipe: pipe_arg,
-                retn: MonoType::Var(Tvar(0))
-            }))
+                retn: MonoType::Var(Tvar(0)),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(text));
@@ -1031,18 +1033,18 @@ mod tests {
         let parse_text = "   forall [t1, t2] where t1: Nullable t2: Comparable {test: t1 | testAgain: bool | testLast: [uint]} ";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Nullable); 
-        bounds.insert(Tvar(1),kinds);
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Nullable);
+        bounds.insert(Tvar(1), kinds);
 
-        let mut kinds = HashSet::new(); 
-        kinds.insert(Kind::Comparable); 
-        bounds.insert(Tvar(2),kinds);
+        let mut kinds = Vec::new();
+        kinds.push(Kind::Comparable);
+        bounds.insert(Tvar(2), kinds);
 
         let output = PolyType {
             free: vec![Tvar(1), Tvar(2)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Row(Box::new(Row::Extension { 
+            cons: bounds,
+            expr: MonoType::Row(Box::new(Row::Extension {
                 head: Property {
                     k: "test".to_string(),
                     v: MonoType::Var(Tvar(1)),
@@ -1058,41 +1060,41 @@ mod tests {
                             v: MonoType::Arr(Box::new(Array(MonoType::Uint))),
                         },
                         tail: MonoType::Row(Box::new(Row::Empty)),
-                    }))
-                }))
-            }))
+                    })),
+                })),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(parse_text));
 
-        let text = "forall [t0] where t0: Nullable {}"; 
+        let text = "forall [t0] where t0: Nullable {}";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Nullable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Nullable);
+        bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Row(Box::new(Row::Empty))
+            cons: bounds,
+            expr: MonoType::Row(Box::new(Row::Empty)),
         };
 
         assert_eq!(Ok(output), Parse(text));
 
-        let text = "forall [t0] where t0: Comparable {a: int | b: string | c: bool}"; 
+        let text = "forall [t0] where t0: Comparable {a: int | b: string | c: bool}";
 
         let mut bounds = HashMap::new();
-        let mut kinds = HashSet::new(); 
+        let mut kinds = Vec::new();
 
-        kinds.insert(Kind::Comparable); 
-        bounds.insert(Tvar(0),kinds);
+        kinds.push(Kind::Comparable);
+        bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
             free: vec![Tvar(0)],
-            cons: Some(TvarKinds(bounds)), 
-            expr: MonoType::Row(Box::new(Row::Extension { 
+            cons: bounds,
+            expr: MonoType::Row(Box::new(Row::Extension {
                 head: Property {
                     k: 'a'.to_string(),
                     v: MonoType::Int,
@@ -1108,9 +1110,9 @@ mod tests {
                             v: MonoType::Bool,
                         },
                         tail: MonoType::Row(Box::new(Row::Empty)),
-                    }))
-                }))
-            }))
+                    })),
+                })),
+            })),
         };
 
         assert_eq!(Ok(output), Parse(text));
@@ -1118,377 +1120,1150 @@ mod tests {
 
     #[test]
     fn lex_polytypes() {
-        let polytype = Lex("forall [t0] where t0: Addable int"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Addable".to_string())},
-            Token{token_type: TokenType::INT, text: Some("int".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], polytype); 
+        let polytype = Lex("forall [t0] where t0: Addable int");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Addable".to_string())
+                },
+                Token {
+                    token_type: TokenType::INT,
+                    text: Some("int".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            polytype
+        );
 
-        let polytype = Lex("forall [t0, t1] where t0: Addable + Subtractable [int]"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())}, 
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Addable".to_string())},
-            Token{token_type: TokenType::PLUS, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Subtractable".to_string())},
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None},
-            Token{token_type: TokenType::INT, text: Some("int".to_string())},
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], polytype); 
+        let polytype = Lex("forall [t0, t1] where t0: Addable + Subtractable [int]");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Addable".to_string())
+                },
+                Token {
+                    token_type: TokenType::PLUS,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Subtractable".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::INT,
+                    text: Some("int".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            polytype
+        );
 
-        let polytype = Lex("forall [t0, t1] where t0: Nullable + Comparable [[time]]"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())}, 
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Nullable".to_string())},
-            Token{token_type: TokenType::PLUS, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Comparable".to_string())},
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None},
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None},
-            Token{token_type: TokenType::TIME, text: Some("time".to_string())},
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], polytype);
+        let polytype = Lex("forall [t0, t1] where t0: Nullable + Comparable [[time]]");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Nullable".to_string())
+                },
+                Token {
+                    token_type: TokenType::PLUS,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Comparable".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::TIME,
+                    text: Some("time".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            polytype
+        );
 
-        let polytype = Lex("forall [t0, t1] where t1: Comparable + Divisible {first: uint | second: string | third: duration}"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())}, 
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Comparable".to_string())},
-            Token{token_type: TokenType::PLUS, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Divisible".to_string())},
-            Token{token_type: TokenType::LEFTCURLYBRAC, text: None},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("first".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::UINT, text: Some("uint".to_string())},
-            Token{token_type: TokenType::WITH, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("second".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::STRING, text: Some("string".to_string())},
-            Token{token_type: TokenType::WITH, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("third".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::DURATION, text: Some("duration".to_string())},
-            Token{token_type: TokenType::RIGHTCURLYBRAC, text: None}, 
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], polytype); 
+        let polytype = Lex("forall [t0, t1] where t1: Comparable + Divisible {first: uint | second: string | third: duration}");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Comparable".to_string())
+                },
+                Token {
+                    token_type: TokenType::PLUS,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Divisible".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTCURLYBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("first".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::UINT,
+                    text: Some("uint".to_string())
+                },
+                Token {
+                    token_type: TokenType::WITH,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("second".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::STRING,
+                    text: Some("string".to_string())
+                },
+                Token {
+                    token_type: TokenType::WITH,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("third".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::DURATION,
+                    text: Some("duration".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTCURLYBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            polytype
+        );
 
-        let polytype = Lex("forall [t0, t1] where t1: Addable (x: float, ?y: regexp, <-pipe: t1) -> t1"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())}, 
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("Addable".to_string())},
-            Token{token_type: TokenType::LEFTPAREN, text: None},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("x".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::FLOAT, text: Some("float".to_string())},
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::QUESTIONMARK, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("y".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::REGEXP, text: Some("regexp".to_string())},
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::PIPE, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("pipe".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())},
-            Token{token_type: TokenType::RIGHTPAREN, text: None}, 
-            Token{token_type: TokenType::ARROW, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], polytype); 
+        let polytype =
+            Lex("forall [t0, t1] where t1: Addable (x: float, ?y: regexp, <-pipe: t1) -> t1");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("Addable".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("x".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::FLOAT,
+                    text: Some("float".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::QUESTIONMARK,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("y".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::REGEXP,
+                    text: Some("regexp".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::PIPE,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("pipe".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::ARROW,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            polytype
+        );
     }
 
     #[test]
     fn lex_operators() {
         let tokens = Lex("{} [] ( ) ? : , + <- <> -> |");
-        assert_eq!(vec![
-            Token{token_type: TokenType::LEFTCURLYBRAC, text: None}, 
-            Token{token_type: TokenType::RIGHTCURLYBRAC, text: None},
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None},
-            Token{token_type: TokenType::LEFTPAREN, text: None}, 
-            Token{token_type: TokenType::RIGHTPAREN, text: None},
-            Token{token_type: TokenType::QUESTIONMARK, text: None},
-            Token{token_type: TokenType::COLON, text: None},
-            Token{token_type: TokenType::COMMA, text: None},
-            Token{token_type: TokenType::PLUS, text: None},
-            Token{token_type: TokenType::PIPE, text: None},
-            Token{token_type: TokenType::ERROR, text: None},
-            Token{token_type: TokenType::ARROW,text: None}, 
-            Token{token_type: TokenType::WITH,text: None}, 
-            Token{token_type: TokenType::EOF, text: None},
-            ], tokens);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::LEFTCURLYBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::RIGHTCURLYBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::LEFTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::RIGHTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::QUESTIONMARK,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::PLUS,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::PIPE,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::ERROR,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::ARROW,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WITH,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            tokens
+        );
     }
 
     #[test]
     fn lex_functions() {
-        let function = Lex("(x: bool, ?y: string, <-test: t0) -> t0"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::LEFTPAREN, text: None},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("x".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::BOOL, text: Some("bool".to_string())},
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::QUESTIONMARK, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("y".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::STRING, text: Some("string".to_string())},
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::PIPE, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("test".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::RIGHTPAREN, text: None}, 
-            Token{token_type: TokenType::ARROW, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], function);   
+        let function = Lex("(x: bool, ?y: string, <-test: t0) -> t0");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::LEFTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("x".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::BOOL,
+                    text: Some("bool".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::QUESTIONMARK,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("y".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::STRING,
+                    text: Some("string".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::PIPE,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("test".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::ARROW,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            function
+        );
 
-        let function = Lex("(onearg: int, ?twoarg: time, <-: t12) -> t12"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::LEFTPAREN, text: None},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("onearg".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::INT, text: Some("int".to_string())},
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::QUESTIONMARK, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("twoarg".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::TIME, text: Some("time".to_string())},
-            Token{token_type: TokenType::COMMA, text: None}, 
-            Token{token_type: TokenType::PIPE, text: None}, 
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t12".to_string())},
-            Token{token_type: TokenType::RIGHTPAREN, text: None}, 
-            Token{token_type: TokenType::ARROW, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t12".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], function);  
+        let function = Lex("(onearg: int, ?twoarg: time, <-: t12) -> t12");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::LEFTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("onearg".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::INT,
+                    text: Some("int".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::QUESTIONMARK,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("twoarg".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::TIME,
+                    text: Some("time".to_string())
+                },
+                Token {
+                    token_type: TokenType::COMMA,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::PIPE,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t12".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTPAREN,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::ARROW,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t12".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            function
+        );
     }
 
     #[test]
     fn lex_rows() {
-        let row = Lex("{one: time | tWO: t0 | THREE: t1}"); 
-        assert_eq!(vec![
-            Token{token_type: TokenType::LEFTCURLYBRAC, text: None},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("one".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::TIME, text: Some("time".to_string())},
-            Token{token_type: TokenType::WITH, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("tWO".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::WITH, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("THREE".to_string())},
-            Token{token_type: TokenType::COLON, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t1".to_string())},
-            Token{token_type: TokenType::RIGHTCURLYBRAC, text: None}, 
-            Token{token_type: TokenType::EOF, text: None}, 
-        ], row);   
+        let row = Lex("{one: time | tWO: t0 | THREE: t1}");
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::LEFTCURLYBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("one".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::TIME,
+                    text: Some("time".to_string())
+                },
+                Token {
+                    token_type: TokenType::WITH,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("tWO".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::WITH,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("THREE".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t1".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTCURLYBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            row
+        );
     }
 
     #[test]
-    fn lex_idents_keywords_and_edge_cases(){
+    fn lex_idents_keywords_and_edge_cases() {
         let valid_type_var = Lex("t0");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], valid_type_var);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            valid_type_var
+        );
 
         let idents = Lex("to");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("to".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-        ], idents);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("to".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            idents
+        );
 
         let keyword = Lex("if");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("if".to_string())}, 
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("if".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("i3");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("i3".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("i3".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("forall");
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-        ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("floor");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("floor".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("floor".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("where");
-        assert_eq!(vec![
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("waits");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("waits".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("waits".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("w");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("w".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("w".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("add");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("add".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("add".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("addable");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("addable".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("addable".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("itt");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("itt".to_string())}, 
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
-        
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("itt".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
         let keyword = Lex("itscool");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("itscool".to_string())}, 
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("itscool".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("string");
-        assert_eq!(vec![
-            Token{token_type: TokenType::STRING, text: Some("string".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::STRING,
+                    text: Some("string".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("str");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("str".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("str".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("bool");
-        assert_eq!(vec![
-            Token{token_type: TokenType::BOOL, text: Some("bool".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::BOOL,
+                    text: Some("bool".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("boolean");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("boolean".to_string())},
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("boolean".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("regexp");
-        assert_eq!(vec![
-            Token{token_type: TokenType::REGEXP, text: Some("regexp".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::REGEXP,
+                    text: Some("regexp".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("reg ");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("reg".to_string())}, 
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("reg".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("relax");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("relax".to_string())}, 
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
-
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("relax".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("forall [t0] ");
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::EOF, text: None}, 
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("forallt");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("forallt".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("forallt".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("forall [t0] where t0:");
-        assert_eq!(vec![
-            Token{token_type: TokenType::FORALL, text: Some("forall".to_string())}, 
-            Token{token_type: TokenType::LEFTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::RIGHTSQUAREBRAC, text: None}, 
-            Token{token_type: TokenType::WHERE, text: Some("where".to_string())},
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::COLON, text: None},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::FORALL,
+                    text: Some("forall".to_string())
+                },
+                Token {
+                    token_type: TokenType::LEFTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::RIGHTSQUAREBRAC,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::WHERE,
+                    text: Some("where".to_string())
+                },
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("t0:\nfloat");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("t0".to_string())},
-            Token{token_type: TokenType::COLON, text: None},
-            Token{token_type: TokenType::FLOAT, text: Some("float".to_string())},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("t0".to_string())
+                },
+                Token {
+                    token_type: TokenType::COLON,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::FLOAT,
+                    text: Some("float".to_string())
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
 
         let keyword = Lex("reg <-");
-        assert_eq!(vec![
-            Token{token_type: TokenType::IDENTIFIER, text: Some("reg".to_string())}, 
-            Token{token_type: TokenType::PIPE, text: None},
-            Token{token_type: TokenType::EOF, text: None},
-            ], keyword);
-    }        
+        assert_eq!(
+            vec![
+                Token {
+                    token_type: TokenType::IDENTIFIER,
+                    text: Some("reg".to_string())
+                },
+                Token {
+                    token_type: TokenType::PIPE,
+                    text: None
+                },
+                Token {
+                    token_type: TokenType::EOF,
+                    text: None
+                },
+            ],
+            keyword
+        );
+    }
 }


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

This PR adds the type environment used for looking up an identifier's polytype during inference. It also adds unimplemented `infer` methods for generating constraints from each expression. Finally I implement constraint generation for function blocks as an example of how type environments are consumed.