### PR TITLE
feat(libflux/semantic): serialize semantic graph flatbuffers

### DIFF
--- a/libflux/src/flux/ast/flatbuffers/mod.rs
+++ b/libflux/src/flux/ast/flatbuffers/mod.rs
@@ -692,7 +692,6 @@ impl<'a> ast::walk::Visitor<'a> for SerializingVisitor<'a> {
                         package,
                         imports,
                         body,
-                        ..fbast::FileArgs::default()
                     },
                 );
                 v.files.push(f);

--- a/libflux/src/flux/semantic/flatbuffers/mod.rs
+++ b/libflux/src/flux/semantic/flatbuffers/mod.rs
@@ -1,3 +1,1151 @@
 #![allow(clippy::all)]
 pub mod semantic_generated;
 pub mod types;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::ast;
+
+use crate::semantic;
+use crate::semantic::walk;
+use flatbuffers::{UnionWIPOffset, WIPOffset};
+use semantic_generated::fbsemantic;
+
+extern crate chrono;
+use chrono::Offset;
+
+pub fn serialize(semantic_pkg: &mut semantic::nodes::Package) -> Result<(Vec<u8>, usize), String> {
+    let mut v = new_serializing_visitor_with_capacity(1024);
+    walk::walk(&mut v, Rc::new(walk::Node::Package(semantic_pkg)));
+    v.finish()
+}
+
+fn new_serializing_visitor_with_capacity<'a>(_capacity: usize) -> SerializingVisitor<'a> {
+    SerializingVisitor {
+        inner: Rc::new(RefCell::new(SerializingVisitorState::new_with_capacity(
+            _capacity,
+        ))),
+    }
+}
+
+struct SerializingVisitor<'a> {
+    inner: Rc<RefCell<SerializingVisitorState<'a>>>,
+}
+
+impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
+    fn visit(&mut self, _node: Rc<walk::Node<'_>>) -> bool {
+        let v = self.inner.borrow();
+        if let Some(_) = &v.err {
+            return false;
+        }
+        Some(SerializingVisitor {
+            inner: Rc::clone(&self.inner),
+        });
+        true
+    }
+
+    fn done(&mut self, node: Rc<walk::Node<'_>>) {
+        let mut v = &mut *self.inner.borrow_mut();
+        if let Some(_) = &v.err {
+            return;
+        }
+        let node = &*node;
+        let loc = v.create_loc(node.loc());
+        match node {
+            walk::Node::IntegerLit(int) => {
+                let int_typ = int.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, int_typ);
+
+                let int = fbsemantic::IntegerLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::IntegerLiteralArgs {
+                        loc,
+                        value: int.value,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack
+                    .push((int.as_union_value(), fbsemantic::Expression::IntegerLiteral))
+            }
+            walk::Node::UintLit(uint) => {
+                let uint_typ = uint.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, uint_typ);
+
+                let uint = fbsemantic::UnsignedIntegerLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::UnsignedIntegerLiteralArgs {
+                        loc,
+                        value: uint.value,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    uint.as_union_value(),
+                    fbsemantic::Expression::UnsignedIntegerLiteral,
+                ))
+            }
+            walk::Node::FloatLit(float) => {
+                let float_typ = float.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, float_typ);
+
+                let float = fbsemantic::FloatLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::FloatLiteralArgs {
+                        loc,
+                        value: float.value,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack
+                    .push((float.as_union_value(), fbsemantic::Expression::FloatLiteral))
+            }
+            walk::Node::RegexpLit(regex) => {
+                let regex_val = v.create_string(&regex.value);
+                let regex_typ = regex.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, regex_typ);
+
+                let regex = fbsemantic::RegexpLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::RegexpLiteralArgs {
+                        loc,
+                        value: regex_val,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    regex.as_union_value(),
+                    fbsemantic::Expression::RegexpLiteral,
+                ))
+            }
+            walk::Node::StringLit(string) => {
+                let string_val = v.create_string(&string.value);
+                let string_typ = string.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, string_typ);
+
+                let string = fbsemantic::StringLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::StringLiteralArgs {
+                        loc,
+                        value: string_val,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    string.as_union_value(),
+                    fbsemantic::Expression::StringLiteral,
+                ))
+            }
+
+            walk::Node::DurationLit(dur_lit) => {
+                let mut dur_vec: Vec<WIPOffset<fbsemantic::Duration>> = Vec::new();
+                let magnitude = match dur_lit.value.num_nanoseconds() {
+                    Some(mag) => mag,
+                    None => {
+                        v.err = Some(String::from("Empty duration value"));
+                        return;
+                    }
+                };
+                let dur = fbsemantic::Duration::create(
+                    &mut v.builder,
+                    &fbsemantic::DurationArgs {
+                        magnitude,
+                        unit: fbsemantic::TimeUnit::ns,
+                    },
+                );
+                dur_vec.push(dur);
+                let value = Some(v.builder.create_vector(dur_vec.as_slice()));
+
+                let dur_typ = dur_lit.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, dur_typ);
+
+                let dur_lit = fbsemantic::DurationLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::DurationLiteralArgs {
+                        loc,
+                        value,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    dur_lit.as_union_value(),
+                    fbsemantic::Expression::DurationLiteral,
+                ))
+            }
+
+            walk::Node::DateTimeLit(datetime) => {
+                let val = datetime.value.to_rfc3339();
+                let val = v.create_string(&val);
+
+                let secs = datetime.value.timestamp();
+                let nano_secs = datetime.value.timestamp_subsec_nanos();
+                let offset = datetime.value.offset().fix().local_minus_utc();
+
+                let time = fbsemantic::Time::create(
+                    &mut v.builder,
+                    &fbsemantic::TimeArgs {
+                        secs: secs,
+                        nsecs: nano_secs,
+                        offset: offset,
+                    },
+                );
+
+                let date_typ = datetime.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, date_typ);
+
+                let datetime = fbsemantic::DateTimeLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::DateTimeLiteralArgs {
+                        loc,
+                        value: Some(time),
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    datetime.as_union_value(),
+                    fbsemantic::Expression::DateTimeLiteral,
+                ))
+            }
+
+            walk::Node::BooleanLit(boolean) => {
+                let boolean_typ = boolean.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, boolean_typ);
+                let boolean = fbsemantic::BooleanLiteral::create(
+                    &mut v.builder,
+                    &fbsemantic::BooleanLiteralArgs {
+                        loc,
+                        value: boolean.value,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    boolean.as_union_value(),
+                    fbsemantic::Expression::BooleanLiteral,
+                ))
+            }
+
+            walk::Node::IdentifierExpr(id) => {
+                let name = v.create_string(&id.name);
+                let id_typ = id.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, id_typ);
+
+                let ident = fbsemantic::IdentifierExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::IdentifierExpressionArgs {
+                        loc,
+                        name,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    ident.as_union_value(),
+                    fbsemantic::Expression::IdentifierExpression,
+                ))
+            }
+
+            walk::Node::Identifier(id) => {
+                let name = v.create_string(&id.name);
+                let identifier = fbsemantic::Identifier::create(
+                    &mut v.builder,
+                    &fbsemantic::IdentifierArgs { loc, name },
+                );
+                v.identifiers.push(identifier)
+            }
+
+            walk::Node::Property(prop) => {
+                // the value for a property is always an expression
+                let key = v.pop_ident();
+                let (value, value_type) = v.pop_expr();
+
+                let prop = fbsemantic::Property::create(
+                    &mut v.builder,
+                    &fbsemantic::PropertyArgs {
+                        loc,
+                        key,
+                        value_type,
+                        value,
+                    },
+                );
+                v.properties.push(prop);
+            }
+
+            walk::Node::UnaryExpr(unary) => {
+                let operator = fb_operator(&unary.operator);
+                let (argument, argument_type) = v.pop_expr();
+
+                let unary_typ = unary.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, unary_typ);
+                let unary = fbsemantic::UnaryExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::UnaryExpressionArgs {
+                        loc,
+                        operator,
+                        argument,
+                        argument_type,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    unary.as_union_value(),
+                    fbsemantic::Expression::UnaryExpression,
+                ));
+            }
+
+            walk::Node::ObjectExpr(obj) => {
+                let with = match obj.with {
+                    None => None,
+                    Some(_) => v.pop_expr_with_kind(fbsemantic::Expression::IdentifierExpression),
+                };
+
+                let properties = {
+                    let prop_vec = v.create_property_vector(obj.properties.len());
+                    let fb_prop_vec = v.builder.create_vector(&prop_vec.as_slice());
+                    Some(fb_prop_vec)
+                };
+
+                let obj_type = obj.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, obj_type);
+
+                let obj = fbsemantic::ObjectExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::ObjectExpressionArgs {
+                        loc,
+                        with,
+                        properties,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    obj.as_union_value(),
+                    fbsemantic::Expression::ObjectExpression,
+                ));
+            }
+
+            walk::Node::IndexExpr(ind) => {
+                let (index, index_type) = v.pop_expr();
+                let (array, array_type) = v.pop_expr();
+                let ind_type = ind.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, ind_type);
+
+                let index = fbsemantic::IndexExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::IndexExpressionArgs {
+                        loc,
+                        array,
+                        array_type,
+                        index,
+                        index_type,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    index.as_union_value(),
+                    fbsemantic::Expression::IndexExpression,
+                ));
+            }
+
+            walk::Node::MemberExpr(member) => {
+                let property = v.create_string(&member.property);
+                let (object, object_type) = v.pop_expr();
+
+                let member_typ = member.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, member_typ);
+
+                let mem = fbsemantic::MemberExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::MemberExpressionArgs {
+                        loc,
+                        object,
+                        object_type,
+                        property,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    mem.as_union_value(),
+                    fbsemantic::Expression::MemberExpression,
+                ));
+            }
+
+            walk::Node::LogicalExpr(logical) => {
+                let operator = fb_logical_operator(&logical.operator);
+                let (right, right_type) = v.pop_expr();
+                let (left, left_type) = v.pop_expr();
+
+                let logical_typ = logical.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, logical_typ);
+
+                let logical = fbsemantic::LogicalExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::LogicalExpressionArgs {
+                        loc,
+                        operator,
+                        left_type,
+                        left,
+                        right_type,
+                        right,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    logical.as_union_value(),
+                    fbsemantic::Expression::LogicalExpression,
+                ));
+            }
+
+            walk::Node::ConditionalExpr(cond) => {
+                let (alternate, alternate_type) = v.pop_expr();
+                let (consequent, consequent_type) = v.pop_expr();
+                let (test, test_type) = v.pop_expr();
+
+                let cond_typ = cond.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, cond_typ);
+
+                let cond = fbsemantic::ConditionalExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::ConditionalExpressionArgs {
+                        loc,
+                        test,
+                        test_type,
+                        alternate,
+                        alternate_type,
+                        consequent,
+                        consequent_type,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    cond.as_union_value(),
+                    fbsemantic::Expression::ConditionalExpression,
+                ));
+            }
+
+            walk::Node::CallExpr(call) => {
+                let (pipe, pipe_type) = {
+                    match &call.pipe {
+                        Some(_) => {
+                            let expr = v.pop_expr();
+                            expr
+                        }
+                        _ => (None, fbsemantic::Expression::NONE),
+                    }
+                };
+
+                let (callee, callee_type) = v.pop_expr();
+
+                let arguments = {
+                    let arg_num = call.arguments.len();
+                    let start = v.properties.len() - arg_num;
+                    let arg_slice = &v.properties.as_slice()[start..];
+                    let vec = v.builder.create_vector(arg_slice);
+                    v.properties.truncate(start);
+                    Some(vec)
+                };
+
+                let call_typ = call.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, call_typ);
+
+                let call = fbsemantic::CallExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::CallExpressionArgs {
+                        loc,
+                        callee,
+                        callee_type,
+                        arguments,
+                        pipe,
+                        pipe_type,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    call.as_union_value(),
+                    fbsemantic::Expression::CallExpression,
+                ));
+            }
+
+            walk::Node::BinaryExpr(bin) => {
+                let operator = fb_operator(&bin.operator);
+                let (right, right_type) = v.pop_expr();
+                let (left, left_type) = v.pop_expr();
+
+                let bin_typ = bin.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, bin_typ);
+
+                let bin = fbsemantic::BinaryExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::BinaryExpressionArgs {
+                        loc,
+                        operator,
+                        left_type,
+                        left,
+                        right_type,
+                        right,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    bin.as_union_value(),
+                    fbsemantic::Expression::BinaryExpression,
+                ));
+            }
+
+            walk::Node::FunctionExpr(func) => {
+                let params = {
+                    let par_num = func.params.len();
+                    let start = v.params.len() - par_num;
+                    let par_slice = &v.params.as_slice()[start..];
+                    let vec = v.builder.create_vector(par_slice);
+                    v.params.truncate(start);
+                    Some(vec)
+                };
+
+                let mut block_len = 0;
+                let mut current = &func.body;
+                loop {
+                    block_len += 1;
+                    match current {
+                        semantic::nodes::Block::Expr(_, next) => {
+                            current = next.as_ref();
+                        }
+                        semantic::nodes::Block::Variable(_, next) => {
+                            current = next.as_ref();
+                        }
+                        semantic::nodes::Block::Return(retn) => {
+                            break;
+                        }
+                    }
+                }
+                let body_vec = {
+                    let stmt_vec = v.create_stmt_vector(block_len);
+                    Some(v.builder.create_vector(&stmt_vec.as_slice()))
+                };
+                let body = Some(fbsemantic::Block::create(
+                    &mut v.builder,
+                    &fbsemantic::BlockArgs {
+                        loc,
+                        body: body_vec,
+                    },
+                ));
+
+                let func_typ = func.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, func_typ);
+
+                let func = fbsemantic::FunctionExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::FunctionExpressionArgs {
+                        loc,
+                        params,
+                        body,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    func.as_union_value(),
+                    fbsemantic::Expression::FunctionExpression,
+                ));
+            }
+
+            walk::Node::FunctionParameter(func_param) => {
+                let key = v.pop_ident();
+
+                let (default, default_type) = {
+                    match &func_param.default {
+                        Some(_) => v.pop_expr(),
+                        _ => (None, fbsemantic::Expression::NONE),
+                    }
+                };
+
+                let func_param = fbsemantic::FunctionParameter::create(
+                    &mut v.builder,
+                    &fbsemantic::FunctionParameterArgs {
+                        loc,
+                        key,
+                        is_pipe: func_param.is_pipe,
+                        default,
+                        default_type,
+                    },
+                );
+                v.params.push(func_param);
+            }
+
+            walk::Node::ArrayExpr(array) => {
+                let num_elems = array.elements.len();
+                let start = v.expr_stack.len() - num_elems;
+                let elements = {
+                    let elems = &v.expr_stack.as_slice()[start..];
+                    let mut wrapped_elems = Vec::with_capacity(num_elems);
+                    for (e, et) in elems {
+                        wrapped_elems.push(fbsemantic::WrappedExpression::create(
+                            &mut v.builder,
+                            &fbsemantic::WrappedExpressionArgs {
+                                expression_type: *et,
+                                expression: Some(*e),
+                            },
+                        ));
+                    }
+                    Some(v.builder.create_vector(wrapped_elems.as_slice()))
+                };
+                v.expr_stack.truncate(start);
+                let arr_typ = array.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, arr_typ);
+
+                let array = fbsemantic::ArrayExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::ArrayExpressionArgs {
+                        loc,
+                        elements,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    array.as_union_value(),
+                    fbsemantic::Expression::ArrayExpression,
+                ))
+            }
+
+            walk::Node::TextPart(tp) => {
+                let text_value = Some(v.builder.create_string(tp.value.as_str()));
+                let text = fbsemantic::StringExpressionPart::create(
+                    &mut v.builder,
+                    &fbsemantic::StringExpressionPartArgs {
+                        loc,
+                        text_value,
+                        ..fbsemantic::StringExpressionPartArgs::default()
+                    },
+                );
+                v.string_expr_parts.push(text);
+            }
+
+            walk::Node::InterpolatedPart(_) => {
+                let (interpolated_expression, interpolated_expression_type) = v.pop_expr();
+                let inter = fbsemantic::StringExpressionPart::create(
+                    &mut v.builder,
+                    &fbsemantic::StringExpressionPartArgs {
+                        loc,
+                        interpolated_expression_type,
+                        interpolated_expression,
+                        ..fbsemantic::StringExpressionPartArgs::default()
+                    },
+                );
+                v.string_expr_parts.push(inter);
+            }
+
+            walk::Node::StringExpr(string) => {
+                let parts = {
+                    let num_parts = string.parts.len();
+                    let start = v.string_expr_parts.len() - num_parts;
+                    let parts_sl = &v.string_expr_parts.as_slice()[start..];
+                    let vec = v.builder.create_vector(parts_sl);
+                    v.string_expr_parts.truncate(start);
+                    Some(vec)
+                };
+                let string_typ = string.typ.clone();
+                let (typ, typ_type) = types::build_type(&mut v.builder, string_typ);
+
+                let string = fbsemantic::StringExpression::create(
+                    &mut v.builder,
+                    &fbsemantic::StringExpressionArgs {
+                        loc,
+                        parts,
+                        typ: Some(typ),
+                        typ_type,
+                    },
+                );
+                v.expr_stack.push((
+                    string.as_union_value(),
+                    fbsemantic::Expression::StringExpression,
+                ));
+            }
+
+            walk::Node::MemberAssgn(mem) => {
+                let (init_, init__type) = v.pop_expr();
+                let member = v.pop_expr_with_kind(fbsemantic::Expression::MemberExpression);
+                let mem = fbsemantic::MemberAssignment::create(
+                    &mut v.builder,
+                    &fbsemantic::MemberAssignmentArgs {
+                        loc,
+                        member,
+                        init__type,
+                        init_,
+                    },
+                );
+                v.stmts.push((
+                    mem.as_union_value(),
+                    fbsemantic::Statement::MemberAssignment,
+                ));
+            }
+
+            walk::Node::VariableAssgn(native) => {
+                let (init_, init__type) = v.pop_expr();
+                let identifier = v.pop_ident();
+
+                let poly = native.poly_type_of();
+                let typ = Some(types::build_polytype(&mut v.builder, poly));
+
+                let native = fbsemantic::NativeVariableAssignment::create(
+                    &mut v.builder,
+                    &fbsemantic::NativeVariableAssignmentArgs {
+                        loc,
+                        identifier,
+                        init__type,
+                        init_,
+                        typ,
+                    },
+                );
+                v.stmts.push((
+                    native.as_union_value(),
+                    fbsemantic::Statement::NativeVariableAssignment,
+                ));
+            }
+
+            walk::Node::ReturnStmt(_) => {
+                let (argument, argument_type) = v.pop_expr();
+                let return_st = fbsemantic::ReturnStatement::create(
+                    &mut v.builder,
+                    &fbsemantic::ReturnStatementArgs {
+                        loc,
+                        argument,
+                        argument_type,
+                    },
+                );
+                v.stmts.push((
+                    return_st.as_union_value(),
+                    fbsemantic::Statement::ReturnStatement,
+                ));
+            }
+
+            walk::Node::ExprStmt(_) => {
+                let (expression, expression_type) = v.pop_expr();
+                let expr = fbsemantic::ExpressionStatement::create(
+                    &mut v.builder,
+                    &fbsemantic::ExpressionStatementArgs {
+                        loc,
+                        expression,
+                        expression_type,
+                    },
+                );
+                v.stmts.push((
+                    expr.as_union_value(),
+                    fbsemantic::Statement::ExpressionStatement,
+                ));
+            }
+
+            walk::Node::TestStmt(test) => {
+                let assignment = {
+                    match v.stmts.pop() {
+                        Some((union, fbsemantic::Statement::NativeVariableAssignment)) => {
+                            Some(WIPOffset::new(union.value()))
+                        }
+                        _ => {
+                            v.err = Some(String::from(
+                                "failed to pop assignment statement from stmt vector",
+                            ));
+                            return;
+                        }
+                    }
+                };
+
+                let test = fbsemantic::TestStatement::create(
+                    &mut v.builder,
+                    &fbsemantic::TestStatementArgs { loc, assignment },
+                );
+                v.stmts
+                    .push((test.as_union_value(), fbsemantic::Statement::TestStatement));
+            }
+
+            walk::Node::BuiltinStmt(builtin) => {
+                let id = v.pop_ident();
+                let builtin = fbsemantic::BuiltinStatement::create(
+                    &mut v.builder,
+                    &fbsemantic::BuiltinStatementArgs { loc, id },
+                );
+                v.stmts.push((
+                    builtin.as_union_value(),
+                    fbsemantic::Statement::BuiltinStatement,
+                ));
+            }
+
+            walk::Node::OptionStmt(opt) => {
+                let (assignment, assignment_type) = {
+                    match &opt.assignment {
+                        semantic::nodes::Assignment::Variable(_) => match v.stmts.pop() {
+                            Some((nva, fbsemantic::Statement::NativeVariableAssignment)) => {
+                                (Some(nva), fbsemantic::Assignment::NativeVariableAssignment)
+                            }
+                            Some((_, ty)) => {
+                                v.err =
+                                    Some(String::from(format!("found {:?} in stmt vector", ty)));
+                                return;
+                            }
+                            None => {
+                                v.err = Some(String::from(
+                                    "Native assignment was not added to SerializingVisitor",
+                                ));
+                                return;
+                            }
+                        },
+                        semantic::nodes::Assignment::Member(_) => match v.stmts.pop() {
+                            Some((member, fbsemantic::Statement::MemberAssignment)) => {
+                                (Some(member), fbsemantic::Assignment::MemberAssignment)
+                            }
+                            _ => {
+                                v.err = Some(String::from(
+                                    "Member assignment was not added to SerializingVisitor",
+                                ));
+                                return;
+                            }
+                        },
+                    }
+                };
+                let opt = fbsemantic::OptionStatement::create(
+                    &mut v.builder,
+                    &fbsemantic::OptionStatementArgs {
+                        loc,
+                        assignment,
+                        assignment_type,
+                    },
+                );
+                v.stmts
+                    .push((opt.as_union_value(), fbsemantic::Statement::OptionStatement));
+            }
+
+            walk::Node::Block(block) => {
+                // Block statements must be convered in this enum in order to also walk all child nodes.
+                // However, block statements are consumed by the function expression node so that
+                // blocks are only constructed once all child nodes have been traversed.
+            }
+
+            walk::Node::ImportDeclaration(imp) => {
+                let alias = {
+                    match imp.alias {
+                        Some(_) => v.pop_ident(),
+                        _ => None,
+                    }
+                };
+
+                let path = v.pop_expr_with_kind(fbsemantic::Expression::StringLiteral);
+                let import = fbsemantic::ImportDeclaration::create(
+                    &mut v.builder,
+                    &fbsemantic::ImportDeclarationArgs { loc, alias, path },
+                );
+                v.import_decls.push(import);
+            }
+
+            walk::Node::PackageClause(_) => {
+                let name = v.pop_ident();
+                let pc = fbsemantic::PackageClause::create(
+                    &mut v.builder,
+                    &fbsemantic::PackageClauseArgs { loc, name },
+                );
+                v.package_clause = Some(pc);
+            }
+
+            walk::Node::File(file) => {
+                let package = v.package_clause;
+                v.package_clause = None;
+
+                let imports = Some(v.builder.create_vector(v.import_decls.as_slice()));
+                v.import_decls.clear();
+
+                let stmt_vec = v.create_stmt_vector(file.body.len());
+                let body = Some(v.builder.create_vector(&stmt_vec.as_slice()));
+
+                let file = fbsemantic::File::create(
+                    &mut v.builder,
+                    &fbsemantic::FileArgs {
+                        loc,
+                        package,
+                        imports,
+                        body,
+                    },
+                );
+                v.files.push(file);
+            }
+
+            walk::Node::Package(pac) => {
+                let package = v.create_string(&pac.package);
+                let files = {
+                    let mut fs: Vec<WIPOffset<fbsemantic::File>> = Vec::new();
+                    std::mem::swap(&mut v.files, &mut fs);
+                    Some(v.builder.create_vector(fs.as_slice()))
+                };
+                v.package = Some(fbsemantic::Package::create(
+                    &mut v.builder,
+                    &fbsemantic::PackageArgs {
+                        loc,
+                        package,
+                        files,
+                    },
+                ));
+            }
+        }
+    }
+}
+
+impl<'a> SerializingVisitor<'a> {
+    fn finish(self) -> Result<(Vec<u8>, usize), String> {
+        let v = match Rc::try_unwrap(self.inner) {
+            Ok(sv) => sv,
+            Err(_) => return Err(String::from("error unwrapping rc")),
+        };
+        let mut v = v.into_inner();
+        if let Some(e) = v.err {
+            return Err(e);
+        };
+        let pkg = match v.package {
+            None => return Err(String::from("missing serialized package")),
+            Some(pkg) => pkg,
+        };
+        v.builder.finish(pkg, None);
+
+        // Collapse releases ownership of the byte vector and returns it to caller.
+        Ok(v.builder.collapse())
+    }
+}
+
+struct SerializingVisitorState<'a> {
+    // Any error that occurred during serialization, returned by the visitor's finish method.
+    err: Option<String>,
+
+    builder: flatbuffers::FlatBufferBuilder<'a>,
+
+    package: Option<WIPOffset<fbsemantic::Package<'a>>>,
+    package_clause: Option<WIPOffset<fbsemantic::PackageClause<'a>>>,
+
+    import_decls: Vec<WIPOffset<fbsemantic::ImportDeclaration<'a>>>,
+    files: Vec<WIPOffset<fbsemantic::File<'a>>>,
+    blocks: Vec<WIPOffset<fbsemantic::Block<'a>>>,
+    stmts: Vec<(WIPOffset<UnionWIPOffset>, fbsemantic::Statement)>,
+    vars: Vec<(WIPOffset<UnionWIPOffset>, fbsemantic::Var<'a>)>,
+    params: Vec<WIPOffset<fbsemantic::FunctionParameter<'a>>>,
+
+    expr_stack: Vec<(WIPOffset<UnionWIPOffset>, fbsemantic::Expression)>,
+    properties: Vec<WIPOffset<fbsemantic::Property<'a>>>,
+    identifiers: Vec<WIPOffset<fbsemantic::Identifier<'a>>>,
+    string_expr_parts: Vec<WIPOffset<fbsemantic::StringExpressionPart<'a>>>,
+}
+
+impl<'a> SerializingVisitorState<'a> {
+    fn new_with_capacity(capacity: usize) -> SerializingVisitorState<'a> {
+        SerializingVisitorState {
+            err: None,
+            builder: flatbuffers::FlatBufferBuilder::new_with_capacity(capacity),
+            package: None,
+            package_clause: None,
+            import_decls: Vec::new(),
+            files: Vec::new(),
+            blocks: Vec::new(),
+            stmts: Vec::new(),
+            vars: Vec::new(),
+            params: Vec::new(),
+            expr_stack: Vec::new(),
+            properties: Vec::new(),
+            identifiers: Vec::new(),
+            string_expr_parts: Vec::new(),
+        }
+    }
+
+    fn pop_expr(&mut self) -> (Option<WIPOffset<UnionWIPOffset>>, fbsemantic::Expression) {
+        match self.expr_stack.pop() {
+            None => {
+                self.err = Some(String::from("Tried popping empty expression stack"));
+                return (None, fbsemantic::Expression::NONE);
+            }
+            Some((o, e)) => (Some(o), e),
+        }
+    }
+
+    fn pop_expr_with_kind<T>(&mut self, kind: fbsemantic::Expression) -> Option<WIPOffset<T>> {
+        match self.expr_stack.pop() {
+            Some((wipo, e)) => {
+                if e == kind {
+                    Some(WIPOffset::new(wipo.value()))
+                } else {
+                    self.err = Some(String::from(format!(
+                        "expected {} on expr stack, got {}",
+                        fbsemantic::enum_name_expression(kind),
+                        fbsemantic::enum_name_expression(e)
+                    )));
+                    return None;
+                }
+            }
+            None => {
+                self.err = Some(String::from(format!(
+                    "Tried popping empty expression stack"
+                )));
+                return None;
+            }
+        }
+    }
+
+    fn pop_ident<T>(&mut self) -> Option<WIPOffset<T>> {
+        match self.identifiers.pop() {
+            None => {
+                self.err = Some(String::from(format!(
+                    "Tried popping empty identifier stack"
+                )));
+                return None;
+            }
+            Some(wip) => Some(WIPOffset::new(wip.value())),
+        }
+    }
+
+    fn create_string(&mut self, str: &String) -> Option<WIPOffset<&'a str>> {
+        Some(self.builder.create_string(str.as_str()))
+    }
+
+    fn create_opt_string(&mut self, str: &Option<String>) -> Option<WIPOffset<&'a str>> {
+        match str {
+            None => None,
+            Some(str) => Some(self.builder.create_string(str.as_str())),
+        }
+    }
+
+    fn create_stmt_vector(
+        &mut self,
+        num_of_stmts: usize,
+    ) -> Vec<WIPOffset<fbsemantic::WrappedStatement<'a>>> {
+        let start = self.stmts.len() - num_of_stmts;
+        let union_stmts = &self.stmts.as_slice()[start..];
+        let mut wrapped_stmts: Vec<WIPOffset<fbsemantic::WrappedStatement>> =
+            Vec::with_capacity(num_of_stmts);
+
+        for (stmt, stmt_type) in union_stmts {
+            let wrapped_st = fbsemantic::WrappedStatement::create(
+                &mut self.builder,
+                &fbsemantic::WrappedStatementArgs {
+                    statement_type: *stmt_type,
+                    statement: Some(*stmt),
+                },
+            );
+            wrapped_stmts.push(wrapped_st);
+        }
+        self.stmts.truncate(start);
+        wrapped_stmts
+    }
+
+    fn create_property_vector(
+        &mut self,
+        n_props: usize,
+    ) -> Vec<WIPOffset<fbsemantic::Property<'a>>> {
+        let start = self.properties.len() - n_props;
+        self.properties.split_off(start)
+    }
+
+    fn pop_assignment_stmt(
+        &mut self,
+    ) -> (Option<WIPOffset<UnionWIPOffset>>, fbsemantic::Assignment) {
+        match self.stmts.pop() {
+            Some((va, fbsemantic::Statement::NativeVariableAssignment)) => {
+                (Some(va), fbsemantic::Assignment::NativeVariableAssignment)
+            }
+            None => {
+                self.err = Some(String::from(
+                    "Tried popping empty statement stack. Expected assignment on top of stack.",
+                ));
+                (None, fbsemantic::Assignment::NONE)
+            }
+            Some(_) => {
+                self.err = Some(String::from(
+                    "Expected assignment on top of stack statement stack.",
+                ));
+                (None, fbsemantic::Assignment::NONE)
+            }
+        }
+    }
+
+    fn create_loc(
+        &mut self,
+        loc: &ast::SourceLocation,
+    ) -> Option<WIPOffset<fbsemantic::SourceLocation<'a>>> {
+        let file = self.create_opt_string(&loc.file);
+        let source = self.create_opt_string(&loc.source);
+
+        Some(fbsemantic::SourceLocation::create(
+            &mut self.builder,
+            &fbsemantic::SourceLocationArgs {
+                file,
+                start: Some(&fbsemantic::Position::new(
+                    loc.start.line as i32,
+                    loc.start.column as i32,
+                )),
+                end: Some(&fbsemantic::Position::new(
+                    loc.end.line as i32,
+                    loc.end.column as i32,
+                )),
+                source,
+            },
+        ))
+    }
+}
+
+fn fb_operator(o: &ast::Operator) -> fbsemantic::Operator {
+    match o {
+        ast::Operator::MultiplicationOperator => fbsemantic::Operator::MultiplicationOperator,
+        ast::Operator::DivisionOperator => fbsemantic::Operator::DivisionOperator,
+        ast::Operator::ModuloOperator => fbsemantic::Operator::ModuloOperator,
+        ast::Operator::PowerOperator => fbsemantic::Operator::PowerOperator,
+        ast::Operator::AdditionOperator => fbsemantic::Operator::AdditionOperator,
+        ast::Operator::SubtractionOperator => fbsemantic::Operator::SubtractionOperator,
+        ast::Operator::LessThanEqualOperator => fbsemantic::Operator::LessThanEqualOperator,
+        ast::Operator::LessThanOperator => fbsemantic::Operator::LessThanOperator,
+        ast::Operator::GreaterThanEqualOperator => fbsemantic::Operator::GreaterThanEqualOperator,
+        ast::Operator::GreaterThanOperator => fbsemantic::Operator::GreaterThanOperator,
+        ast::Operator::StartsWithOperator => fbsemantic::Operator::StartsWithOperator,
+        ast::Operator::InOperator => fbsemantic::Operator::InOperator,
+        ast::Operator::NotOperator => fbsemantic::Operator::NotOperator,
+        ast::Operator::ExistsOperator => fbsemantic::Operator::ExistsOperator,
+        ast::Operator::NotEmptyOperator => fbsemantic::Operator::NotEmptyOperator,
+        ast::Operator::EmptyOperator => fbsemantic::Operator::EmptyOperator,
+        ast::Operator::EqualOperator => fbsemantic::Operator::EqualOperator,
+        ast::Operator::NotEqualOperator => fbsemantic::Operator::NotEqualOperator,
+        ast::Operator::RegexpMatchOperator => fbsemantic::Operator::RegexpMatchOperator,
+        ast::Operator::NotRegexpMatchOperator => fbsemantic::Operator::NotRegexpMatchOperator,
+        ast::Operator::InvalidOperator => fbsemantic::Operator::InvalidOperator,
+    }
+}
+
+fn fb_logical_operator(lo: &ast::LogicalOperator) -> fbsemantic::LogicalOperator {
+    match lo {
+        ast::LogicalOperator::AndOperator => fbsemantic::LogicalOperator::AndOperator,
+        ast::LogicalOperator::OrOperator => fbsemantic::LogicalOperator::OrOperator,
+    }
+}
+
+fn fb_duration(d: &String) -> Result<fbsemantic::TimeUnit, String> {
+    match d.as_str() {
+        "y" => Ok(fbsemantic::TimeUnit::y),
+        "mo" => Ok(fbsemantic::TimeUnit::mo),
+        "w" => Ok(fbsemantic::TimeUnit::w),
+        "d" => Ok(fbsemantic::TimeUnit::d),
+        "h" => Ok(fbsemantic::TimeUnit::h),
+        "m" => Ok(fbsemantic::TimeUnit::m),
+        "s" => Ok(fbsemantic::TimeUnit::s),
+        "ms" => Ok(fbsemantic::TimeUnit::ms),
+        "us" => Ok(fbsemantic::TimeUnit::us),
+        "ns" => Ok(fbsemantic::TimeUnit::ns),
+        s => Err(String::from(format!("unknown time unit {}", s))),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
+++ b/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
@@ -7428,12 +7428,12 @@ pub mod fbsemantic {
                 )
         }
         #[inline]
-        pub fn arguments(&self) -> Option<ObjectExpression<'a>> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<ObjectExpression<'a>>>(
-                    CallExpression::VT_ARGUMENTS,
-                    None,
-                )
+        pub fn arguments(
+            &self,
+        ) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Property<'a>>>> {
+            self._tab.get::<flatbuffers::ForwardsUOffset<
+                flatbuffers::Vector<flatbuffers::ForwardsUOffset<Property<'a>>>,
+            >>(CallExpression::VT_ARGUMENTS, None)
         }
         #[inline]
         pub fn pipe_type(&self) -> Expression {
@@ -7925,7 +7925,11 @@ pub mod fbsemantic {
         pub loc: Option<flatbuffers::WIPOffset<SourceLocation<'a>>>,
         pub callee_type: Expression,
         pub callee: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-        pub arguments: Option<flatbuffers::WIPOffset<ObjectExpression<'a>>>,
+        pub arguments: Option<
+            flatbuffers::WIPOffset<
+                flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Property<'a>>>,
+            >,
+        >,
         pub pipe_type: Expression,
         pub pipe: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
         pub typ_type: MonoType,
@@ -7973,12 +7977,16 @@ pub mod fbsemantic {
                 .push_slot_always::<flatbuffers::WIPOffset<_>>(CallExpression::VT_CALLEE, callee);
         }
         #[inline]
-        pub fn add_arguments(&mut self, arguments: flatbuffers::WIPOffset<ObjectExpression<'b>>) {
-            self.fbb_
-                .push_slot_always::<flatbuffers::WIPOffset<ObjectExpression>>(
-                    CallExpression::VT_ARGUMENTS,
-                    arguments,
-                );
+        pub fn add_arguments(
+            &mut self,
+            arguments: flatbuffers::WIPOffset<
+                flatbuffers::Vector<'b, flatbuffers::ForwardsUOffset<Property<'b>>>,
+            >,
+        ) {
+            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+                CallExpression::VT_ARGUMENTS,
+                arguments,
+            );
         }
         #[inline]
         pub fn add_pipe_type(&mut self, pipe_type: Expression) {

--- a/libflux/src/flux/semantic/flatbuffers/tests.rs
+++ b/libflux/src/flux/semantic/flatbuffers/tests.rs
@@ -1,0 +1,807 @@
+extern crate flatbuffers;
+extern crate walkdir;
+
+use super::semantic_generated::fbsemantic; 
+use crate::semantic; 
+use crate::ast; 
+use crate::semantic::analyze; 
+use chrono::FixedOffset; 
+
+#[test]
+fn test_serialize() {
+    let f = vec![
+        crate::parser::parse_string(
+            "test1",
+            r#"
+package testpkg
+
+option now = () => (2030-01-01T00:00:00Z)
+option foo.bar = "baz"
+builtin foo
+
+test aggregate_window_empty = () => ({
+    input: testing.loadStorage(csv: inData),
+    want: testing.loadMem(csv: outData),
+    fn: (table=<-) =>
+        table
+            |> range(start: 2018-05-22T19:53:26Z, stop: 2018-05-22T19:55:00Z)
+            |> aggregateWindow(every: 30s, fn: sum),
+})
+"#,
+        ),
+        crate::parser::parse_string(
+            "test2",
+            r#"
+a
+
+arr = [0, 1, 2]
+f = (i) => i
+ff = (i=<-, j) => {
+  k = i + j
+  return k
+}
+b = z and y
+b = z or y
+o = {red: "red", "blue": 30}
+m = o.red
+i = arr[0]
+n = 10 - 5 + 10
+n = 10 / 5 * 10
+m = 13 % 3
+p = 2^10
+b = 10 < 30
+b = 10 <= 30
+b = 10 > 30
+b = 10 >= 30
+eq = 10 == 10
+neq = 11 != 10
+b = not false
+e = exists o.red
+tables |> f()
+fncall = id(v: 20)
+fncall2 = foo(v: 20, w: "bar")
+v = if true then 70.0 else 140.0 
+ans = "the answer is ${v}"
+paren = (1)
+
+i = 1
+f = 1.0
+s = "foo"
+d = 10s
+b = true
+dt = 2030-01-01T00:00:00Z
+re =~ /foo/
+re !~ /foo/
+"#,
+        ),
+    ];
+    let pkg = ast::Package {
+        base: ast::BaseNode {
+            ..ast::BaseNode::default()
+        },
+        path: String::from("./"),
+        package: String::from("test"),
+        files: f,
+    };
+    let mut pkg = match analyze(pkg) {
+        Ok(pkg) => pkg, 
+        Err(e) => {
+            assert!(false, e);
+            return;
+        }
+    }; 
+    let (vec, offset) = match super::serialize(&mut pkg) {
+        Ok((v, o)) => (v, o),
+        Err(e) => {
+            assert!(false, e);
+            return;
+        }
+    };
+    let fb = &vec.as_slice()[offset..];
+    match compare_semantic_fb(&pkg, fb) {
+        Err(e) => assert!(false, e),
+        _ => (),
+    }
+}
+
+fn compare_semantic_fb(semantic_pkg: &semantic::nodes::Package, fb: &[u8]) -> Result<(), String> {
+    let fb_pkg = fbsemantic::get_root_as_package(fb);
+    compare_pkg_fb(semantic_pkg, &fb_pkg)?;
+    Ok(())
+}
+
+fn compare_pkg_fb(semantic_pkg: &semantic::nodes::Package, fb_pkg: &fbsemantic::Package) -> Result<(), String> {
+    compare_loc(&semantic_pkg.loc, &fb_pkg.loc())?;
+    compare_strings("package name", &semantic_pkg.package, &fb_pkg.package())?;
+
+    let fb_files = &fb_pkg.files();
+    let fb_files = unwrap_or_fail("package files", fb_files)?;
+    compare_vec_len(&semantic_pkg.files, &fb_files)?;
+    let mut i: usize = 0;
+    loop {
+        if i >= semantic_pkg.files.len() {
+            return Ok(());
+        }
+
+        let semantic_file = &semantic_pkg.files[i];
+        let fb_file = &fb_files.get(i);
+        compare_files(semantic_file, fb_file)?;
+        i = i + 1;
+    }
+}
+
+fn compare_files(semantic_file: &semantic::nodes::File, fb_file: &fbsemantic::File) -> Result<(), String> {
+    compare_loc(&semantic_file.loc, &fb_file.loc())?;
+    let semantic_file_name = &semantic_file.package.as_ref().unwrap().name.name; 
+    let fb_file_name = &fb_file.package().unwrap().name().unwrap().name(); 
+    compare_strings("file name", semantic_file_name, fb_file_name)?;
+    compare_package_clause(&semantic_file.package, &fb_file.package())?;
+    compare_imports(&semantic_file.imports, &fb_file.imports())?;
+    compare_stmt_vectors(&semantic_file.body, &fb_file.body())?;
+    Ok(())
+}
+
+fn compare_stmt_vectors(
+    semantic_stmts: &Vec<semantic::nodes::Statement>,
+    fb_stmts: &Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<fbsemantic::WrappedStatement>>>,
+) -> Result<(), String> {
+    let fb_stmts = unwrap_or_fail("statement list", fb_stmts)?;
+    compare_vec_len(semantic_stmts, fb_stmts)?;
+    let mut i: usize = 0;
+    loop {
+        if i >= semantic_stmts.len() {
+            break Ok(());
+        }
+        let fb_stmt_ty = fb_stmts.get(i).statement_type();
+        let fb_stmt = &fb_stmts.get(i).statement();
+        compare_stmts(&semantic_stmts[i], fb_stmt_ty, fb_stmt)?;
+        i = i + 1;
+    }
+}
+
+fn compare_stmts(
+    semantic_stmt: &semantic::nodes::Statement,
+    fb_stmt_ty: fbsemantic::Statement,
+    fb_stmt: &Option<flatbuffers::Table>,
+) -> Result<(), String> {
+    let fb_tbl = unwrap_or_fail("statement", fb_stmt)?;
+    match (semantic_stmt, fb_stmt_ty) {
+        (semantic::nodes::Statement::Variable(semantic_stmt), fbsemantic::Statement::NativeVariableAssignment) => {
+            let fb_stmt = fbsemantic::NativeVariableAssignment::init_from_table(*fb_tbl);
+            compare_var_assign(&semantic_stmt, &Some(fb_stmt))
+        }
+        (semantic::nodes::Statement::Expr(semantic_stmt), fbsemantic::Statement::ExpressionStatement) => {
+            let fb_stmt = fbsemantic::ExpressionStatement::init_from_table(*fb_tbl);
+            compare_loc(&semantic_stmt.loc, &fb_stmt.loc())?;
+            compare_exprs(
+                &semantic_stmt.expression,
+                fb_stmt.expression_type(),
+                &fb_stmt.expression(),
+            )?;
+            Ok(())
+        }
+        (semantic::nodes::Statement::Option(semantic_stmt), fbsemantic::Statement::OptionStatement) => {
+            let fb_stmt = fbsemantic::OptionStatement::init_from_table(*fb_tbl);
+            compare_loc(&semantic_stmt.loc, &fb_stmt.loc())?;
+            compare_assignments(
+                &semantic_stmt.assignment,
+                fb_stmt.assignment_type(),
+                &fb_stmt.assignment(),
+            )
+        }
+        (semantic::nodes::Statement::Return(semantic_stmt), fbsemantic::Statement::ReturnStatement) => {
+            let fb_stmt = fbsemantic::ReturnStatement::init_from_table(*fb_tbl);
+            compare_loc(&semantic_stmt.loc, &fb_stmt.loc())?;
+            compare_exprs(
+                &semantic_stmt.argument,
+                fb_stmt.argument_type(),
+                &fb_stmt.argument(),
+            )
+        }
+        (semantic::nodes::Statement::Test(semantic_stmt), fbsemantic::Statement::TestStatement) => {
+            let fb_stmt = fbsemantic::TestStatement::init_from_table(*fb_tbl);
+            compare_loc(&semantic_stmt.loc, &fb_stmt.loc())
+        }
+        (semantic::nodes::Statement::Builtin(semantic_stmt), fbsemantic::Statement::BuiltinStatement) => {
+            let fb_stmt = fbsemantic::BuiltinStatement::init_from_table(*fb_tbl);
+            compare_loc(&semantic_stmt.loc, &fb_stmt.loc())?;
+            compare_ids(&semantic_stmt.id, &fb_stmt.id())
+        }
+        (semantic_stmt, fb_ty) => {
+            let semantic_stmt_ty = semantic::walk::Node::from_stmt(semantic_stmt);
+            let fb_ty = fbsemantic::enum_name_statement(fb_ty);
+            Err(String::from(format!(
+                "wrong statement type; semantic = {}, fb = {}",
+                semantic_stmt_ty, fb_ty
+            )))
+        }
+    }
+}
+
+fn compare_ids(semantic_id: &semantic::nodes::Identifier, fb_id: &Option<fbsemantic::Identifier>) -> Result<(), String> {
+    let fb_id = unwrap_or_fail("id", fb_id)?;
+    compare_loc(&semantic_id.loc, &fb_id.loc())?;
+    compare_strings("id", &semantic_id.name, &fb_id.name())?;
+    Ok(())
+}
+
+fn compare_id_exprs(semantic_id: &semantic::nodes::IdentifierExpr, fb_id: &Option<fbsemantic::IdentifierExpression>) -> Result<(), String> {
+    let fb_id = unwrap_or_fail("id", fb_id)?;
+    compare_loc(&semantic_id.loc, &fb_id.loc())?;
+    compare_strings("id", &semantic_id.name, &fb_id.name())?;
+    Ok(())
+}
+
+fn compare_opt_ids(
+    semantic_id: &Option<semantic::nodes::Identifier>,
+    fb_id: &Option<fbsemantic::Identifier>,
+) -> Result<(), String> {
+    match (semantic_id, fb_id) {
+        (None, None) => Ok(()),
+        (Some(_), None) => Err(String::from("compare opt ids, semantic had one, fb did not")),
+        (None, Some(_)) => Err(String::from("compare opt ids, semantic had none, fb did")),
+        (Some(semantic_id), fb_id) => compare_ids(semantic_id, fb_id),
+    }
+}
+
+fn compare_opt_expr_ids(
+    semantic_id: &Option<semantic::nodes::IdentifierExpr>,
+    fb_id: &Option<fbsemantic::IdentifierExpression>,
+) -> Result<(), String> {
+    match (semantic_id, fb_id) {
+        (None, None) => Ok(()),
+        (Some(_), None) => Err(String::from("compare opt ids, semantic had one, fb did not")),
+        (None, Some(_)) => Err(String::from("compare opt ids, semantic had none, fb did")),
+        (Some(semantic_id), fb_id) => compare_id_exprs(semantic_id, fb_id),
+    }
+}
+
+fn compare_assignments(
+    semantic_asgn: &semantic::nodes::Assignment,
+    fb_asgn_ty: fbsemantic::Assignment,
+    fb_asgn: &Option<flatbuffers::Table>,
+) -> Result<(), String> {
+    let fb_tbl = unwrap_or_fail("assign", fb_asgn)?;
+    match (semantic_asgn, fb_asgn_ty) {
+        (semantic::nodes::Assignment::Variable(semantic_va), fbsemantic::Assignment::NativeVariableAssignment) => {
+            let fb_va = fbsemantic::NativeVariableAssignment::init_from_table(*fb_tbl);
+            compare_var_assign(semantic_va, &Some(fb_va))
+        }
+        (semantic::nodes::Assignment::Member(semantic_ma), fbsemantic::Assignment::MemberAssignment) => {
+            let fb_ma = fbsemantic::MemberAssignment::init_from_table(*fb_tbl);
+            compare_loc(&semantic_ma.loc, &fb_ma.loc())?;
+            compare_member_expr(&semantic_ma.member, &fb_ma.member())?;
+            compare_exprs(&semantic_ma.init, fb_ma.init__type(), &fb_ma.init_())
+        }
+        _ => Err(String::from("assignment mismatch")),
+    }
+}
+
+fn compare_member_expr(
+    semantic_me: &semantic::nodes::MemberExpr,
+    fb_me: &Option<fbsemantic::MemberExpression>,
+) -> Result<(), String> {
+    let fb_me = unwrap_or_fail("member expression", fb_me)?;
+    compare_loc(&semantic_me.loc, &fb_me.loc())?;
+    compare_exprs(&semantic_me.object, fb_me.object_type(), &fb_me.object())
+}
+
+
+fn compare_var_assign(
+    semantic_va: &semantic::nodes::VariableAssgn,
+    fb_va: &Option<fbsemantic::NativeVariableAssignment>,
+) -> Result<(), String> {
+    let fb_va = unwrap_or_fail("var assign", fb_va)?;
+    compare_loc(&semantic_va.loc, &fb_va.loc())?;
+    compare_ids(&semantic_va.id, &fb_va.identifier())?;
+    compare_exprs(&semantic_va.init, fb_va.init__type(), &fb_va.init_())
+}
+
+fn compare_exprs(
+    semantic_expr: &semantic::nodes::Expression,
+    fb_expr_ty: fbsemantic::Expression,
+    fb_tbl: &Option<flatbuffers::Table>,
+) -> Result<(), String> {
+    let fb_tbl = unwrap_or_fail("expr", fb_tbl)?;
+    match (semantic_expr, fb_expr_ty) {
+        (semantic::nodes::Expression::Integer(semantic_int), fbsemantic::Expression::IntegerLiteral) => {
+            let fb_int = fbsemantic::IntegerLiteral::init_from_table(*fb_tbl);
+            compare_loc(&semantic_expr.loc(), &fb_int.loc())?;
+            match semantic_int.value == fb_int.value() {
+                true => Ok(()),
+                false => Err(String::from(format!(
+                    "int lit mismatch; semantic = {}, fb = {}",
+                    semantic_int.value,
+                    fb_int.value()
+                ))),
+            }
+        }
+        (semantic::nodes::Expression::Float(semantic_float), fbsemantic::Expression::FloatLiteral) => {
+            let fb_float = fbsemantic::FloatLiteral::init_from_table(*fb_tbl);
+            compare_loc(&semantic_float.loc, &fb_float.loc())?;
+            match semantic_float.value == fb_float.value() {
+                true => Ok(()),
+                false => Err(String::from(format!(
+                    "float lit mismatch; semantic = {}, fb = {}",
+                    semantic_float.value,
+                    fb_float.value()
+                ))),
+            }
+        }
+        (semantic::nodes::Expression::StringLit(semantic_string), fbsemantic::Expression::StringLiteral) => {
+            let fb_string = fbsemantic::StringLiteral::init_from_table(*fb_tbl);
+            compare_loc(&semantic_string.loc, &fb_string.loc())?;
+            let fb_value = fb_string.value();
+            let fb_value = unwrap_or_fail("string lit string", &fb_value)?;
+            match &semantic_string.value.as_str() == fb_value {
+                true => Ok(()),
+                false => Err(String::from(format!(
+                    "string lit mismatch; semantic = {}, fb = {}",
+                    semantic_string.value, fb_value,
+                ))),
+            }
+        }
+        // (semantic::nodes::Expression::Duration(semantic_dur), fbsemantic::Expression::DurationLiteral) => {
+        //     let fb_dur_lit = fbsemantic::DurationLiteral::init_from_table(*fb_tbl);
+        //     compare_loc(&semantic_dur.loc, &fb_dur_lit.loc())?;
+
+        //     let fb_val = fb_dur_lit.value();
+        //     let fb_values = unwrap_or_fail("dur lit values", &fb_val)?;
+            
+        //     compare_vec_len(&semantic_dur.value, fb_values)?;
+        //     let mut i: usize = 0;
+        //     loop {
+        //         if i >= semantic_dur.values.len() {
+        //             break Ok(());
+        //         }
+        //         let semantic_d = &semantic_dur.values[i];
+        //         let fb_d = fb_values.get(i);
+        //         if semantic_d.magnitude != fb_d.magnitude() {
+        //             return Err(String::from("invalid duration magnitude"));
+        //         }
+        //         if semantic_d.unit != fbsemantic::enum_name_time_unit(fb_d.unit()) {
+        //             return Err(String::from("invalid duration time unit"));
+        //         }
+        //         i = i + 1;
+        //     }
+        // }
+        (semantic::nodes::Expression::DateTime(semantic_dtl), fbsemantic::Expression::DateTimeLiteral) => {
+            let fb_dtl = fbsemantic::DateTimeLiteral::init_from_table(*fb_tbl);
+            let fb_dtl_val = fb_dtl.value().unwrap(); 
+            let dtl = chrono::DateTime::<FixedOffset>::from_utc(
+                chrono::NaiveDateTime::from_timestamp(fb_dtl_val.secs(), fb_dtl_val.nsecs()),
+                FixedOffset::east(fb_dtl_val.offset()),
+            );
+            compare_loc(&semantic_dtl.loc, &fb_dtl.loc())?;
+            if semantic_dtl.value != dtl {
+                return Err(String::from("invalid DateTimeLiteral value"));
+            }
+            Ok(())
+        }
+        (semantic::nodes::Expression::Regexp(semantic_rel), fbsemantic::Expression::RegexpLiteral) => {
+            let fb_rel = fbsemantic::RegexpLiteral::init_from_table(*fb_tbl);
+            compare_loc(&semantic_rel.loc, &fb_rel.loc())?;
+            compare_strings("regexp lit value", &semantic_rel.value, &fb_rel.value())?;
+            Ok(())
+        }
+        (semantic::nodes::Expression::Identifier(semantic_id), fbsemantic::Expression::IdentifierExpression) => {
+            let fb_id = fbsemantic::IdentifierExpression::init_from_table(*fb_tbl);
+            compare_id_exprs(semantic_id, &Some(fb_id))?;
+            Ok(())
+        }
+        (semantic::nodes::Expression::Array(semantic_ae), fbsemantic::Expression::ArrayExpression) => {
+            let fb_ae = fbsemantic::ArrayExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_ae.loc, &fb_ae.loc())?;
+            let fb_elems = fb_ae.elements();
+            let fb_elems = unwrap_or_fail("array elems", &fb_elems)?;
+            compare_vec_len(&semantic_ae.elements, fb_elems)?;
+
+            let mut i: usize = 0;
+            loop {
+                if i >= semantic_ae.elements.len() {
+                    break Ok(());
+                }
+                let fb_we = &fb_elems.get(i);
+                let fb_e = &fb_we.expression(); 
+                compare_exprs(&semantic_ae.elements[i], fb_we.expression_type(), fb_e)?;
+                i = i + 1
+            }
+        }
+        (semantic::nodes::Expression::Function(semantic_fe), fbsemantic::Expression::FunctionExpression) => {
+            Ok(())
+            // let fb_fe = fbsemantic::FunctionExpression::init_from_table(*fb_tbl);
+            // compare_loc(&semantic_fe.loc, &fb_fe.loc())?;
+            // compare_params(&semantic_fe.params, &fb_fe.params())?;
+
+            // // compare function bodies 
+            // compare_loc(&semantic_fe.body.loc(), &fb_fe.body().unwrap().loc());
+            // let mut block_len: usize = 0; 
+            // let mut current_sem = &semantic_fe.body;  
+            // let fb_list = fb_fe.body().unwrap().body().unwrap(); 
+            // loop {
+            //     match current_sem {
+            //         semantic::nodes::Block::Expr(expr_statement, next) => {
+            //             compare_exprs(
+            //                 &expr_statement.expression, 
+            //                 fb_expr_ty: fbsemantic::Expression, 
+            //                 &fb_list.get(block_len).statement)
+            //             current_sem = next.as_ref(); 
+            //         }
+            //         semantic::nodes::Block::Variable(_, next) => {
+            //             current_sem = next.as_ref();
+            //         }
+            //         semantic::nodes::Block::Return(retn) => {
+            //             break Ok(()); 
+            //         }
+            //     }
+            //     block_len += 1;
+            // }
+        }
+        (semantic::nodes::Expression::Logical(semantic_le), fbsemantic::Expression::LogicalExpression) => {
+            let fb_le = fbsemantic::LogicalExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_le.loc, &fb_le.loc())?;
+            compare_exprs(&semantic_le.left, fb_le.left_type(), &fb_le.left())?;
+            compare_exprs(&semantic_le.right, fb_le.right_type(), &fb_le.right())?;
+            match semantic_logical_operator(&fb_le.operator()) == semantic_le.operator {
+                true => Ok(()),
+                false => Err(String::from("logical operator mismatch")),
+            }
+        }
+        (semantic::nodes::Expression::Object(semantic_oe), fbsemantic::Expression::ObjectExpression) => {
+            let fb_oe = fbsemantic::ObjectExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_oe.loc, &fb_oe.loc())?;
+            compare_property_list(&semantic_oe.properties, &fb_oe.properties())?;
+            compare_opt_expr_ids(&semantic_oe.with, &fb_oe.with())
+        }
+        (semantic::nodes::Expression::Member(semantic_me), fbsemantic::Expression::MemberExpression) => {
+            let fb_me = fbsemantic::MemberExpression::init_from_table(*fb_tbl);
+            compare_member_expr(&semantic_me, &Some(fb_me))
+        }
+        (semantic::nodes::Expression::Index(semantic_ie), fbsemantic::Expression::IndexExpression) => {
+            let fb_ie = fbsemantic::IndexExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_ie.loc, &fb_ie.loc())?;
+            compare_exprs(&semantic_ie.array, fb_ie.array_type(), &fb_ie.array())?;
+            compare_exprs(&semantic_ie.index, fb_ie.index_type(), &fb_ie.index())
+        }
+        (semantic::nodes::Expression::Binary(semantic_be), fbsemantic::Expression::BinaryExpression) => {
+            let fb_be = fbsemantic::BinaryExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_be.loc, &fb_be.loc())?;
+            compare_exprs(&semantic_be.left, fb_be.left_type(), &fb_be.left())?;
+            compare_exprs(&semantic_be.right, fb_be.right_type(), &fb_be.right())?;
+            match semantic_operator(fb_be.operator()) == semantic_be.operator {
+                true => Ok(()),
+                false => Err(String::from("binary operator mismatch")),
+            }
+        }
+        (semantic::nodes::Expression::Unary(semantic_ue), fbsemantic::Expression::UnaryExpression) => {
+            let fb_ue = fbsemantic::UnaryExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_ue.loc, &fb_ue.loc())?;
+            compare_exprs(&semantic_ue.argument, fb_ue.argument_type(), &fb_ue.argument())?;
+            match semantic_operator(fb_ue.operator()) == semantic_ue.operator {
+                true => Ok(()),
+                false => Err(String::from("unary operator mismatch")),
+            }
+        }
+        (semantic::nodes::Expression::Call(semantic_ce), fbsemantic::Expression::CallExpression) => {
+            let fb_ce = fbsemantic::CallExpression::init_from_table(*fb_tbl);
+            compare_call_exprs(&semantic_ce, &Some(fb_ce))
+        }
+        (semantic::nodes::Expression::Conditional(semantic_ce), fbsemantic::Expression::ConditionalExpression) => {
+            let fb_ce = fbsemantic::ConditionalExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_ce.loc, &fb_ce.loc())?;
+            compare_exprs(&semantic_ce.test, fb_ce.test_type(), &fb_ce.test())?;
+            compare_exprs(
+                &semantic_ce.consequent,
+                fb_ce.consequent_type(),
+                &fb_ce.consequent(),
+            )?;
+            compare_exprs(
+                &semantic_ce.alternate,
+                fb_ce.alternate_type(),
+                &fb_ce.alternate(),
+            )
+        }
+        (semantic::nodes::Expression::StringExpr(semantic_se), fbsemantic::Expression::StringExpression) => {
+            let fb_se = fbsemantic::StringExpression::init_from_table(*fb_tbl);
+            compare_loc(&semantic_se.loc, &fb_se.loc())?;
+            compare_string_expr_part_list(&semantic_se.parts, &fb_se.parts())
+        }
+        (semantic_expr, fb_expr_ty) => {
+            let semantic_expr_ty = semantic::walk::Node::from_expr(semantic_expr);
+            let fb_ty = fbsemantic::enum_name_expression(fb_expr_ty);
+            Err(String::from(format!(
+                "wrong expr type; semantic = {}, fb = {}",
+                semantic_expr_ty, fb_ty
+            )))
+        }
+    }
+}
+
+fn compare_property_list(
+    semantic_pl: &Vec<semantic::nodes::Property>,
+    fb_pl: &Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<fbsemantic::Property>>>,
+) -> Result<(), String> {
+    let fb_pl = unwrap_or_fail("property list", fb_pl)?;
+    compare_vec_len(semantic_pl, fb_pl)?;
+    let mut i: usize = 0;
+    loop {
+        if i >= semantic_pl.len() {
+            return Ok(());
+        }
+
+        compare_property(&semantic_pl[i], &fb_pl.get(i))?;
+        i = i + 1;
+    }
+}
+
+fn compare_params(
+    semantic_params: &Vec<semantic::nodes::FunctionParameter>,
+    fb_params: &Option<flatbuffers::Vector<flatbuffers::ForwardsUOffset<fbsemantic::FunctionParameter>>>,
+) -> Result<(), String> {
+    let fb_params = unwrap_or_fail("params", fb_params)?;
+    compare_vec_len(semantic_params, fb_params)?;
+    let mut i: usize = 0;
+    loop {
+        if i >= semantic_params.len() {
+            return Ok(());
+        }
+
+        compare_param(&semantic_params[i], &fb_params.get(i))?;
+        i = i + 1;
+    }
+}
+
+fn compare_param(semantic_param: &semantic::nodes::FunctionParameter, fb_param: &fbsemantic::FunctionParameter) -> Result<(), String> {
+    compare_loc(&semantic_param.loc, &fb_param.loc())?;
+    if semantic_param.is_pipe != fb_param.is_pipe() {
+        return Err(format!("mismatch: semantic: {}, fb: {}", semantic_param.is_pipe, fb_param.is_pipe()));
+    }
+    compare_ids(&semantic_param.key, &fb_param.key()); 
+    compare_exprs(&semantic_param.default.as_ref().unwrap(), fb_param.default_type(), &fb_param.default())
+}
+
+fn compare_property(semantic_prop: &semantic::nodes::Property, fb_prop: &fbsemantic::Property) -> Result<(), String> {
+    compare_loc(&semantic_prop.loc, &fb_prop.loc())?;
+    compare_ids(&semantic_prop.key, &fb_prop.key()); 
+    let expr_prop = &semantic_prop.value; 
+    compare_exprs(&expr_prop, fb_prop.value_type(), &fb_prop.value())
+}
+
+fn compare_package_clause(
+    semantic_pkg_clause: &Option<semantic::nodes::PackageClause>,
+    fb_pkg_clause: &Option<fbsemantic::PackageClause>,
+) -> Result<(), String> {
+    let (semantic_pkg_clause, fb_pkg_clause) = match (semantic_pkg_clause, fb_pkg_clause) {
+        (None, None) => return Ok(()),
+        (None, Some(_)) => return Err(String::from("found package clause where not expected")),
+        (Some(_), None) => return Err(String::from("missing package clause")),
+        (Some(ac), Some(fc)) => (ac, fc),
+    };
+    compare_loc(&semantic_pkg_clause.loc, &fb_pkg_clause.loc())?;
+    compare_ids(&semantic_pkg_clause.name, &fb_pkg_clause.name())?;
+    Ok(())
+}
+
+fn compare_imports(
+    semantic_imports: &Vec<semantic::nodes::ImportDeclaration>,
+    fb_imports: &Option<
+        flatbuffers::Vector<flatbuffers::ForwardsUOffset<fbsemantic::ImportDeclaration>>,
+    >,
+) -> Result<(), String> {
+    let fb_imports = unwrap_or_fail("imports", fb_imports)?;
+    compare_vec_len(semantic_imports, fb_imports)?;
+    let mut i: usize = 0;
+    loop {
+        if i >= semantic_imports.len() {
+            break Ok(());
+        }
+
+        compare_import_decls(&semantic_imports[i], &fb_imports.get(i))?;
+        i = i + 1;
+    }
+}
+
+fn compare_import_decls(
+    semantic_id: &semantic::nodes::ImportDeclaration,
+    fb_id: &fbsemantic::ImportDeclaration,
+) -> Result<(), String> {
+    compare_opt_ids(&semantic_id.alias, &fb_id.alias())?;
+    compare_string_lits(&semantic_id.path, &fb_id.path())?;
+    Ok(())
+}
+
+fn compare_loc(
+    semantic_loc: &ast::SourceLocation,
+    fb_loc: &Option<fbsemantic::SourceLocation>,
+) -> Result<(), String> {
+    let fb_loc = unwrap_or_fail("source location", fb_loc)?;
+    compare_opt_strings("source location file", &semantic_loc.file, &fb_loc.file())?;
+    compare_pos(&semantic_loc.start, &fb_loc.start())?;
+    compare_pos(&semantic_loc.end, &fb_loc.end())?;
+    compare_opt_strings("source location source", &semantic_loc.source, &fb_loc.source())?;
+    Ok(())
+}
+
+fn compare_vec_len<T, U>(semantic_vec: &Vec<T>, fb_vec: &flatbuffers::Vector<U>) -> Result<(), String> {
+    match semantic_vec.len() == fb_vec.len() {
+        true => Ok(()),
+        false => Err(String::from(format!(
+            "vectors have different lengths: semantic = {}, fb = {}",
+            semantic_vec.len(),
+            fb_vec.len(),
+        ))),
+    }
+}
+
+fn unwrap_or_fail<'a, T>(msg: &str, o: &'a Option<T>) -> Result<&'a T, String> {
+    match o {
+        None => Err(String::from(format!("missing {}", msg))),
+        Some(t) => Ok(t),
+    }
+}
+
+fn compare_strings(msg: &str, semantic_str: &String, fb_str: &Option<&str>) -> Result<(), String> {
+    let fb_str = unwrap_or_fail("string", fb_str)?;
+    if semantic_str.as_str() != *fb_str {
+        return Err(format!(
+            "{} mismatch: semantic: {}, fb: {}",
+            msg, semantic_str, fb_str
+        ));
+    };
+    Ok(())
+}
+
+fn compare_opt_strings(
+    msg: &str,
+    semantic_str: &Option<String>,
+    fb_str: &Option<&str>,
+) -> Result<(), String> {
+    match (semantic_str, fb_str) {
+        (None, None) => return Ok(()),
+        (None, Some(s)) => Err(String::from(format!(
+            "comparing opt string for {}: semantic had none, fb had {}",
+            msg, s,
+        ))),
+        (Some(s), None) => Err(String::from(format!(
+            "comparing opt string for {}: semantic had {}, fb had none",
+            msg, s,
+        ))),
+        (Some(semantic_str), fb_str) => compare_strings(msg, semantic_str, fb_str),
+    }
+}
+
+fn compare_pos(semantic_pos: &ast::Position, fb_pos: &Option<&fbsemantic::Position>) -> Result<(), String> {
+    let fb_pos = unwrap_or_fail("position", fb_pos)?;
+    if semantic_pos.line != fb_pos.line() as u32 {
+        return Err(String::from(format!(
+            "semantic line position is {}, fb is {}",
+            semantic_pos.line,
+            fb_pos.line()
+        )));
+    }
+    if semantic_pos.column != fb_pos.column() as u32 {
+        return Err(String::from(format!(
+            "semantic column position is {}, fb is {}",
+            semantic_pos.line,
+            fb_pos.line()
+        )));
+    }
+    Ok(())
+}
+
+fn compare_string_lits(
+    semantic_lit: &semantic::nodes::StringLit,
+    fb_lit: &Option<fbsemantic::StringLiteral>,
+) -> Result<(), String> {
+    let fb_lit = unwrap_or_fail("string literal", fb_lit)?;
+    compare_loc(&semantic_lit.loc, &fb_lit.loc())?;
+    compare_strings("string literal value", &semantic_lit.value, &fb_lit.value())?;
+    Ok(())
+}
+
+fn compare_opt_exprs(
+    semantic_expr: &Option<semantic::nodes::Expression>,
+    fb_expr_ty: fbsemantic::Expression,
+    fb_expr: &Option<flatbuffers::Table>,
+) -> Result<(), String> {
+    match (semantic_expr, fb_expr_ty) {
+        (None, fbsemantic::Expression::NONE) => Ok(()),
+        (None, _) => Err(String::from("expected no expr but got one")),
+        (Some(_), fbsemantic::Expression::NONE) => Err(String::from("expected an expr but got none")),
+        (Some(semantic_expr), _) => compare_exprs(semantic_expr, fb_expr_ty, fb_expr),
+    }
+}
+
+fn compare_call_exprs(
+    semantic_ce: &semantic::nodes::CallExpr,
+    fb_ce: &Option<fbsemantic::CallExpression>,
+) -> Result<(), String> {
+    let fb_ce = unwrap_or_fail("call expr", fb_ce)?;
+    compare_loc(&semantic_ce.loc, &fb_ce.loc())?;
+    compare_exprs(&semantic_ce.callee, fb_ce.callee_type(), &fb_ce.callee())?;
+    let semantic_args = &semantic_ce.arguments[0];
+    let fb_args = fb_ce.arguments().unwrap();
+    compare_property(semantic_args, &fb_args); 
+    Ok(())
+}
+
+fn compare_string_expr_part_list(
+    semantic_parts: &Vec<semantic::nodes::StringExprPart>,
+    fb_parts: &Option<
+        flatbuffers::Vector<flatbuffers::ForwardsUOffset<fbsemantic::StringExpressionPart>>,
+    >,
+) -> Result<(), String> {
+    let fb_parts = unwrap_or_fail("string expr parts", fb_parts)?;
+    compare_vec_len(semantic_parts, fb_parts)?;
+    let mut i: usize = 0;
+    loop {
+        if i >= semantic_parts.len() {
+            break Ok(());
+        }
+
+        compare_string_expr_part(&semantic_parts[i], &fb_parts.get(i))?;
+        i = i + 1
+    }
+}
+
+fn compare_string_expr_part(
+    semantic_part: &semantic::nodes::StringExprPart,
+    fb_part: &fbsemantic::StringExpressionPart,
+) -> Result<(), String> {
+    match (
+        semantic_part,
+        fb_part.text_value(),
+        fb_part.interpolated_expression_type(),
+        fb_part.interpolated_expression(),
+    ) {
+        (semantic::nodes::StringExprPart::Text(semantic_text), Some(fb_text), fbsemantic::Expression::NONE, None) => {
+            compare_loc(&semantic_text.loc, &fb_part.loc())?;
+            match semantic_text.value.as_str() == fb_text {
+                true => Ok(()),
+                false => Err(String::from(
+                    "mismatch in value of text part of string expr",
+                )),
+            }
+        }
+        (semantic::nodes::StringExprPart::Interpolated(semantic_ip), None, fb_expr_ty, fb_expr) => {
+            compare_loc(&semantic_ip.loc, &fb_part.loc())?;
+            compare_exprs(&semantic_ip.expression, fb_expr_ty, &fb_expr)
+        }
+        _ => Err(String::from(
+            "mismatch in string expr part text/interpolated",
+        )),
+    }
+}
+
+fn semantic_operator(fb_op: fbsemantic::Operator) -> ast::Operator {
+    match fb_op {
+        fbsemantic::Operator::MultiplicationOperator => ast::Operator::MultiplicationOperator,
+        fbsemantic::Operator::DivisionOperator => ast::Operator::DivisionOperator,
+        fbsemantic::Operator::ModuloOperator => ast::Operator::ModuloOperator,
+        fbsemantic::Operator::PowerOperator => ast::Operator::PowerOperator,
+        fbsemantic::Operator::AdditionOperator => ast::Operator::AdditionOperator,
+        fbsemantic::Operator::SubtractionOperator => ast::Operator::SubtractionOperator,
+        fbsemantic::Operator::LessThanEqualOperator => ast::Operator::LessThanEqualOperator,
+        fbsemantic::Operator::LessThanOperator => ast::Operator::LessThanOperator,
+        fbsemantic::Operator::GreaterThanEqualOperator => ast::Operator::GreaterThanEqualOperator,
+        fbsemantic::Operator::GreaterThanOperator => ast::Operator::GreaterThanOperator,
+        fbsemantic::Operator::StartsWithOperator => ast::Operator::StartsWithOperator,
+        fbsemantic::Operator::InOperator => ast::Operator::InOperator,
+        fbsemantic::Operator::NotOperator => ast::Operator::NotOperator,
+        fbsemantic::Operator::ExistsOperator => ast::Operator::ExistsOperator,
+        fbsemantic::Operator::NotEmptyOperator => ast::Operator::NotEmptyOperator,
+        fbsemantic::Operator::EmptyOperator => ast::Operator::EmptyOperator,
+        fbsemantic::Operator::EqualOperator => ast::Operator::EqualOperator,
+        fbsemantic::Operator::NotEqualOperator => ast::Operator::NotEqualOperator,
+        fbsemantic::Operator::RegexpMatchOperator => ast::Operator::RegexpMatchOperator,
+        fbsemantic::Operator::NotRegexpMatchOperator => ast::Operator::NotRegexpMatchOperator,
+        fbsemantic::Operator::InvalidOperator => ast::Operator::InvalidOperator,
+    }
+}
+
+fn semantic_logical_operator(lo: &fbsemantic::LogicalOperator) -> ast::LogicalOperator {
+    match lo {
+        fbsemantic::LogicalOperator::AndOperator => ast::LogicalOperator::AndOperator,
+        fbsemantic::LogicalOperator::OrOperator => ast::LogicalOperator::OrOperator,
+    }
+}

