### PR TITLE
docs(SPEC): add power operator to SPEC

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -103,7 +103,7 @@ The following keywords are reserved and may not be used as identifiers:
 The following character sequences represent operators:
 
     +   ==   !=   (   )   =>
-    -   <    !~   [   ]
+    -   <    !~   [   ]   ^
     *   >    =~   {   }
     /   <=   =    ,   :
     %   >=   <-   .   |>


### PR DESCRIPTION
The power operator was added a while back but it was missed in the SPEC. This fixes that.


### Done checklist
- [x] docs/SPEC.md updated
- [ ] Test cases written
