### PR TITLE
feat(semantic): add Numeric and Row kind constraints

### DIFF
--- a/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
+++ b/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
@@ -159,13 +159,15 @@ pub mod fbsemantic {
         Addable = 0,
         Subtractable = 1,
         Divisible = 2,
-        Comparable = 3,
-        Equatable = 4,
-        Nullable = 5,
+        Numeric = 3,
+        Comparable = 4,
+        Equatable = 5,
+        Nullable = 6,
+        Row = 7,
     }
 
     const ENUM_MIN_KIND: u8 = 0;
-    const ENUM_MAX_KIND: u8 = 5;
+    const ENUM_MAX_KIND: u8 = 7;
 
     impl<'a> flatbuffers::Follow<'a> for Kind {
         type Inner = Self;
@@ -199,23 +201,27 @@ pub mod fbsemantic {
     }
 
     #[allow(non_camel_case_types)]
-    const ENUM_VALUES_KIND: [Kind; 6] = [
+    const ENUM_VALUES_KIND: [Kind; 8] = [
         Kind::Addable,
         Kind::Subtractable,
         Kind::Divisible,
+        Kind::Numeric,
         Kind::Comparable,
         Kind::Equatable,
         Kind::Nullable,
+        Kind::Row,
     ];
 
     #[allow(non_camel_case_types)]
-    const ENUM_NAMES_KIND: [&'static str; 6] = [
+    const ENUM_NAMES_KIND: [&'static str; 8] = [
         "Addable",
         "Subtractable",
         "Divisible",
+        "Numeric",
         "Comparable",
         "Equatable",
         "Nullable",
+        "Row",
     ];
 
     pub fn enum_name_kind(e: Kind) -> &'static str {

--- a/libflux/src/flux/semantic/flatbuffers/types.rs
+++ b/libflux/src/flux/semantic/flatbuffers/types.rs
@@ -74,9 +74,11 @@ impl From<fb::Kind> for Kind {
             fb::Kind::Addable => Kind::Addable,
             fb::Kind::Subtractable => Kind::Subtractable,
             fb::Kind::Divisible => Kind::Divisible,
+            fb::Kind::Numeric => Kind::Numeric,
             fb::Kind::Comparable => Kind::Comparable,
             fb::Kind::Equatable => Kind::Equatable,
             fb::Kind::Nullable => Kind::Nullable,
+            fb::Kind::Row => Kind::Row,
         }
     }
 }
@@ -87,9 +89,11 @@ impl From<Kind> for fb::Kind {
             Kind::Addable => fb::Kind::Addable,
             Kind::Subtractable => fb::Kind::Subtractable,
             Kind::Divisible => fb::Kind::Divisible,
+            Kind::Numeric => fb::Kind::Numeric,
             Kind::Comparable => fb::Kind::Comparable,
             Kind::Equatable => fb::Kind::Equatable,
             Kind::Nullable => fb::Kind::Nullable,
+            Kind::Row => fb::Kind::Row,
         }
     }
 }

--- a/libflux/src/flux/semantic/mod.rs
+++ b/libflux/src/flux/semantic/mod.rs
@@ -20,7 +20,7 @@ mod tests;
 #[allow(unused, non_snake_case)]
 pub mod flatbuffers;
 
-mod builtins;
+pub mod builtins;
 
 use crate::ast;
 use crate::parser::parse_string;

--- a/libflux/src/flux/semantic/parser/mod.rs
+++ b/libflux/src/flux/semantic/parser/mod.rs
@@ -394,9 +394,11 @@ impl Parser<'_> {
             "Addable" => Ok(Kind::Addable),
             "Subtractable" => Ok(Kind::Subtractable),
             "Divisible" => Ok(Kind::Divisible),
+            "Numeric" => Ok(Kind::Numeric),
             "Comparable" => Ok(Kind::Comparable),
             "Nullable" => Ok(Kind::Nullable),
             "Equatable" => Ok(Kind::Equatable),
+            "Row" => Ok(Kind::Row),
             _ => Err("Constraints must have a valid Kind"),
         }
     }

--- a/semantic/internal/fbsemantic/Kind.go
+++ b/semantic/internal/fbsemantic/Kind.go
@@ -8,16 +8,20 @@ const (
 	KindAddable      Kind = 0
 	KindSubtractable Kind = 1
 	KindDivisible    Kind = 2
-	KindComparable   Kind = 3
-	KindEquatable    Kind = 4
-	KindNullable     Kind = 5
+	KindNumeric      Kind = 3
+	KindComparable   Kind = 4
+	KindEquatable    Kind = 5
+	KindNullable     Kind = 6
+	KindRow          Kind = 7
 )
 
 var EnumNamesKind = map[Kind]string{
 	KindAddable:      "Addable",
 	KindSubtractable: "Subtractable",
 	KindDivisible:    "Divisible",
+	KindNumeric:      "Numeric",
 	KindComparable:   "Comparable",
 	KindEquatable:    "Equatable",
 	KindNullable:     "Nullable",
+	KindRow:          "Row",
 }

--- a/semantic/semantic.fbs
+++ b/semantic/semantic.fbs
@@ -79,9 +79,11 @@ enum Kind : ubyte {
   Addable,
   Subtractable,
   Divisible,
+  Numeric,
   Comparable,
   Equatable,
   Nullable,
+  Row,
 }
 
 table Constraint {


### PR DESCRIPTION
This adds two new kind constraints to type inference:
- `Numeric` for int, uint and float.  There are a few transformations where we would error if a certain column like `_value` is not numeric.
- `Row` to indicate a TVar must be a Row type.

I also updated the builtin types that were already merged to reflect the changes.