### PR TITLE
feat(tableutil): add internal table utility for streaming tables

### DIFF
--- a/arrow/repeat.go
+++ b/arrow/repeat.go
@@ -1,0 +1,69 @@
+package arrow
+
+import (
+	"fmt"
+
+	"github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// Repeat will construct an arrow array that repeats
+// the value n times.
+func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
+	switch v.Type() {
+	case semantic.Int:
+		b := array.NewInt64Builder(mem)
+		b.Reserve(n)
+		v := v.Int()
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
+		return b.NewArray()
+	case semantic.UInt:
+		b := array.NewUint64Builder(mem)
+		b.Reserve(n)
+		v := v.UInt()
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
+		return b.NewArray()
+	case semantic.Float:
+		b := array.NewFloat64Builder(mem)
+		b.Reserve(n)
+		v := v.Float()
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
+		return b.NewArray()
+	case semantic.String:
+		b := array.NewBinaryBuilder(mem, arrow.BinaryTypes.String)
+		b.Reserve(n)
+		b.ReserveData(n * len(v.Str()))
+		v := v.Str()
+		for i := 0; i < n; i++ {
+			b.AppendString(v)
+		}
+		return b.NewArray()
+	case semantic.Bool:
+		b := array.NewBooleanBuilder(mem)
+		b.Reserve(n)
+		v := v.Bool()
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
+		return b.NewArray()
+	case semantic.Time:
+		b := array.NewInt64Builder(mem)
+		b.Reserve(n)
+		v := int64(v.Time())
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
+		return b.NewArray()
+	default:
+		panic(fmt.Errorf("unknown builder for type: %s", v.Type()))
+	}
+}

