### PR TITLE
fix(flux): Address more clippy lints

### DIFF
--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]
-#![allow(clippy::len_zero, clippy::or_fun_call, clippy::needless_return)]
+#![allow(clippy::or_fun_call, clippy::needless_return)]
 #![allow(clippy::collapsible_if, clippy::module_inception)]
 #![allow(clippy::many_single_char_names, clippy::redundant_field_names)]
 #![allow(clippy::unknown_clippy_lints)]

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -10,7 +10,7 @@
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]
-#![allow(clippy::or_fun_call, clippy::needless_return)]
+#![allow(clippy::needless_return)]
 #![allow(clippy::collapsible_if, clippy::module_inception)]
 #![allow(clippy::many_single_char_names, clippy::redundant_field_names)]
 #![allow(clippy::unknown_clippy_lints)]

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -10,8 +10,7 @@
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]
-#![allow(clippy::needless_return)]
-#![allow(clippy::collapsible_if, clippy::module_inception)]
+#![allow(clippy::needless_return, clippy::module_inception)]
 #![allow(clippy::many_single_char_names, clippy::redundant_field_names)]
 #![allow(clippy::unknown_clippy_lints)]
 

--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -963,7 +963,7 @@ impl Parser {
             callee: expr,
             arguments: vec![],
         };
-        if params.len() > 0 {
+        if !params.is_empty() {
             call.arguments.push(Expression::Object(Box::new(ObjectExpr {
                 base: self.base_node_from_others(
                     &params.first().expect("len > 0, impossible").base,

--- a/libflux/src/flux/parser/strconv.rs
+++ b/libflux/src/flux/parser/strconv.rs
@@ -166,7 +166,7 @@ fn parse_magnitude(chars: &mut Peekable<Chars>) -> Result<i64, String> {
             None => break,
         }
     }
-    if m.len() == 0 {
+    if m.is_empty() {
         return Err(String::from("parsing empty magnitude"));
     }
     let parsed = m.parse::<i64>();
@@ -191,7 +191,7 @@ fn parse_unit(chars: &mut Peekable<Chars>) -> Result<String, String> {
             None => break,
         }
     }
-    if u.len() == 0 {
+    if u.is_empty() {
         return Err(String::from("parsing empty unit"));
     }
     if u == "µs" {

--- a/libflux/src/flux/semantic/env.rs
+++ b/libflux/src/flux/semantic/env.rs
@@ -58,12 +58,10 @@ impl Environment {
     pub fn lookup(&self, v: &str) -> Option<&PolyType> {
         if let Some(t) = self.values.get(v) {
             Some(t)
+        } else if let Some(env) = &self.parent {
+            env.lookup(v)
         } else {
-            if let Some(env) = &self.parent {
-                env.lookup(v)
-            } else {
-                None
-            }
+            None
         }
     }
     // Add a new variable binding to the current stack frame

--- a/libflux/src/flux/semantic/mod.rs
+++ b/libflux/src/flux/semantic/mod.rs
@@ -39,7 +39,7 @@ impl From<InferError> for SemanticError {
 pub fn analyze_source(source: &str) -> AnalysisResult<nodes::Package> {
     let file = parse_string("", source);
     let errs = ast::check::check(ast::walk::Node::File(&file));
-    if errs.len() > 0 {
+    if !errs.is_empty() {
         return Err(format!("got errors on parsing: {:?}", errs));
     }
     let ast_pkg = ast::Package {

--- a/libflux/src/flux/semantic/types.rs
+++ b/libflux/src/flux/semantic/types.rs
@@ -504,8 +504,8 @@ impl Tvar {
     fn unify_with_tvar(self, tv: Tvar, cons: &mut TvarKinds) -> Result<Substitution, Error> {
         // Kind constraints for both type variables
         let kinds = union(
-            cons.remove(&self).unwrap_or(Vec::new()),
-            cons.remove(&tv).unwrap_or(Vec::new()),
+            cons.remove(&self).unwrap_or_default(),
+            cons.remove(&tv).unwrap_or_default(),
         );
         if !kinds.is_empty() {
             cons.insert(tv, kinds);
@@ -622,14 +622,14 @@ impl cmp::PartialEq for Row {
                     head,
                     tail: MonoType::Row(o),
                 } => {
-                    a.entry(&head.k).or_insert(Vec::new()).push(&head.v);
+                    a.entry(&head.k).or_insert_with(Vec::new).push(&head.v);
                     self = o;
                 }
                 Row::Extension {
                     head,
                     tail: MonoType::Var(t),
                 } => {
-                    a.entry(&head.k).or_insert(Vec::new()).push(&head.v);
+                    a.entry(&head.k).or_insert_with(Vec::new).push(&head.v);
                     break Some(t);
                 }
                 _ => return false,
@@ -643,14 +643,14 @@ impl cmp::PartialEq for Row {
                     head,
                     tail: MonoType::Row(o),
                 } => {
-                    b.entry(&head.k).or_insert(Vec::new()).push(&head.v);
+                    b.entry(&head.k).or_insert_with(Vec::new).push(&head.v);
                     r = o;
                 }
                 Row::Extension {
                     head,
                     tail: MonoType::Var(t),
                 } => {
-                    b.entry(&head.k).or_insert(Vec::new()).push(&head.v);
+                    b.entry(&head.k).or_insert_with(Vec::new).push(&head.v);
                     break Some(t);
                 }
                 _ => return false,

--- a/libflux/src/flux/semantic/types.rs
+++ b/libflux/src/flux/semantic/types.rs
@@ -741,32 +741,30 @@ impl Row {
                     } else {
                         t.unify(u, cons, f)
                     }
+                } else if a == b {
+                    let lv = MonoType::Var(l);
+                    let rv = MonoType::Var(r);
+                    let sub = t.unify(u, cons, f)?;
+                    apply_then_unify(lv, rv, sub, cons, f)
                 } else {
-                    if a == b {
-                        let lv = MonoType::Var(l);
-                        let rv = MonoType::Var(r);
-                        let sub = t.unify(u, cons, f)?;
-                        apply_then_unify(lv, rv, sub, cons, f)
-                    } else {
-                        let var = f.fresh();
-                        let sub = l.unify(
-                            MonoType::from(Row::Extension {
-                                head: Property { k: b, v: u },
-                                tail: MonoType::Var(var),
-                            }),
-                            cons,
-                        )?;
-                        apply_then_unify(
-                            MonoType::Var(r),
-                            MonoType::from(Row::Extension {
-                                head: Property { k: a, v: t },
-                                tail: MonoType::Var(var),
-                            }),
-                            sub,
-                            cons,
-                            f,
-                        )
-                    }
+                    let var = f.fresh();
+                    let sub = l.unify(
+                        MonoType::from(Row::Extension {
+                            head: Property { k: b, v: u },
+                            tail: MonoType::Var(var),
+                        }),
+                        cons,
+                    )?;
+                    apply_then_unify(
+                        MonoType::Var(r),
+                        MonoType::from(Row::Extension {
+                            head: Property { k: a, v: t },
+                            tail: MonoType::Var(var),
+                        }),
+                        sub,
+                        cons,
+                        f,
+                    )
                 }
             }
             (


### PR DESCRIPTION
This patch addresses three more clippy lints: `len_zero`, `or_fun_call`, and `collapsible_if`. The details of these lints can be found at the following links:

  - [len_zero](https://rust-lang.github.io/rust-clippy/master/index.html#len_zero)
  - [of_fun_call](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call)
  - [collapsible_if](https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if)