### PR TITLE
feat(stdlib): expose the optimized pivot

### DIFF
--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -643,6 +643,41 @@ func RunTableTests(t *testing.T, tt TableTest) {
 		})
 		tt.finish(false)
 	})
+	tt.run(t, "EmptyAfterDo", func(tt *tableTest) {
+		// It should be ok to call empty after do and get the same result.
+		tt.do(func(tbl flux.Table) error {
+			want := tbl.Empty()
+			if err := tbl.Do(func(cr flux.ColReader) error {
+				if cr.Len() > 0 {
+					want = false
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+			got := tbl.Empty()
+
+			if got != want {
+				tt.t.Errorf("unexpected value for empty -got/+want\n\t- %v\n\t+ %v", got, want)
+			}
+			return nil
+		})
+		tt.finish(true)
+	})
+	tt.run(t, "EmptyAfterDone", func(tt *tableTest) {
+		// It should be ok to call empty after done and get the same result.
+		tt.do(func(tbl flux.Table) error {
+			want := tbl.Empty()
+			tbl.Done()
+			got := tbl.Empty()
+
+			if got != want {
+				tt.t.Errorf("unexpected value for empty -got/+want\n\t- %v\n\t+ %v", got, want)
+			}
+			return nil
+		})
+		tt.finish(false)
+	})
 	tt.run(t, "Retain", func(tt *tableTest) {
 		// Retain should allow the column reader to be used outside of Do.
 		tt.do(func(tbl flux.Table) error {

--- a/stdlib/universe/pivot_test.go
+++ b/stdlib/universe/pivot_test.go
@@ -1324,7 +1324,14 @@ func TestPivot2_Process(t *testing.T) {
 				tc.want,
 				nil,
 				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
-					tr, d, err := universe.NewPivotTransformation2(context.Background(), *tc.spec, id, alloc)
+					spec := *tc.spec
+					spec.IsKeyColumnFunc = func(label string) bool {
+						return true
+					}
+					spec.IsSortedByFunc = func(cols []string, desc bool) bool {
+						return true
+					}
+					tr, d, err := universe.NewPivotTransformation2(context.Background(), spec, id, alloc)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -1339,6 +1346,12 @@ func TestPivot2_Process_VariousSchemas(t *testing.T) {
 		RowKey:      []string{"_time"},
 		ColumnKey:   []string{"_field"},
 		ValueColumn: "_value",
+		IsKeyColumnFunc: func(label string) bool {
+			return true
+		},
+		IsSortedByFunc: func(cols []string, desc bool) bool {
+			return true
+		},
 	}
 	mem := &memory.Allocator{}
 	id := executetest.RandomDatasetID()
@@ -1397,6 +1410,12 @@ func benchmarkPivot(b *testing.B, n int) {
 		RowKey:      []string{execute.DefaultTimeColLabel},
 		ColumnKey:   []string{"_field"},
 		ValueColumn: execute.DefaultValueColLabel,
+		IsSortedByFunc: func(cols []string, desc bool) bool {
+			return true
+		},
+		IsKeyColumnFunc: func(label string) bool {
+			return true
+		},
 	}
 	for i := 0; i < b.N; i++ {
 		executetest.ProcessBenchmarkHelper(b,


### PR DESCRIPTION
This allows the planner to add methods to determine if the new pivot can
be used to the pivot procedure spec.

These methods may be temporary at the moment.

This also adds an additional table test to ensure that `Empty()`
continues functioning and returning the same value after the table has
been read.

#2133

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written