### PR TITLE
refactor(libflux): remove usage of malloc from Rust scanner

### DIFF
--- a/libflux/Dockerfile
+++ b/libflux/Dockerfile
@@ -63,7 +63,7 @@ RUN rustup component add rust-std --target wasm32-unknown-unknown
 
 VOLUME /src
 VOLUME $HOME/.cache
-WORKDIR /src/parser
+WORKDIR /src
 
 # This is a workaround to chown the $HOME/.cache dir on startup as the builder user.
 # This way the build cache can be reused between runs.

--- a/libflux/Dockerfile
+++ b/libflux/Dockerfile
@@ -63,7 +63,7 @@ RUN rustup component add rust-std --target wasm32-unknown-unknown
 
 VOLUME /src
 VOLUME $HOME/.cache
-WORKDIR /src
+WORKDIR /src/parser
 
 # This is a workaround to chown the $HOME/.cache dir on startup as the builder user.
 # This way the build cache can be reused between runs.

--- a/libflux/build.sh
+++ b/libflux/build.sh
@@ -29,4 +29,5 @@ docker run \
     --name $imagename \
     -v "$DIR:$SRC_DIR" \
     -v "$DIR/.cache:/home/builder/.cache" \
+    --env AR=llvm-ar \
     $imagename wasm-pack build --scope influxdata "$@"

