### PR TITLE
Chore: Fix or suppress warnings in flatbuffers

### DIFF
--- a/libflux/src/ast/flatbuffers/mod.rs
+++ b/libflux/src/ast/flatbuffers/mod.rs
@@ -1,3 +1,4 @@
+#[allow(non_snake_case,unused)]
 mod ast_generated;
 
 use std::cell::RefCell;
@@ -18,7 +19,7 @@ pub fn serialize(ast_pkg: &ast::Package) -> Result<(Vec<u8>, usize), String> {
     v.finish()
 }
 
-fn new_serializing_visitor_with_capacity<'a>(capacity: usize) -> SerializingVisitor<'a> {
+fn new_serializing_visitor_with_capacity<'a>(_capacity: usize) -> SerializingVisitor<'a> {
     SerializingVisitor {
         inner: Rc::new(RefCell::new(SerializingVisitorState::new_with_capacity(
             1024,
@@ -533,14 +534,14 @@ impl<'a> ast::walk::Visitor<'a> for SerializingVisitor<'a> {
                     .push((be.as_union_value(), fbast::Expression::BadExpression));
             }
             walk::Node::VariableAssgn(_) => {
-                let (init_, init__type) = v.pop_expr();
+                let (init_, init_type) = v.pop_expr();
                 let id = v.pop_expr_with_kind(fbast::Expression::Identifier);
                 let va = fbast::VariableAssignment::create(
                     &mut v.builder,
                     &fbast::VariableAssignmentArgs {
                         base_node,
                         id,
-                        init__type,
+                        init__type: init_type,
                         init_,
                     },
                 );
@@ -548,14 +549,14 @@ impl<'a> ast::walk::Visitor<'a> for SerializingVisitor<'a> {
                     .push((va.as_union_value(), fbast::Statement::VariableAssignment));
             }
             walk::Node::MemberAssgn(_) => {
-                let (init_, init__type) = v.pop_expr();
+                let (init_, init_type) = v.pop_expr();
                 let member = v.pop_expr_with_kind(fbast::Expression::MemberExpression);
                 let ma = fbast::MemberAssignment::create(
                     &mut v.builder,
                     &fbast::MemberAssignmentArgs {
                         base_node,
                         member,
-                        init__type,
+                        init__type: init_type,
                         init_,
                     },
                 );
@@ -898,6 +899,8 @@ impl<'a> SerializingVisitorState<'a> {
     }
 }
 
+// This is a convenience function for debugging.
+#[allow(dead_code)]
 fn print_expr_stack(st: &Vec<(WIPOffset<UnionWIPOffset>, fbast::Expression)>) {
     if st.len() == 0 {
         return;

--- a/libflux/src/ast/flatbuffers/tests.rs
+++ b/libflux/src/ast/flatbuffers/tests.rs
@@ -746,20 +746,6 @@ fn compare_opt_exprs(
     }
 }
 
-fn compare_ops(ast_op: ast::Operator, fb_op: fbast::Operator) -> Result<(), String> {
-    match ast_op == ast_operator(fb_op) {
-        true => Ok(()),
-        false => {
-            let ast_op = ast_op.to_string();
-            let fb_op = fbast::enum_name_operator(fb_op);
-            Err(String::from(format!(
-                "operator mismatch; ast = {}, fb = {}",
-                ast_op, fb_op
-            )))
-        }
-    }
-}
-
 fn compare_imports(
     ast_imports: &Vec<ast::ImportDeclaration>,
     fb_imports: &Option<

--- a/libflux/src/ast/mod.rs
+++ b/libflux/src/ast/mod.rs
@@ -1,7 +1,5 @@
 pub mod check;
 
-// Disable warnings because the flatbuffers module is generated code.
-#[allow(warnings)]
 pub mod flatbuffers;
 pub mod walk;
 


### PR DESCRIPTION
The flatbuffer module has some autogenerated code that will send out
warnings due to stylistic issues, e.g. variables named `init__type` instead
of `init_type`.

This patch addresses those issues by renaming the variable `init__type`
to `init_type` in `mod.rs` and then suppressing all warnings that may
come from the generated code by allowing non_snake_case in the generated
file. The warnings for the module are quieter now.

Additionally, this patch also adds `#[allow(dead_code)]` to
`print_expr_stack`, which is helpful for debugging. It also uses the
underscore prefix on a parameter that is not used in a function.