### PR TITLE
feat(libflux): create utility program for building libflux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-# Top level Makefile for the entire project
-#
-# This Makefile encodes the "go generate" prerequeisites ensuring that the proper tooling is installed and
+# This Makefile encodes the "go generate" prerequisites ensuring that the proper tooling is installed and
 # that the generate steps are executed when their prerequeisites files change.
 #
 # This Makefile follows a few conventions:
@@ -43,7 +41,8 @@ GENERATED_TARGETS = \
 	semantic/internal/fbsemantic \
 	libflux/src/ast/flatbuffers/ast_generated.rs \
 	libflux/src/semantic/flatbuffers/semantic_generated.rs \
-	libflux/scanner.c
+	libflux/scanner.c \
+	libflux/go/libflux/flux.h
 
 generate: $(GENERATED_TARGETS)
 
@@ -78,6 +77,9 @@ libflux: libflux/target/debug/libflux.a
 # command line interface than the gnu equivalent.
 libflux/target/debug/libflux.a:
 	cd libflux && $(CARGO) build $(CARGO_ARGS)
+
+libflux/go/libflux/flux.h: libflux/include/influxdata/flux.h
+	$(GO_GENERATE) ./libflux/go/libflux
 
 # The dependency file produced by Rust appears to be wrong and uses
 # absolute paths while we use relative paths everywhere. So we need

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/segmentio/kafka-go v0.1.0
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
-	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/spf13/pflag v1.0.3
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1

--- a/internal/cmd/flux-config/build.go
+++ b/internal/cmd/flux-config/build.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const modulePath = "github.com/influxdata/flux"
+
+type Module struct {
+	Path      string
+	Version   string
+	Dir       string
+	GoMod     string
+	GoVersion string
+}
+
+func getGoCache() (string, error) {
+	var buf strings.Builder
+	cmd := exec.Command("go", "env", "GOCACHE")
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func getModule() (*Module, error) {
+	cmd := exec.Command("go", "list", "-m", "-json", modulePath)
+	r, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	var m Module
+	if err := json.NewDecoder(r).Decode(&m); err != nil {
+		return nil, err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func copySources(srcdir string, mod *Module) error {
+	// Retrieve the sources from the module.
+	root := filepath.Join(mod.Dir, "libflux")
+	if _, err := os.Stat(root); err != nil {
+		return fmt.Errorf("libflux sources not present: %s", err)
+	}
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if path == root || err != nil {
+			return nil
+		} else if info.IsDir() && info.Name() == "target" {
+			return filepath.SkipDir
+		}
+
+		relpath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(srcdir, relpath)
+		if _, err := os.Lstat(target); err == nil {
+			_ = os.Remove(target)
+		}
+		if err := os.Symlink(path, target); err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+}
+
+func runCargo(srcdir string) error {
+	var out io.Writer = os.Stderr
+	if !flags.Verbose {
+		out = &bytes.Buffer{}
+	}
+	cmd := exec.Command("cargo", "build", "--release")
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Dir = srcdir
+	if err := cmd.Run(); err != nil {
+		if r, ok := out.(io.Reader); ok {
+			_, _ = io.Copy(os.Stderr, r)
+		}
+		return err
+	}
+	return nil
+}
+
+func build() (string, error) {
+	mod, err := getModule()
+	if err != nil {
+		return "", err
+	}
+
+	gocache, err := getGoCache()
+	if err != nil {
+		return "", err
+	}
+
+	version := mod.Version
+	if version == "" {
+		version = "latest"
+	}
+	srcdir := filepath.Join(gocache, "libflux", "@"+mod.Version)
+	if err := os.MkdirAll(srcdir, 0755); err != nil {
+		return "", err
+	}
+	if err := copySources(srcdir, mod); err != nil {
+		return "", err
+	}
+
+	// Run cargo to build the library.
+	if err := runCargo(srcdir); err != nil {
+		return "", err
+	}
+	// Create a directory for the library and static link it there.
+	// This is done to avoid picking up the dynamic library when linking.
+	libDir := filepath.Join(srcdir, "lib")
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		return "", err
+	}
+	target := filepath.Join(libDir, "libflux.a")
+	if _, err := os.Stat(target); err == nil {
+		_ = os.Remove(target)
+	}
+	if err := os.Link(
+		filepath.Join(srcdir, "target/release/libflux.a"),
+		target,
+	); err != nil {
+		return "", err
+	}
+	return libDir, nil
+}

--- a/internal/cmd/flux-config/main.go
+++ b/internal/cmd/flux-config/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+var flags struct {
+	Cflags  bool
+	Libs    bool
+	Verbose bool
+}
+
+func getCflags() (string, error) {
+	// TODO(jsternberg): Output the location of influxdata/flux.h.
+	return "", errors.New("not supported yet")
+}
+
+func getLdflags() (string, error) {
+	dir, err := build()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("-L%s", dir), nil
+}
+
+func main() {
+	pflag.BoolVar(&flags.Cflags, "cflags", false, "output all pre-processor and compiler flags")
+	pflag.BoolVar(&flags.Libs, "libs", false, "output all linker flags")
+	pflag.BoolVarP(&flags.Verbose, "verbose", "v", false, "verbose output from builds")
+	pflag.Parse()
+
+	var out strings.Builder
+	if flags.Cflags {
+		cflags, err := getCflags()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: cflags: %s.\n", err)
+			os.Exit(1)
+		}
+		if len(cflags) > 0 {
+			if out.Len() > 0 {
+				out.WriteByte(' ')
+			}
+			out.WriteString(cflags)
+		}
+	}
+
+	if flags.Libs {
+		ldflags, err := getLdflags()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "error: ldflags: %s.\n", err)
+			os.Exit(1)
+		}
+		if len(ldflags) > 0 {
+			if out.Len() > 0 {
+				out.WriteByte(' ')
+			}
+			out.WriteString(ldflags)
+		}
+	}
+	fmt.Println(out.String())
+}

