### PR TITLE
chore(flux): fail make on clippy lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test-go: libflux
 	$(GO_TEST) $(GO_TEST_FLAGS) ./...
 
 test-rust:
-	cd libflux && $(CARGO) test $(CARGO_ARGS) && $(CARGO) clippy $(CARGO_ARGS)
+	cd libflux && $(CARGO) test $(CARGO_ARGS) && $(CARGO) clippy $(CARGO_ARGS) -- -Dclippy::all
 
 test-race: libflux
 	$(GO_TEST) -race -count=1 ./...

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -303,7 +303,7 @@ impl<'a> Iterator for NodeIterator<'a> {
                 match item {
                     Node::Package(m) => {
                         self.iter_stack.push(it);
-                        self.iter_stack.push(m.into_iter());
+                        self.iter_stack.push(m.iter());
                         self.next()
                     }
                     Node::Builtin(ty) => {


### PR DESCRIPTION
This patch fixes an issue where `cargo clippy` returns a zero exit code
unless explicitly told to fail on clippy lints. Additionally, it fixes a
recently introduced lint that caused me to noticed the issue.
