### PR TITLE
test(usage): Update usage tests to filter out metrics with hostnames containing gateway-internal

### DIFF
--- a/stdlib/testing/usage/api_test.flux
+++ b/stdlib/testing/usage/api_test.flux
@@ -1,6 +1,7 @@
 package usage_test
 
 import "testing"
+import "strings"
 
 // This dataset has been generated with this query:
 // from(bucket: "system_usage")
@@ -1659,6 +1660,15 @@ inData = "
 ,,115,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:55:50.868423971Z,0,resp_bytes,http_request,/api/v2/write,gateway-77ff9ccb7d-j664w,043e0780ee2b1000,204
 ,,115,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:57:45.370635649Z,0,resp_bytes,http_request,/api/v2/write,gateway-77ff9ccb7d-j664w,043e0780ee2b1000,204
 ,,115,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:59:38.077384742Z,0,resp_bytes,http_request,/api/v2/write,gateway-77ff9ccb7d-j664w,043e0780ee2b1000,204
+
+#group,false,false,true,true,false,false,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string,string,string
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,endpoint,hostname,org_id,status
+,,116,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:54:58.578035263Z,0,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-j664w,03cbe13cce931000,204
+,,116,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:55:50.868423971Z,0,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-j664w,03cbe13cce931000,204
+,,116,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:57:45.370635649Z,0,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-j664w,03cbe13cce931000,204
+,,116,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:59:38.077384742Z,0,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-j664w,03cbe13cce931000,204
 "
 
 outData = "
@@ -1676,7 +1686,10 @@ _f = (table=<-) => table
     |> filter(fn: (r) =>
         r.org_id == "03cbe13cce931000"
         and r._measurement == "http_request"
-        and ((r.endpoint == "/api/v2/write" and r._field == "req_bytes") or (r.endpoint == "/api/v2/query" and r._field == "resp_bytes"))
+        and ((r.endpoint == "/api/v2/write" and
+            r._field == "req_bytes" and
+            strings.containsStr(v: r.hostname, substr: "gateway-internal") != true)  or
+        (r.endpoint == "/api/v2/query" and r._field == "resp_bytes"))
     )
     |> group()
     |> aggregateWindow(every: 1h, fn: count)

--- a/stdlib/testing/usage/writes_test.flux
+++ b/stdlib/testing/usage/writes_test.flux
@@ -1,6 +1,7 @@
 package usage_test
 
 import "testing"
+import "strings"
 
 // This dataset has been generated with this query:
 // from(bucket: "system_usage")
@@ -3323,6 +3324,15 @@ inData = "
 ,,45,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:52:40.649498775Z,12735,req_bytes,http_request,/api/v2/write,gateway-77ff9ccb7d-6rltl,043502a6825c5000,204
 ,,45,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:55:00.568727137Z,12447,req_bytes,http_request,/api/v2/write,gateway-77ff9ccb7d-6rltl,043502a6825c5000,204
 ,,45,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T13:56:00.879036783Z,12763,req_bytes,http_request,/api/v2/write,gateway-77ff9ccb7d-6rltl,043502a6825c5000,204
+
+#group,false,false,true,true,false,false,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string,string,string
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,endpoint,hostname,org_id,status
+,,46,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T11:04:00.464241913Z,10000,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-p9w8t,03d01b74c8e09000,204
+,,46,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T11:05:50.453929422Z,10000,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-p9w8t,03d01b74c8e09000,204
+,,46,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T11:08:40.56350665Z,10000,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-p9w8t,03d01b74c8e09000,204
+,,46,2019-08-01T11:00:00Z,2019-08-01T14:00:00Z,2019-08-01T11:09:00.464069692Z,10000,req_bytes,http_request,/api/v2/write,gateway-internal-77ff9ccb7d-p9w8t,03d01b74c8e09000,204
 "
 
 outData = "
@@ -3343,6 +3353,7 @@ _f = (table=<-) => table
         and r._field == "req_bytes"
         and r.endpoint == "/api/v2/write"
         and r.status == "204"
+        and (strings.containsStr(v: r.hostname, substr: "gateway-internal") != true)
     )
     |> group()
     |> aggregateWindow(every: 1h, fn: sum)


### PR DESCRIPTION
Updating the flux tests for usage api count and writes to filter out metrics with hostnames containing gateway-internal.

### Done checklist
- [x] Test cases written