--- a/libflux/go/libflux/flux.h
+++ b/libflux/go/libflux/flux.h
@@ -1,0 +1,53 @@
+#ifndef _INFLUXDATA_FLUX_H
+#define _INFLUXDATA_FLUX_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// flux_ast_t is the AST representation of a flux query.
+struct flux_ast_t;
+
+// flux_buffer_t is a reference to a byte-slice.
+struct flux_buffer_t {
+	// data is a pointer to the data contained within the buffer.
+	void *data;
+
+	// len is the length of the buffer.
+	size_t len;
+};
+
+// flux_error_t represents a flux error.
+struct flux_error_t;
+
+// flux_parse will take in a string and return the AST representation
+// of the query.
+struct flux_ast_t *flux_parse(const char *);
+
+struct flux_buffer_t *flux_parse_fb(const char *);
+
+// flux_ast_marshal_json will marshal json and fill in the given buffer
+// with the data. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_ast_marshal_json(struct flux_ast_t *, struct flux_buffer_t *);
+
+// flux_buffer_free will free the memory that was allocated for a buffer.
+// This should only be called if the caller is the one who owns the data.
+void flux_buffer_free(struct flux_buffer_t *);
+
+// flux_error_str will return a string representation of the error.
+// This will allocate memory for the returned string.
+const char *flux_error_str(struct flux_error_t *);
+
+// flux_free will free a resource.
+void flux_free(void *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libflux/go/libflux/parser.go
+++ b/libflux/go/libflux/parser.go
@@ -2,9 +2,9 @@
 
 package libflux
 
-// #cgo CFLAGS: -I${SRCDIR}/../../include
+// #cgo CFLAGS: -I.
 // #cgo LDFLAGS: -L. -lflux
-// #include <influxdata/flux.h>
+// #include "flux.h"
 // #include <stdlib.h>
 import "C"
 
@@ -15,6 +15,8 @@ import (
 
 	"github.com/influxdata/flux/ast"
 )
+
+//go:generate cp ../../include/influxdata/flux.h flux.h
 
 // freeable indicates a resource that has memory
 // allocated to it outside of Go and must be freed.


### PR DESCRIPTION
The utility program will build libflux in the go build cache and then
print out command line options to be used with a compiler. This matches
the same interface as `pkg-config` and can be used in a similar way.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written