### PR TITLE
fix: properly use a fake version with flux-config when no version is present

### DIFF
--- a/internal/cmd/flux-config/build.go
+++ b/internal/cmd/flux-config/build.go
@@ -118,9 +118,9 @@ func build() (string, error) {
 
 	version := mod.Version
 	if version == "" {
-		version = "latest"
+		version = "dev"
 	}
-	srcdir := filepath.Join(gocache, "libflux", "@"+mod.Version)
+	srcdir := filepath.Join(gocache, "libflux", "@"+version)
 	if err := os.MkdirAll(srcdir, 0755); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written