### PR TITLE
refactor: expand the interface for BufferedTable

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -79,6 +79,14 @@ func (tb *tableBuffer) Empty() bool {
 	return len(tb.buffers) == 0
 }
 
+func (tb *tableBuffer) Buffer(i int) flux.ColReader {
+	return tb.buffers[i]
+}
+
+func (tb *tableBuffer) BufferN() int {
+	return len(tb.buffers)
+}
+
 func (tb *tableBuffer) Copy() flux.BufferedTable {
 	for i := tb.i; i < len(tb.buffers); i++ {
 		tb.buffers[i].Retain()

--- a/result.go
+++ b/result.go
@@ -54,6 +54,14 @@ type Table interface {
 type BufferedTable interface {
 	Table
 
+	// Buffer returns the i'th buffer in the buffered table.
+	// This allows accessing the buffered table contents without
+	// using the Table.
+	Buffer(i int) ColReader
+
+	// BufferN returns the number of buffers in this table.
+	BufferN() int
+
 	// Copy will return a copy of the BufferedTable without
 	// consuming the Table itself. If this Table has already
 	// been consumed by the Do method, then this will panic.


### PR DESCRIPTION
The `BufferedTable` now exposes the buffers within the table through two
new methods that give the number of buffers and return the buffers
themselves.

BREAKING CHANGE: The interface for `BufferedTable` changed so
implementors of the interface will need to implement the two new
methods.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written