### PR TITLE
ci(release): fix the ci release to use `>` instead of `|`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,14 +106,14 @@ jobs:
       - checkout
       - run:
           name: Generate changelog
-          command: |
+          command: >
             ./gotool.sh github.com/influxdata/changelog generate
                 --version $CIRCLE_TAG
                 --commit-url https://github.com/influxdata/flux/commit
                 -o release-notes.txt
       - run:
           name: Perform release
-          command: |
+          command: >
             ./gotool.sh github.com/goreleaser/goreleaser release
                 --rm-dist --release-notes release-notes.txt
 


### PR DESCRIPTION
The `>` in a yaml file ensures that the line is treated as a single
line. The `|` will preserve newlines and since it is a single command
split over multiple lines, the `>` is more appropriate.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written