### PR TITLE
feat(libflux): inject types in the semantic graph

### DIFF
--- a/libflux/src/semantic/mod.rs
+++ b/libflux/src/semantic/mod.rs
@@ -19,9 +19,21 @@ mod tests;
 
 use crate::ast;
 use crate::parser::parse_string;
-use crate::semantic::analyze::Result;
+use crate::semantic::analyze::analyze_with;
+use crate::semantic::analyze::Result as AnalysisResult;
+use crate::semantic::analyze::SemanticError;
+use crate::semantic::env::Environment;
+use crate::semantic::fresh::Fresher;
+use crate::semantic::nodes::Error as InferError;
+use crate::semantic::nodes::{infer_pkg_types, inject_pkg_types, Importer};
 
-pub fn analyze_source(source: &str) -> Result<nodes::Package> {
+impl From<InferError> for SemanticError {
+    fn from(err: InferError) -> SemanticError {
+        err.msg.clone()
+    }
+}
+
+pub fn analyze_source(source: &str) -> AnalysisResult<nodes::Package> {
     let file = parse_string("", source);
     let errs = ast::check::check(ast::walk::Node::File(&file));
     if errs.len() > 0 {
@@ -33,5 +45,9 @@ pub fn analyze_source(source: &str) -> Result<nodes::Package> {
         package: "main".to_string(),
         files: vec![file],
     };
-    analyze(ast_pkg)
+    let mut f = Fresher::new();
+    let mut sem_pkg = analyze_with(ast_pkg, &mut f)?;
+    // TODO(affo): add a stdlib Importer.
+    let (_, sub) = infer_pkg_types(&mut sem_pkg, Environment::empty(), &mut f, &Importer::new())?;
+    Ok(inject_pkg_types(sem_pkg, &sub))
 }

--- a/libflux/src/semantic/sub.rs
+++ b/libflux/src/semantic/sub.rs
@@ -11,10 +11,17 @@ use std::collections::HashMap;
 #[derive(Debug, PartialEq)]
 pub struct Substitution(HashMap<Tvar, MonoType>);
 
-// Derive a substitution from a hash map
+// Derive a substitution from a hash map.
 impl From<HashMap<Tvar, MonoType>> for Substitution {
     fn from(values: HashMap<Tvar, MonoType>) -> Substitution {
         Substitution(values)
+    }
+}
+
+// Derive a hash map from a substitution.
+impl From<Substitution> for HashMap<Tvar, MonoType> {
+    fn from(sub: Substitution) -> HashMap<Tvar, MonoType> {
+        sub.0
     }
 }
 

--- a/libflux/src/semantic/walk/mod.rs
+++ b/libflux/src/semantic/walk/mod.rs
@@ -2,3 +2,6 @@ mod walk;
 mod walk_mut;
 pub use walk::*;
 pub use walk_mut::*;
+
+#[cfg(test)]
+mod test_utils;

--- a/libflux/src/semantic/walk/test_utils.rs
+++ b/libflux/src/semantic/walk/test_utils.rs
@@ -1,0 +1,19 @@
+use crate::ast;
+use crate::parser::parse_string;
+use crate::semantic::analyze;
+use crate::semantic::nodes;
+
+pub fn compile(source: &str) -> nodes::Package {
+    let file = parse_string("", source);
+    let errs = ast::check::check(ast::walk::Node::File(&file));
+    if errs.len() > 0 {
+        panic!(format!("got errors on parsing: {:?}", errs));
+    }
+    let ast_pkg = ast::Package {
+        base: file.base.clone(),
+        path: "".to_string(),
+        package: "main".to_string(),
+        files: vec![file],
+    };
+    analyze(ast_pkg).unwrap()
+}

--- a/libflux/src/semantic/walk/walk.rs
+++ b/libflux/src/semantic/walk/walk.rs
@@ -1,5 +1,6 @@
 use crate::ast::SourceLocation;
 use crate::semantic::nodes::*;
+use crate::semantic::types::MonoType;
 use std::fmt;
 use std::rc::Rc;
 
@@ -141,6 +142,31 @@ impl<'a> Node<'a> {
             Node::InterpolatedPart(n) => &n.loc,
             Node::VariableAssgn(n) => &n.loc,
             Node::MemberAssgn(n) => &n.loc,
+        }
+    }
+    pub fn type_of(&self) -> Option<&MonoType> {
+        match self {
+            Node::IdentifierExpr(n) => Some(&n.typ),
+            Node::ArrayExpr(n) => Some(&n.typ),
+            Node::FunctionExpr(n) => Some(&n.typ),
+            Node::LogicalExpr(n) => Some(&n.typ),
+            Node::ObjectExpr(n) => Some(&n.typ),
+            Node::MemberExpr(n) => Some(&n.typ),
+            Node::IndexExpr(n) => Some(&n.typ),
+            Node::BinaryExpr(n) => Some(&n.typ),
+            Node::UnaryExpr(n) => Some(&n.typ),
+            Node::CallExpr(n) => Some(&n.typ),
+            Node::ConditionalExpr(n) => Some(&n.typ),
+            Node::StringExpr(n) => Some(&n.typ),
+            Node::IntegerLit(n) => Some(&n.typ),
+            Node::FloatLit(n) => Some(&n.typ),
+            Node::StringLit(n) => Some(&n.typ),
+            Node::DurationLit(n) => Some(&n.typ),
+            Node::UintLit(n) => Some(&n.typ),
+            Node::BooleanLit(n) => Some(&n.typ),
+            Node::DateTimeLit(n) => Some(&n.typ),
+            Node::RegexpLit(n) => Some(&n.typ),
+            _ => None,
         }
     }
 }
