### PR TITLE
refactor(depedencies): use http client interface

### DIFF
--- a/dependencies/http/http.go
+++ b/dependencies/http/http.go
@@ -1,0 +1,32 @@
+package http
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+type Client interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// NewDefaultTransport creates a new transport with sane defaults.
+func NewDefaultClient() *http.Client {
+	// These defaults are copied from http.DefaultTransport.
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				// DualStack is deprecated
+			}).DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       10 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			// Fields below are NOT part of Go's defaults
+			MaxIdleConnsPerHost: 100,
+		},
+	}
+}

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -1,0 +1,10 @@
+package http
+
+import "testing"
+
+func TestNewDefaultClient(t *testing.T) {
+	c := NewDefaultClient()
+	if c == nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Replace concrete `*http.Client` dependency with an interface.

Necessary for https://github.com/influxdata/influxdb/pull/15713