### PR TITLE
feat(semantic/builtins): add types for some universe builtins

### DIFF
--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -295,6 +295,266 @@ pub fn builtins() -> Builtins<'static> {
                 "assertEquals" => Node::Builtin("forall [t0] (name: string, got: [t0], want: [t0]) -> [t0]"),
                 "assertEmpty" => Node::Builtin("forall [t0] () -> [t0]"),
                 "diff" => Node::Builtin("forall [t0] (got: [t0], want: [t0], ?verbose: bool) -> [{_diff: string | t0}]"),
+            "universe" => Node::Package(maplit::hashmap! {
+                "inf" => Node::Builtin("forall [] duration"),
+                "int" => Node::Builtin("forall [t0] (v: t0) -> int"),
+                "integral" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?unit: duration,
+                        ?timeColumn: string,
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                "join" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: t0,
+                        ?method: string,
+                        ?on: [string]
+                    ) -> [t1]
+                "#),
+                // This function would almost have input/output types that match, but:
+                // input column may start as int, uint or float, and always ends up as float.
+                "kaufmansAMA" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        n: int,
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                // either column list or predicate must be provided
+                "keep" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?columns: [string],
+                        ?fn: (column: string) -> bool
+                    ) -> [t1]
+                "#),
+                // the "fn" parameter to keyValues is suspicous: https://github.com/influxdata/flux/issues/2235
+                "keyValues" => Node::Builtin(r#"
+                    forall [t0, t1, t2, t3] where t0: Row, t3: Row (
+                        <-tables: [t0],
+                        ?keyColumns: [string],
+                        ?fn: t1
+                    ) -> [{_key: string | _value: t2 | t3}]
+                "#),
+                "keys" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                "last" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]"),
+                "length" => Node::Builtin("forall [t0] (arr: [t0]) -> int"),
+                "limit"  => Node::Builtin("forall [t0] (<-tables: [t0], n: int, ?offset: int) -> [t0]"),
+                "linearBins" => Node::Builtin(r#"
+                    forall [] (
+                        start: float,
+                        width: float,
+                        count: int,
+                        ?infinity: bool
+                    ) -> [float]
+                "#),
+                "logarithmicBins" => Node::Builtin(r#"
+                    forall [] (
+                        start: float,
+                        factor: float,
+                        count: int,
+                        ?infinity: bool
+                    ) -> [float]
+                "#),
+                "map" => Node::Builtin("forall [t0, t1] (<-tables: [t0], fn: (r: t0) -> t1, ?mergeKey: bool) -> [t1]"),
+                "max" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]"),
+                "mean" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                "min" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]"),
+                "mode" => Node::Builtin(r#"
+                    forall [t0, t1, t2] where t0: Row, t2: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [{_value: t1 | t2}]
+                "#),
+                "movingAverage" => Node::Builtin("forall [t0, t1] where t0: Numeric (<-tables: [{_value: t0 | t1}], n: int) -> [{_value: float | t1}]"),
+                "pivot" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        rowKey: [string],
+                        columnKey: [string],
+                        valueColumn: string
+                    ) -> [t1]
+                "#),
+                "quantile" => Node::Builtin(r#"
+                    forall [t0] where t0: Row (
+                        <-tables: [t0],
+                        ?column: string,
+                        q: float,
+                        ?compression: float,
+                        ?method: string
+                    ) -> [t0]
+                "#),
+                // start and stop should be able to constrained to time or duration with a kind constraint:
+                // https://github.com/influxdata/flux/issues/2243
+                "range" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t3: Row (
+                        <-tables: [t0],
+                        start: t1,
+                        ?stop: t2,
+                        ?timeColumn: string,
+                        ?startColumn: string,
+                        ?stopColumn: string
+                    ) -> [t3]
+                "#),
+                "reduce" => Node::Builtin(r#"
+                    forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (
+                        <-tables: [t0],
+                        fn: (r: t0, accumulator: t1) -> t1,
+                        identity: t1
+                    ) -> [t2]
+                "#),
+                "relativeStrengthIndex" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        n: int,
+                        ?columns: [string]
+                    ) -> [t1]
+                "#),
+                // Either fn or columns should be specified
+                "rename" => Node::Builtin(r#"
+                    forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (
+                        <-tables: [t0],
+                        ?fn: (column: string) -> string,
+                        ?columns: t1
+                    ) -> [t2]
+                "#),
+                "sample" => Node::Builtin(r#"
+                    forall [t0] where t0: Row (
+                        <-tables: [t0],
+                        n: int,
+                        ?pos: int,
+                        ?column: string
+                    ) -> [t0]
+                "#),
+                "set" => Node::Builtin(r#"
+                    forall [t0] where t0: Row (
+                        <-tables: [t0],
+                        key: string,
+                        value: string
+                    ) -> [t0]
+                "#),
+                // This is an aggregate function, and may clobber value columns
+                "skew" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                "sleep" => Node::Builtin(r#"
+                    forall [t0] (
+                        <-v: t0,
+                        "duration": duration
+                    ) -> t0
+                "#),
+                "sort" => Node::Builtin(r#"
+                    forall [t0] where t0: Row (
+                        <-tables: [t0],
+                        ?columns: [string],
+                        ?desc: bool
+                    ) -> [t0]
+                "#),
+                "spread" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                "stateTracking" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        fn: (r: t0) -> bool,
+                        ?countColumn: string,
+                        ?durationColumn: string,
+                        ?durationUnit: duration,
+                        ?timeColumn: string
+                    ) -> [t1]
+                "#),
+                "stddev" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?column: string,
+                        mode: string
+                    ) -> [t1]
+                "#),
+                "string" => Node::Builtin("forall [t0] (v: t0) -> string"),
+                "sum" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [t1]
+                "#),
+                "tableFind" => Node::Builtin(r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        fn: (key: t1) -> bool
+                    ) -> t0
+                "#),
+                "tail" => Node::Builtin(r#"
+                    forall [t0] (
+                        <-tables: [t0],
+                        n: int,
+                        ?offset: int
+                    ) -> [t0]
+                "#),
+                "time" => Node::Builtin("forall [t0] (v: t0) -> time"),
+                "timeShift" => Node::Builtin(r#"
+                    forall [t0] (
+                        <-tables: [t0],
+                        "duration": duration,
+                        ?columns: [string]
+                    ) -> [t0]
+                "#),
+                "tripleExponentialDerivative" => Node::Builtin(r#"
+                    forall [t0] where t0: Numeric, t1: Row (
+                        <-tables: [{_value: t0 | t1}],
+                        n: int
+                    ) -> [{_value: float | t1}]
+                "#),
+                "true" => Node::Builtin("forall [] bool"),
+                "uint" => Node::Builtin("forall [t0] (v: t0) -> uint"),
+                // This is suspicous: each input table stream is not restricted to the same schema.
+                // What's the right signature?
+                "union" => Node::Builtin(r#"
+                    forall [t0] where t0: Row, t1: Row (
+                        tables: [[t0]]
+                    ) -> [t1]
+                "#),
+                "unique" => Node::Builtin(r#"
+                    forall [t0] where t0: Row (
+                        <-tables: [t0],
+                        ?column: string
+                    ) -> [t0]
+                "#),
+                "window" => Node::Builtin(r#"
+                    forall [t0] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?every: duration,
+                        ?period: duration,
+                        ?offset: duration,
+                        ?timeColumn: string,
+                        ?startColumn: string,
+                        ?stopColumn: string,
+                        ?createEmpty: bool
+                    ) -> [t1]
+                "#),
+                "yield" => Node::Builtin(r#"
+                    forall [t0] where t0: Row (
+                        <-tables: [t0],
+                        ?name: string
+                    ) -> [t0]
+                "#),
             }),
         },
     }


### PR DESCRIPTION
This is another part of work that was started here: https://github.com/influxdata/flux/pull/2228

This includes the builtins in the `universe` package, from letters I through Z.