--- a/libflux/src/flux/semantic/flatbuffers/types.rs
+++ b/libflux/src/flux/semantic/flatbuffers/types.rs
@@ -301,7 +301,7 @@ fn build_type_assignment<'a>(
 }
 
 /// Encodes a polytype as a flatbuffer
-fn build_polytype<'a>(
+pub fn build_polytype<'a>(
     builder: &mut flatbuffers::FlatBufferBuilder<'a>,
     t: PolyType,
 ) -> flatbuffers::WIPOffset<fb::PolyType<'a>> {
@@ -343,7 +343,7 @@ fn build_constraint<'a>(
     )
 }
 
-fn build_type<'a>(
+pub fn build_type<'a>(
     builder: &mut flatbuffers::FlatBufferBuilder<'a>,
     t: MonoType,
 ) -> (

--- a/libflux/src/flux/semantic/mod.rs
+++ b/libflux/src/flux/semantic/mod.rs
@@ -2,6 +2,7 @@ pub mod analyze;
 pub use analyze::analyze;
 
 mod import;
+
 mod infer;
 mod sub;
 

--- a/libflux/src/flux/semantic/walk/walk.rs
+++ b/libflux/src/flux/semantic/walk/walk.rs
@@ -171,9 +171,9 @@ impl<'a> Node<'a> {
     }
 }
 
