### PR TITLE
fix: update make release to make sure local and remote are in sync 

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,27 @@ cd $DIR
 
 set -e
 
+remote=$(git rev-parse "@{u}") # "@{u}" gets the current upstream branch
+local=$(git rev-parse @) # '@' gets the current local branch 
+
+# check if local commit syncs with remote 
+if [ "$remote" != "$local" ]; then
+    echo "Error: local commit does not match remote. Exiting release script."
+    exit 1
+fi 
+
+# remove any excess brackets, space/tab characters and 'origin' branch and sort the tags
+git_remote_tags () { git ls-remote --tags origin | grep -v '{}' | sort | tr -d [[:blank:]] ; }
+git_local_tags () { git show-ref --tags | grep -v '{}' | grep -v 'origin'| sort | tr -d [[:blank:]] ; }
+
+# check if local tags are different from remote tags
+if ! diff -q <(git_remote_tags) <(git_local_tags) &>/dev/null; then
+    echo "Error: local tags do not match remote. Exiting release script."
+    exit 1
+fi
+
+# cut the next Flux release
 version=$(go run github.com/influxdata/changelog nextver)
-git tag -s -m "Release $version" $version
+git tag -s -m "Release $version" "$version"
 git push origin "$version"
+


### PR DESCRIPTION
There was an issue with `make release` being able to cut a release without local changes being up to date and in sync with remote. 

These changes check the current commit against the latest commit on the remote version of the branch. They also check that all the tags on both local and remote are the same. If there are inconsistencies, then the script will error. 

**For reviewers:** I was not sure how to test this file without accidentally cutting a bunch of releases. If you have suggestions on how I can test these changes, please let me know. Otherwise, please keep that in mind as you review. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