--- a/internal/execute/tableutil/stream.go
+++ b/internal/execute/tableutil/stream.go
@@ -1,0 +1,187 @@
+package tableutil
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// SendFunc is used to send a flux.ColReader to a table stream so
+// it can be read by the table consumer.
+type SendFunc func(flux.ColReader)
+
+// Stream will call StreamWithContext with a background context.
+func Stream(f func(ctx context.Context, fn SendFunc) error) (flux.Table, error) {
+	return StreamWithContext(context.Background(), f)
+}
+
+// StreamWithContext will create a table that streams column readers
+// through the flux.Table. This method will return only after
+// the function buffers the first column reader.
+// This first column reader is used to identify the group key
+// and columns for the entire table stream.
+//
+// Implementors using this *must* return at least one table.
+// If the function returns without returning at least one table,
+// then an error will be returned. If the first table that is returned
+// is empty, then this will return an empty table and further buffers
+// will not be used.
+func StreamWithContext(ctx context.Context, f func(ctx context.Context, fn SendFunc) error) (flux.Table, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	ch := make(chan streamBuffer)
+
+	// Create the send method.
+	send := func(cr flux.ColReader) {
+		select {
+		case ch <- streamBuffer{cr: cr}:
+		case <-ctx.Done():
+			// We could not send the column reader because this was cancelled.
+			cr.Release()
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(ch)
+		if err := f(ctx, send); err != nil {
+			ch <- streamBuffer{err: err}
+		}
+	}()
+
+	select {
+	case sp := <-ch:
+		cr, err := sp.cr, sp.err
+		if cr == nil {
+			if err == nil {
+				err = errors.New(codes.Internal, "empty table stream")
+			}
+			cancel()
+			return nil, err
+		}
+
+		// Retrieve the group key and columns from the column reader.
+		key, cols := cr.Key(), cr.Cols()
+
+		// If the table is empty, signal to the context
+		// that we are not expecting more tables just
+		// in case the implementor does something wrong.
+		// We also release the column reader since we don't need
+		// it anymore and set it to nil.
+		empty := cr.Len() == 0
+		if empty {
+			cancel()
+			cr.Release()
+			cr = nil
+		}
+		return &streamTable{
+			first:  cr,
+			key:    key,
+			cols:   cols,
+			cancel: cancel,
+			ch:     ch,
+			done:   done,
+			empty:  empty,
+		}, nil
+	case <-ctx.Done():
+		cancel()
+		return nil, ctx.Err()
+	}
+}
+
+// streamBuffer is a column reader or error sent
+// from the streaming function.
+type streamBuffer struct {
+	cr  flux.ColReader
+	err error
+}
+
+// streamTable is an implementation of flux.Table
+// that will stream buffers from a column reader.
+type streamTable struct {
+	used   int32
+	first  flux.ColReader
+	key    flux.GroupKey
+	cols   []flux.ColMeta
+	cancel func()
+	ch     <-chan streamBuffer
+	done   <-chan struct{}
+	empty  bool
+}
+
+func (s *streamTable) Key() flux.GroupKey {
+	return s.key
+}
+
+func (s *streamTable) Cols() []flux.ColMeta {
+	return s.cols
+}
+
+func (s *streamTable) Do(f func(flux.ColReader) error) error {
+	if !atomic.CompareAndSwapInt32(&s.used, 0, 1) {
+		return errors.New(codes.Internal, "table already read")
+	}
+
+	// Ensure that we always call cancel to free any resources from
+	// the context after we have completely read the channel.
+	defer s.cancel()
+
+	// If the table is empty, return immediately.
+	// We already released the column reader.
+	if s.empty {
+		return nil
+	}
+
+	// Act on the first column reader that was read.
+	if err := f(s.first); err != nil {
+		s.first.Release()
+		s.first = nil
+		return nil
+	}
+	s.first.Release()
+	s.first = nil
+
+	for sp := range s.ch {
+		cr, err := sp.cr, sp.err
+		if err != nil {
+			return err
+		}
+		if err := f(cr); err != nil {
+			cr.Release()
+			return err
+		}
+		cr.Release()
+	}
+	// Allow the stream function to exit.
+	<-s.done
+	return nil
+}
+
+func (s *streamTable) Done() {
+	if atomic.CompareAndSwapInt32(&s.used, 0, 1) {
+		if s.first != nil {
+			s.first.Release()
+			s.first = nil
+		}
+		s.cancel()
+	}
+	// Wait for the stream function to exit before we return.
+	<-s.done
+}
+
+func (s *streamTable) Empty() bool {
+	return s.empty
+}
+
+// IsDone is used to allow the tests to access internal parts
+// of the table structure for the table tests.
+// This method can only be used by asserting that it exists
+// through an anonymous interface. This should not be used
+// outside of testing code because there is no guarantee
+// on the safety of this method.
+func (s *streamTable) IsDone() bool {
+	return s.empty || atomic.LoadInt32(&s.used) != 0
+}

--- a/internal/execute/tableutil/stream_test.go
+++ b/internal/execute/tableutil/stream_test.go
@@ -1,0 +1,143 @@
+package tableutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/internal/execute/tableutil"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/values"
+)
+
+type TableIterator []flux.Table
+
+func (t TableIterator) Do(f func(flux.Table) error) error {
+	for _, tbl := range t {
+		if err := f(tbl); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestStream(t *testing.T) {
+	executetest.RunTableTests(t,
+		executetest.TableTest{
+			NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+				// Only a single buffer.
+				tbl1 := MustStreamContext(ctx, func(ctx context.Context, fn tableutil.SendFunc) error {
+					key := execute.NewGroupKey(
+						[]flux.ColMeta{
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "_field", Type: flux.TString},
+						},
+						[]values.Value{
+							values.NewString("m0"),
+							values.NewString("f0"),
+						},
+					)
+					cols := append(key.Cols(),
+						flux.ColMeta{Label: "_time", Type: flux.TTime},
+						flux.ColMeta{Label: "_value", Type: flux.TFloat},
+					)
+					vs := make([]array.Interface, len(cols))
+					vs[0] = arrow.Repeat(key.Value(0), 3, alloc)
+					vs[1] = arrow.Repeat(key.Value(1), 3, alloc)
+					vs[2] = arrow.NewInt([]int64{0, 1, 2}, alloc)
+					vs[3] = arrow.NewFloat([]float64{4, 8, 7}, alloc)
+					fn(&arrow.TableBuffer{
+						GroupKey: key,
+						Columns:  cols,
+						Values:   vs,
+					})
+					return nil
+				})
+				// Multiple buffers.
+				tbl2 := MustStreamContext(ctx, func(ctx context.Context, fn tableutil.SendFunc) error {
+					key := execute.NewGroupKey(
+						[]flux.ColMeta{
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "_field", Type: flux.TString},
+						},
+						[]values.Value{
+							values.NewString("m1"),
+							values.NewString("f0"),
+						},
+					)
+					cols := append(key.Cols(),
+						flux.ColMeta{Label: "_time", Type: flux.TTime},
+						flux.ColMeta{Label: "_value", Type: flux.TFloat},
+					)
+					vs := make([]array.Interface, len(cols))
+					vs[0] = arrow.Repeat(key.Value(0), 3, alloc)
+					vs[1] = arrow.Repeat(key.Value(1), 3, alloc)
+					vs[2] = arrow.NewInt([]int64{0, 1, 2}, alloc)
+					vs[3] = arrow.NewFloat([]float64{4, 8, 7}, alloc)
+					fn(&arrow.TableBuffer{
+						GroupKey: key,
+						Columns:  cols,
+						Values:   vs,
+					})
+
+					vs = make([]array.Interface, len(cols))
+					vs[0] = arrow.Repeat(key.Value(0), 5, alloc)
+					vs[1] = arrow.Repeat(key.Value(1), 5, alloc)
+					vs[2] = arrow.NewInt([]int64{3, 4, 5, 6, 7}, alloc)
+					vs[3] = arrow.NewFloat([]float64{2, 9, 4, 6, 2}, alloc)
+					fn(&arrow.TableBuffer{
+						GroupKey: key,
+						Columns:  cols,
+						Values:   vs,
+					})
+					return nil
+				})
+				// Empty table.
+				tbl3 := MustStreamContext(ctx, func(ctx context.Context, fn tableutil.SendFunc) error {
+					key := execute.NewGroupKey(
+						[]flux.ColMeta{
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "_field", Type: flux.TString},
+						},
+						[]values.Value{
+							values.NewString("m2"),
+							values.NewString("f0"),
+						},
+					)
+					cols := append(key.Cols(),
+						flux.ColMeta{Label: "_time", Type: flux.TTime},
+						flux.ColMeta{Label: "_value", Type: flux.TFloat},
+					)
+					vs := make([]array.Interface, len(cols))
+					for i, col := range cols {
+						vs[i] = arrow.NewBuilder(col.Type, alloc).NewArray()
+					}
+					fn(&arrow.TableBuffer{
+						GroupKey: key,
+						Columns:  cols,
+						Values:   vs,
+					})
+					return nil
+				})
+				return TableIterator(
+					[]flux.Table{tbl1, tbl2, tbl3},
+				)
+			},
+			IsDone: func(tbl flux.Table) bool {
+				return tbl.(interface{ IsDone() bool }).IsDone()
+			},
+		},
+	)
+}
+
+func MustStreamContext(ctx context.Context, f func(ctx context.Context, fn tableutil.SendFunc) error) flux.Table {
+	tbl, err := tableutil.StreamWithContext(ctx, f)
+	if err != nil {
+		panic(err)
+	}
+	return tbl
+}

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -2,16 +2,19 @@ package gen
 
 import (
 	"container/heap"
+	"context"
 	"math"
 	"math/rand"
 	"strings"
 	"time"
 
+	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/execute/tableutil"
 	"github.com/influxdata/flux/memory"
-	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -368,30 +371,64 @@ func (dg *dataGenerator) Do(f func(tbl flux.Table) error) error {
 		sg.Type = vt.Type
 
 		for _, s := range sg.Series {
-			builder := execute.NewColListTableBuilder(s, dg.Allocator)
-			startIdx, _ := builder.AddCol(flux.ColMeta{
-				Label: execute.DefaultStartColLabel,
-				Type:  flux.TTime,
-			})
-			stopIdx, _ := builder.AddCol(flux.ColMeta{
-				Label: execute.DefaultStopColLabel,
-				Type:  flux.TTime,
-			})
-			_ = execute.AddTableKeyCols(s, builder)
-			start, stop := dg.Generate(builder, dg.Rand, sg.Type)
-			for i := 0; i < dg.NumPoints; i++ {
-				_ = builder.AppendTime(startIdx, start)
-				_ = builder.AppendTime(stopIdx, stop)
-				_ = execute.AppendKeyValues(s, builder)
-			}
+			tbl, err := tableutil.Stream(func(ctx context.Context, fn tableutil.SendFunc) error {
+				// Construct the table columns.
+				cols := make([]flux.ColMeta, len(s.Cols())+2)
+				copy(cols, s.Cols())
+				cols[len(cols)-2] = flux.ColMeta{Label: execute.DefaultTimeColLabel, Type: flux.TTime}
+				cols[len(cols)-1] = flux.ColMeta{Label: execute.DefaultValueColLabel, Type: sg.Type}
 
-			table, err := builder.Table()
+				// Only construct the key values once for the first table
+				// and then reuse them for each one with a slice.
+				// The first table should always be the biggest because of
+				// the size constraint.
+				// These are constructed lazily below.
+				keyValues := make([]array.Interface, len(s.Cols()))
+				defer func() {
+					for _, vs := range keyValues {
+						if vs != nil {
+							vs.Release()
+						}
+					}
+				}()
+
+				start, n := dg.Start, dg.NumPoints
+				for n > 0 {
+					tb := &arrow.TableBuffer{
+						GroupKey: s,
+						Columns:  cols,
+						Values:   make([]array.Interface, len(cols)),
+					}
+
+					var ts *array.Int64
+					ts, start, n = dg.generateBufferTimes(start, n)
+					for i, v := range s.Values() {
+						if keyValues[i] == nil {
+							keyValues[i] = arrow.Repeat(v, ts.Len(), dg.Allocator)
+						}
+						vs := keyValues[i]
+						if vs.Len() == ts.Len() {
+							vs.Retain()
+						} else {
+							vs = array.NewSlice(vs, 0, int64(ts.Len()))
+						}
+						tb.Values[i] = vs
+					}
+					tb.Values[len(cols)-2] = ts
+					tb.Values[len(cols)-1] = dg.generateBufferValues(dg.Rand, sg.Type, ts.Len())
+
+					if err := tb.Validate(); err != nil {
+						return err
+					}
+					fn(tb)
+				}
+				return nil
+			})
 			if err != nil {
-				builder.Release()
 				return err
 			}
-			builder.Release()
-			if err := f(table); err != nil {
+
+			if err := f(tbl); err != nil {
 				return err
 			}
 		}
@@ -400,72 +437,47 @@ func (dg *dataGenerator) Do(f func(tbl flux.Table) error) error {
 	return nil
 }
 
-func (dg *dataGenerator) Generate(tb execute.TableBuilder, r *rand.Rand, typ flux.ColType) (start, stop values.Time) {
-	var next func() values.Value
+func (dg *dataGenerator) generateBufferTimes(start values.Time, n int) (ts *array.Int64, stop values.Time, left int) {
+	size := n
+	if size > 1024 {
+		size = 1024
+	}
+
+	b := arrow.NewIntBuilder(dg.Allocator)
+	b.Reserve(size)
+	for stop = start; b.Len() < size; stop = stop.Add(dg.Period) {
+		b.Append(int64(stop))
+	}
+	return b.NewInt64Array(), stop, n - size
+}
+
+func (dg *dataGenerator) generateBufferValues(r *rand.Rand, typ flux.ColType, n int) array.Interface {
 	switch typ {
 	case flux.TFloat:
-		next = func() values.Value {
+		b := arrow.NewFloatBuilder(dg.Allocator)
+		b.Reserve(n)
+		for i := 0; i < n; i++ {
 			if dg.Nulls > 0.0 && dg.Nulls > r.Float64() {
-				return values.NewNull(semantic.Float)
+				b.AppendNull()
 			}
 			v := rand.NormFloat64() * 50
-			return values.NewFloat(v)
+			b.Append(v)
 		}
+		return b.NewArray()
 	case flux.TInt:
-		next = func() values.Value {
+		b := arrow.NewIntBuilder(dg.Allocator)
+		b.Reserve(n)
+		for i := 0; i < n; i++ {
 			if dg.Nulls > 0.0 && dg.Nulls > r.Float64() {
-				return values.NewNull(semantic.Int)
+				b.AppendNull()
 			}
 			v := rand.Intn(201) - 100
-			return values.NewInt(int64(v))
+			b.Append(int64(v))
 		}
-	case flux.TUInt:
-		next = func() values.Value {
-			if dg.Nulls > 0.0 && dg.Nulls > r.Float64() {
-				return values.NewNull(semantic.UInt)
-			}
-			v := rand.Intn(101)
-			return values.NewUInt(uint64(v))
-		}
-	case flux.TString:
-		next = func() values.Value {
-			if dg.Nulls > 0.0 && dg.Nulls > r.Float64() {
-				return values.NewNull(semantic.String)
-			}
-			v := genTagValue(r, 3, 8)
-			return values.NewString(v)
-		}
-	case flux.TBool:
-		next = func() values.Value {
-			if dg.Nulls > 0.0 && dg.Nulls > r.Float64() {
-				return values.NewNull(semantic.Bool)
-			}
-			v := r.Intn(2) == 1
-			return values.NewBool(v)
-		}
+		return b.NewArray()
 	default:
 		panic("implement me")
 	}
-
-	timeIdx, _ := tb.AddCol(flux.ColMeta{
-		Label: execute.DefaultTimeColLabel,
-		Type:  flux.TTime,
-	})
-	valueIdx, _ := tb.AddCol(flux.ColMeta{
-		Label: execute.DefaultValueColLabel,
-		Type:  typ,
-	})
-
-	start, stop = dg.Start, dg.Start
-	for i, ts := 0, dg.Start; i < dg.NumPoints; i, ts = i+1, ts.Add(dg.Period) {
-		_ = tb.AppendTime(timeIdx, ts)
-		_ = tb.AppendValue(valueIdx, next())
-		_ = tb.AppendValue(valueIdx, next())
-		if ts > stop {
-			stop = ts
-		}
-	}
-	return start, stop
 }
 
 type result struct {

--- a/internal/gen/input_test.go
+++ b/internal/gen/input_test.go
@@ -1,0 +1,73 @@
+package gen_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/internal/gen"
+	"github.com/influxdata/flux/memory"
+)
+
+func TestInput_TableTest(t *testing.T) {
+	executetest.RunTableTests(t, executetest.TableTest{
+		NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+			schema := gen.Schema{
+				Tags: []gen.Tag{
+					{Name: "_measurement", Cardinality: 1},
+					{Name: "_field", Cardinality: 1},
+					{Name: "t0", Cardinality: 100},
+				},
+				NumPoints: 100,
+				Alloc:     alloc,
+			}
+			tables, err := gen.Input(schema)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return tables
+		},
+		IsDone: func(tbl flux.Table) bool {
+			return tbl.(interface{ IsDone() bool }).IsDone()
+		},
+	})
+}
+
+func benchmarkInput(b *testing.B, n int) {
+	schema := gen.Schema{
+		Tags: []gen.Tag{
+			{Name: "_measurement", Cardinality: 1},
+			{Name: "_field", Cardinality: 1},
+			{Name: "t0", Cardinality: 100},
+		},
+		NumPoints: n,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ti, err := gen.Input(schema)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if err := ti.Do(func(tbl flux.Table) error {
+			return nil
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkInput(b *testing.B) {
+	b.Run("1000", func(b *testing.B) {
+		benchmarkInput(b, 1000)
+	})
+	b.Run("100000", func(b *testing.B) {
+		benchmarkInput(b, 100000)
+	})
+	b.Run("1000000", func(b *testing.B) {
+		benchmarkInput(b, 1000000)
+	})
+}


### PR DESCRIPTION
This creates a new utility for constructing a table stream. Its primary
focus is to allow sources that create tables to easily create buffered
table streams. This is demonstrated by updating the internal point
generator so that it will now natively construct arrow arrays using the
arrow table buffer and stream the chunks downstream using the stream
method.

These utilities are being kept as internal packages while we experiment
with possible methods of constructing tables quickly and efficiently.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written