--- a/libflux/src/parser/mod.rs
+++ b/libflux/src/parser/mod.rs
@@ -190,7 +190,7 @@ impl Parser {
                     return t;
                 }
                 _ => {
-                    let pos = self.pos(t.start_offset);
+                    let pos = ast::Position::from(&t.start_pos);
                     self.errs.push(format!(
                         "expected {}, got {} ({}) at {}:{}",
                         format_token(exp),
@@ -285,20 +285,21 @@ impl Parser {
     }
 
     fn base_node_from_tokens(&mut self, start: &Token, end: &Token) -> BaseNode {
-        let start = self.pos(start.start_offset);
-        let end = self.pos(end.start_offset + end.lit.len() as u32);
+        let start = ast::Position::from(&start.start_pos);
+        let end = ast::Position::from(&end.end_pos);
         self.base_node(self.source_location(&start, &end))
     }
 
     fn base_node_from_other_start(&mut self, start: &BaseNode, end: &Token) -> BaseNode {
-        self.base_node(self.source_location(
-            &start.location.start,
-            &self.pos(end.start_offset + end.lit.len() as u32),
-        ))
+        self.base_node(
+            self.source_location(&start.location.start, &ast::Position::from(&end.end_pos)),
+        )
     }
 
     fn base_node_from_other_end(&mut self, start: &Token, end: &BaseNode) -> BaseNode {
-        self.base_node(self.source_location(&self.pos(start.start_offset), &end.location.end))
+        self.base_node(
+            self.source_location(&ast::Position::from(&start.start_pos), &end.location.end),
+        )
     }
 
     fn base_node_from_others(&mut self, start: &BaseNode, end: &BaseNode) -> BaseNode {
@@ -313,18 +314,14 @@ impl Parser {
         if !start.is_valid() || !end.is_valid() {
             return SourceLocation::default();
         }
-        let s_off = self.s.offset(scanner::Position::from(start)) as usize;
-        let e_off = self.s.offset(scanner::Position::from(end)) as usize;
+        let s_off = self.s.offset(&scanner::Position::from(start)) as usize;
+        let e_off = self.s.offset(&scanner::Position::from(end)) as usize;
         SourceLocation {
             file: Some(self.fname.clone()),
             start: start.clone(),
             end: end.clone(),
             source: Some(self.source[s_off..e_off].to_string()),
         }
-    }
-
-    fn pos(&self, p: u32) -> ast::Position {
-        ast::Position::from(&self.s.pos(p))
     }
 
     pub fn parse_file(&mut self, fname: String) -> File {
@@ -348,7 +345,7 @@ impl Parser {
         }
         File {
             base: BaseNode {
-                location: self.source_location(&self.pos(t.start_offset), &end),
+                location: self.source_location(&ast::Position::from(&t.start_pos), &end),
                 errors: vec![],
             },
             name: self.fname.clone(),
@@ -565,8 +562,8 @@ impl Parser {
                     //  an operator and create a binary expression. For now, skip past it.
                     let invalid_t = self.scan();
                     let loc = self.source_location(
-                        &self.pos(invalid_t.start_offset),
-                        &self.pos(invalid_t.start_offset + invalid_t.lit.len() as u32),
+                        &ast::Position::from(&invalid_t.start_pos),
+                        &ast::Position::from(&invalid_t.end_pos),
                     );
                     self.errs
                         .push(format!("invalid expression {}: {}", loc, invalid_t.lit));
@@ -1030,8 +1027,8 @@ impl Parser {
                 // The BadExpr is an error per se. We want to leave errors to parents.
                 base: BaseNode {
                     location: self.source_location(
-                        &self.pos(t.start_offset),
-                        &self.pos(t.start_offset + t.lit.len() as u32),
+                        &ast::Position::from(&t.start_pos),
+                        &ast::Position::from(&t.end_pos),
                     ),
                     errors: vec![],
                 },
@@ -1071,8 +1068,8 @@ impl Parser {
                 }
                 _ => {
                     let loc = self.source_location(
-                        &self.pos(t.start_offset),
-                        &self.pos(t.start_offset + t.lit.len() as u32),
+                        &ast::Position::from(&t.start_pos),
+                        &ast::Position::from(&t.end_pos),
                     );
                     self.errs.push(format!(
                         "got unexpected token in string expression {}@{}:{}-{}:{}: {}",
@@ -1211,8 +1208,8 @@ impl Parser {
                             // The BadExpr is an error per se. We want to leave errors to parents.
                             base: BaseNode {
                                 location: self.source_location(
-                                    &self.pos(t.start_offset),
-                                    &self.pos(t.start_offset + t.lit.len() as u32),
+                                    &ast::Position::from(&t.start_pos),
+                                    &ast::Position::from(&t.end_pos),
                                 ),
                                 errors: vec![],
                             },
@@ -1287,8 +1284,8 @@ impl Parser {
                         Expression::Bad(_) => {
                             let invalid_t = self.scan();
                             let loc = self.source_location(
-                                &self.pos(invalid_t.start_offset),
-                                &self.pos(invalid_t.start_offset + invalid_t.lit.len() as u32),
+                                &ast::Position::from(&invalid_t.start_pos),
+                                &&ast::Position::from(&invalid_t.end_pos),
                             );
                             self.errs
                                 .push(format!("invalid expression {}: {}", loc, invalid_t.lit));
@@ -1467,9 +1464,15 @@ impl Parser {
         self.errs.append(&mut errs);
         let end = self.peek();
         Property {
-            base: self.base_node_from_pos(&self.pos(t.start_offset), &self.pos(end.start_offset)),
+            base: self.base_node_from_pos(
+                &ast::Position::from(&t.start_pos),
+                &ast::Position::from(&end.start_pos),
+            ),
             key: PropertyKey::StringLit(StringLit {
-                base: self.base_node_from_pos(&self.pos(t.start_offset), &self.pos(t.start_offset)),
+                base: self.base_node_from_pos(
+                    &ast::Position::from(&t.start_pos),
+                    &ast::Position::from(&t.start_pos),
+                ),
                 value: "<invalid>".to_string(),
             }),
             value,

--- a/libflux/src/scanner/mod.rs
+++ b/libflux/src/scanner/mod.rs
@@ -155,8 +155,14 @@ impl Scanner {
                             lit: nc.to_string(),
                             start_offset: self.ts,
                             end_offset: self.ts + size as u32,
-                            start_pos: Position { line: 0, column: 0 },
-                            end_pos: Position { line: 0, column: 0 },
+                            start_pos: Position {
+                                line: token_start_line,
+                                column: token_start_col,
+                            },
+                            end_pos: Position {
+                                line: token_start_line,
+                                column: token_start_col + size as u32,
+                            },
                         };
                     }
                     // This should be impossible as we would have produced an EOF token
@@ -183,8 +189,14 @@ impl Scanner {
                 )),
                 start_offset: self.ts,
                 end_offset: self.te,
-                start_pos: Position { line: 0, column: 0 },
-                end_pos: Position { line: 0, column: 0 },
+                start_pos: Position {
+                    line: token_start_line,
+                    column: token_start_col,
+                },
+                end_pos: Position {
+                    line: token_end_line,
+                    column: token_end_col,
+                },
             };
 
             assert_eq!(

--- a/libflux/src/scanner/mod.rs
+++ b/libflux/src/scanner/mod.rs
@@ -28,7 +28,10 @@ pub struct Position {
 pub struct Token {
     pub tok: TOK,
     pub lit: String,
-    pub pos: u32,
+    pub start_offset: u32,
+    pub end_offset: u32,
+    pub start_pos: Position,
+    pub end_pos: Position,
 }
 
 impl Scanner {
@@ -38,7 +41,7 @@ impl Scanner {
         let bytes = data.as_bytes();
         let end = ((ptr as usize) + bytes.len()) as *const CChar;
         return Scanner {
-            data: data,
+            data,
             ps: ptr as *const CChar,
             p: ptr as *const CChar,
             pe: end,
@@ -94,7 +97,10 @@ impl Scanner {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: self.te,
+            start_offset: self.te,
+            end_offset: self.te,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 },
         }
     }
 
@@ -133,7 +139,10 @@ impl Scanner {
                         return Token {
                             tok: TOK_ILLEGAL,
                             lit: nc.to_string(),
-                            pos: self.ts,
+                            start_offset: self.ts,
+                            end_offset: self.ts + size as u32,
+                            start_pos: Position { line: 0, column: 0 },
+                            end_pos: Position { line: 0, column: 0 },
                         };
                     }
                     // This should be impossible as we would have produced an EOF token
@@ -158,7 +167,10 @@ impl Scanner {
                 lit: String::from(str::from_utf8_unchecked(
                     &self.data.as_bytes()[(self.ts as usize)..(self.te as usize)],
                 )),
-                pos: self.ts,
+                start_offset: self.ts,
+                end_offset: self.te,
+                start_pos: Position { line: 0, column: 0 },
+                end_pos: Position { line: 0, column: 0 },
             };
             // Skipping comments.
             // TODO(affo): return comments to attach them to nodes within the AST.

--- a/libflux/src/scanner/scanner.h
+++ b/libflux/src/scanner/scanner.h
@@ -75,18 +75,13 @@ WASM_EXPORT int scan(
     const unsigned char *data,
     const unsigned char *pe,
     const unsigned char *eof,
-
     const unsigned char **last_newline,
     unsigned int *cur_line,
-
     unsigned int *token,
     unsigned int *token_start,
     unsigned int *token_start_line,
     unsigned int *token_start_col,
     unsigned int *token_end,
     unsigned int *token_end_line,
-    unsigned int *token_end_col,
-
-    const unsigned int **newlines,
-    unsigned int *newlines_len
+    unsigned int *token_end_col
 );

--- a/libflux/src/scanner/scanner.h
+++ b/libflux/src/scanner/scanner.h
@@ -69,6 +69,24 @@ enum TOK {
 #define WASM_EXPORT __attribute__ ((visibility("default")))
 
 // Scan reads the input and reports the next lexical token. Returns the execution state.
-WASM_EXPORT int scan(int mode, const unsigned char **p, const unsigned char *data, const unsigned char *pe,
-        const unsigned char *eof, unsigned int *token, unsigned int *token_start, unsigned int *token_end,
-        const unsigned int **newlines, unsigned int *newlines_len);
+WASM_EXPORT int scan(
+    int mode,
+    const unsigned char **p,
+    const unsigned char *data,
+    const unsigned char *pe,
+    const unsigned char *eof,
+
+    const unsigned char **last_newline,
+    unsigned int *cur_line,
+
+    unsigned int *token,
+    unsigned int *token_start,
+    unsigned int *token_start_line,
+    unsigned int *token_start_col,
+    unsigned int *token_end,
+    unsigned int *token_end_line,
+    unsigned int *token_end_col,
+
+    const unsigned int **newlines,
+    unsigned int *newlines_len
+);

--- a/libflux/src/scanner/scanner.rl
+++ b/libflux/src/scanner/scanner.rl
@@ -1,6 +1,6 @@
 #include "scanner.h"
-
-#define NULL ((void*)0)
+#include <stdlib.h>
+//#define NULL ((void*)0)
 
 %%{
     machine flux;

--- a/libflux/src/scanner/scanner.rl
+++ b/libflux/src/scanner/scanner.rl
@@ -1,5 +1,6 @@
 #include "scanner.h"
-#include <stdlib.h>
+
+#define NULL ((void*)0)
 
 %%{
     machine flux;

--- a/libflux/src/scanner/tests.rs
+++ b/libflux/src/scanner/tests.rs
@@ -940,6 +940,61 @@ fn test_scan_unread() {
 }
 
 #[test]
+fn test_scan_unread_with_newlines() {
+    let text = r#"regex =
+
+
+/foo/"#;
+    let cdata = CString::new(text).expect("CString::new failed");
+    let mut s = Scanner::new(cdata);
+    assert_eq!(
+        s.scan(),
+        Token {
+            tok: TOK_IDENT,
+            lit: String::from("regex"),
+            start_offset: 0,
+            end_offset: 5,
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 6 },
+        }
+    );
+    assert_eq!(
+        s.scan(),
+        Token {
+            tok: TOK_ASSIGN,
+            lit: String::from("="),
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 },
+        }
+    );
+    assert_eq!(
+        s.scan(),
+        Token {
+            tok: TOK_DIV,
+            lit: String::from("/"),
+            start_offset: 10,
+            end_offset: 11,
+            start_pos: Position { line: 4, column: 1 },
+            end_pos: Position { line: 4, column: 2 },
+        }
+    );
+    s.unread();
+    assert_eq!(
+        s.scan_with_regex(),
+        Token {
+            tok: TOK_REGEX,
+            lit: String::from("/foo/"),
+            start_offset: 10,
+            end_offset: 15,
+            start_pos: Position { line: 4, column: 1 },
+            end_pos: Position { line: 4, column: 6 },
+        }
+    );
+}
+
+#[test]
 fn test_scan_comments() {
     let text = r#"// this is a comment.
 a

--- a/libflux/src/scanner/tests.rs
+++ b/libflux/src/scanner/tests.rs
@@ -11,7 +11,10 @@ fn test_scan() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("from"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 4,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -19,7 +22,10 @@ fn test_scan() {
         Token {
             tok: TOK_LPAREN,
             lit: String::from("("),
-            pos: 4,
+            start_offset: 4,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -27,7 +33,10 @@ fn test_scan() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("bucket"),
-            pos: 5,
+            start_offset: 5,
+            end_offset: 11,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -35,7 +44,10 @@ fn test_scan() {
         Token {
             tok: TOK_COLON,
             lit: String::from(":"),
-            pos: 11,
+            start_offset: 11,
+            end_offset: 12,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -43,7 +55,10 @@ fn test_scan() {
         Token {
             tok: TOK_STRING,
             lit: String::from("\"foo\""),
-            pos: 12,
+            start_offset: 12,
+            end_offset: 17,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -51,7 +66,10 @@ fn test_scan() {
         Token {
             tok: TOK_RPAREN,
             lit: String::from(")"),
-            pos: 17,
+            start_offset: 17,
+            end_offset: 18,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -59,7 +77,10 @@ fn test_scan() {
         Token {
             tok: TOK_PIPE_FORWARD,
             lit: String::from("|>"),
-            pos: 19,
+            start_offset: 19,
+            end_offset: 21,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -67,7 +88,10 @@ fn test_scan() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("range"),
-            pos: 22,
+            start_offset: 22,
+            end_offset: 27,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -75,7 +99,10 @@ fn test_scan() {
         Token {
             tok: TOK_LPAREN,
             lit: String::from("("),
-            pos: 27,
+            start_offset: 27,
+            end_offset: 28,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -83,7 +110,10 @@ fn test_scan() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("start"),
-            pos: 28,
+            start_offset: 28,
+            end_offset: 33,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -91,7 +121,10 @@ fn test_scan() {
         Token {
             tok: TOK_COLON,
             lit: String::from(":"),
-            pos: 33,
+            start_offset: 33,
+            end_offset: 34,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -99,7 +132,10 @@ fn test_scan() {
         Token {
             tok: TOK_SUB,
             lit: String::from("-"),
-            pos: 35,
+            start_offset: 35,
+            end_offset: 36,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -107,7 +143,10 @@ fn test_scan() {
         Token {
             tok: TOK_DURATION,
             lit: String::from("1m"),
-            pos: 36,
+            start_offset: 36,
+            end_offset: 38,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -115,7 +154,10 @@ fn test_scan() {
         Token {
             tok: TOK_RPAREN,
             lit: String::from(")"),
-            pos: 38,
+            start_offset: 38,
+            end_offset: 39,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -123,7 +165,10 @@ fn test_scan() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 39,
+            start_offset: 39,
+            end_offset: 39,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -138,7 +183,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("a"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -146,7 +194,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_ADD,
             lit: String::from("+"),
-            pos: 2,
+            start_offset: 2,
+            end_offset: 3,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -154,7 +205,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("b"),
-            pos: 4,
+            start_offset: 4,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -162,7 +216,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_REGEXEQ,
             lit: String::from("=~"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 8,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -170,7 +227,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_REGEX,
             lit: String::from("/.*[0-9]/"),
-            pos: 9,
+            start_offset: 9,
+            end_offset: 18,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -178,7 +238,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_DIV,
             lit: String::from("/"),
-            pos: 19,
+            start_offset: 19,
+            end_offset: 20,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -186,7 +249,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_INT,
             lit: String::from("2"),
-            pos: 21,
+            start_offset: 21,
+            end_offset: 22,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -194,7 +260,10 @@ fn test_scan_with_regex() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 22,
+            start_offset: 22,
+            end_offset: 22,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -209,7 +278,10 @@ fn test_scan_string_expr_simple() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -217,7 +289,10 @@ fn test_scan_string_expr_simple() {
         Token {
             tok: TOK_STRINGEXPR,
             lit: String::from("${"),
-            pos: 1,
+            start_offset: 1,
+            end_offset: 3,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -225,7 +300,10 @@ fn test_scan_string_expr_simple() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b}"),
-            pos: 3,
+            start_offset: 3,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -233,7 +311,10 @@ fn test_scan_string_expr_simple() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 9,
+            start_offset: 9,
+            end_offset: 10,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -248,7 +329,10 @@ fn test_scan_string_expr_start_with_text() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -256,7 +340,10 @@ fn test_scan_string_expr_start_with_text() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b = "),
-            pos: 1,
+            start_offset: 1,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -264,7 +351,10 @@ fn test_scan_string_expr_start_with_text() {
         Token {
             tok: TOK_STRINGEXPR,
             lit: String::from("${"),
-            pos: 9,
+            start_offset: 9,
+            end_offset: 11,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -272,7 +362,10 @@ fn test_scan_string_expr_start_with_text() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b}"),
-            pos: 11,
+            start_offset: 11,
+            end_offset: 17,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -280,7 +373,10 @@ fn test_scan_string_expr_start_with_text() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 17,
+            start_offset: 17,
+            end_offset: 18,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -295,7 +391,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -303,7 +402,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b = "),
-            pos: 1,
+            start_offset: 1,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -311,7 +413,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_STRINGEXPR,
             lit: String::from("${"),
-            pos: 9,
+            start_offset: 9,
+            end_offset: 11,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -319,7 +424,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b} and a - b = "),
-            pos: 11,
+            start_offset: 11,
+            end_offset: 30,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -327,7 +435,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_STRINGEXPR,
             lit: String::from("${"),
-            pos: 30,
+            start_offset: 30,
+            end_offset: 32,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -335,7 +446,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a - b}"),
-            pos: 32,
+            start_offset: 32,
+            end_offset: 38,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -343,7 +457,10 @@ fn test_scan_string_expr_multiple() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 38,
+            start_offset: 38,
+            end_offset: 39,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -358,7 +475,10 @@ fn test_scan_string_expr_end_with_text() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -366,7 +486,10 @@ fn test_scan_string_expr_end_with_text() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b = "),
-            pos: 1,
+            start_offset: 1,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -374,7 +497,10 @@ fn test_scan_string_expr_end_with_text() {
         Token {
             tok: TOK_STRINGEXPR,
             lit: String::from("${"),
-            pos: 9,
+            start_offset: 9,
+            end_offset: 11,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -382,7 +508,10 @@ fn test_scan_string_expr_end_with_text() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("a + b} and a - b = ?"),
-            pos: 11,
+            start_offset: 11,
+            end_offset: 31,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -390,7 +519,10 @@ fn test_scan_string_expr_end_with_text() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 31,
+            start_offset: 31,
+            end_offset: 32,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -405,7 +537,10 @@ fn test_scan_string_expr_escaped_quotes() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -413,7 +548,10 @@ fn test_scan_string_expr_escaped_quotes() {
         Token {
             tok: TOK_TEXT,
             lit: String::from(r#"these \"\" are escaped quotes"#),
-            pos: 1,
+            start_offset: 1,
+            end_offset: 30,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -421,7 +559,10 @@ fn test_scan_string_expr_escaped_quotes() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 30,
+            start_offset: 30,
+            end_offset: 31,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -436,7 +577,10 @@ fn test_scan_string_expr_not_escaped_quotes() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -444,7 +588,10 @@ fn test_scan_string_expr_not_escaped_quotes() {
         Token {
             tok: TOK_TEXT,
             lit: String::from("this "),
-            pos: 1,
+            start_offset: 1,
+            end_offset: 6,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -452,7 +599,10 @@ fn test_scan_string_expr_not_escaped_quotes() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -460,7 +610,10 @@ fn test_scan_string_expr_not_escaped_quotes() {
         Token {
             tok: TOK_TEXT,
             lit: String::from(" is not an escaped quote"),
-            pos: 7,
+            start_offset: 7,
+            end_offset: 31,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -468,7 +621,10 @@ fn test_scan_string_expr_not_escaped_quotes() {
         Token {
             tok: TOK_QUOTE,
             lit: String::from("\""),
-            pos: 31,
+            start_offset: 31,
+            end_offset: 32,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -483,7 +639,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_INT,
             lit: String::from("1"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     s.unread();
@@ -492,7 +651,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_INT,
             lit: String::from("1"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 1,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 
@@ -501,7 +663,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_REGEX,
             lit: String::from("/ 2 /"),
-            pos: 2,
+            start_offset: 2,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     s.unread();
@@ -510,7 +675,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_DIV,
             lit: String::from("/"),
-            pos: 2,
+            start_offset: 2,
+            end_offset: 3,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -518,7 +686,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_INT,
             lit: String::from("2"),
-            pos: 4,
+            start_offset: 4,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -526,7 +697,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_DIV,
             lit: String::from("/"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -534,7 +708,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_INT,
             lit: String::from("3"),
-            pos: 8,
+            start_offset: 8,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     // test unread idempotence
@@ -548,7 +725,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_INT,
             lit: String::from("3"),
-            pos: 8,
+            start_offset: 8,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -556,7 +736,10 @@ fn test_scan_unread() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 9,
+            start_offset: 9,
+            end_offset: 9,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -577,7 +760,10 @@ a
         Token {
             tok: TOK_IDENT,
             lit: String::from("a"),
-            pos: 22,
+            start_offset: 22,
+            end_offset: 23,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -585,7 +771,10 @@ a
         Token {
             tok: TOK_INT,
             lit: String::from("1"),
-            pos: 95,
+            start_offset: 95,
+            end_offset: 96,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -593,7 +782,10 @@ a
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 114,
+            start_offset: 114,
+            end_offset: 114,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 
@@ -605,7 +797,10 @@ a
         Token {
             tok: TOK_IDENT,
             lit: String::from("a"),
-            pos: 22,
+            start_offset: 22,
+            end_offset: 23,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -613,7 +808,10 @@ a
         Token {
             tok: TOK_INT,
             lit: String::from("1"),
-            pos: 95,
+            start_offset: 95,
+            end_offset: 96,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -621,7 +819,10 @@ a
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 114,
+            start_offset: 114,
+            end_offset: 114,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -637,7 +838,10 @@ fn test_scan_eof() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 0,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -645,7 +849,10 @@ fn test_scan_eof() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 0,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -653,7 +860,10 @@ fn test_scan_eof() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 0,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -661,7 +871,10 @@ fn test_scan_eof() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 0,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -669,7 +882,10 @@ fn test_scan_eof() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 0,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -677,7 +893,10 @@ fn test_scan_eof() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 0,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -699,7 +918,10 @@ fn test_scan_eof_trailing_spaces() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 7,
+            start_offset: 7,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 
@@ -710,7 +932,10 @@ fn test_scan_eof_trailing_spaces() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 7,
+            start_offset: 7,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -725,7 +950,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("legal"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -733,7 +961,10 @@ fn test_illegal() {
         Token {
             tok: TOK_ILLEGAL,
             lit: String::from("@"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -741,7 +972,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("illegal"),
-            pos: 8,
+            start_offset: 8,
+            end_offset: 15,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 
@@ -752,7 +986,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("legal"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -760,7 +997,10 @@ fn test_illegal() {
         Token {
             tok: TOK_ILLEGAL,
             lit: String::from("@"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     s.unread();
@@ -769,7 +1009,10 @@ fn test_illegal() {
         Token {
             tok: TOK_ILLEGAL,
             lit: String::from("@"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -777,7 +1020,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("illegal"),
-            pos: 8,
+            start_offset: 8,
+            end_offset: 15,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 
@@ -788,7 +1034,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("legal"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -796,7 +1045,10 @@ fn test_illegal() {
         Token {
             tok: TOK_ILLEGAL,
             lit: String::from("@"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -804,7 +1056,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("illegal"),
-            pos: 8,
+            start_offset: 8,
+            end_offset: 15,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 
@@ -815,7 +1070,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("legal"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -823,7 +1081,10 @@ fn test_illegal() {
         Token {
             tok: TOK_ILLEGAL,
             lit: String::from("@"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     s.unread();
@@ -832,7 +1093,10 @@ fn test_illegal() {
         Token {
             tok: TOK_ILLEGAL,
             lit: String::from("@"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 7,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -840,7 +1104,10 @@ fn test_illegal() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("illegal"),
-            pos: 8,
+            start_offset: 8,
+            end_offset: 15,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -855,7 +1122,10 @@ fn test_scan_duration() {
         Token {
             tok: TOK_IDENT,
             lit: String::from("dur"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 3,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -863,7 +1133,10 @@ fn test_scan_duration() {
         Token {
             tok: TOK_ASSIGN,
             lit: String::from("="),
-            pos: 4,
+            start_offset: 4,
+            end_offset: 5,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -871,7 +1144,10 @@ fn test_scan_duration() {
         Token {
             tok: TOK_DURATION,
             lit: String::from("1y3mo2w1d4h1m30s1ms2µs70ns"),
-            pos: 6,
+            start_offset: 6,
+            end_offset: 33,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(
@@ -879,7 +1155,10 @@ fn test_scan_duration() {
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 33,
+            start_offset: 33,
+            end_offset: 33,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
 }
@@ -965,7 +1244,10 @@ c = 1 + 2
         Token {
             tok: TOK_IDENT,
             lit: String::from("ms"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 2,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(0), Position { line: 1, column: 1 });
@@ -974,7 +1256,10 @@ c = 1 + 2
         Token {
             tok: TOK_ASSIGN,
             lit: String::from("="),
-            pos: 3,
+            start_offset: 3,
+            end_offset: 4,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(3), Position { line: 1, column: 4 });
@@ -983,7 +1268,10 @@ c = 1 + 2
         Token {
             tok: TOK_STRING,
             lit: String::from("\"multiline\nstring\n\""),
-            pos: 5,
+            start_offset: 5,
+            end_offset: 24,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(5), Position { line: 1, column: 6 });
@@ -996,7 +1284,10 @@ c = 1 + 2
         Token {
             tok: TOK_IDENT,
             lit: String::from("c"),
-            pos: 38,
+            start_offset: 38,
+            end_offset: 39,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(38), Position { line: 7, column: 1 });
@@ -1005,7 +1296,10 @@ c = 1 + 2
         Token {
             tok: TOK_ASSIGN,
             lit: String::from("="),
-            pos: 40,
+            start_offset: 40,
+            end_offset: 41,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(40), Position { line: 7, column: 3 });
@@ -1014,7 +1308,10 @@ c = 1 + 2
         Token {
             tok: TOK_INT,
             lit: String::from("1"),
-            pos: 42,
+            start_offset: 42,
+            end_offset: 43,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(42), Position { line: 7, column: 5 });
@@ -1023,7 +1320,10 @@ c = 1 + 2
         Token {
             tok: TOK_ADD,
             lit: String::from("+"),
-            pos: 44,
+            start_offset: 44,
+            end_offset: 45,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(44), Position { line: 7, column: 7 });
@@ -1032,7 +1332,10 @@ c = 1 + 2
         Token {
             tok: TOK_INT,
             lit: String::from("2"),
-            pos: 46,
+            start_offset: 46,
+            end_offset: 47,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(46), Position { line: 7, column: 9 });
@@ -1041,7 +1344,10 @@ c = 1 + 2
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 52,
+            start_offset: 52,
+            end_offset: 52,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(s.pos(48), Position { line: 8, column: 1 });
@@ -1128,7 +1434,10 @@ c = 1 + 2
         Token {
             tok: TOK_IDENT,
             lit: String::from("ms"),
-            pos: 0,
+            start_offset: 0,
+            end_offset: 2,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(0, s.offset(Position { line: 1, column: 1 }));
@@ -1137,7 +1446,10 @@ c = 1 + 2
         Token {
             tok: TOK_ASSIGN,
             lit: String::from("="),
-            pos: 3,
+            start_offset: 3,
+            end_offset: 4,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(3, s.offset(Position { line: 1, column: 4 }));
@@ -1146,7 +1458,10 @@ c = 1 + 2
         Token {
             tok: TOK_STRING,
             lit: String::from("\"multiline\nstring\n\""),
-            pos: 5,
+            start_offset: 5,
+            end_offset: 24,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(5, s.offset(Position { line: 1, column: 6 }));
@@ -1159,7 +1474,10 @@ c = 1 + 2
         Token {
             tok: TOK_IDENT,
             lit: String::from("c"),
-            pos: 38,
+            start_offset: 38,
+            end_offset: 39,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(38, s.offset(Position { line: 7, column: 1 }));
@@ -1168,7 +1486,10 @@ c = 1 + 2
         Token {
             tok: TOK_ASSIGN,
             lit: String::from("="),
-            pos: 40,
+            start_offset: 40,
+            end_offset: 41,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(40, s.offset(Position { line: 7, column: 3 }));
@@ -1177,7 +1498,10 @@ c = 1 + 2
         Token {
             tok: TOK_INT,
             lit: String::from("1"),
-            pos: 42,
+            start_offset: 42,
+            end_offset: 43,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(42, s.offset(Position { line: 7, column: 5 }));
@@ -1186,7 +1510,10 @@ c = 1 + 2
         Token {
             tok: TOK_ADD,
             lit: String::from("+"),
-            pos: 44,
+            start_offset: 44,
+            end_offset: 45,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(44, s.offset(Position { line: 7, column: 7 }));
@@ -1195,7 +1522,10 @@ c = 1 + 2
         Token {
             tok: TOK_INT,
             lit: String::from("2"),
-            pos: 46,
+            start_offset: 46,
+            end_offset: 47,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(46, s.offset(Position { line: 7, column: 9 }));
@@ -1204,7 +1534,10 @@ c = 1 + 2
         Token {
             tok: TOK_EOF,
             lit: String::from(""),
-            pos: 52,
+            start_offset: 52,
+            end_offset: 52,
+            start_pos: Position { line: 0, column: 0 },
+            end_pos: Position { line: 0, column: 0 }
         }
     );
     assert_eq!(48, s.offset(Position { line: 8, column: 1 }));

--- a/libflux/src/scanner/tests.rs
+++ b/libflux/src/scanner/tests.rs
@@ -236,8 +236,14 @@ fn test_scan() {
             lit: String::from(""),
             start_offset: 39,
             end_offset: 39,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 40
+            },
+            end_pos: Position {
+                line: 1,
+                column: 40
+            }
         }
     );
 }
@@ -349,8 +355,14 @@ fn test_scan_with_regex() {
             lit: String::from(""),
             start_offset: 22,
             end_offset: 22,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 23
+            },
+            end_pos: Position {
+                line: 1,
+                column: 23
+            }
         }
     );
 }
@@ -933,8 +945,14 @@ fn test_scan_unread() {
             lit: String::from(""),
             start_offset: 9,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 10
+            },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
 }
@@ -1034,8 +1052,14 @@ a
             lit: String::from(""),
             start_offset: 114,
             end_offset: 114,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 7,
+                column: 18
+            },
+            end_pos: Position {
+                line: 7,
+                column: 18
+            }
         }
     );
 
@@ -1071,8 +1095,14 @@ a
             lit: String::from(""),
             start_offset: 114,
             end_offset: 114,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 7,
+                column: 18
+            },
+            end_pos: Position {
+                line: 7,
+                column: 18
+            }
         }
     );
 }
@@ -1090,8 +1120,8 @@ fn test_scan_eof() {
             lit: String::from(""),
             start_offset: 0,
             end_offset: 0,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 1 }
         }
     );
     assert_eq!(
@@ -1101,8 +1131,8 @@ fn test_scan_eof() {
             lit: String::from(""),
             start_offset: 0,
             end_offset: 0,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 1 }
         }
     );
     assert_eq!(
@@ -1112,8 +1142,8 @@ fn test_scan_eof() {
             lit: String::from(""),
             start_offset: 0,
             end_offset: 0,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 1 }
         }
     );
     assert_eq!(
@@ -1123,8 +1153,8 @@ fn test_scan_eof() {
             lit: String::from(""),
             start_offset: 0,
             end_offset: 0,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 1 }
         }
     );
     assert_eq!(
@@ -1134,8 +1164,8 @@ fn test_scan_eof() {
             lit: String::from(""),
             start_offset: 0,
             end_offset: 0,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 1 }
         }
     );
     assert_eq!(
@@ -1145,8 +1175,8 @@ fn test_scan_eof() {
             lit: String::from(""),
             start_offset: 0,
             end_offset: 0,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 1 }
         }
     );
 }
@@ -1170,8 +1200,8 @@ fn test_scan_eof_trailing_spaces() {
             lit: String::from(""),
             start_offset: 7,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 2, column: 5 },
+            end_pos: Position { line: 2, column: 5 }
         }
     );
 
@@ -1184,8 +1214,8 @@ fn test_scan_eof_trailing_spaces() {
             lit: String::from(""),
             start_offset: 7,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 2, column: 5 },
+            end_pos: Position { line: 2, column: 5 }
         }
     );
 }
@@ -1422,261 +1452,14 @@ fn test_scan_duration() {
             lit: String::from(""),
             start_offset: 33,
             end_offset: 33,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
-        }
-    );
-}
-
-#[test]
-fn test_scan_newlines() {
-    let text = r#"multiline_string = "I
-am
-a
-multiline
-string.
-"
-
-// I am a
-// comment.
-
-1
-2
-3
-
-4
-// comment.
-"#;
-    let cdata = CString::new(text).expect("CString::new failed");
-    let mut s = Scanner::new(cdata);
-    assert_eq!(s.lines, vec![0]);
-    s.scan(); // multiline_string
-    s.scan(); // =
-    s.scan(); // "..."
-    s.scan(); // // I am a\n// comment.
-    s.scan(); // "1"
-    s.scan(); // "2"
-    s.scan(); // "3"
-    s.scan(); // "4"
-    s.scan(); // // comment.\nEOF
-    s.scan(); // EOF
-
-    // we don't care of the intermediate steps for s.lines.
-    // Only the final result is important.
-    assert_eq!(
-        s.lines,
-        vec![0, 22, 25, 27, 37, 45, 47, 48, 58, 70, 71, 73, 75, 77, 78, 80, 92]
-    );
-
-    // with regex
-    let cdata = CString::new(text).expect("CString::new failed");
-    let mut s = Scanner::new(cdata);
-    assert_eq!(s.lines, vec![0]);
-    s.scan_with_regex(); // multiline_string
-    s.scan_with_regex(); // =
-    s.scan_with_regex(); // "..."
-    s.scan_with_regex(); // // I am a\n// comment.
-    s.scan_with_regex(); // "1"
-    s.scan_with_regex(); // "2"
-    s.scan_with_regex(); // "3"
-    s.scan_with_regex(); // "4"
-    s.scan_with_regex(); // // comment.\nEOF
-    s.scan_with_regex(); // EOF
-    assert_eq!(
-        s.lines,
-        vec![0, 22, 25, 27, 37, 45, 47, 48, 58, 70, 71, 73, 75, 77, 78, 80, 92]
-    );
-}
-
-#[test]
-fn test_scan_position() {
-    let text = r#"ms = "multiline
-string
-"
-
-// comment
-
-c = 1 + 2
-
-
-
-
-"#;
-    let cdata = CString::new(text).expect("CString::new failed");
-    let mut s = Scanner::new(cdata);
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_IDENT,
-            lit: String::from("ms"),
-            start_offset: 0,
-            end_offset: 2,
-            start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 3 }
-        }
-    );
-    assert_eq!(s.pos(0), Position { line: 1, column: 1 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_ASSIGN,
-            lit: String::from("="),
-            start_offset: 3,
-            end_offset: 4,
-            start_pos: Position { line: 1, column: 4 },
-            end_pos: Position { line: 1, column: 5 }
-        }
-    );
-    assert_eq!(s.pos(3), Position { line: 1, column: 4 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_STRING,
-            lit: String::from("\"multiline\nstring\n\""),
-            start_offset: 5,
-            end_offset: 24,
-            start_pos: Position { line: 1, column: 6 },
-            end_pos: Position { line: 3, column: 2 }
-        }
-    );
-    assert_eq!(s.pos(5), Position { line: 1, column: 6 });
-    assert_eq!(s.pos(16), Position { line: 2, column: 1 });
-    assert_eq!(s.pos(20), Position { line: 2, column: 5 });
-    assert_eq!(s.pos(23), Position { line: 3, column: 1 });
-    assert_eq!(s.pos(24), Position { line: 3, column: 2 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_IDENT,
-            lit: String::from("c"),
-            start_offset: 38,
-            end_offset: 39,
-            start_pos: Position { line: 7, column: 1 },
-            end_pos: Position { line: 7, column: 2 }
-        }
-    );
-    assert_eq!(s.pos(38), Position { line: 7, column: 1 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_ASSIGN,
-            lit: String::from("="),
-            start_offset: 40,
-            end_offset: 41,
-            start_pos: Position { line: 7, column: 3 },
-            end_pos: Position { line: 7, column: 4 }
-        }
-    );
-    assert_eq!(s.pos(40), Position { line: 7, column: 3 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_INT,
-            lit: String::from("1"),
-            start_offset: 42,
-            end_offset: 43,
-            start_pos: Position { line: 7, column: 5 },
-            end_pos: Position { line: 7, column: 6 }
-        }
-    );
-    assert_eq!(s.pos(42), Position { line: 7, column: 5 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_ADD,
-            lit: String::from("+"),
-            start_offset: 44,
-            end_offset: 45,
-            start_pos: Position { line: 7, column: 7 },
-            end_pos: Position { line: 7, column: 8 }
-        }
-    );
-    assert_eq!(s.pos(44), Position { line: 7, column: 7 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_INT,
-            lit: String::from("2"),
-            start_offset: 46,
-            end_offset: 47,
-            start_pos: Position { line: 7, column: 9 },
+            start_pos: Position {
+                line: 1,
+                column: 34
+            },
             end_pos: Position {
-                line: 7,
-                column: 10
+                line: 1,
+                column: 34
             }
-        }
-    );
-    assert_eq!(s.pos(46), Position { line: 7, column: 9 });
-    assert_eq!(
-        s.scan(),
-        Token {
-            tok: TOK_EOF,
-            lit: String::from(""),
-            start_offset: 52,
-            end_offset: 52,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
-        }
-    );
-    assert_eq!(s.pos(48), Position { line: 8, column: 1 });
-    assert_eq!(s.pos(49), Position { line: 9, column: 1 });
-    assert_eq!(
-        s.pos(50),
-        Position {
-            line: 10,
-            column: 1,
-        }
-    );
-    assert_eq!(
-        s.pos(51),
-        Position {
-            line: 11,
-            column: 1,
-        }
-    );
-    assert_eq!(
-        s.pos(52),
-        Position {
-            line: 12,
-            column: 1,
-        }
-    );
-
-    // Ok, now re-assert every position without scanning.
-    // The scanner should keep the position unchanged.
-    assert_eq!(s.pos(0), Position { line: 1, column: 1 });
-    assert_eq!(s.pos(3), Position { line: 1, column: 4 });
-    assert_eq!(s.pos(5), Position { line: 1, column: 6 });
-    assert_eq!(s.pos(16), Position { line: 2, column: 1 });
-    assert_eq!(s.pos(20), Position { line: 2, column: 5 });
-    assert_eq!(s.pos(23), Position { line: 3, column: 1 });
-    assert_eq!(s.pos(24), Position { line: 3, column: 2 });
-    assert_eq!(s.pos(38), Position { line: 7, column: 1 });
-    assert_eq!(s.pos(40), Position { line: 7, column: 3 });
-    assert_eq!(s.pos(42), Position { line: 7, column: 5 });
-    assert_eq!(s.pos(44), Position { line: 7, column: 7 });
-    assert_eq!(s.pos(46), Position { line: 7, column: 9 });
-    assert_eq!(s.pos(48), Position { line: 8, column: 1 });
-    assert_eq!(s.pos(49), Position { line: 9, column: 1 });
-    assert_eq!(
-        s.pos(50),
-        Position {
-            line: 10,
-            column: 1,
-        }
-    );
-    assert_eq!(
-        s.pos(51),
-        Position {
-            line: 11,
-            column: 1,
-        }
-    );
-    assert_eq!(
-        s.pos(52),
-        Position {
-            line: 12,
-            column: 1,
         }
     );
 }
@@ -1708,7 +1491,7 @@ c = 1 + 2
             end_pos: Position { line: 1, column: 3 }
         }
     );
-    assert_eq!(0, s.offset(Position { line: 1, column: 1 }));
+    assert_eq!(0, s.offset(&Position { line: 1, column: 1 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1720,7 +1503,7 @@ c = 1 + 2
             end_pos: Position { line: 1, column: 5 }
         }
     );
-    assert_eq!(3, s.offset(Position { line: 1, column: 4 }));
+    assert_eq!(3, s.offset(&Position { line: 1, column: 4 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1732,11 +1515,8 @@ c = 1 + 2
             end_pos: Position { line: 3, column: 2 }
         }
     );
-    assert_eq!(5, s.offset(Position { line: 1, column: 6 }));
-    assert_eq!(16, s.offset(Position { line: 2, column: 1 }));
-    assert_eq!(20, s.offset(Position { line: 2, column: 5 }));
-    assert_eq!(23, s.offset(Position { line: 3, column: 1 }));
-    assert_eq!(24, s.offset(Position { line: 3, column: 2 }));
+    assert_eq!(5, s.offset(&Position { line: 1, column: 6 }));
+    assert_eq!(24, s.offset(&Position { line: 3, column: 2 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1748,7 +1528,7 @@ c = 1 + 2
             end_pos: Position { line: 7, column: 2 }
         }
     );
-    assert_eq!(38, s.offset(Position { line: 7, column: 1 }));
+    assert_eq!(38, s.offset(&Position { line: 7, column: 1 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1760,7 +1540,7 @@ c = 1 + 2
             end_pos: Position { line: 7, column: 4 }
         }
     );
-    assert_eq!(40, s.offset(Position { line: 7, column: 3 }));
+    assert_eq!(40, s.offset(&Position { line: 7, column: 3 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1772,7 +1552,7 @@ c = 1 + 2
             end_pos: Position { line: 7, column: 6 }
         }
     );
-    assert_eq!(42, s.offset(Position { line: 7, column: 5 }));
+    assert_eq!(42, s.offset(&Position { line: 7, column: 5 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1784,7 +1564,7 @@ c = 1 + 2
             end_pos: Position { line: 7, column: 8 }
         }
     );
-    assert_eq!(44, s.offset(Position { line: 7, column: 7 }));
+    assert_eq!(44, s.offset(&Position { line: 7, column: 7 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1799,7 +1579,7 @@ c = 1 + 2
             }
         }
     );
-    assert_eq!(46, s.offset(Position { line: 7, column: 9 }));
+    assert_eq!(46, s.offset(&Position { line: 7, column: 9 }));
     assert_eq!(
         s.scan(),
         Token {
@@ -1807,67 +1587,45 @@ c = 1 + 2
             lit: String::from(""),
             start_offset: 52,
             end_offset: 52,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 12,
+                column: 1
+            },
+            end_pos: Position {
+                line: 12,
+                column: 1
+            }
         }
     );
-    assert_eq!(48, s.offset(Position { line: 8, column: 1 }));
-    assert_eq!(49, s.offset(Position { line: 9, column: 1 }));
     assert_eq!(
-        50,
-        s.offset(Position {
-            line: 10,
-            column: 1,
-        })
-    );
-    assert_eq!(
-        51,
-        s.offset(Position {
-            line: 11,
-            column: 1,
+        47,
+        s.offset(&Position {
+            line: 7,
+            column: 10
         })
     );
     assert_eq!(
         52,
-        s.offset(Position {
+        s.offset(&Position {
             line: 12,
-            column: 1,
+            column: 1
         })
     );
 
     // Ok, now re-assert every offset without scanning.
     // The scanner should keep the position unchanged.
-    assert_eq!(0, s.offset(Position { line: 1, column: 1 }));
-    assert_eq!(3, s.offset(Position { line: 1, column: 4 }));
-    assert_eq!(5, s.offset(Position { line: 1, column: 6 }));
-    assert_eq!(16, s.offset(Position { line: 2, column: 1 }));
-    assert_eq!(20, s.offset(Position { line: 2, column: 5 }));
-    assert_eq!(23, s.offset(Position { line: 3, column: 1 }));
-    assert_eq!(24, s.offset(Position { line: 3, column: 2 }));
-    assert_eq!(38, s.offset(Position { line: 7, column: 1 }));
-    assert_eq!(40, s.offset(Position { line: 7, column: 3 }));
-    assert_eq!(42, s.offset(Position { line: 7, column: 5 }));
-    assert_eq!(44, s.offset(Position { line: 7, column: 7 }));
-    assert_eq!(46, s.offset(Position { line: 7, column: 9 }));
-    assert_eq!(48, s.offset(Position { line: 8, column: 1 }));
-    assert_eq!(49, s.offset(Position { line: 9, column: 1 }));
-    assert_eq!(
-        50,
-        s.offset(Position {
-            line: 10,
-            column: 1,
-        })
-    );
-    assert_eq!(
-        51,
-        s.offset(Position {
-            line: 11,
-            column: 1,
-        })
-    );
+    assert_eq!(0, s.offset(&Position { line: 1, column: 1 }));
+    assert_eq!(3, s.offset(&Position { line: 1, column: 4 }));
+    assert_eq!(5, s.offset(&Position { line: 1, column: 6 }));
+    assert_eq!(24, s.offset(&Position { line: 3, column: 2 }));
+    assert_eq!(38, s.offset(&Position { line: 7, column: 1 }));
+    assert_eq!(40, s.offset(&Position { line: 7, column: 3 }));
+    assert_eq!(42, s.offset(&Position { line: 7, column: 5 }));
+    assert_eq!(44, s.offset(&Position { line: 7, column: 7 }));
+    assert_eq!(46, s.offset(&Position { line: 7, column: 9 }));
     assert_eq!(
         52,
-        s.offset(Position {
+        s.offset(&Position {
             line: 12,
             column: 1,
         })

--- a/libflux/src/scanner/tests.rs
+++ b/libflux/src/scanner/tests.rs
@@ -13,8 +13,8 @@ fn test_scan() {
             lit: String::from("from"),
             start_offset: 0,
             end_offset: 4,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 5 }
         }
     );
     assert_eq!(
@@ -24,8 +24,8 @@ fn test_scan() {
             lit: String::from("("),
             start_offset: 4,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 5 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -35,8 +35,11 @@ fn test_scan() {
             lit: String::from("bucket"),
             start_offset: 5,
             end_offset: 11,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 6 },
+            end_pos: Position {
+                line: 1,
+                column: 12
+            }
         }
     );
     assert_eq!(
@@ -46,8 +49,14 @@ fn test_scan() {
             lit: String::from(":"),
             start_offset: 11,
             end_offset: 12,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 12
+            },
+            end_pos: Position {
+                line: 1,
+                column: 13
+            }
         }
     );
     assert_eq!(
@@ -57,8 +66,14 @@ fn test_scan() {
             lit: String::from("\"foo\""),
             start_offset: 12,
             end_offset: 17,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 13
+            },
+            end_pos: Position {
+                line: 1,
+                column: 18
+            }
         }
     );
     assert_eq!(
@@ -68,8 +83,14 @@ fn test_scan() {
             lit: String::from(")"),
             start_offset: 17,
             end_offset: 18,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 18
+            },
+            end_pos: Position {
+                line: 1,
+                column: 19
+            }
         }
     );
     assert_eq!(
@@ -79,8 +100,14 @@ fn test_scan() {
             lit: String::from("|>"),
             start_offset: 19,
             end_offset: 21,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 20
+            },
+            end_pos: Position {
+                line: 1,
+                column: 22
+            }
         }
     );
     assert_eq!(
@@ -90,8 +117,14 @@ fn test_scan() {
             lit: String::from("range"),
             start_offset: 22,
             end_offset: 27,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 23
+            },
+            end_pos: Position {
+                line: 1,
+                column: 28
+            }
         }
     );
     assert_eq!(
@@ -101,8 +134,14 @@ fn test_scan() {
             lit: String::from("("),
             start_offset: 27,
             end_offset: 28,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 28
+            },
+            end_pos: Position {
+                line: 1,
+                column: 29
+            }
         }
     );
     assert_eq!(
@@ -112,8 +151,14 @@ fn test_scan() {
             lit: String::from("start"),
             start_offset: 28,
             end_offset: 33,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 29
+            },
+            end_pos: Position {
+                line: 1,
+                column: 34
+            }
         }
     );
     assert_eq!(
@@ -123,8 +168,14 @@ fn test_scan() {
             lit: String::from(":"),
             start_offset: 33,
             end_offset: 34,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 34
+            },
+            end_pos: Position {
+                line: 1,
+                column: 35
+            }
         }
     );
     assert_eq!(
@@ -134,8 +185,14 @@ fn test_scan() {
             lit: String::from("-"),
             start_offset: 35,
             end_offset: 36,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 36
+            },
+            end_pos: Position {
+                line: 1,
+                column: 37
+            }
         }
     );
     assert_eq!(
@@ -145,8 +202,14 @@ fn test_scan() {
             lit: String::from("1m"),
             start_offset: 36,
             end_offset: 38,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 37
+            },
+            end_pos: Position {
+                line: 1,
+                column: 39
+            }
         }
     );
     assert_eq!(
@@ -156,8 +219,14 @@ fn test_scan() {
             lit: String::from(")"),
             start_offset: 38,
             end_offset: 39,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 39
+            },
+            end_pos: Position {
+                line: 1,
+                column: 40
+            }
         }
     );
     assert_eq!(
@@ -185,8 +254,8 @@ fn test_scan_with_regex() {
             lit: String::from("a"),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -196,8 +265,8 @@ fn test_scan_with_regex() {
             lit: String::from("+"),
             start_offset: 2,
             end_offset: 3,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 3 },
+            end_pos: Position { line: 1, column: 4 }
         }
     );
     assert_eq!(
@@ -207,8 +276,8 @@ fn test_scan_with_regex() {
             lit: String::from("b"),
             start_offset: 4,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 5 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -218,8 +287,8 @@ fn test_scan_with_regex() {
             lit: String::from("=~"),
             start_offset: 6,
             end_offset: 8,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 9 }
         }
     );
     assert_eq!(
@@ -229,8 +298,14 @@ fn test_scan_with_regex() {
             lit: String::from("/.*[0-9]/"),
             start_offset: 9,
             end_offset: 18,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 10
+            },
+            end_pos: Position {
+                line: 1,
+                column: 19
+            }
         }
     );
     assert_eq!(
@@ -240,8 +315,14 @@ fn test_scan_with_regex() {
             lit: String::from("/"),
             start_offset: 19,
             end_offset: 20,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 20
+            },
+            end_pos: Position {
+                line: 1,
+                column: 21
+            }
         }
     );
     assert_eq!(
@@ -251,8 +332,14 @@ fn test_scan_with_regex() {
             lit: String::from("2"),
             start_offset: 21,
             end_offset: 22,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 22
+            },
+            end_pos: Position {
+                line: 1,
+                column: 23
+            }
         }
     );
     assert_eq!(
@@ -280,8 +367,8 @@ fn test_scan_string_expr_simple() {
             lit: String::from("\""),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -291,8 +378,8 @@ fn test_scan_string_expr_simple() {
             lit: String::from("${"),
             start_offset: 1,
             end_offset: 3,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 2 },
+            end_pos: Position { line: 1, column: 4 }
         }
     );
     assert_eq!(
@@ -302,8 +389,11 @@ fn test_scan_string_expr_simple() {
             lit: String::from("a + b}"),
             start_offset: 3,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 4 },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
     assert_eq!(
@@ -313,8 +403,14 @@ fn test_scan_string_expr_simple() {
             lit: String::from("\""),
             start_offset: 9,
             end_offset: 10,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 10
+            },
+            end_pos: Position {
+                line: 1,
+                column: 11
+            }
         }
     );
 }
@@ -331,8 +427,8 @@ fn test_scan_string_expr_start_with_text() {
             lit: String::from("\""),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -342,8 +438,11 @@ fn test_scan_string_expr_start_with_text() {
             lit: String::from("a + b = "),
             start_offset: 1,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 2 },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
     assert_eq!(
@@ -353,8 +452,14 @@ fn test_scan_string_expr_start_with_text() {
             lit: String::from("${"),
             start_offset: 9,
             end_offset: 11,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 10
+            },
+            end_pos: Position {
+                line: 1,
+                column: 12
+            }
         }
     );
     assert_eq!(
@@ -364,8 +469,14 @@ fn test_scan_string_expr_start_with_text() {
             lit: String::from("a + b}"),
             start_offset: 11,
             end_offset: 17,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 12
+            },
+            end_pos: Position {
+                line: 1,
+                column: 18
+            }
         }
     );
     assert_eq!(
@@ -375,8 +486,14 @@ fn test_scan_string_expr_start_with_text() {
             lit: String::from("\""),
             start_offset: 17,
             end_offset: 18,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 18
+            },
+            end_pos: Position {
+                line: 1,
+                column: 19
+            }
         }
     );
 }
@@ -393,8 +510,8 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("\""),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -404,8 +521,11 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("a + b = "),
             start_offset: 1,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 2 },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
     assert_eq!(
@@ -415,8 +535,14 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("${"),
             start_offset: 9,
             end_offset: 11,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 10
+            },
+            end_pos: Position {
+                line: 1,
+                column: 12
+            }
         }
     );
     assert_eq!(
@@ -426,8 +552,14 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("a + b} and a - b = "),
             start_offset: 11,
             end_offset: 30,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 12
+            },
+            end_pos: Position {
+                line: 1,
+                column: 31
+            }
         }
     );
     assert_eq!(
@@ -437,8 +569,14 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("${"),
             start_offset: 30,
             end_offset: 32,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 31
+            },
+            end_pos: Position {
+                line: 1,
+                column: 33
+            }
         }
     );
     assert_eq!(
@@ -448,8 +586,14 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("a - b}"),
             start_offset: 32,
             end_offset: 38,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 33
+            },
+            end_pos: Position {
+                line: 1,
+                column: 39
+            }
         }
     );
     assert_eq!(
@@ -459,8 +603,14 @@ fn test_scan_string_expr_multiple() {
             lit: String::from("\""),
             start_offset: 38,
             end_offset: 39,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 39
+            },
+            end_pos: Position {
+                line: 1,
+                column: 40
+            }
         }
     );
 }
@@ -477,8 +627,8 @@ fn test_scan_string_expr_end_with_text() {
             lit: String::from("\""),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -488,8 +638,11 @@ fn test_scan_string_expr_end_with_text() {
             lit: String::from("a + b = "),
             start_offset: 1,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 2 },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
     assert_eq!(
@@ -499,8 +652,14 @@ fn test_scan_string_expr_end_with_text() {
             lit: String::from("${"),
             start_offset: 9,
             end_offset: 11,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 10
+            },
+            end_pos: Position {
+                line: 1,
+                column: 12
+            }
         }
     );
     assert_eq!(
@@ -510,8 +669,14 @@ fn test_scan_string_expr_end_with_text() {
             lit: String::from("a + b} and a - b = ?"),
             start_offset: 11,
             end_offset: 31,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 12
+            },
+            end_pos: Position {
+                line: 1,
+                column: 32
+            }
         }
     );
     assert_eq!(
@@ -521,8 +686,14 @@ fn test_scan_string_expr_end_with_text() {
             lit: String::from("\""),
             start_offset: 31,
             end_offset: 32,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 32
+            },
+            end_pos: Position {
+                line: 1,
+                column: 33
+            }
         }
     );
 }
@@ -539,8 +710,8 @@ fn test_scan_string_expr_escaped_quotes() {
             lit: String::from("\""),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -550,8 +721,11 @@ fn test_scan_string_expr_escaped_quotes() {
             lit: String::from(r#"these \"\" are escaped quotes"#),
             start_offset: 1,
             end_offset: 30,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 2 },
+            end_pos: Position {
+                line: 1,
+                column: 31
+            }
         }
     );
     assert_eq!(
@@ -561,8 +735,14 @@ fn test_scan_string_expr_escaped_quotes() {
             lit: String::from("\""),
             start_offset: 30,
             end_offset: 31,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 31
+            },
+            end_pos: Position {
+                line: 1,
+                column: 32
+            }
         }
     );
 }
@@ -579,8 +759,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             lit: String::from("\""),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     assert_eq!(
@@ -590,8 +770,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             lit: String::from("this "),
             start_offset: 1,
             end_offset: 6,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 2 },
+            end_pos: Position { line: 1, column: 7 }
         }
     );
     assert_eq!(
@@ -601,8 +781,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             lit: String::from("\""),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     assert_eq!(
@@ -612,8 +792,11 @@ fn test_scan_string_expr_not_escaped_quotes() {
             lit: String::from(" is not an escaped quote"),
             start_offset: 7,
             end_offset: 31,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 8 },
+            end_pos: Position {
+                line: 1,
+                column: 32
+            }
         }
     );
     assert_eq!(
@@ -623,8 +806,14 @@ fn test_scan_string_expr_not_escaped_quotes() {
             lit: String::from("\""),
             start_offset: 31,
             end_offset: 32,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position {
+                line: 1,
+                column: 32
+            },
+            end_pos: Position {
+                line: 1,
+                column: 33
+            }
         }
     );
 }
@@ -641,8 +830,8 @@ fn test_scan_unread() {
             lit: String::from("1"),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
     s.unread();
@@ -653,8 +842,8 @@ fn test_scan_unread() {
             lit: String::from("1"),
             start_offset: 0,
             end_offset: 1,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 2 }
         }
     );
 
@@ -665,8 +854,8 @@ fn test_scan_unread() {
             lit: String::from("/ 2 /"),
             start_offset: 2,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 3 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     s.unread();
@@ -677,8 +866,8 @@ fn test_scan_unread() {
             lit: String::from("/"),
             start_offset: 2,
             end_offset: 3,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 3 },
+            end_pos: Position { line: 1, column: 4 }
         }
     );
     assert_eq!(
@@ -688,8 +877,8 @@ fn test_scan_unread() {
             lit: String::from("2"),
             start_offset: 4,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 5 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -699,8 +888,8 @@ fn test_scan_unread() {
             lit: String::from("/"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     assert_eq!(
@@ -710,8 +899,11 @@ fn test_scan_unread() {
             lit: String::from("3"),
             start_offset: 8,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 9 },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
     // test unread idempotence
@@ -727,8 +919,11 @@ fn test_scan_unread() {
             lit: String::from("3"),
             start_offset: 8,
             end_offset: 9,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 9 },
+            end_pos: Position {
+                line: 1,
+                column: 10
+            }
         }
     );
     assert_eq!(
@@ -762,8 +957,8 @@ a
             lit: String::from("a"),
             start_offset: 22,
             end_offset: 23,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 2, column: 1 },
+            end_pos: Position { line: 2, column: 2 }
         }
     );
     assert_eq!(
@@ -773,8 +968,8 @@ a
             lit: String::from("1"),
             start_offset: 95,
             end_offset: 96,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 6, column: 1 },
+            end_pos: Position { line: 6, column: 2 }
         }
     );
     assert_eq!(
@@ -799,8 +994,8 @@ a
             lit: String::from("a"),
             start_offset: 22,
             end_offset: 23,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 2, column: 1 },
+            end_pos: Position { line: 2, column: 2 }
         }
     );
     assert_eq!(
@@ -810,8 +1005,8 @@ a
             lit: String::from("1"),
             start_offset: 95,
             end_offset: 96,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 6, column: 1 },
+            end_pos: Position { line: 6, column: 2 }
         }
     );
     assert_eq!(
@@ -952,8 +1147,8 @@ fn test_illegal() {
             lit: String::from("legal"),
             start_offset: 0,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -963,8 +1158,8 @@ fn test_illegal() {
             lit: String::from("@"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     assert_eq!(
@@ -974,8 +1169,11 @@ fn test_illegal() {
             lit: String::from("illegal"),
             start_offset: 8,
             end_offset: 15,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 9 },
+            end_pos: Position {
+                line: 1,
+                column: 16
+            }
         }
     );
 
@@ -988,8 +1186,8 @@ fn test_illegal() {
             lit: String::from("legal"),
             start_offset: 0,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -999,8 +1197,8 @@ fn test_illegal() {
             lit: String::from("@"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     s.unread();
@@ -1011,8 +1209,8 @@ fn test_illegal() {
             lit: String::from("@"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     assert_eq!(
@@ -1022,8 +1220,11 @@ fn test_illegal() {
             lit: String::from("illegal"),
             start_offset: 8,
             end_offset: 15,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 9 },
+            end_pos: Position {
+                line: 1,
+                column: 16
+            }
         }
     );
 
@@ -1036,8 +1237,8 @@ fn test_illegal() {
             lit: String::from("legal"),
             start_offset: 0,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -1047,8 +1248,8 @@ fn test_illegal() {
             lit: String::from("@"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     assert_eq!(
@@ -1058,8 +1259,11 @@ fn test_illegal() {
             lit: String::from("illegal"),
             start_offset: 8,
             end_offset: 15,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 9 },
+            end_pos: Position {
+                line: 1,
+                column: 16
+            }
         }
     );
 
@@ -1072,8 +1276,8 @@ fn test_illegal() {
             lit: String::from("legal"),
             start_offset: 0,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -1083,8 +1287,8 @@ fn test_illegal() {
             lit: String::from("@"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     s.unread();
@@ -1095,8 +1299,8 @@ fn test_illegal() {
             lit: String::from("@"),
             start_offset: 6,
             end_offset: 7,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position { line: 1, column: 8 }
         }
     );
     assert_eq!(
@@ -1106,8 +1310,11 @@ fn test_illegal() {
             lit: String::from("illegal"),
             start_offset: 8,
             end_offset: 15,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 9 },
+            end_pos: Position {
+                line: 1,
+                column: 16
+            }
         }
     );
 }
@@ -1124,8 +1331,8 @@ fn test_scan_duration() {
             lit: String::from("dur"),
             start_offset: 0,
             end_offset: 3,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 4 }
         }
     );
     assert_eq!(
@@ -1135,8 +1342,8 @@ fn test_scan_duration() {
             lit: String::from("="),
             start_offset: 4,
             end_offset: 5,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 5 },
+            end_pos: Position { line: 1, column: 6 }
         }
     );
     assert_eq!(
@@ -1146,8 +1353,11 @@ fn test_scan_duration() {
             lit: String::from("1y3mo2w1d4h1m30s1ms2µs70ns"),
             start_offset: 6,
             end_offset: 33,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 7 },
+            end_pos: Position {
+                line: 1,
+                column: 34
+            }
         }
     );
     assert_eq!(
@@ -1246,8 +1456,8 @@ c = 1 + 2
             lit: String::from("ms"),
             start_offset: 0,
             end_offset: 2,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 3 }
         }
     );
     assert_eq!(s.pos(0), Position { line: 1, column: 1 });
@@ -1258,8 +1468,8 @@ c = 1 + 2
             lit: String::from("="),
             start_offset: 3,
             end_offset: 4,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 4 },
+            end_pos: Position { line: 1, column: 5 }
         }
     );
     assert_eq!(s.pos(3), Position { line: 1, column: 4 });
@@ -1270,8 +1480,8 @@ c = 1 + 2
             lit: String::from("\"multiline\nstring\n\""),
             start_offset: 5,
             end_offset: 24,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 6 },
+            end_pos: Position { line: 3, column: 2 }
         }
     );
     assert_eq!(s.pos(5), Position { line: 1, column: 6 });
@@ -1286,8 +1496,8 @@ c = 1 + 2
             lit: String::from("c"),
             start_offset: 38,
             end_offset: 39,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 1 },
+            end_pos: Position { line: 7, column: 2 }
         }
     );
     assert_eq!(s.pos(38), Position { line: 7, column: 1 });
@@ -1298,8 +1508,8 @@ c = 1 + 2
             lit: String::from("="),
             start_offset: 40,
             end_offset: 41,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 3 },
+            end_pos: Position { line: 7, column: 4 }
         }
     );
     assert_eq!(s.pos(40), Position { line: 7, column: 3 });
@@ -1310,8 +1520,8 @@ c = 1 + 2
             lit: String::from("1"),
             start_offset: 42,
             end_offset: 43,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 5 },
+            end_pos: Position { line: 7, column: 6 }
         }
     );
     assert_eq!(s.pos(42), Position { line: 7, column: 5 });
@@ -1322,8 +1532,8 @@ c = 1 + 2
             lit: String::from("+"),
             start_offset: 44,
             end_offset: 45,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 7 },
+            end_pos: Position { line: 7, column: 8 }
         }
     );
     assert_eq!(s.pos(44), Position { line: 7, column: 7 });
@@ -1334,8 +1544,11 @@ c = 1 + 2
             lit: String::from("2"),
             start_offset: 46,
             end_offset: 47,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 9 },
+            end_pos: Position {
+                line: 7,
+                column: 10
+            }
         }
     );
     assert_eq!(s.pos(46), Position { line: 7, column: 9 });
@@ -1436,8 +1649,8 @@ c = 1 + 2
             lit: String::from("ms"),
             start_offset: 0,
             end_offset: 2,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 1 },
+            end_pos: Position { line: 1, column: 3 }
         }
     );
     assert_eq!(0, s.offset(Position { line: 1, column: 1 }));
@@ -1448,8 +1661,8 @@ c = 1 + 2
             lit: String::from("="),
             start_offset: 3,
             end_offset: 4,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 4 },
+            end_pos: Position { line: 1, column: 5 }
         }
     );
     assert_eq!(3, s.offset(Position { line: 1, column: 4 }));
@@ -1460,8 +1673,8 @@ c = 1 + 2
             lit: String::from("\"multiline\nstring\n\""),
             start_offset: 5,
             end_offset: 24,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 1, column: 6 },
+            end_pos: Position { line: 3, column: 2 }
         }
     );
     assert_eq!(5, s.offset(Position { line: 1, column: 6 }));
@@ -1476,8 +1689,8 @@ c = 1 + 2
             lit: String::from("c"),
             start_offset: 38,
             end_offset: 39,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 1 },
+            end_pos: Position { line: 7, column: 2 }
         }
     );
     assert_eq!(38, s.offset(Position { line: 7, column: 1 }));
