### PR TITLE
fix(libflux): Address even more clippy lints

### DIFF
--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
 #![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
 #![allow(clippy::new_without_default, clippy::wrong_self_convention)]
-#![allow(clippy::try_err, clippy::ptr_offset_with_cast, clippy::clone_on_copy)]
+#![allow(clippy::ptr_offset_with_cast, clippy::clone_on_copy)]
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -5,7 +5,6 @@
 #![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
 #![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
 #![allow(clippy::new_without_default, clippy::wrong_self_convention)]
-#![allow(clippy::clone_on_copy)]
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
 #![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
 #![allow(clippy::new_without_default, clippy::wrong_self_convention)]
-#![allow(clippy::ptr_offset_with_cast, clippy::clone_on_copy)]
+#![allow(clippy::clone_on_copy)]
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]

--- a/libflux/src/flux/scanner/mod.rs
+++ b/libflux/src/flux/scanner/mod.rs
@@ -150,7 +150,7 @@ impl Scanner {
                 Some(nc) => {
                     let size = nc.len_utf8();
                     // Advance the data pointer to after the character we just emitted.
-                    self.p = unsafe { self.p.offset(size as isize) };
+                    self.p = unsafe { self.p.add(size) };
                     Token {
                         tok: TOK_ILLEGAL,
                         lit: nc.to_string(),

--- a/libflux/src/flux/scanner/mod.rs
+++ b/libflux/src/flux/scanner/mod.rs
@@ -77,10 +77,7 @@ impl Scanner {
     }
 
     pub fn offset(&self, pos: &Position) -> u32 {
-        self.positions
-            .get(pos)
-            .expect("position should be in map")
-            .clone()
+        *self.positions.get(pos).expect("position should be in map")
     }
 
     fn get_eof_token(&self) -> Token {

--- a/libflux/src/flux/semantic/analyze.rs
+++ b/libflux/src/flux/semantic/analyze.rs
@@ -269,7 +269,7 @@ fn analyze_block(block: ast::Block, fresher: &mut Fresher) -> Result<Block> {
     let block = if let Some(ast::Statement::Return(stmt)) = body.next() {
         Block::Return(analyze_expression(stmt.argument, fresher)?)
     } else {
-        return Err("missing return statement in block".to_string())?;
+        return Err("missing return statement in block".to_string());
     };
 
     body.try_fold(block, |acc, s| match s {


### PR DESCRIPTION
This patch addresses the following clippy lints:

- [`clippy::try_err`](https://rust-lang.github.io/rust-clippy/master/index.html#try_err)
- [`clippy::ptr_offset_with_cast`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_offset_with_cast)
- [`clippy::clone_on_copy`](https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy)