### PR TITLE
ci: build libflux wasm target in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       - run: make vet
       - run: make staticcheck
       - run: make checkgenerate
+      - run: make libflux-wasm
       - run: make test GO_TEST_FLAGS='-coverprofile=coverage.txt -covermode=atomic'
       - run:
           name: Uploading coverage report

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build: libflux
 
 clean:
 	rm -rf bin
-	cd libflux; $(CARGO) clean
+	cd libflux && $(CARGO) clean && rm -rf pkg
 
 cleangenerate:
 	rm -rf $(GENERATED_TARGETS)
@@ -151,7 +151,8 @@ bench:
 release:
 	./release.sh
 
-
+libflux-wasm:
+	cd libflux && CC=clang AR=llvm-ar wasm-pack build --scope influxdata --dev
 
 .PHONY: generate \
 	clean \
@@ -159,6 +160,7 @@ release:
 	build \
 	default \
 	libflux \
+	libflux-wasm \
 	fmt \
 	checkfmt \
 	tidy \

--- a/libflux/README.md
+++ b/libflux/README.md
@@ -60,7 +60,7 @@ Before running it for the first time, you'll have to follow these steps:
    $ cd ../pkg
    $ yarn link
    $ cd ../site
-   $ yarn link @influxdata/flux-parser
+   $ yarn link @influxdata/flux
    ```
 
 Now you should be able to run the web app:


### PR DESCRIPTION
This adds a `libflux-wasm` target to the Makefile and builds adds that target to the CircleCI configuration.