@@ -1488,8 +1701,8 @@ c = 1 + 2
             lit: String::from("="),
             start_offset: 40,
             end_offset: 41,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 3 },
+            end_pos: Position { line: 7, column: 4 }
         }
     );
     assert_eq!(40, s.offset(Position { line: 7, column: 3 }));
@@ -1500,8 +1713,8 @@ c = 1 + 2
             lit: String::from("1"),
             start_offset: 42,
             end_offset: 43,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 5 },
+            end_pos: Position { line: 7, column: 6 }
         }
     );
     assert_eq!(42, s.offset(Position { line: 7, column: 5 }));
@@ -1512,8 +1725,8 @@ c = 1 + 2
             lit: String::from("+"),
             start_offset: 44,
             end_offset: 45,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 7 },
+            end_pos: Position { line: 7, column: 8 }
         }
     );
     assert_eq!(44, s.offset(Position { line: 7, column: 7 }));
@@ -1524,8 +1737,11 @@ c = 1 + 2
             lit: String::from("2"),
             start_offset: 46,
             end_offset: 47,
-            start_pos: Position { line: 0, column: 0 },
-            end_pos: Position { line: 0, column: 0 }
+            start_pos: Position { line: 7, column: 9 },
+            end_pos: Position {
+                line: 7,
+                column: 10
+            }
         }
     );
     assert_eq!(46, s.offset(Position { line: 7, column: 9 }));


### PR DESCRIPTION
We currently use a linked list (which needs `alloc` and `free`) to keep track of where newlines are when scanning tokens.  This was problematic because the wasm build has poor support for these C library functions.

This PR does the following:
- Avoids using `malloc` inside of the C code that hosts the Ragel scanner, by tracking newlines in- and outside of tokens.  The returned token now contains both offset and line/column for its beginning and end.
- Makes some minor tweaks to the docker file that does the wasm build on Mac.
- Removes the `Scanner::pos()` method (which translates from buffer offset to line/col) from the public interface of the scanner, since this info is now available directly from the token.
- The parser still needs to go from line/column back to an offset to get the raw source for each AST node.  To achieve this, I re-implemented the `Scanner::offset()` method using a hash map.
- We previously were not able to correctly compute line/column when doing an `unread` (needed to correctly handle regular expressions), this fixes that issue and adds a test.
- We also had a similar issue when creating a `BadStatement` or `BadExpression` due to an invalid token.

I took care to ensure that we get the same answer as before by keeping both mechanisms for determining line/column around and using `assert_eq!` that they are the same (and then deleting the linked list code once I was convinced)