### PR TITLE
docs(spec): restrict intervals to only use one type of base unit for a duration

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -167,30 +167,27 @@ When several durations are specified together, larger units must appear before s
     duration_lit  = { int_lit duration_unit } .
     duration_unit = "y" | "mo" | "w" | "d" | "h" | "m" | "s" | "ms" | "us" | "µs" | "ns" .
 
-| Units    | Meaning                                 |
-| -----    | -------                                 |
-| y        | year (12 months)                        |
-| mo       | month                                   |
-| w        | week (7 days)                           |
-| d        | day                                     |
-| h        | hour (60 minutes)                       |
-| m        | minute (60 seconds)                     |
-| s        | second                                  |
-| ms       | milliseconds (1 thousandth of a second) |
-| us or µs | microseconds (1 millionth of a second)  |
-| ns       | nanoseconds (1 billionth of a second)   |
+| Units    | Meaning                                 | Base |
+| -----    | -------                                 | ---- |
+| y        | year (12 months)                        | mo   |
+| mo       | month                                   | mo   |
+| w        | week (7 days)                           | ns   |
+| d        | day                                     | ns   |
+| h        | hour (60 minutes)                       | ns   |
+| m        | minute (60 seconds)                     | ns   |
+| s        | second                                  | ns   |
+| ms       | milliseconds (1 thousandth of a second) | ns   |
+| us or µs | microseconds (1 millionth of a second)  | ns   |
+| ns       | nanoseconds (1 billionth of a second)   | ns   |
 
 Durations represent a length of time.
 Lengths of time are dependent on specific instants in time they occur and as such, durations do not represent a fixed amount of time.
-There are no amount of days equal to a month, as months vary in their number of days.
-Durations are a tuple of positive integers that represent a duration and the sign of the duration (positive or negative).
-Durations are implemented this way so that it is possible to determine whether or not a duration is positive or negative.
-Since duration values are dependent on their context, the only way to know if a duration is a positive or negative number is if all of the magnitudes have the same sign.
-In the canonical implementation, this is implemented as a tuple of the months and nanoseconds and a boolean that indicates whether it is positive or negative.
-The spec does not prescribe a specific implementation and other implementations may use a different internal representation.
+A duration is composed of a tuple of months and nanoseconds along with whether the duration is positive or negative.
+Each duration unit corresponds to one of these two base units.
+It is possible to compose a duration of multiple base units.
 
 Durations cannot be combined by addition and subtraction.
-This is because all magnitudes in the tuple need to be a positive integer and that cannot be guaranteed when using addition and subtraction.
+This is because all of the values in the tuple must have the same sign and it is not possible to guarantee that is true when addition and subtraction are allowed.
 Durations can be multiplied by any integer value.
 The unary negative operator is the equivalent of multiplying the duration by -1.
 These operations are performed on each time unit independently.
@@ -1197,6 +1194,8 @@ Intervals has the following parameters:
 The Nth interval start date is the initial start date plus the offset plus an Nth multiple of the every parameter.
 Each interval stop date is equal to the interval start date plus the period duration.
 When filtering intervals each potential interval is passed to the filter function, when the function returns false, that interval is excluded from the set of intervals.
+The `every` parameter must contain duration units for only one base unit as defined in the duration literals.
+It is not possible to mix months and nanoseconds in an interval.
 
 The intervals function has the following signature:
 
@@ -1210,6 +1209,8 @@ Examples:
     intervals(every:1w, offset:1d)             // 1 week intervals starting on Monday (by default weeks start on Sunday)
     intervals(every:1d, period:-1h)            // the hour from 11PM - 12AM every night
     intervals(every:1mo, period:-1d)           // the last day of each month
+    intervals(every:1mo2w)                     // not allowed because it is composed of different base units
+    intervals(every:1mo, period:1mo2w)         // this is fine since the period can mix base units
 
 Examples using a predicate:
 


### PR DESCRIPTION
The spec now specifies that the base units for a duration unit are
months and nanoseconds and each of the other units corresponds to one of
these two rather than leaving this unspecified. It also continues to say
that both of these may be used with each other.

It adds a restriction for intervals, which are used for windows, that
says that a duration used for an interval can only correspond to one of
these base units. This is because it is possible for us to have regular
intervals when only one of these base units is used, but it would be
difficult to reason and verify about what each window should look like
when these are mixed and there isn't a compelling reason to allow the
duration units to be mixed when it concerns intervals.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written