### PR TITLE
perf(arrow): use resize instead of reserve

### DIFF
--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -7,7 +7,7 @@ import (
 
 func NewBool(vs []bool, alloc *memory.Allocator) *array.Boolean {
 	b := NewBoolBuilder(alloc)
-	b.Reserve(len(vs))
+	b.Resize(len(vs))
 	for _, v := range vs {
 		b.UnsafeAppend(v)
 	}

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -7,7 +7,7 @@ import (
 
 func NewFloat(vs []float64, alloc *memory.Allocator) *array.Float64 {
 	b := NewFloatBuilder(alloc)
-	b.Reserve(len(vs))
+	b.Resize(len(vs))
 	for _, v := range vs {
 		b.UnsafeAppend(v)
 	}

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -7,7 +7,7 @@ import (
 
 func NewInt(vs []int64, alloc *memory.Allocator) *array.Int64 {
 	b := NewIntBuilder(alloc)
-	b.Reserve(len(vs))
+	b.Resize(len(vs))
 	for _, v := range vs {
 		b.UnsafeAppend(v)
 	}

--- a/arrow/repeat.go
+++ b/arrow/repeat.go
@@ -16,7 +16,7 @@ func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 	switch v.Type() {
 	case semantic.Int:
 		b := array.NewInt64Builder(mem)
-		b.Reserve(n)
+		b.Resize(n)
 		v := v.Int()
 		for i := 0; i < n; i++ {
 			b.Append(v)
@@ -24,7 +24,7 @@ func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 		return b.NewArray()
 	case semantic.UInt:
 		b := array.NewUint64Builder(mem)
-		b.Reserve(n)
+		b.Resize(n)
 		v := v.UInt()
 		for i := 0; i < n; i++ {
 			b.Append(v)
@@ -32,7 +32,7 @@ func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 		return b.NewArray()
 	case semantic.Float:
 		b := array.NewFloat64Builder(mem)
-		b.Reserve(n)
+		b.Resize(n)
 		v := v.Float()
 		for i := 0; i < n; i++ {
 			b.Append(v)
@@ -40,7 +40,7 @@ func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 		return b.NewArray()
 	case semantic.String:
 		b := array.NewBinaryBuilder(mem, arrow.BinaryTypes.String)
-		b.Reserve(n)
+		b.Resize(n)
 		b.ReserveData(n * len(v.Str()))
 		v := v.Str()
 		for i := 0; i < n; i++ {
@@ -49,7 +49,7 @@ func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 		return b.NewArray()
 	case semantic.Bool:
 		b := array.NewBooleanBuilder(mem)
-		b.Reserve(n)
+		b.Resize(n)
 		v := v.Bool()
 		for i := 0; i < n; i++ {
 			b.Append(v)
@@ -57,7 +57,7 @@ func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 		return b.NewArray()
 	case semantic.Time:
 		b := array.NewInt64Builder(mem)
-		b.Reserve(n)
+		b.Resize(n)
 		v := int64(v.Time())
 		for i := 0; i < n; i++ {
 			b.Append(v)

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -8,7 +8,7 @@ import (
 
 func NewString(vs []string, alloc *memory.Allocator) *array.Binary {
 	b := NewStringBuilder(alloc)
-	b.Reserve(len(vs))
+	b.Resize(len(vs))
 	sz := 0
 	for _, v := range vs {
 		sz += len(v)

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -7,7 +7,7 @@ import (
 
 func NewUint(vs []uint64, alloc *memory.Allocator) *array.Uint64 {
 	b := NewUintBuilder(alloc)
-	b.Reserve(len(vs))
+	b.Resize(len(vs))
 	for _, v := range vs {
 		b.UnsafeAppend(v)
 	}


### PR DESCRIPTION
Reserve is meant for appending when you don't know the final size of the
array. Resize is meant for when you know the exact size. When using
Reserve, it changes the size to the closest power of 2 that fits the
elements you are going to append while Resize gives you the exact
amount.

When using Reserve, the buffers are very likely to trigger a
reallocation so it can resize the buffers to a smaller amount and incur
a copy between these buffers. To avoid this, it is better to use Resize
when we know the exact size which is true of all of these functions.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written