### PR TITLE
feat(semantic): interpret months as part of the semantic duration

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1299,6 +1299,19 @@ func toDuration(l Duration) (time.Duration, error) {
 	return dur, err
 }
 
+const (
+	NanosecondUnit  = "ns"
+	MicrosecondUnit = "us"
+	MillisecondUnit = "ms"
+	SecondUnit      = "s"
+	MinuteUnit      = "m"
+	HourUnit        = "h"
+	DayUnit         = "d"
+	WeekUnit        = "w"
+	MonthUnit       = "mo"
+	YearUnit        = "y"
+)
+
 // DurationLiteral represents the elapsed time between two instants as an
 // int64 nanosecond count with syntax of golang's time.Duration
 // TODO: this may be better as a class initialization

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -271,9 +271,13 @@ func compile(n semantic.Node, typeSol semantic.TypeSolution, scope Scope, funcEx
 			time: values.ConvertTime(n.Value),
 		}, nil
 	case *semantic.DurationLiteral:
+		v, err := values.FromDurationValues(n.Values)
+		if err != nil {
+			return nil, err
+		}
 		return &durationEvaluator{
 			t:        monoType(typeSol.TypeOf(n)),
-			duration: values.ConvertDuration(n.Value),
+			duration: v,
 		}, nil
 	case *semantic.UnaryExpression:
 		node, err := compile(n.Argument, typeSol, scope, funcExprs)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -551,7 +551,11 @@ func (itrp *Interpreter) doLiteral(lit semantic.Literal) (values.Value, error) {
 	case *semantic.DateTimeLiteral:
 		return values.NewTime(values.Time(l.Value.UnixNano())), nil
 	case *semantic.DurationLiteral:
-		return values.NewDuration(values.ConvertDuration(l.Value)), nil
+		dur, err := values.FromDurationValues(l.Values)
+		if err != nil {
+			return nil, err
+		}
+		return values.NewDuration(dur), nil
 	case *semantic.FloatLiteral:
 		return values.NewFloat(l.Value), nil
 	case *semantic.IntegerLiteral:
@@ -1145,9 +1149,17 @@ func resolveValue(v values.Value) (semantic.Node, bool, error) {
 			Value: v.Regexp(),
 		}, true, nil
 	case semantic.Duration:
-		return &semantic.DurationLiteral{
-			Value: v.Duration().Duration(),
-		}, true, nil
+		d := v.Duration()
+		var node semantic.Expression = &semantic.DurationLiteral{
+			Values: d.AsValues(),
+		}
+		if d.IsNegative() {
+			node = &semantic.UnaryExpression{
+				Operator: ast.SubtractionOperator,
+				Argument: node,
+			}
+		}
+		return node, true, nil
 	case semantic.Function:
 		resolver, ok := v.Function().(Resolver)
 		if ok {

--- a/semantic/analyze.go
+++ b/semantic/analyze.go
@@ -2,7 +2,6 @@ package semantic
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
@@ -678,13 +677,9 @@ func analyzeDateTimeLiteral(lit *ast.DateTimeLiteral) (*DateTimeLiteral, error) 
 	}, nil
 }
 func analyzeDurationLiteral(lit *ast.DurationLiteral) (*DurationLiteral, error) {
-	duration, err := ast.DurationFrom(lit, time.Time{})
-	if err != nil {
-		return nil, err
-	}
 	return &DurationLiteral{
-		loc:   loc(lit.Location()),
-		Value: duration,
+		loc:    loc(lit.Location()),
+		Values: lit.Values,
 	}, nil
 }
 func analyzeFloatLiteral(lit *ast.FloatLiteral) (*FloatLiteral, error) {

--- a/semantic/graph.go
+++ b/semantic/graph.go
@@ -970,7 +970,7 @@ func (l *DateTimeLiteral) Copy() Node {
 type DurationLiteral struct {
 	loc `json:"-"`
 
-	Value time.Duration `json:"value"`
+	Values []ast.Duration `json:"values"`
 }
 
 func (*DurationLiteral) NodeType() string { return "DurationLiteral" }

--- a/semantic/graph_test.go
+++ b/semantic/graph_test.go
@@ -2,7 +2,6 @@ package semantic_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/ast"
@@ -332,12 +331,20 @@ func TestNew(t *testing.T) {
 										Value: &semantic.StringLiteral{Value: "foo"},
 									},
 									{
-										Key:   &semantic.Identifier{Name: "every"},
-										Value: &semantic.DurationLiteral{Value: 1 * time.Hour},
+										Key: &semantic.Identifier{Name: "every"},
+										Value: &semantic.DurationLiteral{
+											Values: []ast.Duration{
+												{Magnitude: 1, Unit: ast.HourUnit},
+											},
+										},
 									},
 									{
-										Key:   &semantic.Identifier{Name: "delay"},
-										Value: &semantic.DurationLiteral{Value: 10 * time.Minute},
+										Key: &semantic.Identifier{Name: "delay"},
+										Value: &semantic.DurationLiteral{
+											Values: []ast.Duration{
+												{Magnitude: 10, Unit: ast.MinuteUnit},
+											},
+										},
 									},
 									{
 										Key:   &semantic.Identifier{Name: "cron"},

--- a/semantic/json.go
+++ b/semantic/json.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
@@ -993,34 +992,11 @@ func (l *DurationLiteral) MarshalJSON() ([]byte, error) {
 	raw := struct {
 		Type string `json:"type"`
 		*Alias
-		Value string `json:"value"`
 	}{
 		Type:  l.NodeType(),
 		Alias: (*Alias)(l),
-		Value: l.Value.String(),
 	}
 	return json.Marshal(raw)
-}
-func (l *DurationLiteral) UnmarshalJSON(data []byte) error {
-	type Alias DurationLiteral
-	raw := struct {
-		*Alias
-		Value string `json:"value"`
-	}{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	if raw.Alias != nil {
-		*l = *(*DurationLiteral)(raw.Alias)
-	}
-
-	value, err := time.ParseDuration(raw.Value)
-	if err != nil {
-		return err
-	}
-	l.Value = value
-	return nil
 }
 
 func (l *DateTimeLiteral) MarshalJSON() ([]byte, error) {

--- a/semantic/json_test.go
+++ b/semantic/json_test.go
@@ -96,12 +96,20 @@ func TestJSONMarshal(t *testing.T) {
 								Value: &semantic.StringLiteral{Value: "foo"},
 							},
 							{
-								Key:   &semantic.Identifier{Name: "every"},
-								Value: &semantic.DurationLiteral{Value: 1 * time.Hour},
+								Key: &semantic.Identifier{Name: "every"},
+								Value: &semantic.DurationLiteral{
+									Values: []ast.Duration{
+										{Magnitude: 1, Unit: ast.HourUnit},
+									},
+								},
 							},
 							{
-								Key:   &semantic.Identifier{Name: "delay"},
-								Value: &semantic.DurationLiteral{Value: 10 * time.Minute},
+								Key: &semantic.Identifier{Name: "delay"},
+								Value: &semantic.DurationLiteral{
+									Values: []ast.Duration{
+										{Magnitude: 10, Unit: ast.MinuteUnit},
+									},
+								},
 							},
 							{
 								Key:   &semantic.Identifier{Name: "cron"},
@@ -115,7 +123,7 @@ func TestJSONMarshal(t *testing.T) {
 					},
 				},
 			},
-			want: `{"type":"OptionStatement","assignment":{"type":"NativeVariableAssignment","identifier":{"type":"Identifier","name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","value":"1h0m0s"}},{"type":"Property","key":{"type":"Identifier","name":"delay"},"value":{"type":"DurationLiteral","value":"10m0s"}},{"type":"Property","key":{"type":"Identifier","name":"cron"},"value":{"type":"StringLiteral","value":"0 2 * * *"}},{"type":"Property","key":{"type":"Identifier","name":"retry"},"value":{"type":"IntegerLiteral","value":"5"}}]}}}`,
+			want: `{"type":"OptionStatement","assignment":{"type":"NativeVariableAssignment","identifier":{"type":"Identifier","name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","values":[{"magnitude":1,"unit":"h"}]}},{"type":"Property","key":{"type":"Identifier","name":"delay"},"value":{"type":"DurationLiteral","values":[{"magnitude":10,"unit":"m"}]}},{"type":"Property","key":{"type":"Identifier","name":"cron"},"value":{"type":"StringLiteral","value":"0 2 * * *"}},{"type":"Property","key":{"type":"Identifier","name":"retry"},"value":{"type":"IntegerLiteral","value":"5"}}]}}}`,
 		},
 		{
 			name: "qualified option statement",
@@ -342,9 +350,12 @@ func TestJSONMarshal(t *testing.T) {
 		{
 			name: "duration literal",
 			node: &semantic.DurationLiteral{
-				Value: time.Hour + time.Minute,
+				Values: []ast.Duration{
+					{Magnitude: 1, Unit: ast.HourUnit},
+					{Magnitude: 1, Unit: ast.MinuteUnit},
+				},
 			},
-			want: `{"type":"DurationLiteral","value":"1h1m0s"}`,
+			want: `{"type":"DurationLiteral","values":[{"magnitude":1,"unit":"h"},{"magnitude":1,"unit":"m"}]}`,
 		},
 		{
 			name: "datetime literal",

--- a/values/time_test.go
+++ b/values/time_test.go
@@ -190,7 +190,7 @@ func TestParseDuration(t *testing.T) {
 			}
 
 			if !got.Equal(tt.want) {
-				t.Fatalf("unexpected duration value -want/+got:\n\t- %s\n\t+ %s", got, tt.want)
+				t.Fatalf("unexpected duration value -want/+got:\n\t- %s\n\t+ %s", tt.want, got)
 			}
 		})
 	}
@@ -295,7 +295,7 @@ func TestDuration_String(t *testing.T) {
 	} {
 		t.Run(tt.want, func(t *testing.T) {
 			if got, want := tt.d.String(), tt.want; got != want {
-				t.Fatalf("unexpected duration string -want/+got:\n\t- %q\n\t+ %q", got, want)
+				t.Fatalf("unexpected duration string -want/+got:\n\t- %q\n\t+ %q", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
This changes the semantic duration literal to keep the months and other
duration units from the AST rather than converting it into a
`time.Duration`.

This also updates the semantic node's json encoding to emit these
magnitudes and units similar to the AST rather than a string
representation of the duration.

In total, this causes the semantic analyzer to create the
`Duration` value properly.

BREAKING CHANGE: The semantic node's duration literal has a different
json encoding and a different struct signature.

Fixes #2069.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written