### PR TITLE
fix(libflux): enable strict mode by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ export GO_TEST_FLAGS=
 export GO_GENERATE=go generate $(GO_ARGS)
 export GO_VET=env GO111MODULE=on go vet $(GO_ARGS)
 export CARGO=cargo
-export CARGO_ARGS=--features strict
+export CARGO_ARGS=
 
 define go_deps
 	$(shell env GO111MODULE=on go list -f "{{range .GoFiles}} {{$$.Dir}}/{{.}}{{end}}" $(1))

--- a/libflux/src/flux/Cargo.toml
+++ b/libflux/src/flux/Cargo.toml
@@ -10,6 +10,8 @@ path = "lib.rs"
 crate-type = ["rlib", "staticlib", "cdylib"]
 
 [features]
+default = ["strict"]
+
 strict = []
 
 [dependencies]


### PR DESCRIPTION
`cargo` doesn't seem to pass `--features` flags to the sub-crates. This
patch enables the strict mode by default on the crate.
