### PR TITLE
fix(flux): Address some clippy lints

### DIFF
--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -2,7 +2,7 @@
 // XXX: phummer (2 Dec 2019) - These lints should be removed one at a time
 // until these lines are entirely removed. If lint still must be ignored, it
 // should be at a more specific module or file level.
-#![allow(clippy::useless_format, clippy::cmp_owned, clippy::while_let_loop)]
+#![allow(clippy::cmp_owned, clippy::while_let_loop)]
 #![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
 #![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
 #![allow(clippy::new_without_default, clippy::wrong_self_convention)]
@@ -18,6 +18,7 @@
 extern crate chrono;
 #[macro_use]
 extern crate serde_derive;
+
 extern crate serde_aux;
 
 pub mod ast;

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -2,7 +2,7 @@
 // XXX: phummer (2 Dec 2019) - These lints should be removed one at a time
 // until these lines are entirely removed. If lint still must be ignored, it
 // should be at a more specific module or file level.
-#![allow(clippy::cmp_owned, clippy::while_let_loop)]
+#![allow(clippy::while_let_loop)]
 #![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
 #![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
 #![allow(clippy::new_without_default, clippy::wrong_self_convention)]

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -2,7 +2,6 @@
 // XXX: phummer (2 Dec 2019) - These lints should be removed one at a time
 // until these lines are entirely removed. If lint still must be ignored, it
 // should be at a more specific module or file level.
-#![allow(clippy::while_let_loop)]
 #![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
 #![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
 #![allow(clippy::new_without_default, clippy::wrong_self_convention)]
@@ -18,7 +17,6 @@
 extern crate chrono;
 #[macro_use]
 extern crate serde_derive;
-
 extern crate serde_aux;
 
 pub mod ast;

--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -1337,7 +1337,7 @@ impl Parser {
         let t = self.peek();
         match t.tok {
             TOK_IDENT => {
-                if t.lit != "with".to_string() {
+                if t.lit != "with" {
                     self.errs.push("".to_string())
                 }
                 self.consume();

--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -1213,7 +1213,7 @@ impl Parser {
                                 ),
                                 errors: vec![],
                             },
-                            text: format!("{}", t.lit),
+                            text: t.lit.to_string(),
                             expression: None,
                         })));
                     }

--- a/libflux/src/flux/parser/strconv.rs
+++ b/libflux/src/flux/parser/strconv.rs
@@ -17,19 +17,14 @@ pub fn parse_string(lit: &str) -> Result<String, String> {
 pub fn parse_text(lit: &str) -> Result<String, String> {
     let mut s = Vec::with_capacity(lit.len());
     let mut chars = lit.char_indices();
-    loop {
-        match chars.next() {
-            Some((_, c)) => {
-                match c {
-                    '\\' => match push_unescaped(&mut s, &mut chars) {
-                        Err(e) => return Err(e.to_string()),
-                        _ => (),
-                    },
-                    // this char can have any byte length
-                    _ => s.extend_from_slice(c.to_string().as_bytes()),
-                }
-            }
-            None => break,
+    while let Some((_, c)) = chars.next() {
+        match c {
+            '\\' => match push_unescaped(&mut s, &mut chars) {
+                Err(e) => return Err(e.to_string()),
+                _ => (),
+            },
+            // this char can have any byte length
+            _ => s.extend_from_slice(c.to_string().as_bytes()),
         }
     }
     let converted = std::str::from_utf8(&s);
@@ -153,17 +148,12 @@ pub fn parse_duration(lit: &str) -> Result<Vec<ast::Duration>, String> {
 
 fn parse_magnitude(chars: &mut Peekable<Chars>) -> Result<i64, String> {
     let mut m = String::new();
-    loop {
-        match chars.peek() {
-            Some(c) => {
-                if !c.is_digit(10) {
-                    break;
-                } else {
-                    m.push(*c);
-                    chars.next();
-                }
-            }
-            None => break,
+    while let Some(c) = chars.peek() {
+        if !c.is_digit(10) {
+            break;
+        } else {
+            m.push(*c);
+            chars.next();
         }
     }
     if m.len() == 0 {
@@ -178,17 +168,12 @@ fn parse_magnitude(chars: &mut Peekable<Chars>) -> Result<i64, String> {
 
 fn parse_unit(chars: &mut Peekable<Chars>) -> Result<String, String> {
     let mut u = String::new();
-    loop {
-        match chars.peek() {
-            Some(c) => {
-                if !c.is_alphabetic() {
-                    break;
-                } else {
-                    u.push(*c);
-                    chars.next();
-                }
-            }
-            None => break,
+    while let Some(c) = chars.peek() {
+        if !c.is_alphabetic() {
+            break;
+        } else {
+            u.push(*c);
+            chars.next();
         }
     }
     if u.len() == 0 {


### PR DESCRIPTION
This patch addresses a line of outstanding clippy lints, notable `useless_format`, `cmp_owned`, and `while_let_loop`.