### PR TITLE
feat(values): add month support when adding durations to a time value

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -219,10 +219,12 @@ Examples:
     2018-01-31T00:00:00Z + 1mo      // 2018-02-28T00:00:00Z, February 31th is rolled back to the last day of the month, February 28th in 2018.
 
     // Addition and subtraction of durations to date times does not commute
-    2018-02-28T00:00:00Z + 1mo + 1d // 2018-03-29T00:00:00Z
-    2018-02-28T00:00:00Z + 1d + 1mo // 2018-04-01T00:00:00Z
-    2018-01-01T00:00:00Z + 2mo - 1d // 2018-02-28T00:00:00Z
-    2018-01-01T00:00:00Z - 1d + 3mo // 2018-03-31T00:00:00Z
+    2018-02-28T00:00:00Z + 1mo + 1d  // 2018-03-29T00:00:00Z
+    2018-02-28T00:00:00Z + 1d + 1mo  // 2018-04-01T00:00:00Z
+    2018-01-01T00:00:00Z + 2mo - 1d  // 2018-02-28T00:00:00Z
+    2018-01-01T00:00:00Z - 1d + 3mo  // 2018-03-31T00:00:00Z
+    2018-01-31T00:00:00Z + 1mo + 1mo // 2018-03-28T00:00:00Z
+    2018-01-31T00:00:00Z + 2mo       // 2018-03-31T00:00:00Z
 
     // Addition and subtraction of durations to date times applies months, days and seconds in that order.
     2018-01-28T00:00:00Z + 1mo + 2d // 2018-03-02T00:00:00Z
@@ -231,6 +233,14 @@ Examples:
     2018-02-01T00:00:00Z + 2mo2d    // 2018-04-03T00:00:00Z
     2018-01-01T00:00:00Z + 1mo30d   // 2018-03-02T00:00:00Z, Months are applied first to get February 1st, then days are added resulting in March 2 in 2018.
     2018-01-31T00:00:00Z + 1mo1d    // 2018-03-01T00:00:00Z, Months are applied first to get February 28th, then days are added resulting in March 1 in 2018.
