### PR TITLE
fix: type-checker

### DIFF
--- a/libflux/src/semantic/infer.rs
+++ b/libflux/src/semantic/infer.rs
@@ -66,7 +66,10 @@ pub fn solve(
             }
             Constraint::Equal(t, other) => {
                 // Apply the current substitution to the constraint, then unify
-                let s = t.clone().apply(&sub).unify(other.clone(), with)?;
+                let s = t
+                    .clone()
+                    .apply(&sub)
+                    .unify(other.clone().apply(&sub), with)?;
                 Ok(sub.merge(s))
             }
         })

--- a/libflux/src/semantic/infer.rs
+++ b/libflux/src/semantic/infer.rs
@@ -89,7 +89,7 @@ pub fn generalize(env: &Environment, with: &HashMap<Tvar, Vec<Kind>>, t: MonoTyp
         }
     }
     PolyType {
-        free: vars,
+        vars: vars,
         cons: cons,
         expr: t,
     }
@@ -104,7 +104,7 @@ pub fn generalize(env: &Environment, with: &HashMap<Tvar, Vec<Kind>>, t: MonoTyp
 pub fn instantiate(poly: PolyType, f: &mut Fresher) -> (MonoType, Constraints) {
     // Substitute fresh type variables for all quantified variables
     let sub: Substitution = poly
-        .free_vars()
+        .vars
         .into_iter()
         .map(|tv| (tv, MonoType::Var(f.fresh())))
         .collect::<HashMap<Tvar, MonoType>>()

--- a/libflux/src/semantic/nodes.rs
+++ b/libflux/src/semantic/nodes.rs
@@ -324,7 +324,7 @@ impl ReturnStmt {
 #[derive(Debug, Derivative, PartialEq, Clone)]
 pub struct VariableAssgn {
     #[derivative(PartialEq = "ignore")]
-    free: Vec<Tvar>,
+    vars: Vec<Tvar>,
 
     #[derivative(PartialEq = "ignore")]
     cons: HashMap<Tvar, Vec<Kind>>,
@@ -338,7 +338,7 @@ pub struct VariableAssgn {
 impl VariableAssgn {
     pub fn new(id: Identifier, init: Expression, loc: ast::SourceLocation) -> VariableAssgn {
         VariableAssgn {
-            free: Vec::new(),
+            vars: Vec::new(),
             cons: HashMap::new(),
             loc,
             id,
@@ -347,7 +347,7 @@ impl VariableAssgn {
     }
     pub fn poly_type_of(&self) -> PolyType {
         PolyType {
-            free: self.free.clone(),
+            vars: self.vars.clone(),
             cons: self.cons.clone(),
             expr: self.init.type_of().clone(),
         }
@@ -378,7 +378,7 @@ impl VariableAssgn {
         //
         // Note these variables are fixed after generalization
         // and so it is safe to update these nodes in place.
-        self.free = p.free.clone();
+        self.vars = p.vars.clone();
         self.cons = p.cons.clone();
 
         // Update the type environment
@@ -895,13 +895,13 @@ mod tests {
         let env = Environment::from(maplit::hashmap! {
             // a = 5
             String::from("a") => PolyType {
-                free: Vec::new(),
+                vars: Vec::new(),
                 cons: HashMap::new(),
                 expr: MonoType::Int,
             },
             // f = (a, b) => 2 * (a + b)
             String::from("f") => PolyType {
-                free: vec![Tvar(0)],
+                vars: vec![Tvar(0)],
                 cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
                 expr: MonoType::Fun(Box::new(types::Function {
                     req: maplit::hashmap! {
@@ -939,7 +939,7 @@ mod tests {
             normalized,
             maplit::hashmap! {
                 String::from("f") => PolyType {
-                    free: vec![Tvar(0)],
+                    vars: vec![Tvar(0)],
                     cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
                     expr: MonoType::Fun(Box::new(types::Function {
                         req: maplit::hashmap! {
@@ -952,12 +952,12 @@ mod tests {
                     })),
                 },
                 String::from("a") => PolyType {
-                    free: Vec::new(),
+                    vars: Vec::new(),
                     cons: HashMap::new(),
                     expr: MonoType::Int,
                 },
                 String::from("x") => PolyType {
-                    free: vec![Tvar(0)],
+                    vars: vec![Tvar(0)],
                     cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
                     expr: MonoType::Fun(Box::new(types::Function {
                         req: maplit::hashmap! {
@@ -970,7 +970,7 @@ mod tests {
                     })),
                 },
                 String::from("y") => PolyType {
-                    free: vec![Tvar(0)],
+                    vars: vec![Tvar(0)],
                     cons: maplit::hashmap! { Tvar(0) => vec![Kind::Addable, Kind::Divisible]},
                     expr: MonoType::Fun(Box::new(types::Function {
                         req: maplit::hashmap! {
@@ -983,7 +983,7 @@ mod tests {
                     })),
                 },
                 String::from("z") => PolyType {
-                    free: Vec::new(),
+                    vars: Vec::new(),
                     cons: HashMap::new(),
                     expr: MonoType::Int,
                 },

--- a/libflux/src/semantic/parser/mod.rs
+++ b/libflux/src/semantic/parser/mod.rs
@@ -232,7 +232,7 @@ impl Parser<'_> {
             return Err("Missing left square bracket");
         }
 
-        let free_vars = self.parse_vars()?;
+        let vars = self.parse_vars()?;
 
         if self.next().token_type != TokenType::RIGHTSQUAREBRAC {
             return Err("Missing right square bracket");
@@ -245,7 +245,7 @@ impl Parser<'_> {
         }
 
         Ok(PolyType {
-            free: free_vars,
+            vars: vars,
             cons: cons,
             expr: self.parse_monotype()?,
         })
@@ -658,7 +658,7 @@ mod tests {
         req_args.insert("y".to_string(), MonoType::Float);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: HashMap::new(),
             expr: MonoType::Fun(Box::new(Function {
                 req: req_args,
@@ -678,7 +678,7 @@ mod tests {
         bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Bool,
         };
@@ -698,7 +698,7 @@ mod tests {
         bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(1)],
+            vars: vec![Tvar(1)],
             cons: bounds,
             expr: MonoType::Float,
         };
@@ -715,7 +715,7 @@ mod tests {
         bounds.insert(Tvar(10), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(10)],
+            vars: vec![Tvar(10)],
             cons: bounds,
             expr: MonoType::Regexp,
         };
@@ -723,7 +723,7 @@ mod tests {
 
         let text = "forall [t0] uint";
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: HashMap::new(),
             expr: MonoType::Uint,
         };
@@ -739,7 +739,7 @@ mod tests {
         bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Bool,
         };
@@ -756,7 +756,7 @@ mod tests {
         bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(1)],
+            vars: vec![Tvar(1)],
             cons: bounds,
             expr: MonoType::Int,
         };
@@ -778,7 +778,7 @@ mod tests {
         bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0), Tvar(1)],
+            vars: vec![Tvar(0), Tvar(1)],
             cons: bounds,
             expr: MonoType::String,
         };
@@ -806,7 +806,7 @@ mod tests {
         bounds.insert(Tvar(1), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0), Tvar(1)],
+            vars: vec![Tvar(0), Tvar(1)],
             cons: bounds,
             expr: MonoType::Arr(Box::new(Array(MonoType::Uint))),
         };
@@ -832,7 +832,7 @@ mod tests {
         bounds.insert(Tvar(2), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0), Tvar(1), Tvar(2), Tvar(3), Tvar(4)],
+            vars: vec![Tvar(0), Tvar(1), Tvar(2), Tvar(3), Tvar(4)],
             cons: bounds,
             expr: MonoType::Arr(Box::new(Array(MonoType::Arr(Box::new(Array(
                 MonoType::Time,
@@ -851,7 +851,7 @@ mod tests {
         bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Arr(Box::new(Array(MonoType::Uint))),
         };
@@ -868,7 +868,7 @@ mod tests {
         bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             // An Array of type Array of type Duration
             expr: MonoType::Arr(Box::new(Array(MonoType::Arr(Box::new(Array(
@@ -902,7 +902,7 @@ mod tests {
         });
 
         let output = PolyType {
-            free: vec![Tvar(12)],
+            vars: vec![Tvar(12)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
                 req: req_arg,
@@ -926,7 +926,7 @@ mod tests {
         req_arg.insert("x".to_string(), MonoType::Var(Tvar(0)));
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
                 req: req_arg,
@@ -958,7 +958,7 @@ mod tests {
         opt_args.insert("y".to_string(), MonoType::Var(Tvar(10)));
 
         let output = PolyType {
-            free: vec![Tvar(1), Tvar(10), Tvar(100)],
+            vars: vec![Tvar(1), Tvar(10), Tvar(100)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
                 req: req_args,
@@ -984,7 +984,7 @@ mod tests {
         });
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
                 req: HashMap::new(),
@@ -1010,7 +1010,7 @@ mod tests {
         });
 
         let output = PolyType {
-            free: vec![Tvar(0), Tvar(1)],
+            vars: vec![Tvar(0), Tvar(1)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
                 req: HashMap::new(),
@@ -1037,7 +1037,7 @@ mod tests {
         bounds.insert(Tvar(2), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(1), Tvar(2)],
+            vars: vec![Tvar(1), Tvar(2)],
             cons: bounds,
             expr: MonoType::Row(Box::new(Row::Extension {
                 head: Property {
@@ -1071,7 +1071,7 @@ mod tests {
         bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Row(Box::new(Row::Empty)),
         };
@@ -1087,7 +1087,7 @@ mod tests {
         bounds.insert(Tvar(0), kinds);
 
         let output = PolyType {
-            free: vec![Tvar(0)],
+            vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Row(Box::new(Row::Extension {
                 head: Property {


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

The first commit renames the field `free` to `vars` in the `PolyType` struct. This is so there's no ambiguity between quantified variables and free variables. `vars` represents quantified variables.

The second commit instantiates the quantified variables of a polytype. Previously it instantiated the free variables of a polytype, which are the type variable that are present in the type minus the quantified variables. This was incorrect.

The third commit applies a substitution to both sides of a constraint before unifying. Previously it applied the substitution to only the left side by mistake.

The fourth commit fixes the type expression parser so that it stops parsing type variable constraints if the last kind is not terminated with a comma.