### PR TITLE
feat(arrow): add support for lazy arrow arrays

### DIFF
--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -25,3 +25,14 @@ func BoolSlice(arr *array.Boolean, i, j int) *array.Boolean {
 func NewBoolBuilder(a *memory.Allocator) *array.BooleanBuilder {
 	return array.NewBooleanBuilder(a)
 }
+
+// AsBools will return the array as a boolean array.
+// This will panic if the array.Interface does not have the
+// bool datatype.
+func AsBools(arr array.Interface) *array.Boolean {
+	if a, ok := arr.(*array.Boolean); ok || As(arr, &a) {
+		return a
+	}
+	// Initiate a panic if we could not typecast this.
+	return arr.(*array.Boolean)
+}

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -25,3 +25,14 @@ func FloatSlice(arr *array.Float64, i, j int) *array.Float64 {
 func NewFloatBuilder(a *memory.Allocator) *array.Float64Builder {
 	return array.NewFloat64Builder(a)
 }
+
+// AsFloats will return the array as a float array.
+// This will panic if the array.Interface does not have the
+// float64 datatype.
+func AsFloats(arr array.Interface) *array.Float64 {
+	if a, ok := arr.(*array.Float64); ok || As(arr, &a) {
+		return a
+	}
+	// Initiate a panic if we could not typecast this.
+	return arr.(*array.Float64)
+}

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -25,3 +25,14 @@ func IntSlice(arr *array.Int64, i, j int) *array.Int64 {
 func NewIntBuilder(a *memory.Allocator) *array.Int64Builder {
 	return array.NewInt64Builder(a)
 }
+
+// AsInts will return the array as an integer array.
+// This will panic if the array.Interface does not have the
+// int64 datatype.
+func AsInts(arr array.Interface) *array.Int64 {
+	if a, ok := arr.(*array.Int64); ok || As(arr, &a) {
+		return a
+	}
+	// Initiate a panic if we could not typecast this.
+	return arr.(*array.Int64)
+}

--- a/arrow/repeat.go
+++ b/arrow/repeat.go
@@ -2,6 +2,8 @@ package arrow
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	"github.com/apache/arrow/go/arrow"
 	"github.com/apache/arrow/go/arrow/array"
@@ -10,60 +12,202 @@ import (
 	"github.com/influxdata/flux/values"
 )
 
-// Repeat will construct an arrow array that repeats
-// the value n times.
+// Repeat will construct an arrow array that repeats the value n times.
 func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
 	switch v.Type() {
 	case semantic.Int:
-		b := array.NewInt64Builder(mem)
-		b.Resize(n)
-		v := v.Int()
-		for i := 0; i < n; i++ {
-			b.Append(v)
-		}
-		return b.NewArray()
+		return RepeatInt(v.Int(), n, mem)
 	case semantic.UInt:
-		b := array.NewUint64Builder(mem)
-		b.Resize(n)
-		v := v.UInt()
-		for i := 0; i < n; i++ {
-			b.Append(v)
-		}
-		return b.NewArray()
+		return RepeatUint(v.UInt(), n, mem)
 	case semantic.Float:
-		b := array.NewFloat64Builder(mem)
-		b.Resize(n)
-		v := v.Float()
-		for i := 0; i < n; i++ {
-			b.Append(v)
-		}
-		return b.NewArray()
+		return RepeatFloat(v.Float(), n, mem)
 	case semantic.String:
-		b := array.NewBinaryBuilder(mem, arrow.BinaryTypes.String)
-		b.Resize(n)
-		b.ReserveData(n * len(v.Str()))
-		v := v.Str()
-		for i := 0; i < n; i++ {
-			b.AppendString(v)
-		}
-		return b.NewArray()
+		return RepeatString(v.Str(), n, mem)
 	case semantic.Bool:
-		b := array.NewBooleanBuilder(mem)
-		b.Resize(n)
-		v := v.Bool()
-		for i := 0; i < n; i++ {
-			b.Append(v)
-		}
-		return b.NewArray()
+		return RepeatBoolean(v.Bool(), n, mem)
 	case semantic.Time:
-		b := array.NewInt64Builder(mem)
-		b.Resize(n)
-		v := int64(v.Time())
-		for i := 0; i < n; i++ {
-			b.Append(v)
-		}
-		return b.NewArray()
+		return RepeatInt(int64(v.Time()), n, mem)
 	default:
 		panic(fmt.Errorf("unknown builder for type: %s", v.Type()))
 	}
+}
+
+// RepeatInt will return an array that repeats an integer n times.
+func RepeatInt(v int64, n int, mem memory.Allocator) array.Interface {
+	return &lazyArray{
+		refCount: 1,
+		dataType: arrow.PrimitiveTypes.Int64,
+		length:   n,
+		init: func(mem memory.Allocator) array.Interface {
+			b := array.NewInt64Builder(mem)
+			b.Resize(n)
+			for i := 0; i < n; i++ {
+				b.Append(v)
+			}
+			return b.NewArray()
+		},
+		mem: mem,
+	}
+}
+
+// RepeatUint will return an array that repeats an unsigned integer n times.
+func RepeatUint(v uint64, n int, mem memory.Allocator) array.Interface {
+	return &lazyArray{
+		refCount: 1,
+		dataType: arrow.PrimitiveTypes.Uint64,
+		length:   n,
+		init: func(mem memory.Allocator) array.Interface {
+			b := array.NewUint64Builder(mem)
+			b.Resize(n)
+			for i := 0; i < n; i++ {
+				b.Append(v)
+			}
+			return b.NewArray()
+		},
+		mem: mem,
+	}
+}
+
+// RepeatFloat will return an array that repeats a float n times.
+func RepeatFloat(v float64, n int, mem memory.Allocator) array.Interface {
+	return &lazyArray{
+		refCount: 1,
+		dataType: arrow.PrimitiveTypes.Float64,
+		length:   n,
+		init: func(mem memory.Allocator) array.Interface {
+			b := array.NewFloat64Builder(mem)
+			b.Resize(n)
+			for i := 0; i < n; i++ {
+				b.Append(v)
+			}
+			return b.NewArray()
+		},
+		mem: mem,
+	}
+}
+
+// RepeatString will return an array that repeats a string n times.
+func RepeatString(v string, n int, mem memory.Allocator) array.Interface {
+	return &lazyArray{
+		refCount: 1,
+		dataType: arrow.BinaryTypes.String,
+		length:   n,
+		init: func(mem memory.Allocator) array.Interface {
+			b := array.NewBinaryBuilder(mem, arrow.BinaryTypes.String)
+			b.Resize(n)
+			b.ReserveData(n * len(v))
+			for i := 0; i < n; i++ {
+				b.AppendString(v)
+			}
+			return b.NewArray()
+		},
+		mem: mem,
+	}
+}
+
+// RepeatBoolean will return an array that repeats a boolean n times.
+func RepeatBoolean(v bool, n int, mem memory.Allocator) array.Interface {
+	return &lazyArray{
+		refCount: 1,
+		dataType: arrow.FixedWidthTypes.Boolean,
+		length:   n,
+		init: func(mem memory.Allocator) array.Interface {
+			// TODO(jsternberg): I think this can be optimized further
+			// because this should just use memset.
+			b := array.NewBooleanBuilder(mem)
+			b.Resize(n)
+			for i := 0; i < n; i++ {
+				b.Append(v)
+			}
+			return b.NewArray()
+		},
+		mem: mem,
+	}
+}
+
+// lazyArray implements a lazily initialized array.
+// When a method on the array.Interface gets called, this will
+// materialize the array exactly once.
+//
+// This can be used for marking that an array of a certain type
+// exists, but wait until it is used until it is initialized.
+// In order to appropriately use these with their realized values,
+// the AsXXX methods should be used.
+type lazyArray struct {
+	refCount int32
+	init     func(memory.Allocator) array.Interface
+	mem      memory.Allocator
+
+	dataType arrow.DataType
+	array    array.Interface
+	length   int
+	mu       sync.RWMutex
+}
+
+func (l *lazyArray) get() array.Interface {
+	l.mu.RLock()
+	if l.array != nil {
+		arr := l.array
+		l.mu.RUnlock()
+		return arr
+	}
+	l.mu.RUnlock()
+
+	// The array has not been created.
+	// Take out the write lock and try to make it.
+	l.mu.Lock()
+	if l.array == nil {
+		l.array = l.init(l.mem)
+	}
+	arr := l.array
+	l.mu.Unlock()
+	return arr
+}
+
+func (l *lazyArray) DataType() arrow.DataType {
+	return l.dataType
+}
+
+func (l *lazyArray) NullN() int {
+	return l.get().NullN()
+}
+
+func (l *lazyArray) NullBitmapBytes() []byte {
+	return l.get().NullBitmapBytes()
+}
+
+func (l *lazyArray) IsNull(i int) bool {
+	return l.get().IsNull(i)
+}
+
+func (l *lazyArray) IsValid(i int) bool {
+	return l.get().IsValid(i)
+}
+
+func (l *lazyArray) Data() *array.Data {
+	return l.get().Data()
+}
+
+func (l *lazyArray) Len() int {
+	return l.length
+}
+
+func (l *lazyArray) Retain() {
+	atomic.AddInt32(&l.refCount, 1)
+}
+
+func (l *lazyArray) Release() {
+	if atomic.AddInt32(&l.refCount, -1) == 0 {
+		l.mu.Lock()
+		if l.array != nil {
+			l.array.Release()
+			l.array = nil
+		}
+		l.mu.Unlock()
+	}
+}
+
+// As will assign the underlying array to the target.
+func (l *lazyArray) As(target interface{}) bool {
+	return As(l.get(), target)
 }

--- a/arrow/repeat_test.go
+++ b/arrow/repeat_test.go
@@ -1,0 +1,90 @@
+package arrow_test
+
+import (
+	"testing"
+
+	stdarrow "github.com/apache/arrow/go/arrow"
+	"github.com/apache/arrow/go/arrow/array"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/values"
+)
+
+func TestRepeat(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		v        interface{}
+		dataType stdarrow.DataType
+		sz       int
+		check    func(t *testing.T, arr array.Interface, mem *memory.Allocator)
+	}{
+		{
+			name:     "Int",
+			v:        int64(5),
+			dataType: stdarrow.PrimitiveTypes.Int64,
+			sz:       stdarrow.Int64Traits.BytesRequired(100),
+			check: func(t *testing.T, arr array.Interface, mem *memory.Allocator) {
+				// Convert the array to an integer.
+				a := arrow.AsInts(arr)
+				for i := 0; i < 100; i++ {
+					if got, want := a.Value(i), int64(5); got != want {
+						t.Fatalf("unexpected value at index %d -want/+got:\n\t- %d\n\t+ %d", i, want, got)
+					}
+				}
+
+				// Use AsInts again.
+				b := arrow.AsInts(arr)
+				for i := 0; i < 100; i++ {
+					if got, want := a.Value(i), int64(5); got != want {
+						t.Fatalf("unexpected value at index %d -want/+got:\n\t- %d\n\t+ %d", i, want, got)
+					}
+				}
+
+				// Retain a reference and ensure the memory is still allocated.
+				a.Retain()
+				b.Retain()
+				arr.Release()
+				mem.AssertSizeAtLeast(t, 1)
+
+				// Release both of these arrays.
+				a.Release()
+				b.Release()
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mem := &memory.Allocator{}
+			defer mem.AssertSize(t, 0)
+
+			// Create an array with repeat using the value.
+			arr := arrow.Repeat(values.New(tt.v), 100, mem)
+
+			// This should not actually trigger any allocations.
+			mem.AssertSize(t, 0)
+
+			// The length should be 10 and should not trigger allocations.
+			if got, want := arr.Len(), 100; got != want {
+				t.Errorf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+			}
+
+			// The data type is the same.
+			if got, want := arr.DataType(), tt.dataType; got != want {
+				t.Errorf("unexpected data type -want/+got:\n\t- %v\n\t+ %v", want, got)
+			}
+
+			// IsValid should return true.
+			if got := arr.IsValid(0); !got {
+				t.Error("unexpected result for checking validity")
+			}
+
+			// The size should not be zero anymore.
+			mem.AssertSizeAtLeast(t, 1)
+
+			// Run custom checks on the actual array.
+			tt.check(t, arr, mem)
+
+			// Release the array.
+			arr.Release()
+		})
+	}
+}

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -31,3 +31,14 @@ func StringSlice(arr *array.Binary, i, j int) *array.Binary {
 func NewStringBuilder(a *memory.Allocator) *array.BinaryBuilder {
 	return array.NewBinaryBuilder(a, arrow.BinaryTypes.String)
 }
+
+// AsStrings will return the array as a string array.
+// This will panic if the array.Interface does not have the
+// string datatype.
+func AsStrings(arr array.Interface) *array.Binary {
+	if a, ok := arr.(*array.Binary); ok || As(arr, &a) {
+		return a
+	}
+	// Initiate a panic if we could not typecast this.
+	return arr.(*array.Binary)
+}

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -25,3 +25,14 @@ func UintSlice(arr *array.Uint64, i, j int) *array.Uint64 {
 func NewUintBuilder(a *memory.Allocator) *array.Uint64Builder {
 	return array.NewUint64Builder(a)
 }
+
+// AsUints will return the array as an unsigned integer array.
+// This will panic if the array.Interface does not have the
+// uint64 datatype.
+func AsUints(arr array.Interface) *array.Uint64 {
+	if a, ok := arr.(*array.Uint64); ok || As(arr, &a) {
+		return a
+	}
+	// Initiate a panic if we could not typecast this.
+	return arr.(*array.Uint64)
+}

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -216,6 +216,25 @@ func (a *Allocator) allocator() memory.Allocator {
 	return a.Allocator
 }
 
+type TestingT interface {
+	Errorf(format string, args ...interface{})
+	Helper()
+}
+
+func (a *Allocator) AssertSize(t TestingT, sz int64) {
+	if got, want := a.Allocated(), sz; got != want {
+		t.Helper()
+		t.Errorf("invalid memory size -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+
+func (a *Allocator) AssertSizeAtLeast(t TestingT, sz int64) {
+	if got, want := a.Allocated(), sz; got < want {
+		t.Helper()
+		t.Errorf("invalid memory size -want/+got:\n\t- at least %d\n\t+ %d", want, got)
+	}
+}
+
 // Manager will manage the memory allowed for the Allocator.
 // The Allocator may use the Manager to request additional memory or to
 // give back memory that is currently in use by the Allocator


### PR DESCRIPTION
This adds support for lazy arrow arrays. The lazy array implements the
`array.Interface` interface, but exposes an interface that allows it to
be converted to the appropriate underlying arrow type if it needs to be
materialized.

This follows a similar pattern to the new error API where there is an
`As` function in the arrow package and it will first check if the array
interface is assignable to the array type directly or if it can be
coerced with `As`. So to type cast an arrow array, you would do this:

    var arr *array.Int64
    if arrow.As(myArr, &arr) {
        return arr
    }

Functions for each of the arrow array types have been added to do this
more easily and to panic when it doesn't work so these can be integrated
easily with the `flux.ColReader`.

This allows `Repeat` to create an array implementation that can
materialize the arrow array at a later time rather than immediately.

Related to influxdata/influxdb#15985.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written