### PR TITLE
refactor(libflux): remove warnings from libflux and set ci to use strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ export GO_TEST_FLAGS=
 export GO_GENERATE=go generate $(GO_ARGS)
 export GO_VET=env GO111MODULE=on go vet $(GO_ARGS)
 export CARGO=cargo
+export CARGO_ARGS=--features strict
 
 define go_deps
 	$(shell env GO111MODULE=on go list -f "{{range .GoFiles}} {{$$.Dir}}/{{.}}{{end}}" $(1))
@@ -68,7 +69,7 @@ libflux: libflux/target/debug/libflux.a
 # The unix sed, which is on darwin machines, has a different
 # command line interface than the gnu equivalent.
 libflux/target/debug/libflux.a:
-	cd libflux && $(CARGO) build
+	cd libflux && $(CARGO) build $(CARGO_ARGS)
 
 # The dependency file produced by Rust appears to be wrong and uses
 # absolute paths while we use relative paths everywhere. So we need
@@ -133,7 +134,7 @@ test-go: libflux
 	$(GO_TEST) $(GO_TEST_FLAGS) ./...
 
 test-rust:
-	cd libflux && $(CARGO) test
+	cd libflux && $(CARGO) test $(CARGO_ARGS)
 
 test-race: libflux
 	$(GO_TEST) -race -count=1 ./...

--- a/libflux/Cargo.toml
+++ b/libflux/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 [lib]
 crate-type = ["rlib", "staticlib", "cdylib"]
 
+[features]
+strict = []
+
 [dependencies]
 serde = "^1.0.59"
 serde_derive = "^1.0.59"

--- a/libflux/src/ast/mod.rs
+++ b/libflux/src/ast/mod.rs
@@ -1,4 +1,7 @@
 pub mod check;
+
+// Disable warnings because the flatbuffers module is generated code.
+#[allow(warnings)]
 pub mod flatbuffers;
 pub mod walk;
 

--- a/libflux/src/lib.rs
+++ b/libflux/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 extern crate chrono;
 #[macro_use]
 extern crate serde_derive;
@@ -14,6 +16,7 @@ use std::os::raw::{c_char, c_void};
 
 use parser::Parser;
 
+#[allow(non_camel_case_types)]
 pub mod ctypes {
     include!(concat!(env!("OUT_DIR"), "/ctypes.rs"));
 }

--- a/libflux/src/scanner/scanner.rl
+++ b/libflux/src/scanner/scanner.rl
@@ -125,7 +125,7 @@
     *|;
 }%%
 
-%% write data;
+%% write data nofinal;
 
 // We need a strategy for tracking newlines while the state machine does its job.
 // At each newline, the state machine will push a new element containing the current offset to a list.
@@ -160,7 +160,7 @@ unsigned int pop(node_t **head) {
 
 int scan(int mode, const unsigned char **pp, const unsigned char *data, const unsigned char *pe, const unsigned char *eof,
         unsigned int *token, unsigned int *token_start, unsigned int *token_end, const unsigned int **newlines, unsigned int *newlines_len) {
-    int cs;
+    int cs = flux_start;
     switch (mode) {
     case 0:
         cs = flux_en_main;

--- a/libflux/src/semantic/analyze.rs
+++ b/libflux/src/semantic/analyze.rs
@@ -1,7 +1,7 @@
 use crate::ast;
 use crate::semantic::fresh::Fresher;
 use crate::semantic::nodes::*;
-use crate::semantic::types::{MonoType, PolyType};
+use crate::semantic::types::MonoType;
 use std::result;
 
 type SemanticError = String;

--- a/libflux/src/semantic/mod.rs
+++ b/libflux/src/semantic/mod.rs
@@ -1,10 +1,21 @@
 mod analyze;
+pub use analyze::analyze;
+
 mod env;
 mod fresh;
 mod infer;
+
+// TODO(jsternberg): Once more work is done on the infer methods,
+// this should be removed and the warnings fixed.
+#[allow(warnings)]
 pub mod nodes;
-mod parser;
+
 mod sub;
-mod tests;
 mod types;
 pub mod walk;
+
+#[cfg(test)]
+mod parser;
+
+#[cfg(test)]
+mod tests;

--- a/libflux/src/semantic/parser/mod.rs
+++ b/libflux/src/semantic/parser/mod.rs
@@ -417,13 +417,13 @@ impl Parser<'_> {
         if token.token_type != TokenType::LEFTSQUAREBRAC {
             Err("Not a valid array monotype")
         } else {
-            let mut token = self.next();
+            let _ = self.next();
 
             // recursively parse the array's monotype
             let monotype = self.parse_monotype();
             match monotype {
                 Ok(monotype) => {
-                    token = self.next();
+                    let token = self.next();
                     if token.token_type == TokenType::RIGHTSQUAREBRAC {
                         Ok(MonoType::Arr(Box::new(Array(monotype))))
                     } else {
@@ -512,14 +512,10 @@ impl Parser<'_> {
         &mut self,
         token: &Token,
     ) -> Result<(String, MonoType), &'static str> {
-        let mut arg_var = String::new();
-
-        match &token.text {
+        let arg_var = match &token.text {
             None => return Err("Invalid format for required arguments"),
-            Some(var) => {
-                arg_var = var.to_string();
-            }
-        }
+            Some(var) => { var.to_string() },
+        };
 
         let token = self.next();
         if token.token_type != TokenType::COLON {

--- a/libflux/src/semantic/types.rs
+++ b/libflux/src/semantic/types.rs
@@ -295,7 +295,6 @@ impl MonoType {
                 | Kind::Comparable
                 | Kind::Equatable
                 | Kind::Nullable => Ok(Substitution::empty()),
-                _ => Err(Error::cannot_constrain(self, with)),
             },
             MonoType::Uint => match with {
                 Kind::Addable
@@ -312,7 +311,6 @@ impl MonoType {
                 | Kind::Comparable
                 | Kind::Equatable
                 | Kind::Nullable => Ok(Substitution::empty()),
-                _ => Err(Error::cannot_constrain(self, with)),
             },
             MonoType::String => match with {
                 Kind::Addable | Kind::Comparable | Kind::Equatable | Kind::Nullable => {

--- a/libflux/src/semantic/walk.rs
+++ b/libflux/src/semantic/walk.rs
@@ -91,7 +91,7 @@ impl<'a> fmt::Display for Node<'a> {
             Node::Block(n) => match n {
                 Block::Variable(_, _) => write!(f, "Block::Variable"),
                 Block::Expr(_, _) => write!(f, "Block::Expr"),
-                Block::Return(expr) => write!(f, "Block::Return"),
+                Block::Return(_) => write!(f, "Block::Return"),
             },
             Node::Property(_) => write!(f, "Property"),
             Node::TextPart(_) => write!(f, "TextPart"),
@@ -987,7 +987,6 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                     Expression::Boolean(ref mut e) => e.loc = base_loc.clone(),
                     Expression::DateTime(ref mut e) => e.loc = base_loc.clone(),
                     Expression::Regexp(ref mut e) => e.loc = base_loc.clone(),
-                    _ => (),
                 };
             };
             walk(


### PR DESCRIPTION
This adds a strict mode to compiling libflux that will turn any warning
into an error. This means that the developer will either have to
explicitly handle the warning in code by using `#[allow(warning_name)]`
or they will have to follow the text of the warning to fix it.

This adds certain `#[allow]` statements into the code because we are
still filling in implementation.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written