### PR TITLE
ci(release): use backslashes to escape newlines for the release scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,15 +106,15 @@ jobs:
       - checkout
       - run:
           name: Generate changelog
-          command: >
-            ./gotool.sh github.com/influxdata/changelog generate
-                --version $CIRCLE_TAG
-                --commit-url https://github.com/influxdata/flux/commit
+          command: |
+            ./gotool.sh github.com/influxdata/changelog generate \
+                --version $CIRCLE_TAG \
+                --commit-url https://github.com/influxdata/flux/commit \
                 -o release-notes.txt
       - run:
           name: Perform release
-          command: >
-            ./gotool.sh github.com/goreleaser/goreleaser release
+          command: |
+            ./gotool.sh github.com/goreleaser/goreleaser release \
                 --rm-dist --release-notes release-notes.txt
 
 workflows:


### PR DESCRIPTION
Backslashes need to be used to escape the newlines for the release
script. I previously tried to use `>` because I was under the impression
it would make it one line, but it only does that if all of the
indentations are the same. Since I would like to keep the current
indentation because I find it more readable, this reverts back to using
`|` and adds backslashes so the line is escaped.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written