### PR TITLE
fix(semantic): add bytes monotype to Rust semantic module

### DIFF
--- a/libflux/src/semantic/flatbuffers/semantic_generated.rs
+++ b/libflux/src/semantic/flatbuffers/semantic_generated.rs
@@ -102,11 +102,12 @@ pub enum Type {
   Duration = 5,
   Time = 6,
   Regexp = 7,
+  Bytes = 8,
 
 }
 
 const ENUM_MIN_TYPE: u8 = 0;
-const ENUM_MAX_TYPE: u8 = 7;
+const ENUM_MAX_TYPE: u8 = 8;
 
 impl<'a> flatbuffers::Follow<'a> for Type {
   type Inner = Self;
@@ -140,7 +141,7 @@ impl flatbuffers::Push for Type {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_TYPE:[Type; 8] = [
+const ENUM_VALUES_TYPE:[Type; 9] = [
   Type::Bool,
   Type::Int,
   Type::Uint,
@@ -148,11 +149,12 @@ const ENUM_VALUES_TYPE:[Type; 8] = [
   Type::String,
   Type::Duration,
   Type::Time,
-  Type::Regexp
+  Type::Regexp,
+  Type::Bytes
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_TYPE:[&'static str; 8] = [
+const ENUM_NAMES_TYPE:[&'static str; 9] = [
     "Bool",
     "Int",
     "Uint",
@@ -160,7 +162,8 @@ const ENUM_NAMES_TYPE:[&'static str; 8] = [
     "String",
     "Duration",
     "Time",
-    "Regexp"
+    "Regexp",
+    "Bytes"
 ];
 
 pub fn enum_name_type(e: Type) -> &'static str {

--- a/libflux/src/semantic/flatbuffers/types.rs
+++ b/libflux/src/semantic/flatbuffers/types.rs
@@ -107,6 +107,7 @@ impl From<fb::Basic<'_>> for MonoType {
             fb::Type::Duration => MonoType::Duration,
             fb::Type::Time => MonoType::Time,
             fb::Type::Regexp => MonoType::Regexp,
+            fb::Type::Bytes => MonoType::Bytes,
         }
     }
 }
@@ -297,6 +298,11 @@ fn build_type<'a>(
             let a = fb::BasicArgs {
                 t: fb::Type::Regexp,
             };
+            let v = fb::Basic::create(builder, &a);
+            (v.as_union_value(), fb::MonoType::Basic)
+        }
+        MonoType::Bytes => {
+            let a = fb::BasicArgs { t: fb::Type::Bytes };
             let v = fb::Basic::create(builder, &a);
             (v.as_union_value(), fb::MonoType::Basic)
         }
@@ -495,6 +501,7 @@ mod tests {
         test_serde("forall [] duration");
         test_serde("forall [] time");
         test_serde("forall [] regexp");
+        test_serde("forall [] bytes");
     }
     #[test]
     fn serde_array_type() {

--- a/libflux/src/semantic/parser/grammar.md
+++ b/libflux/src/semantic/parser/grammar.md
@@ -20,7 +20,7 @@ kind        = IDENTIFIER
 monotype    = type_var | primitive | array | row | function
 
 type_var    = 't' ([0-9])*
-primitive   = INT | FLOAT | STRING | BOOL | DURATION | TIME | REGEXP 
+primitive   = INT | FLOAT | STRING | BOOL | DURATION | TIME | REGEXP | BYTES
 array       = '[' monotype ']'
 row         = '{' properties? '}'
 function    = '(' arguments? ')' '->' monotype
@@ -41,6 +41,7 @@ BOOL        = 'bool'
 DURATION    = 'duration'
 TIME        = 'time'
 REGEXP      = 'regexp'
+BYTES       = 'bytes'
 IDENTIFIER  = [a-zA-Z_] ([0-9a-zA-Z_])*
 WHITESPACE  = [ \t\r\n]+ -> skip
 ```

--- a/libflux/src/semantic/tests.rs
+++ b/libflux/src/semantic/tests.rs
@@ -513,6 +513,14 @@ fn string_interpolation() {
     }
     test_infer_err! {
         env: map![
+            "name" => "forall [] bytes",
+        ],
+        src: r#"
+            "Hello, ${name}!"
+        "#,
+    }
+    test_infer_err! {
+        env: map![
             "name" => "forall [] [int]",
         ],
         src: r#"
@@ -580,6 +588,24 @@ fn array_lit() {
         src: "a = [/a/, /b/, /c/]",
         exp: map![
             "a" => "forall [] [regexp]",
+        ],
+    }
+    test_infer! {
+        env: map![
+            "bs" => "forall [] bytes",
+        ],
+        src: "a = [bs, bs, bs]",
+        exp: map![
+            "a" => "forall [] [bytes]",
+        ],
+    }
+    test_infer! {
+        env: map![
+            "f" => "forall [] () -> bytes",
+        ],
+        src: "a = [f(), f(), f()]",
+        exp: map![
+            "a" => "forall [] [bytes]",
         ],
     }
     test_infer! {
@@ -684,6 +710,15 @@ fn array_expr() {
         src: src,
         exp: map![
             "b" => "forall [] [regexp]",
+        ],
+    }
+    test_infer! {
+        env: map![
+            "a" => "forall [] bytes",
+        ],
+        src: src,
+        exp: map![
+            "b" => "forall [] [bytes]",
         ],
     }
     test_infer! {

--- a/semantic/internal/fbsemantic/Type.go
+++ b/semantic/internal/fbsemantic/Type.go
@@ -13,6 +13,7 @@ const (
 	TypeDuration Type = 5
 	TypeTime     Type = 6
 	TypeRegexp   Type = 7
+	TypeBytes    Type = 8
 )
 
 var EnumNamesType = map[Type]string{
@@ -24,4 +25,5 @@ var EnumNamesType = map[Type]string{
 	TypeDuration: "Duration",
 	TypeTime:     "Time",
 	TypeRegexp:   "Regexp",
+	TypeBytes:    "Bytes",
 }

--- a/semantic/semantic.fbs
+++ b/semantic/semantic.fbs
@@ -17,6 +17,7 @@ enum Type : ubyte {
   Duration,
   Time,
   Regexp,
+  Bytes,
 }
 
 table Var {


### PR DESCRIPTION
This adds the `bytes` monotype to the Rust type code.  This was pretty straightforward, following the examples of the other simple monotypes.

I also fixed an issue discovered during testing with the type expression parser where 0-argument functions did not parse correctly.