-// Private utility functions.
+// Utility functions.
 impl<'a> Node<'a> {
-    fn from_expr(expr: &'a Expression) -> Node {
+    pub fn from_expr(expr: &'a Expression) -> Node {
         match *expr {
             Expression::Identifier(ref e) => Node::IdentifierExpr(e),
             Expression::Array(ref e) => Node::ArrayExpr(e),
@@ -197,7 +197,7 @@ impl<'a> Node<'a> {
             Expression::Regexp(ref e) => Node::RegexpLit(e),
         }
     }
-    fn from_stmt(stmt: &'a Statement) -> Node {
+    pub fn from_stmt(stmt: &'a Statement) -> Node {
         match *stmt {
             Statement::Expr(ref s) => Node::ExprStmt(s),
             Statement::Variable(ref s) => Node::VariableAssgn(s),

--- a/libflux/src/flux/semantic/walk/walk_mut.rs
+++ b/libflux/src/flux/semantic/walk/walk_mut.rs
@@ -50,7 +50,7 @@ pub enum NodeMut<'a> {
     InterpolatedPart(&'a mut InterpolatedPart),
 
     // Assignment.
-    VariableAssgn(&'a mut VariableAssgn),
+    VariableAssgn(&'a mut VariableAssgn), // Native variable assignment
     MemberAssgn(&'a mut MemberAssgn),
 }
 

--- a/semantic/flatbuffers.go
+++ b/semantic/flatbuffers.go
@@ -587,3 +587,23 @@ func getPolyType(fb *fbsemantic.NativeVariableAssignment) (*types.PolyType, erro
 	t := fb.Typ(nil)
 	return types.NewPolyType(t)
 }
+
+func objectExprFromProperties(fb *fbsemantic.CallExpression) (*ObjectExpression, error) {
+	props := make([]*Property, fb.ArgumentsLength())
+	for i := 0; i < fb.ArgumentsLength(); i++ {
+		fbProp := new(fbsemantic.Property)
+		if !fb.Arguments(fbProp, i) {
+			return nil, errors.New(codes.Internal, "missing property")
+		}
+		prop := new(Property)
+		if err := prop.FromBuf(fbProp); err != nil {
+			return nil, err
+		}
+		props = append(props, prop)
+	}
+
+	obj := &ObjectExpression{
+		Properties: props,
+	}
+	return obj, nil
+}

--- a/semantic/flatbuffers_gen.go
+++ b/semantic/flatbuffers_gen.go
@@ -135,11 +135,8 @@ func (rcv *CallExpression) FromBuf(fb *fbsemantic.CallExpression) error {
 	if rcv.Callee, err = fromExpressionTable(fb.Callee, fb.CalleeType()); err != nil {
 		return errors.Wrap(err, codes.Inherit, "CallExpression.Callee")
 	}
-	if fbArguments := fb.Arguments(nil); fbArguments != nil {
-		rcv.Arguments = new(ObjectExpression)
-		if err = rcv.Arguments.FromBuf(fbArguments); err != nil {
-			return errors.Wrap(err, codes.Inherit, "CallExpression.Arguments")
-		}
+	if rcv.Arguments, err = objectExprFromProperties(fb); err != nil {
+		return errors.Wrap(err, codes.Inherit, "CallExpression.Arguments")
 	}
 	if rcv.Pipe, err = fromExpressionTable(fb.Pipe, fb.PipeType()); err != nil {
 		return errors.Wrap(err, codes.Inherit, "CallExpression.Pipe")

--- a/semantic/internal/fbsemantic/CallExpression.go
+++ b/semantic/internal/fbsemantic/CallExpression.go
@@ -60,17 +60,24 @@ func (rcv *CallExpression) Callee(obj *flatbuffers.Table) bool {
 	return false
 }
 
-func (rcv *CallExpression) Arguments(obj *ObjectExpression) *ObjectExpression {
+func (rcv *CallExpression) Arguments(obj *Property, j int) bool {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
-		if obj == nil {
-			obj = new(ObjectExpression)
-		}
+		x := rcv._tab.Vector(o)
+		x += flatbuffers.UOffsetT(j) * 4
+		x = rcv._tab.Indirect(x)
 		obj.Init(rcv._tab.Bytes, x)
-		return obj
+		return true
 	}
-	return nil
+	return false
+}
+
+func (rcv *CallExpression) ArgumentsLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
 }
 
 func (rcv *CallExpression) PipeType() byte {
@@ -129,6 +136,9 @@ func CallExpressionAddCallee(builder *flatbuffers.Builder, callee flatbuffers.UO
 }
 func CallExpressionAddArguments(builder *flatbuffers.Builder, arguments flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(arguments), 0)
+}
+func CallExpressionStartArgumentsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
 }
 func CallExpressionAddPipeType(builder *flatbuffers.Builder, pipeType byte) {
 	builder.PrependByteSlot(4, pipeType, 0)

--- a/semantic/semantic.fbs
+++ b/semantic/semantic.fbs
@@ -111,7 +111,7 @@ union Assignment {
   NativeVariableAssignment,
 }
 
-union Expression  {
+union Expression {
   StringExpression,
   ArrayExpression,
   FunctionExpression,
@@ -302,7 +302,7 @@ table BinaryExpression {
 table CallExpression {
   loc:SourceLocation;
   callee:Expression;
-  arguments:ObjectExpression;
+  arguments:[Property];
   pipe:Expression;
   typ:MonoType;
 }
@@ -341,7 +341,7 @@ table ObjectExpression {
   loc:SourceLocation;
   with:IdentifierExpression;
   properties:[Property];
-  typ:MonoType;
+  typ: MonoType; 
 }
 
 table UnaryExpression {


### PR DESCRIPTION
Semantic graph Flatbuffers need to be serialized in Rust. This commit serializes and performs testing. 

Additional testing may be added to support round trip with deserialization on the Go side. 

The Rust semantic graph `DurationLit` node only contains a single `Duration` value, while the AST and the Go Semantic Graph allow for a list of type `Duration` to accommodate the possible multiple duration values. To temporarily work around this difference, I'm serializing the Flatbuffers `DurationLiteral` with a single duration value stored in a vector. This needs to be fixed before Algorithm W can be deployed in order to not break calendar durations. I'll open another PR to handle that fix to the Rust semantic graph. 

I also worked with @wolffcm to make changes to the code that generates deserializing code on the Go side to accommodate for the difference between CallExpression arguments in the Rust (vector of Properties) and in the Go (pointer to an ObjectExpression) semantic graphs. 

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
