### PR TITLE
fix(e2e-tests): fix e2e usage write test so that its query is properly pushed down

### DIFF
--- a/stdlib/testing/usage/api_test.flux
+++ b/stdlib/testing/usage/api_test.flux
@@ -1686,10 +1686,10 @@ _f = (table=<-) => table
     |> filter(fn: (r) =>
         r.org_id == "03cbe13cce931000"
         and r._measurement == "http_request"
-        and ((r.endpoint == "/api/v2/write" and
-            r._field == "req_bytes" and
-            strings.containsStr(v: r.hostname, substr: "gateway-internal") != true)  or
-        (r.endpoint == "/api/v2/query" and r._field == "resp_bytes"))
+        and ((r.endpoint == "/api/v2/write"
+            and r._field == "req_bytes"
+            and r.hostname !~ /^gateway-internal/)
+        or (r.endpoint == "/api/v2/query" and r._field == "resp_bytes"))
     )
     |> group()
     |> aggregateWindow(every: 1h, fn: count)

--- a/stdlib/testing/usage/writes_test.flux
+++ b/stdlib/testing/usage/writes_test.flux
@@ -3353,7 +3353,7 @@ _f = (table=<-) => table
         and r._field == "req_bytes"
         and r.endpoint == "/api/v2/write"
         and r.status == "204"
-        and (strings.containsStr(v: r.hostname, substr: "gateway-internal") != true)
+        and r.hostname !~ /^gateway-internal/
     )
     |> group()
     |> aggregateWindow(every: 1h, fn: sum)


### PR DESCRIPTION
The original version of the queries used a function invocation that broke being pushed down to storage.

This is a workaround to make everything work.

FYI @ischolten heads up if the queries look good to you.