+
+    // Multiplication works
+    2018-01-01T00:00:00Z + 1mo * 1  // 2018-02-01T00:00:00Z
+    2018-01-01T00:00:00Z + 1mo * 2  // 2018-03-01T00:00:00Z
+    2018-01-01T00:00:00Z + 1mo * 3  // 2018-04-01T00:00:00Z
+    2018-01-31T00:00:00Z + 1mo * 1  // 2018-02-28T00:00:00Z
+    2018-01-31T00:00:00Z + 1mo * 2  // 2018-03-31T00:00:00Z
+    2018-01-31T00:00:00Z + 1mo * 3  // 2018-04-30T00:00:00Z
 
 [IMPL#657](https://github.com/influxdata/platform/issues/657) Implement Duration vectors
 

--- a/execute/window.go
+++ b/execute/window.go
@@ -1,5 +1,13 @@
 package execute
 
+import (
+	"time"
+
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/values"
+)
+
 type Window struct {
 	Every  Duration
 	Period Duration
@@ -8,14 +16,52 @@ type Window struct {
 
 // NewWindow creates a window with the given parameters,
 // and normalizes the offset to a small positive duration.
-func NewWindow(every, period, offset Duration) Window {
+// It also validates that the durations are valid when
+// used within a window.
+func NewWindow(every, period, offset Duration) (Window, error) {
 	// Normalize the offset to a small positive duration
 	offset = offset.Normalize(every)
-	return Window{
+
+	w := Window{
 		Every:  every,
 		Period: period,
 		Offset: offset,
 	}
+	if err := w.IsValid(); err != nil {
+		return Window{}, err
+	}
+	return w, nil
+}
+
+type truncateFunc func(t Time, d Duration) Time
+
+func (w *Window) getTruncateFunc(d Duration) (truncateFunc, error) {
+	switch months, nsecs := d.Months(), d.Nanoseconds(); {
+	case months != 0 && nsecs != 0:
+		return nil, errors.New(codes.Invalid, "duration used as an interval cannot mix month and nanosecond units")
+	case months != 0:
+		return truncateByMonths, nil
+	case nsecs != 0:
+		return truncateByNsecs, nil
+	default:
+		return nil, errors.New(codes.Invalid, "duration used as an interval cannot be zero")
+	}
+}
+
+// truncate will truncate the time using the duration.
+func (w *Window) truncate(t Time) Time {
+	fn, err := w.getTruncateFunc(w.Every)
+	if err != nil {
+		panic(err)
+	}
+	return fn(t, w.Every)
+}
+
+// IsValid will check if this Window is valid and it will
+// return an error if it isn't.
+func (w Window) IsValid() error {
+	_, err := w.getTruncateFunc(w.Every)
+	return err
 }
 
 // GetEarliestBounds returns the bounds for the earliest window bounds
@@ -25,7 +71,7 @@ func (w Window) GetEarliestBounds(t Time) Bounds {
 	// translate to not-offset coordinate
 	t = t.Add(w.Offset.Mul(-1))
 
-	stop := t.Truncate(w.Every).Add(w.Every)
+	stop := w.truncate(t).Add(w.Every)
 
 	// translate to offset coordinate
 	stop = stop.Add(w.Offset)
@@ -54,6 +100,30 @@ func (w Window) GetOverlappingBounds(b Bounds) []Bounds {
 		bi.Start = bi.Start.Add(w.Every)
 		bi.Stop = bi.Stop.Add(w.Every)
 	}
-
 	return bs
+}
+
+// truncateByNsecs will truncate the time to the given number
+// of nanoseconds.
+func truncateByNsecs(t Time, d Duration) Time {
+	remainder := int64(t) % d.Nanoseconds()
+	return t - Time(remainder)
+}
+
+// truncateByMonths will truncate the time to the given
+// number of months.
+func truncateByMonths(t Time, d Duration) Time {
+	ts := t.Time()
+	year, month, _ := ts.Date()
+
+	// Determine the total number of months and truncate
+	// the number of months by the duration amount.
+	total := int64(year*12) + int64(month-1)
+	remainder := total % d.Months()
+	total -= remainder
+
+	// Recreate a new time from the year and month combination.
+	year, month = int(total/12), time.Month(total%12)+1
+	ts = time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	return values.ConvertTime(ts)
 }

--- a/execute/window_test.go
+++ b/execute/window_test.go
@@ -5,48 +5,82 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/values"
 )
 
 func TestNewWindow(t *testing.T) {
-	want := execute.Window{
-		Every:  values.ConvertDuration(time.Minute),
-		Period: values.ConvertDuration(time.Minute),
-		Offset: values.ConvertDuration(time.Second),
-	}
-	got := execute.NewWindow(values.ConvertDuration(time.Minute), values.ConvertDuration(time.Minute), values.ConvertDuration(time.Second))
-	if !cmp.Equal(want, got) {
-		t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
-	}
+	t.Run("normal offset", func(t *testing.T) {
+		want := execute.Window{
+			Every:  values.ConvertDuration(time.Minute),
+			Period: values.ConvertDuration(time.Minute),
+			Offset: values.ConvertDuration(time.Second),
+		}
+		got := MustWindow(values.ConvertDuration(time.Minute), values.ConvertDuration(time.Minute), values.ConvertDuration(time.Second))
+		if !cmp.Equal(want, got) {
+			t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
+		}
+	})
 
 	// offset larger than "every" duration will be normalized
-	want = execute.Window{
-		Every:  values.ConvertDuration(time.Minute),
-		Period: values.ConvertDuration(time.Minute),
-		Offset: values.ConvertDuration(30 * time.Second),
-	}
-	got = execute.NewWindow(
-		values.ConvertDuration(time.Minute),
-		values.ConvertDuration(time.Minute),
-		values.ConvertDuration(2*time.Minute+30*time.Second))
-	if !cmp.Equal(want, got) {
-		t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
-	}
+	t.Run("larger offset", func(t *testing.T) {
+		want := execute.Window{
+			Every:  values.ConvertDuration(time.Minute),
+			Period: values.ConvertDuration(time.Minute),
+			Offset: values.ConvertDuration(30 * time.Second),
+		}
+		got := MustWindow(
+			values.ConvertDuration(time.Minute),
+			values.ConvertDuration(time.Minute),
+			values.ConvertDuration(2*time.Minute+30*time.Second))
+		if !cmp.Equal(want, got) {
+			t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
+		}
+	})
 
 	// Negative offset will be normalized
-	want = execute.Window{
-		Every:  values.ConvertDuration(time.Minute),
-		Period: values.ConvertDuration(time.Minute),
-		Offset: values.ConvertDuration(30 * time.Second),
-	}
-	got = execute.NewWindow(
-		values.ConvertDuration(time.Minute),
-		values.ConvertDuration(time.Minute),
-		values.ConvertDuration(-2*time.Minute+30*time.Second))
-	if !cmp.Equal(want, got) {
-		t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
-	}
+	t.Run("negative offset", func(t *testing.T) {
+		want := execute.Window{
+			Every:  values.ConvertDuration(time.Minute),
+			Period: values.ConvertDuration(time.Minute),
+			Offset: values.ConvertDuration(30 * time.Second),
+		}
+		got := MustWindow(
+			values.ConvertDuration(time.Minute),
+			values.ConvertDuration(time.Minute),
+			values.ConvertDuration(-2*time.Minute+30*time.Second))
+		if !cmp.Equal(want, got) {
+			t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
+		}
+	})
+
+	// Mixed base duration units.
+	t.Run("mixed units", func(t *testing.T) {
+		wantErr := errors.New(codes.Invalid, "duration used as an interval cannot mix month and nanosecond units")
+		_, gotErr := execute.NewWindow(
+			mustParseDuration("1mo2w"),
+			mustParseDuration("1mo2w"),
+			values.Duration{},
+		)
+		if want, got := errAsString(wantErr), errAsString(gotErr); want != got {
+			t.Errorf("window error different; -want/+got:\n%v\n", cmp.Diff(want, got))
+		}
+	})
+
+	// Zero values.
+	t.Run("zero values", func(t *testing.T) {
+		wantErr := errors.New(codes.Invalid, "duration used as an interval cannot be zero")
+		_, gotErr := execute.NewWindow(
+			values.Duration{},
+			values.Duration{},
+			values.Duration{},
+		)
+		if want, got := errAsString(wantErr), errAsString(gotErr); want != got {
+			t.Errorf("window error different; -want/+got:\n%v\n", cmp.Diff(want, got))
+		}
+	})
 }
 
 func TestWindow_GetEarliestBounds(t *testing.T) {
@@ -58,7 +92,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 	}{
 		{
 			name: "simple",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(5*time.Minute),
 				values.ConvertDuration(5*time.Minute),
 				values.ConvertDuration(0)),
@@ -70,7 +104,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 		},
 		{
 			name: "simple with offset",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(5*time.Minute),
 				values.ConvertDuration(5*time.Minute),
 				values.ConvertDuration(30*time.Second)),
@@ -82,7 +116,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 		},
 		{
 			name: "underlapping",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(2*time.Minute),
 				values.ConvertDuration(1*time.Minute),
 				values.ConvertDuration(30*time.Second)),
@@ -94,7 +128,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 		},
 		{
 			name: "underlapping not contained",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(2*time.Minute),
 				values.ConvertDuration(1*time.Minute),
 				values.ConvertDuration(30*time.Second)),
@@ -106,7 +140,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 		},
 		{
 			name: "overlapping",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(1*time.Minute),
 				values.ConvertDuration(2*time.Minute),
 				values.ConvertDuration(30*time.Second)),
@@ -118,7 +152,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 		},
 		{
 			name: "partially overlapping",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(1*time.Minute),
 				values.ConvertDuration(3*time.Minute+30*time.Second),
 				values.ConvertDuration(30*time.Second)),
