### PR TITLE
fix(arrow): add a generic slice function to the arrow utils and fix binary slices

### DIFF
--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -17,9 +17,7 @@ func NewBool(vs []bool, alloc *memory.Allocator) *array.Boolean {
 }
 
 func BoolSlice(arr *array.Boolean, i, j int) *array.Boolean {
-	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
-	defer data.Release()
-	return array.NewBooleanData(data)
+	return Slice(arr, i, j).(*array.Boolean)
 }
 
 func NewBoolBuilder(a *memory.Allocator) *array.BooleanBuilder {

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -17,9 +17,7 @@ func NewFloat(vs []float64, alloc *memory.Allocator) *array.Float64 {
 }
 
 func FloatSlice(arr *array.Float64, i, j int) *array.Float64 {
-	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
-	defer data.Release()
-	return array.NewFloat64Data(data)
+	return Slice(arr, i, j).(*array.Float64)
 }
 
 func NewFloatBuilder(a *memory.Allocator) *array.Float64Builder {

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -17,9 +17,7 @@ func NewInt(vs []int64, alloc *memory.Allocator) *array.Int64 {
 }
 
 func IntSlice(arr *array.Int64, i, j int) *array.Int64 {
-	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
-	defer data.Release()
-	return array.NewInt64Data(data)
+	return Slice(arr, i, j).(*array.Int64)
 }
 
 func NewIntBuilder(a *memory.Allocator) *array.Int64Builder {

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -23,9 +23,7 @@ func NewString(vs []string, alloc *memory.Allocator) *array.Binary {
 }
 
 func StringSlice(arr *array.Binary, i, j int) *array.Binary {
-	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
-	defer data.Release()
-	return array.NewBinaryData(data)
+	return Slice(arr, i, j).(*array.Binary)
 }
 
 func NewStringBuilder(a *memory.Allocator) *array.BinaryBuilder {

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -17,9 +17,7 @@ func NewUint(vs []uint64, alloc *memory.Allocator) *array.Uint64 {
 }
 
 func UintSlice(arr *array.Uint64, i, j int) *array.Uint64 {
-	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
-	defer data.Release()
-	return array.NewUint64Data(data)
+	return Slice(arr, i, j).(*array.Uint64)
 }
 
 func NewUintBuilder(a *memory.Allocator) *array.Uint64Builder {

--- a/arrow/utils.go
+++ b/arrow/utils.go
@@ -120,3 +120,19 @@ func AppendTime(b array.Builder, v values.Time) error {
 	vb.Append(int64(v))
 	return nil
 }
+
+// Slice will construct a new slice of the array using the given
+// start and stop index. The returned array must be released.
+//
+// This is functionally equivalent to using array.NewSlice,
+// but array.NewSlice will construct an array.String when
+// the data type is a string rather than an array.Binary.
+func Slice(arr array.Interface, i, j int) array.Interface {
+	data := array.NewSliceData(arr.Data(), int64(i), int64(j))
+	defer data.Release()
+	// TODO(jsternberg): https://github.com/influxdata/flux/issues/2157
+	if _, ok := arr.(*array.Binary); ok {
+		return array.NewBinaryData(data)
+	}
+	return array.MakeFromData(data)
+}

--- a/execute/executetest/aggregate.go
+++ b/execute/executetest/aggregate.go
@@ -20,11 +20,11 @@ func AggFuncTestHelper(t *testing.T, agg execute.Aggregate, data *array.Float64,
 	h := data.Len() / 2
 	vf := agg.NewFloatAgg()
 
-	d := arrow.FloatSlice(data, 0, h)
+	d := arrow.Slice(data, 0, h).(*array.Float64)
 	vf.DoFloat(d)
 	d.Release()
 	if h < data.Len() {
-		d := arrow.FloatSlice(data, h, data.Len())
+		d := arrow.Slice(data, h, data.Len()).(*array.Float64)
 		vf.DoFloat(d)
 		d.Release()
 	}

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -332,21 +332,8 @@ func (t *RowWiseTable) Do(f func(flux.ColReader) error) error {
 	l := cols[0].Len()
 	for i := 0; i < l; i++ {
 		row := make([]array.Interface, len(t.ColMeta))
-		for j, col := range t.ColMeta {
-			switch col.Type {
-			case flux.TBool:
-				row[j] = arrow.BoolSlice(cols[j].(*array.Boolean), i, i+1)
-			case flux.TFloat:
-				row[j] = arrow.FloatSlice(cols[j].(*array.Float64), i, i+1)
-			case flux.TInt:
-				row[j] = arrow.IntSlice(cols[j].(*array.Int64), i, i+1)
-			case flux.TString:
-				row[j] = arrow.StringSlice(cols[j].(*array.Binary), i, i+1)
-			case flux.TTime:
-				row[j] = arrow.IntSlice(cols[j].(*array.Int64), i, i+1)
-			case flux.TUInt:
-				row[j] = arrow.UintSlice(cols[j].(*array.Uint64), i, i+1)
-			}
+		for j := range t.ColMeta {
+			row[j] = arrow.Slice(cols[j], i, i+1)
 		}
 		if err := f(&ColReader{
 			key:  t.Key(),

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -410,7 +410,7 @@ func (dg *dataGenerator) Do(f func(tbl flux.Table) error) error {
 						if vs.Len() == ts.Len() {
 							vs.Retain()
 						} else {
-							vs = array.NewSlice(vs, 0, int64(ts.Len()))
+							vs = arrow.Slice(vs, 0, ts.Len())
 						}
 						tb.Values[i] = vs
 					}

--- a/internal/moving_average/array_container.go
+++ b/internal/moving_average/array_container.go
@@ -61,22 +61,9 @@ func (a *ArrayContainer) OrigValue(i int) interface{} {
 }
 
 func (a *ArrayContainer) Slice(i int, j int) *ArrayContainer {
-	slice := &ArrayContainer{}
-	switch a.array.(type) {
-	case *array.Boolean:
-		slice.array = arrow.BoolSlice(a.array.(*array.Boolean), i, j)
-	case *array.Int64:
-		slice.array = arrow.IntSlice(a.array.(*array.Int64), i, j)
-	case *array.Uint64:
-		slice.array = arrow.UintSlice(a.array.(*array.Uint64), i, j)
-	case *array.Float64:
-		slice.array = arrow.FloatSlice(a.array.(*array.Float64), i, j)
-	case *array.Binary:
-		slice.array = arrow.StringSlice(a.array.(*array.Binary), i, j)
-	default:
-		slice.array = nil
+	return &ArrayContainer{
+		array: arrow.Slice(a.array, i, j),
 	}
-	return slice
 }
 
 func (a *ArrayContainer) Array() array.Interface {


### PR DESCRIPTION
The generic slice function can be used to create a slice from any array
and the existing slice utilities have been updated to use that. This
slice function mostly exists because binary slices don't work properly.

When you create a slice from a binary type that uses string, the arrow
slice function decides that it should be an `*array.String` instead of
`*array.Binary` and this messes up the column reader.

This fixes that problem by ensuring that it produces a `*array.Binary`
instead until we migrate over to `*array.String` as the canonical type.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written