### PR TITLE
fix(semantic): do not constrain type variables with empty kinds

### DIFF
--- a/libflux/src/semantic/types.rs
+++ b/libflux/src/semantic/types.rs
@@ -416,7 +416,9 @@ impl Tvar {
             cons.remove(&self).unwrap_or(Vec::new()),
             cons.remove(&tv).unwrap_or(Vec::new()),
         );
-        cons.insert(tv, kinds);
+        if !kinds.is_empty() {
+            cons.insert(tv, kinds);
+        }
         Ok(Substitution::from(
             maplit::hashmap! {self => MonoType::Var(tv)},
         ))


### PR DESCRIPTION
This fixes an issue where polytypes would be incorrectly formatted
with a where clause even though its quantified variables were not
constrained with any kinds.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