@@ -130,7 +164,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 		},
 		{
 			name: "partially overlapping (t on boundary)",
-			w: execute.NewWindow(
+			w: MustWindow(
 				values.ConvertDuration(1*time.Minute),
 				values.ConvertDuration(3*time.Minute+30*time.Second),
 				values.ConvertDuration(30*time.Second)),
@@ -154,6 +188,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 }
 
 func TestWindow_GetOverlappingBounds(t *testing.T) {
+	ts, ds := mustParseTime, mustParseDuration
 	testcases := []struct {
 		name string
 		w    execute.Window
@@ -265,6 +300,78 @@ func TestWindow_GetOverlappingBounds(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "by day",
+			b: execute.Bounds{
+				Start: ts("2019-10-01T00:00:00Z"),
+				Stop:  ts("2019-10-08T00:00:00Z"),
+			},
+			w: execute.Window{
+				Every:  ds("1d"),
+				Period: ds("1d"),
+			},
+			want: []execute.Bounds{
+				{Start: ts("2019-10-01T00:00:00Z"), Stop: ts("2019-10-02T00:00:00Z")},
+				{Start: ts("2019-10-02T00:00:00Z"), Stop: ts("2019-10-03T00:00:00Z")},
+				{Start: ts("2019-10-03T00:00:00Z"), Stop: ts("2019-10-04T00:00:00Z")},
+				{Start: ts("2019-10-04T00:00:00Z"), Stop: ts("2019-10-05T00:00:00Z")},
+				{Start: ts("2019-10-05T00:00:00Z"), Stop: ts("2019-10-06T00:00:00Z")},
+				{Start: ts("2019-10-06T00:00:00Z"), Stop: ts("2019-10-07T00:00:00Z")},
+				{Start: ts("2019-10-07T00:00:00Z"), Stop: ts("2019-10-08T00:00:00Z")},
+			},
+		},
+		{
+			name: "by month",
+			b: execute.Bounds{
+				Start: ts("2019-01-01T00:00:00Z"),
+				Stop:  ts("2020-01-01T00:00:00Z"),
+			},
+			w: execute.Window{
+				Every:  ds("1mo"),
+				Period: ds("1mo"),
+			},
+			want: []execute.Bounds{
+				{Start: ts("2019-01-01T00:00:00Z"), Stop: ts("2019-02-01T00:00:00Z")},
+				{Start: ts("2019-02-01T00:00:00Z"), Stop: ts("2019-03-01T00:00:00Z")},
+				{Start: ts("2019-03-01T00:00:00Z"), Stop: ts("2019-04-01T00:00:00Z")},
+				{Start: ts("2019-04-01T00:00:00Z"), Stop: ts("2019-05-01T00:00:00Z")},
+				{Start: ts("2019-05-01T00:00:00Z"), Stop: ts("2019-06-01T00:00:00Z")},
+				{Start: ts("2019-06-01T00:00:00Z"), Stop: ts("2019-07-01T00:00:00Z")},
+				{Start: ts("2019-07-01T00:00:00Z"), Stop: ts("2019-08-01T00:00:00Z")},
+				{Start: ts("2019-08-01T00:00:00Z"), Stop: ts("2019-09-01T00:00:00Z")},
+				{Start: ts("2019-09-01T00:00:00Z"), Stop: ts("2019-10-01T00:00:00Z")},
+				{Start: ts("2019-10-01T00:00:00Z"), Stop: ts("2019-11-01T00:00:00Z")},
+				{Start: ts("2019-11-01T00:00:00Z"), Stop: ts("2019-12-01T00:00:00Z")},
+				{Start: ts("2019-12-01T00:00:00Z"), Stop: ts("2020-01-01T00:00:00Z")},
+			},
+		},
+		{
+			name: "overlapping by month",
+			b: execute.Bounds{
+				Start: ts("2019-01-01T00:00:00Z"),
+				Stop:  ts("2020-01-01T00:00:00Z"),
+			},
+			w: execute.Window{
+				Every:  ds("1mo"),
+				Period: ds("3mo"),
+			},
+			want: []execute.Bounds{
+				{Start: ts("2018-11-01T00:00:00Z"), Stop: ts("2019-02-01T00:00:00Z")},
+				{Start: ts("2018-12-01T00:00:00Z"), Stop: ts("2019-03-01T00:00:00Z")},
+				{Start: ts("2019-01-01T00:00:00Z"), Stop: ts("2019-04-01T00:00:00Z")},
+				{Start: ts("2019-02-01T00:00:00Z"), Stop: ts("2019-05-01T00:00:00Z")},
+				{Start: ts("2019-03-01T00:00:00Z"), Stop: ts("2019-06-01T00:00:00Z")},
+				{Start: ts("2019-04-01T00:00:00Z"), Stop: ts("2019-07-01T00:00:00Z")},
+				{Start: ts("2019-05-01T00:00:00Z"), Stop: ts("2019-08-01T00:00:00Z")},
+				{Start: ts("2019-06-01T00:00:00Z"), Stop: ts("2019-09-01T00:00:00Z")},
+				{Start: ts("2019-07-01T00:00:00Z"), Stop: ts("2019-10-01T00:00:00Z")},
+				{Start: ts("2019-08-01T00:00:00Z"), Stop: ts("2019-11-01T00:00:00Z")},
+				{Start: ts("2019-09-01T00:00:00Z"), Stop: ts("2019-12-01T00:00:00Z")},
+				{Start: ts("2019-10-01T00:00:00Z"), Stop: ts("2020-01-01T00:00:00Z")},
+				{Start: ts("2019-11-01T00:00:00Z"), Stop: ts("2020-02-01T00:00:00Z")},
+				{Start: ts("2019-12-01T00:00:00Z"), Stop: ts("2020-03-01T00:00:00Z")},
+			},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -276,4 +383,35 @@ func TestWindow_GetOverlappingBounds(t *testing.T) {
 			}
 		})
 	}
+}
+
+func MustWindow(every, period, offset execute.Duration) execute.Window {
+	w, err := execute.NewWindow(every, period, offset)
+	if err != nil {
+		panic(err)
+	}
+	return w
+}
+
+func mustParseTime(s string) execute.Time {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		panic(err)
+	}
+	return values.ConvertTime(t)
+}
+
+func mustParseDuration(s string) execute.Duration {
+	d, err := values.ParseDuration(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func errAsString(err error) (s string) {
+	if err != nil {
+		s = err.Error()
+	}
+	return s
 }

--- a/stdlib/date/date.go
+++ b/stdlib/date/date.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -287,7 +288,12 @@ func init() {
 				}
 
 				if v.Type().Nature() == semantic.Time && u.Type().Nature() == semantic.Duration {
-					return values.NewTime(v.Time().Truncate(u.Duration())), nil
+					w, err := execute.NewWindow(u.Duration(), u.Duration(), execute.Duration{})
+					if err != nil {
+						return nil, err
+					}
+					b := w.GetEarliestBounds(v.Time())
+					return values.NewTime(b.Start), nil
 				}
 				return nil, fmt.Errorf("cannot truncate argument t of type %v to unit %v", v.Type().Nature(), u)
 			}, false,

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -175,14 +175,19 @@ func createWindowTransformation(id execute.DatasetID, mode execute.AccumulationM
 		return nil, nil, errors.New(codes.Invalid, "nil bounds passed to window")
 	}
 
+	w, err := execute.NewWindow(
+		s.Window.Every,
+		s.Window.Period,
+		s.Window.Offset,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
 	t := NewFixedWindowTransformation(
 		d,
 		cache,
 		*bounds,
-		execute.NewWindow(
-			values.Duration(s.Window.Every),
-			values.Duration(s.Window.Period),
-			values.Duration(s.Window.Offset)),
+		w,
 		s.TimeColumn,
 		s.StartColumn,
 		s.StopColumn,

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -78,10 +78,10 @@ func TestFixedWindow_PassThrough(t *testing.T) {
 			d,
 			c,
 			execute.Bounds{},
-			execute.NewWindow(
-				values.ConvertDuration(time.Minute),
-				values.ConvertDuration(time.Minute),
-				values.ConvertDuration(0)),
+			execute.Window{
+				Every:  values.ConvertDuration(time.Minute),
+				Period: values.ConvertDuration(time.Minute),
+			},
 			execute.DefaultTimeColLabel,
 			execute.DefaultStartColLabel,
 			execute.DefaultStopColLabel,
@@ -835,11 +835,15 @@ func TestFixedWindow_Process(t *testing.T) {
 			c := execute.NewTableBuilderCache(executetest.UnlimitedAllocator)
 			c.SetTriggerSpec(plan.DefaultTriggerSpec)
 
+			w, err := execute.NewWindow(tc.every, tc.period, tc.offset)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 			fw := universe.NewFixedWindowTransformation(
 				d,
 				c,
 				tc.bounds,
-				execute.NewWindow(tc.every, tc.period, tc.offset),
+				w,
 				execute.DefaultTimeColLabel,
 				execute.DefaultStartColLabel,
 				execute.DefaultStopColLabel,

--- a/values/time_test.go
+++ b/values/time_test.go
@@ -1,6 +1,7 @@
 package values
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -40,41 +41,200 @@ func TestTime_Round(t *testing.T) {
 	}
 }
 
-func TestTime_Truncate(t *testing.T) {
+func TestTime_Add(t *testing.T) {
+	// Note: 2020 is a leap year. Some of these tests
+	// pass through that year to test leap years operate
+	// correctly.
 	for _, tt := range []struct {
-		ts   Time
-		d    Duration
-		want Time
+		t    string
+		d    string
+		want string
 	}{
 		{
-			ts:   Time(time.Second + 500*time.Millisecond),
-			d:    ConvertDuration(time.Second),
-			want: Time(time.Second),
+			t:    "2019-01-01T00:00:00Z",
+			d:    "1ns",
+			want: "2019-01-01T00:00:00.000000001Z",
 		},
 		{
-			ts:   Time(time.Second + 501*time.Millisecond),
-			d:    ConvertDuration(time.Second),
-			want: Time(time.Second),
+			t:    "2019-01-01T00:00:00.000000001Z",
+			d:    "-1ns",
+			want: "2019-01-01T00:00:00Z",
 		},
 		{
-			ts:   Time(time.Second + 499*time.Millisecond),
-			d:    ConvertDuration(time.Second),
-			want: Time(time.Second),
+			t:    "2019-01-01T00:00:00Z",
+			d:    "1d",
+			want: "2019-01-02T00:00:00Z",
 		},
 		{
-			ts:   Time(time.Second + 0*time.Millisecond),
-			d:    ConvertDuration(time.Second),
-			want: Time(time.Second),
+			t:    "2019-01-02T00:00:00Z",
+			d:    "-1d",
+			want: "2019-01-01T00:00:00Z",
 		},
 		{
-			ts:   Time(time.Second + 999*time.Millisecond),
-			d:    ConvertDuration(time.Second),
-			want: Time(time.Second),
+			t:    "2019-01-01T00:00:00Z",
+			d:    "1mo",
+			want: "2019-02-01T00:00:00Z",
+		},
+		{
+			t:    "2019-02-01T00:00:00Z",
+			d:    "-1mo",
+			want: "2019-01-01T00:00:00Z",
+		},
+		{
+			t:    "2019-01-31T00:00:00Z",
+			d:    "1mo",
+			want: "2019-02-28T00:00:00Z",
+		},
+		{
+			t:    "2019-03-31T00:00:00Z",
+			d:    "-1mo",
+			want: "2019-02-28T00:00:00Z",
+		},
+		{
+			t:    "2020-01-31T00:00:00Z",
+			d:    "1mo",
+			want: "2020-02-29T00:00:00Z",
+		},
+		{
+			t:    "2020-03-31T00:00:00Z",
+			d:    "-1mo",
+			want: "2020-02-29T00:00:00Z",
+		},
+		{
+			t:    "2019-01-01T00:00:00Z",
+			d:    "2mo",
+			want: "2019-03-01T00:00:00Z",
+		},
+		{
+			t:    "2019-03-01T00:00:00Z",
+			d:    "-2mo",
+			want: "2019-01-01T00:00:00Z",
+		},
+		{
+			t:    "2019-01-31T00:00:00Z",
+			d:    "2mo",
+			want: "2019-03-31T00:00:00Z",
+		},
+		{
+			t:    "2019-03-31T00:00:00Z",
+			d:    "-2mo",
+			want: "2019-01-31T00:00:00Z",
+		},
+		{
+			t:    "2019-02-28T00:00:00Z",
+			d:    "2mo",
+			want: "2019-04-28T00:00:00Z",
+		},
+		{
+			t:    "2019-04-30T00:00:00Z",
+			d:    "-2mo",
+			want: "2019-02-28T00:00:00Z",
+		},
+		{
+			t:    "2019-01-01T00:00:00Z",
+			d:    "1y",
+			want: "2020-01-01T00:00:00Z",
+		},
+		{
+			t:    "2020-01-01T00:00:00Z",
+			d:    "-1y",
+			want: "2019-01-01T00:00:00Z",
+		},
+		{
+			t:    "2019-01-01T00:00:00Z",
+			d:    "2y",
+			want: "2021-01-01T00:00:00Z",
+		},
+		{
+			t:    "2021-01-01T00:00:00Z",
+			d:    "-2y",
+			want: "2019-01-01T00:00:00Z",
+		},
+		{
+			t:    "2018-01-01T00:00:00Z",
+			d:    "1y6mo",
+			want: "2019-07-01T00:00:00Z",
+		},
+		{
+			t:    "2019-07-01T00:00:00Z",
+			d:    "-1y6mo",
+			want: "2018-01-01T00:00:00Z",
+		},
+		{
+			t:    "2019-01-01T00:00:00Z",
+			d:    "1y6mo",
+			want: "2020-07-01T00:00:00Z",
+		},
+		{
+			t:    "2020-07-01T00:00:00Z",
+			d:    "-1y6mo",
+			want: "2019-01-01T00:00:00Z",
+		},
+		{
+			// Not a leap year. Multiple of 100.
+			t:    "2100-01-01T00:00:00Z",
+			d:    "1y",
+			want: "2101-01-01T00:00:00Z",
+		},
+		{
+			// Not a leap year. Multiple of 100.
+			t:    "2101-01-01T00:00:00Z",
+			d:    "-1y",
+			want: "2100-01-01T00:00:00Z",
+		},
+		{
+			// Not a leap year. Multiple of 100.
+			t:    "2100-01-31T00:00:00Z",
+			d:    "1mo",
+			want: "2100-02-28T00:00:00Z",
+		},
+		{
+			// Not a leap year. Multiple of 100.
+			t:    "2100-03-31T00:00:00Z",
+			d:    "-1mo",
+			want: "2100-02-28T00:00:00Z",
+		},
+		{
+			// Is a leap year. Multiple of 400.
+			t:    "2000-01-01T00:00:00Z",
+			d:    "1y",
+			want: "2001-01-01T00:00:00Z",
+		},
+		{
+			// Is a leap year. Multiple of 400.
+			t:    "2001-01-01T00:00:00Z",
+			d:    "-1y",
+			want: "2000-01-01T00:00:00Z",
+		},
+		{
+			// Is a leap year. Multiple of 400.
+			t:    "2000-01-31T00:00:00Z",
+			d:    "1mo",
+			want: "2000-02-29T00:00:00Z",
+		},
+		{
+			// Is a leap year. Multiple of 400.
+			t:    "2000-03-31T00:00:00Z",
+			d:    "-1mo",
+			want: "2000-02-29T00:00:00Z",
+		},
+		{
+			t:    "2018-12-15T00:00:00Z",
+			d:    "1mo",
+			want: "2019-01-15T00:00:00Z",
+		},
+		{
+			t:    "2019-01-15T00:00:00Z",
+			d:    "-1mo",
+			want: "2018-12-15T00:00:00Z",
 		},
 	} {
-		t.Run(tt.ts.String(), func(t *testing.T) {
-			if want, got := tt.want, tt.ts.Truncate(tt.d); want != got {
-				t.Fatalf("unexpected time -want/+got\n\t- %s\n\t%s", want, got)
+		d := mustParseDuration(tt.d)
+		name := fmt.Sprintf("%s + %s", tt.t, tt.d)
+		t.Run(name, func(t *testing.T) {
+			start := mustParseTime(tt.t)
+			if got, want := start.Add(d), mustParseTime(tt.want); got != want {
+				t.Fatalf("unexpected time -want/+got:\n\t- %s\n\t+ %s", want, got)
 			}
 		})
 	}
@@ -299,4 +459,20 @@ func TestDuration_String(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustParseTime(s string) Time {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		panic(err)
+	}
+	return ConvertTime(t)
+}
+
+func mustParseDuration(s string) Duration {
+	d, err := ParseDuration(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
 }


### PR DESCRIPTION
The `Add` method follows the rules as specified in the spec for how
adding a duration to a time value should happen. It also clarifies that
adding a duration value twice is not the same thing as adding the
equivalent value once. For example, `t + 1mo + 1mo` is not the same as
`t + 2mo`. This is because of the rules regarding the end of the month.
At the same time, doing `t + 1mo * 2` is the same thing as adding `2mo`
because of the rules for how multiplication works with duration values.

The `Add` method is now aware of month boundaries and can be used
properly with years and months now.

This also adds support for using months for a window interval. If you do
`window(every: 1mo)`, it will create windows on month boundaries. The
`every` parameter for `window()` is limited to only using one of the two
base units: months or nanoseconds.

Fixes #2044.

- [x] docs/SPEC.md updated
- [x] Test cases written