@@ -448,12 +474,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::semantic::analyze_source;
-    use crate::semantic::nodes;
-
-    fn compile(source: &str) -> nodes::Package {
-        analyze_source(source).unwrap()
-    }
+    use crate::semantic::walk::test_utils::compile;
 
     mod node_ids {
         use super::*;
@@ -834,7 +855,7 @@ mod tests {
 
         #[test]
         fn test_nesting_count() {
-            let mut pkg = compile(
+            let pkg = compile(
                 r#"
 f = () => {
     // 1
@@ -859,7 +880,7 @@ g()
 "#,
             );
             let mut v = NestingCounter { count: 0 };
-            walk(&mut v, Rc::new(Node::Package(&mut pkg)));
+            walk(&mut v, Rc::new(Node::Package(&pkg)));
             assert_eq!(v.count, 5);
         }
 

--- a/libflux/src/semantic/walk/walk_mut.rs
+++ b/libflux/src/semantic/walk/walk_mut.rs
@@ -1,5 +1,6 @@
 use crate::ast::SourceLocation;
 use crate::semantic::nodes::*;
+use crate::semantic::types::MonoType;
 use std::fmt;
 
 /// NodeMut represents any structure that can appear in the semantic graph.
@@ -141,6 +142,100 @@ impl<'a> NodeMut<'a> {
             NodeMut::VariableAssgn(n) => &n.loc,
             NodeMut::MemberAssgn(n) => &n.loc,
         }
+    }
+    pub fn type_of(&self) -> Option<&MonoType> {
+        match self {
+            NodeMut::IdentifierExpr(n) => Some(&n.typ),
+            NodeMut::ArrayExpr(n) => Some(&n.typ),
+            NodeMut::FunctionExpr(n) => Some(&n.typ),
+            NodeMut::LogicalExpr(n) => Some(&n.typ),
+            NodeMut::ObjectExpr(n) => Some(&n.typ),
+            NodeMut::MemberExpr(n) => Some(&n.typ),
+            NodeMut::IndexExpr(n) => Some(&n.typ),
+            NodeMut::BinaryExpr(n) => Some(&n.typ),
+            NodeMut::UnaryExpr(n) => Some(&n.typ),
+            NodeMut::CallExpr(n) => Some(&n.typ),
+            NodeMut::ConditionalExpr(n) => Some(&n.typ),
+            NodeMut::StringExpr(n) => Some(&n.typ),
+            NodeMut::IntegerLit(n) => Some(&n.typ),
+            NodeMut::FloatLit(n) => Some(&n.typ),
+            NodeMut::StringLit(n) => Some(&n.typ),
+            NodeMut::DurationLit(n) => Some(&n.typ),
+            NodeMut::UintLit(n) => Some(&n.typ),
+            NodeMut::BooleanLit(n) => Some(&n.typ),
+            NodeMut::DateTimeLit(n) => Some(&n.typ),
+            NodeMut::RegexpLit(n) => Some(&n.typ),
+            _ => None,
+        }
+    }
+    pub fn set_loc(&mut self, loc: SourceLocation) {
+        let mut_expr_loc = |expr: &mut Expression, loc: SourceLocation| {
+            match expr {
+                Expression::Identifier(ref mut e) => e.loc = loc,
+                Expression::Array(ref mut e) => e.loc = loc,
+                Expression::Function(ref mut e) => e.loc = loc,
+                Expression::Logical(ref mut e) => e.loc = loc,
+                Expression::Object(ref mut e) => e.loc = loc,
+                Expression::Member(ref mut e) => e.loc = loc,
+                Expression::Index(ref mut e) => e.loc = loc,
+                Expression::Binary(ref mut e) => e.loc = loc,
+                Expression::Unary(ref mut e) => e.loc = loc,
+                Expression::Call(ref mut e) => e.loc = loc,
+                Expression::Conditional(ref mut e) => e.loc = loc,
+                Expression::StringExpr(ref mut e) => e.loc = loc,
+                Expression::Integer(ref mut e) => e.loc = loc,
+                Expression::Float(ref mut e) => e.loc = loc,
+                Expression::StringLit(ref mut e) => e.loc = loc,
+                Expression::Duration(ref mut e) => e.loc = loc,
+                Expression::Uint(ref mut e) => e.loc = loc,
+                Expression::Boolean(ref mut e) => e.loc = loc,
+                Expression::DateTime(ref mut e) => e.loc = loc,
+                Expression::Regexp(ref mut e) => e.loc = loc,
+            };
+        };
+        match self {
+            NodeMut::Package(ref mut n) => n.loc = loc,
+            NodeMut::File(ref mut n) => n.loc = loc,
+            NodeMut::PackageClause(ref mut n) => n.loc = loc,
+            NodeMut::ImportDeclaration(ref mut n) => n.loc = loc,
+            NodeMut::Identifier(ref mut n) => n.loc = loc,
+            NodeMut::IdentifierExpr(ref mut n) => n.loc = loc,
+            NodeMut::ArrayExpr(ref mut n) => n.loc = loc,
+            NodeMut::FunctionExpr(ref mut n) => n.loc = loc,
+            NodeMut::FunctionParameter(ref mut n) => n.loc = loc,
+            NodeMut::LogicalExpr(ref mut n) => n.loc = loc,
+            NodeMut::ObjectExpr(ref mut n) => n.loc = loc,
+            NodeMut::MemberExpr(ref mut n) => n.loc = loc,
+            NodeMut::IndexExpr(ref mut n) => n.loc = loc,
+            NodeMut::BinaryExpr(ref mut n) => n.loc = loc,
+            NodeMut::UnaryExpr(ref mut n) => n.loc = loc,
+            NodeMut::CallExpr(ref mut n) => n.loc = loc,
+            NodeMut::ConditionalExpr(ref mut n) => n.loc = loc,
+            NodeMut::StringExpr(ref mut n) => n.loc = loc,
+            NodeMut::IntegerLit(ref mut n) => n.loc = loc,
+            NodeMut::FloatLit(ref mut n) => n.loc = loc,
+            NodeMut::StringLit(ref mut n) => n.loc = loc,
+            NodeMut::DurationLit(ref mut n) => n.loc = loc,
+            NodeMut::UintLit(ref mut n) => n.loc = loc,
+            NodeMut::BooleanLit(ref mut n) => n.loc = loc,
+            NodeMut::DateTimeLit(ref mut n) => n.loc = loc,
+            NodeMut::RegexpLit(ref mut n) => n.loc = loc,
+            NodeMut::ExprStmt(ref mut n) => n.loc = loc,
+            NodeMut::OptionStmt(ref mut n) => n.loc = loc,
+            NodeMut::ReturnStmt(ref mut n) => n.loc = loc,
+            NodeMut::TestStmt(ref mut n) => n.loc = loc,
+            NodeMut::BuiltinStmt(ref mut n) => n.loc = loc,
+            NodeMut::Block(Block::Variable(ref mut assgn, _)) => assgn.loc = loc,
+            NodeMut::Block(Block::Expr(ref mut estmt, _)) => {
+                mut_expr_loc(&mut estmt.expression, loc)
+            }
+            NodeMut::Block(Block::Return(ref mut expr)) => mut_expr_loc(expr, loc),
+            NodeMut::Property(ref mut n) => n.loc = loc,
+            NodeMut::TextPart(ref mut n) => n.loc = loc,
+            NodeMut::InterpolatedPart(ref mut n) => n.loc = loc,
+            NodeMut::VariableAssgn(ref mut n) => n.loc = loc,
+            NodeMut::MemberAssgn(ref mut n) => n.loc = loc,
+        };
     }
 }
 
@@ -422,12 +517,7 @@ where
 mod tests {
     use super::*;
     use crate::ast;
-    use crate::semantic::analyze_source;
-    use crate::semantic::nodes;
-
-    fn compile(source: &str) -> nodes::Package {
-        analyze_source(source).unwrap()
-    }
+    use crate::semantic::walk::test_utils::compile;
 
     mod node_ids {
         use super::*;
@@ -876,78 +966,8 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                 assert_ne!(loc, base_loc);
             }
             // now mutate the locations
-            let mut_expr_loc = |expr: &mut Expression| {
-                match expr {
-                    Expression::Identifier(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Array(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Function(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Logical(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Object(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Member(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Index(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Binary(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Unary(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Call(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Conditional(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::StringExpr(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Integer(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Float(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::StringLit(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Duration(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Uint(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Boolean(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::DateTime(ref mut e) => e.loc = base_loc.clone(),
-                    Expression::Regexp(ref mut e) => e.loc = base_loc.clone(),
-                };
-            };
             walk_mut(
-                &mut |n: &mut NodeMut| {
-                    match n {
-                        NodeMut::Package(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::File(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::PackageClause(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::ImportDeclaration(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::Identifier(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::IdentifierExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::ArrayExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::FunctionExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::FunctionParameter(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::LogicalExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::ObjectExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::MemberExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::IndexExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::BinaryExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::UnaryExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::CallExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::ConditionalExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::StringExpr(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::IntegerLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::FloatLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::StringLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::DurationLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::UintLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::BooleanLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::DateTimeLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::RegexpLit(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::ExprStmt(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::OptionStmt(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::ReturnStmt(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::TestStmt(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::BuiltinStmt(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::Block(Block::Variable(ref mut assgn, _)) => {
-                            assgn.loc = base_loc.clone()
-                        }
-                        NodeMut::Block(Block::Expr(ref mut estmt, _)) => {
-                            mut_expr_loc(&mut estmt.expression)
-                        }
-                        NodeMut::Block(Block::Return(ref mut expr)) => mut_expr_loc(expr),
-                        NodeMut::Property(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::TextPart(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::InterpolatedPart(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::VariableAssgn(ref mut n) => n.loc = base_loc.clone(),
-                        NodeMut::MemberAssgn(ref mut n) => n.loc = base_loc.clone(),
-                    };
-                },
+                &mut |n: &mut NodeMut| n.set_loc(base_loc.clone()),
                 &mut NodeMut::Package(&mut pkg),
             );
             // now assert that every location is the base one

--- a/libflux/tests/analyze_test.rs
+++ b/libflux/tests/analyze_test.rs
@@ -1,0 +1,175 @@
+extern crate flux;
+
+use flux::ast;
+use flux::semantic::analyze_source;
+use flux::semantic::nodes::*;
+use flux::semantic::types::{Function, MonoType, Tvar};
+use flux::semantic::walk::{walk_mut, NodeMut};
+use maplit;
+use std::collections::HashMap;
+
+use pretty_assertions::assert_eq;
+
+#[test]
+fn analyze_end_to_end() {
+    let mut got = analyze_source(
+        r#"
+n = 1
+s = "string"
+f = (a) => a + a
+f(a: n)
+f(a: s)
+        "#,
+    )
+    .unwrap();
+    let f_type = Function {
+        req: maplit::hashmap! {
+            "a".to_string() => MonoType::Var(Tvar(4)),
+        },
+        opt: HashMap::new(),
+        pipe: None,
+        retn: MonoType::Var(Tvar(4)),
+    };
+    let f_call_int_type = Function {
+        req: maplit::hashmap! {
+            "a".to_string() => MonoType::Int,
+        },
+        opt: HashMap::new(),
+        pipe: None,
+        retn: MonoType::Int,
+    };
+    let f_call_string_type = Function {
+        req: maplit::hashmap! {
+            "a".to_string() => MonoType::String,
+        },
+        opt: HashMap::new(),
+        pipe: None,
+        retn: MonoType::String,
+    };
+    let want = Package {
+        loc: ast::BaseNode::default().location,
+        package: "main".to_string(),
+        files: vec![File {
+            loc: ast::BaseNode::default().location,
+            package: None,
+            imports: Vec::new(),
+            body: vec![
+                Statement::Variable(VariableAssgn::new(
+                    Identifier {
+                        loc: ast::BaseNode::default().location,
+                        name: "n".to_string(),
+                    },
+                    Expression::Integer(IntegerLit {
+                        loc: ast::BaseNode::default().location,
+                        typ: MonoType::Int,
+                        value: 1,
+                    }),
+                    ast::BaseNode::default().location,
+                )),
+                Statement::Variable(VariableAssgn::new(
+                    Identifier {
+                        loc: ast::BaseNode::default().location,
+                        name: "s".to_string(),
+                    },
+                    Expression::StringLit(StringLit {
+                        loc: ast::BaseNode::default().location,
+                        typ: MonoType::String,
+                        value: "string".to_string(),
+                    }),
+                    ast::BaseNode::default().location,
+                )),
+                Statement::Variable(VariableAssgn::new(
+                    Identifier {
+                        loc: ast::BaseNode::default().location,
+                        name: "f".to_string(),
+                    },
+                    Expression::Function(Box::new(FunctionExpr {
+                        loc: ast::BaseNode::default().location,
+                        typ: MonoType::Fun(Box::new(f_type)),
+                        params: vec![FunctionParameter {
+                            loc: ast::BaseNode::default().location,
+                            is_pipe: false,
+                            key: Identifier {
+                                loc: ast::BaseNode::default().location,
+                                name: "a".to_string(),
+                            },
+                            default: None,
+                        }],
+                        body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+                            loc: ast::BaseNode::default().location,
+                            typ: MonoType::Var(Tvar(4)),
+                            operator: ast::Operator::AdditionOperator,
+                            left: Expression::Identifier(IdentifierExpr {
+                                loc: ast::BaseNode::default().location,
+                                typ: MonoType::Var(Tvar(4)),
+                                name: "a".to_string(),
+                            }),
+                            right: Expression::Identifier(IdentifierExpr {
+                                loc: ast::BaseNode::default().location,
+                                typ: MonoType::Var(Tvar(4)),
+                                name: "a".to_string(),
+                            }),
+                        }))),
+                    })),
+                    ast::BaseNode::default().location,
+                )),
+                Statement::Expr(ExprStmt {
+                    loc: ast::BaseNode::default().location,
+                    expression: Expression::Call(Box::new(CallExpr {
+                        loc: ast::BaseNode::default().location,
+                        typ: MonoType::Int,
+                        pipe: None,
+                        callee: Expression::Identifier(IdentifierExpr {
+                            loc: ast::BaseNode::default().location,
+                            typ: MonoType::Fun(Box::new(f_call_int_type)),
+                            name: "f".to_string(),
+                        }),
+                        arguments: vec![Property {
+                            loc: ast::BaseNode::default().location,
+                            key: Identifier {
+                                loc: ast::BaseNode::default().location,
+                                name: "a".to_string(),
+                            },
+                            value: Expression::Identifier(IdentifierExpr {
+                                loc: ast::BaseNode::default().location,
+                                typ: MonoType::Int,
+                                name: "n".to_string(),
+                            }),
+                        }],
+                    })),
+                }),
+                Statement::Expr(ExprStmt {
+                    loc: ast::BaseNode::default().location,
+                    expression: Expression::Call(Box::new(CallExpr {
+                        loc: ast::BaseNode::default().location,
+                        typ: MonoType::String,
+                        pipe: None,
+                        callee: Expression::Identifier(IdentifierExpr {
+                            loc: ast::BaseNode::default().location,
+                            typ: MonoType::Fun(Box::new(f_call_string_type)),
+                            name: "f".to_string(),
+                        }),
+                        arguments: vec![Property {
+                            loc: ast::BaseNode::default().location,
+                            key: Identifier {
+                                loc: ast::BaseNode::default().location,
+                                name: "a".to_string(),
+                            },
+                            value: Expression::Identifier(IdentifierExpr {
+                                loc: ast::BaseNode::default().location,
+                                typ: MonoType::String,
+                                name: "s".to_string(),
+                            }),
+                        }],
+                    })),
+                }),
+            ],
+        }],
+    };
+    // We don't want to test the locations, so we override those with the base one.
+    walk_mut(
+        &mut |n: &mut NodeMut| n.set_loc(ast::BaseNode::default().location),
+        &mut NodeMut::Package(&mut got),
+    );
+    assert_eq!(want, got);
+}


### PR DESCRIPTION
This PR adds type injection in the semantic graph.

 - `inject.rs` injects types
 - `semantic::analyze_source` now inject types in the analyzed source;
 - added e2e test for `analyze_source`
 - `Substitutable` change to take `&self` -> this allows to avoid unnecessary type cloning.
 - util methods in `walk::{Node, NodeMut}`.