### PR TITLE
feat(semantic): custom PartialEq for polytypes

### DIFF
--- a/libflux/src/semantic/mod.rs
+++ b/libflux/src/semantic/mod.rs
@@ -16,3 +16,6 @@ pub mod walk;
 
 #[cfg(test)]
 mod parser;
+
+#[cfg(test)]
+mod tests;

--- a/libflux/src/semantic/nodes.rs
+++ b/libflux/src/semantic/nodes.rs
@@ -1007,7 +1007,7 @@ mod tests {
         let normalized: HashMap<String, PolyType> = env
             .values
             .into_iter()
-            .map(|(k, v)| (k, v.normalize(&mut Fresher::new())))
+            .map(|(k, v)| (k, v.fresh(&mut Fresher::new())))
             .collect();
 
         assert_eq!(


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

Two polytypes are equivalent modulo their quantified variables, i.e their parameter names. For example, the following two polytypes should compare as equal.

    forall [t0, t1] (<-: [t0], fn: (x: t0) -> t1) -> [t1]
    forall [t5, t9] (<-: [t5], fn: (x: t5) -> t9) -> [t9]

This PR implements the PartialEq trait for polytypes. It calculates the max type variable of each polytype and then instantiates fresh types with a fresher derived from this type variable. By using a fresher derived from the maximum type variable we are ensured to generate equivalent polytypes.
