### PR TITLE
chore(libflux): continue driving down lint

### DIFF
--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -243,7 +243,7 @@ impl FunctionBody {
     }
 }
 
-fn serialize_errors<S>(errors: &Vec<String>, ser: S) -> Result<S::Ok, S::Error>
+fn serialize_errors<S>(errors: &[String], ser: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -1,15 +1,9 @@
 #![cfg_attr(feature = "strict", deny(warnings))]
+#![allow(clippy::unknown_clippy_lints)]
 // XXX: phummer (2 Dec 2019) - These lints should be removed one at a time
 // until these lines are entirely removed. If lint still must be ignored, it
 // should be at a more specific module or file level.
-#![allow(clippy::single_char_pattern, clippy::chars_last_cmp)]
-#![allow(clippy::chars_next_cmp, clippy::unnecessary_operation)]
-#![allow(clippy::new_without_default, clippy::wrong_self_convention)]
-#![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
-#![allow(clippy::single_match, clippy::unnecessary_fold)]
-#![allow(clippy::module_inception)]
-#![allow(clippy::many_single_char_names, clippy::redundant_field_names)]
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(clippy::module_inception, clippy::many_single_char_names)]
 
 extern crate chrono;
 #[macro_use]

--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -150,13 +150,10 @@ impl Parser {
 
     // peek_with_regex is the same as peek, except that the scan step will allow scanning regexp tokens.
     fn peek_with_regex(&mut self) -> Token {
-        match &self.t {
-            Some(Token { tok: TOK_DIV, .. }) => {
-                self.t = None;
-                self.s.unread();
-            }
-            _ => (),
-        };
+        if let Some(Token { tok: TOK_DIV, .. }) = &self.t {
+            self.t = None;
+            self.s.unread();
+        }
         match self.t.clone() {
             Some(t) => t,
             None => {
@@ -331,19 +328,16 @@ impl Parser {
         let t = self.peek();
         let mut end = ast::Position::invalid();
         let pkg = self.parse_package_clause();
-        match &pkg {
-            Some(pkg) => end = pkg.base.location.end.clone(),
-            _ => (),
+        if let Some(pkg) = &pkg {
+            end = pkg.base.location.end.clone();
         }
         let imports = self.parse_import_list();
-        match imports.last() {
-            Some(import) => end = import.base.location.end.clone(),
-            _ => (),
+        if let Some(import) = imports.last() {
+            end = import.base.location.end.clone();
         }
         let body = self.parse_statement_list();
-        match body.last() {
-            Some(stmt) => end = stmt.base().location.end.clone(),
-            _ => (),
+        if let Some(stmt) = body.last() {
+            end = stmt.base().location.end.clone();
         }
         File {
             base: BaseNode {
@@ -392,8 +386,8 @@ impl Parser {
         let path = self.parse_string_literal();
         ImportDeclaration {
             base: self.base_node_from_other_end(&t, &path.base),
-            alias: alias,
-            path: path,
+            alias,
+            path,
         }
     }
 
@@ -480,7 +474,7 @@ impl Parser {
             base: self.base_node_from_other_end(&t, assignment.base()),
             assignment: VariableAssgn {
                 base: self.base_node_from_others(&id.base, assignment.base()),
-                id: id,
+                id,
                 init: assignment,
             },
         }))
@@ -558,21 +552,18 @@ impl Parser {
             !stop_tokens.contains(&t.tok) && self.more()
         } {
             let e = self.parse_expression();
-            match e {
-                Expression::Bad(_) => {
-                    // We got a BadExpression, push the error and consume the token.
-                    // TODO(jsternberg): We should pretend the token is
-                    //  an operator and create a binary expression. For now, skip past it.
-                    let invalid_t = self.scan();
-                    let loc = self.source_location(
-                        &ast::Position::from(&invalid_t.start_pos),
-                        &ast::Position::from(&invalid_t.end_pos),
-                    );
-                    self.errs
-                        .push(format!("invalid expression {}: {}", loc, invalid_t.lit));
-                    continue;
-                }
-                _ => (),
+            if let Expression::Bad(_) = e {
+                // We got a BadExpression, push the error and consume the token.
+                // TODO(jsternberg): We should pretend the token is
+                //  an operator and create a binary expression. For now, skip past it.
+                let invalid_t = self.scan();
+                let loc = self.source_location(
+                    &ast::Position::from(&invalid_t.start_pos),
+                    &ast::Position::from(&invalid_t.end_pos),
+                );
+                self.errs
+                    .push(format!("invalid expression {}: {}", loc, invalid_t.lit));
+                continue;
             };
             match expr {
                 Some(ex) => {
@@ -766,9 +757,8 @@ impl Parser {
             TOK_REGEXNEQ => res = Some(Operator::NotRegexpMatchOperator),
             _ => (),
         }
-        match res {
-            Some(_) => self.consume(),
-            None => (),
+        if res.is_some() {
+            self.consume();
         }
         res
     }
@@ -803,9 +793,8 @@ impl Parser {
             TOK_SUB => res = Some(Operator::SubtractionOperator),
             _ => (),
         }
-        match res {
-            Some(_) => self.consume(),
-            None => (),
+        if res.is_some() {
+            self.consume();
         }
         res
     }
@@ -842,9 +831,8 @@ impl Parser {
             TOK_POW => res = Some(Operator::PowerOperator),
             _ => (),
         }
-        match res {
-            Some(_) => self.consume(),
-            None => (),
+        if res.is_some() {
+            self.consume();
         }
         res
     }
@@ -883,7 +871,7 @@ impl Parser {
                     res = Expression::PipeExpr(Box::new(PipeExpr {
                         base: self.base_node_from_others(res.base(), &call.base),
                         argument: res,
-                        call: call,
+                        call,
                     }));
                 }
             }
@@ -901,17 +889,14 @@ impl Parser {
     fn parse_unary_expression(&mut self) -> Expression {
         let t = self.peek();
         let op = self.parse_additive_operator();
-        match op {
-            Some(op) => {
-                let expr = self.parse_unary_expression();
-                return Expression::Unary(Box::new(UnaryExpr {
-                    base: self.base_node_from_other_end(&t, expr.base()),
-                    operator: op,
-                    argument: expr,
-                }));
-            }
-            None => (),
-        }
+        if let Some(op) = op {
+            let expr = self.parse_unary_expression();
+            return Expression::Unary(Box::new(UnaryExpr {
+                base: self.base_node_from_other_end(&t, expr.base()),
+                operator: op,
+                argument: expr,
+            }));
+        };
         self.parse_postfix_expression()
     }
     fn parse_postfix_expression(&mut self) -> Expression {
@@ -1066,7 +1051,7 @@ impl Parser {
                 TOK_QUOTE => {
                     return StringExpr {
                         base: self.base_node_from_tokens(&start, &t),
-                        parts: parts,
+                        parts,
                     }
                 }
                 _ => {
@@ -1129,7 +1114,7 @@ impl Parser {
         let value = strconv::parse_string(t.lit.as_str()).unwrap();
         StringLit {
             base: self.base_node_from_token(&t),
-            value: value,
+            value,
         }
     }
     fn parse_regexp_literal(&mut self) -> RegexpLit {
@@ -1154,7 +1139,7 @@ impl Parser {
         let value = strconv::parse_time(t.lit.as_str()).unwrap();
         DateTimeLit {
             base: self.base_node_from_token(&t),
-            value: value,
+            value,
         }
     }
     fn parse_duration_literal(&mut self) -> DurationLit {
@@ -1162,7 +1147,7 @@ impl Parser {
         let values = strconv::parse_duration(t.lit.as_str()).unwrap();
         DurationLit {
             base: self.base_node_from_token(&t),
-            values: values,
+            values,
         }
     }
     fn parse_pipe_literal(&mut self) -> PipeLit {
@@ -1283,18 +1268,15 @@ impl Parser {
                 let mut expr = self.parse_expression_suffix(Expression::Identifier(key));
                 while self.more() {
                     let rhs = self.parse_expression();
-                    match rhs {
-                        Expression::Bad(_) => {
-                            let invalid_t = self.scan();
-                            let loc = self.source_location(
-                                &ast::Position::from(&invalid_t.start_pos),
-                                &&ast::Position::from(&invalid_t.end_pos),
-                            );
-                            self.errs
-                                .push(format!("invalid expression {}: {}", loc, invalid_t.lit));
-                            continue;
-                        }
-                        _ => (),
+                    if let Expression::Bad(_) = rhs {
+                        let invalid_t = self.scan();
+                        let loc = self.source_location(
+                            &ast::Position::from(&invalid_t.start_pos),
+                            &&ast::Position::from(&invalid_t.end_pos),
+                        );
+                        self.errs
+                            .push(format!("invalid expression {}: {}", loc, invalid_t.lit));
+                        continue;
                     };
                     expr = Expression::Binary(Box::new(BinaryExpr {
                         base: self.base_node_from_others(expr.base(), rhs.base()),
@@ -1431,8 +1413,8 @@ impl Parser {
         };
         Property {
             base: self.base_node_from_others(key.base(), value_base),
-            key: key,
-            value: value,
+            key,
+            value,
         }
     }
     fn parse_invalid_property(&mut self) -> Property {
@@ -1483,10 +1465,9 @@ impl Parser {
     }
     fn parse_property_value(&mut self) -> Option<Expression> {
         let res = self.parse_expression_while_more(None, &[TOK_COMMA, TOK_COLON]);
-        match res {
+        if res.is_none() {
             // TODO: return a BadExpr here. It would help simplify logic.
-            None => self.errs.push(String::from("missing property value")),
-            _ => (),
+            self.errs.push(String::from("missing property value"));
         }
         res
     }
@@ -1504,15 +1485,15 @@ impl Parser {
     fn parse_parameter(&mut self) -> Property {
         let key = self.parse_identifier();
         let base: BaseNode;
-        let mut value = None;
-        if self.peek().tok == TOK_ASSIGN {
+        let value = if self.peek().tok == TOK_ASSIGN {
             self.consume();
             let v = self.parse_expression();
             base = self.base_node_from_others(&key.base, v.base());
-            value = Some(v);
+            Some(v)
         } else {
-            base = self.base_node(key.base.location.clone())
-        }
+            base = self.base_node(key.base.location.clone());
+            None
+        };
         Property {
             base,
             key: PropertyKey::Identifier(key),

--- a/libflux/src/flux/parser/strconv.rs
+++ b/libflux/src/flux/parser/strconv.rs
@@ -8,7 +8,7 @@ use crate::ast;
 use regex::Regex;
 
 pub fn parse_string(lit: &str) -> Result<String, String> {
-    if lit.len() < 2 || lit.chars().next().unwrap() != '"' || lit.chars().last().unwrap() != '"' {
+    if lit.len() < 2 || !lit.starts_with('"') || !lit.ends_with('"') {
         return Err("invalid string literal".to_string());
     }
     parse_text(&lit[1..lit.len() - 1])
@@ -19,10 +19,11 @@ pub fn parse_text(lit: &str) -> Result<String, String> {
     let mut chars = lit.char_indices();
     while let Some((_, c)) = chars.next() {
         match c {
-            '\\' => match push_unescaped(&mut s, &mut chars) {
-                Err(e) => return Err(e.to_string()),
-                _ => (),
-            },
+            '\\' => {
+                if let Err(e) = push_unescaped(&mut s, &mut chars) {
+                    return Err(e.to_string());
+                }
+            }
             // this char can have any byte length
             _ => s.extend_from_slice(c.to_string().as_bytes()),
         }
@@ -80,10 +81,10 @@ pub fn parse_regex(lit: &str) -> Result<String, String> {
     if lit.len() < 3 {
         return Err(String::from("regexp must be at least 3 characters"));
     }
-    if lit.chars().next().unwrap() != '/' {
+    if !lit.starts_with('/') {
         return Err(String::from("regexp literal must start with a slash"));
     }
-    if lit.chars().last().unwrap() != '/' {
+    if !lit.ends_with('/') {
         return Err(String::from("regexp literal must end with a slash"));
     }
 
@@ -103,7 +104,7 @@ pub fn parse_regex(lit: &str) -> Result<String, String> {
 }
 
 pub fn parse_time(lit: &str) -> Result<DateTime<FixedOffset>, String> {
-    let parsed = if !lit.contains("T") {
+    let parsed = if !lit.contains('T') {
         let naive = NaiveDate::parse_from_str(lit, "%Y-%m-%d");
         match naive {
             Ok(date) => {

--- a/libflux/src/flux/semantic/analyze.rs
+++ b/libflux/src/flux/semantic/analyze.rs
@@ -14,7 +14,7 @@ pub type Result<T> = result::Result<T, SemanticError>;
 // If one wants to do so, he should explicitly pkg.clone() and incur consciously in the memory
 // overhead involved.
 pub fn analyze(pkg: ast::Package) -> Result<Package> {
-    analyze_with(pkg, &mut Fresher::new())
+    analyze_with(pkg, &mut Fresher::default())
 }
 
 // analyze_with runs analyze using the provided Fresher.
@@ -32,7 +32,7 @@ fn analyze_package(pkg: ast::Package, fresher: &mut Fresher) -> Result<Package> 
     Ok(Package {
         loc: pkg.base.location,
         package: pkg.package,
-        files: files,
+        files,
     })
 }
 
@@ -236,8 +236,8 @@ fn analyze_function_params(
         let key = analyze_identifier(id, fresher)?;
         let mut default: Option<Expression> = None;
         let mut is_pipe = false;
-        match prop.value {
-            Some(expr) => match expr {
+        if let Some(expr) = prop.value {
+            match expr {
                 ast::Expression::PipeLit(_) => {
                     if piped {
                         return Err("only a single argument may be piped".to_string());
@@ -247,8 +247,7 @@ fn analyze_function_params(
                     };
                 }
                 e => default = Some(analyze_expression(e, fresher)?),
-            },
-            None => (),
+            }
         };
         params.push(FunctionParameter {
             loc: prop.base.location,

--- a/libflux/src/flux/semantic/bootstrap.rs
+++ b/libflux/src/flux/semantic/bootstrap.rs
@@ -221,7 +221,10 @@ fn dependencies<'a>(
 }
 
 // Constructs a polytype, or more specifically a generic row type, from a hash map
-pub fn build_polytype(from: HashMap<String, PolyType>, f: &mut Fresher) -> Result<PolyType, Error> {
+pub fn build_polytype<S: ::std::hash::BuildHasher>(
+    from: HashMap<String, PolyType, S>,
+    f: &mut Fresher,
+) -> Result<PolyType, Error> {
     let (r, cons) = build_row(from, f);
     let mut kinds = HashMap::new();
     let sub = infer::solve(&cons, &mut kinds, f)?;
@@ -232,7 +235,10 @@ pub fn build_polytype(from: HashMap<String, PolyType>, f: &mut Fresher) -> Resul
     ))
 }
 
-fn build_row(from: HashMap<String, PolyType>, f: &mut Fresher) -> (Row, Constraints) {
+fn build_row<S: ::std::hash::BuildHasher>(
+    from: HashMap<String, PolyType, S>,
+    f: &mut Fresher,
+) -> (Row, Constraints) {
     let mut r = Row::Empty;
     let mut cons = Constraints::empty();
 

--- a/libflux/src/flux/semantic/env.rs
+++ b/libflux/src/flux/semantic/env.rs
@@ -56,6 +56,11 @@ impl Environment {
             values: HashMap::new(),
         }
     }
+    // The following clippy lint is ignored due to taking a `Self` type as the
+    // first parameter, which clippy wrongly identifies as the parameter name,
+    // used in a place that shouldn't take a `self` parameter.
+    // See https://github.com/rust-lang/rust-clippy/issues/3414
+    #[allow(clippy::wrong_self_convention)]
     pub fn new(from: Self) -> Environment {
         Environment {
             parent: Some(Box::new(from)),

--- a/libflux/src/flux/semantic/flatbuffers/types.rs
+++ b/libflux/src/flux/semantic/flatbuffers/types.rs
@@ -60,7 +60,7 @@ impl From<fb::PolyType<'_>> for Option<PolyType> {
         for i in 0..c.len() {
             let constraint: Option<(Tvar, Kind)> = c.get(i).into();
             let (tv, kind) = constraint?;
-            cons.entry(tv).or_insert(Vec::new()).push(kind);
+            cons.entry(tv).or_insert_with(Vec::new).push(kind);
         }
         Some(PolyType {
             vars,

--- a/libflux/src/flux/semantic/fresh.rs
+++ b/libflux/src/flux/semantic/fresh.rs
@@ -13,14 +13,16 @@ impl From<u64> for Fresher {
 }
 
 impl Fresher {
-    pub fn new() -> Fresher {
-        Fresher(0)
-    }
-
     pub fn fresh(&mut self) -> Tvar {
         let u = self.0;
         self.0 += 1;
         Tvar(u)
+    }
+}
+
+impl Default for Fresher {
+    fn default() -> Self {
+        Self(0)
     }
 }
 
@@ -43,6 +45,7 @@ impl<T: Fresh> Fresh for Option<T> {
     }
 }
 
+#[allow(clippy::implicit_hasher)]
 impl<T: Fresh> Fresh for HashMap<String, T> {
     fn fresh(self, f: &mut Fresher, sub: &mut HashMap<Tvar, Tvar>) -> Self {
         self.into_iter()
@@ -53,6 +56,7 @@ impl<T: Fresh> Fresh for HashMap<String, T> {
     }
 }
 
+#[allow(clippy::implicit_hasher)]
 impl<T: Hash + Ord + Eq + Fresh, S> Fresh for HashMap<T, S> {
     fn fresh(self, f: &mut Fresher, sub: &mut HashMap<Tvar, Tvar>) -> Self {
         self.into_iter()

--- a/libflux/src/flux/semantic/infer.rs
+++ b/libflux/src/flux/semantic/infer.rs
@@ -102,8 +102,8 @@ pub fn generalize(env: &Environment, with: &HashMap<Tvar, Vec<Kind>>, t: MonoTyp
         }
     }
     PolyType {
-        vars: vars,
-        cons: cons,
+        vars,
+        cons,
         expr: t,
     }
 }

--- a/libflux/src/flux/semantic/mod.rs
+++ b/libflux/src/flux/semantic/mod.rs
@@ -45,7 +45,7 @@ pub fn analyze_source(source: &str) -> AnalysisResult<nodes::Package> {
         package: "main".to_string(),
         files: vec![file],
     };
-    let mut f = Fresher::new();
+    let mut f = Fresher::default();
     let mut sem_pkg = analyze_with(ast_pkg, &mut f)?;
     // TODO(affo): add a stdlib Importer.
     let (_, sub) = infer_pkg_types(&mut sem_pkg, Environment::empty(), &mut f, &None, &None)?;

--- a/libflux/src/flux/semantic/nodes.rs
+++ b/libflux/src/flux/semantic/nodes.rs
@@ -595,7 +595,7 @@ impl VariableAssgn {
         self.cons = p.cons.clone();
 
         // Update the type environment
-        &mut env.add(String::from(&self.id.name), p);
+        env.add(String::from(&self.id.name), p);
         Ok((env, constraints))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
@@ -823,10 +823,9 @@ impl FunctionExpr {
     pub fn defaults(&self) -> Vec<&FunctionParameter> {
         let mut ds = Vec::new();
         for p in &self.params {
-            match p.default {
-                Some(_) => ds.push(p),
-                None => (),
-            }
+            if p.default.is_some() {
+                ds.push(p);
+            };
         }
         ds
     }
@@ -1585,7 +1584,7 @@ const YEARS: f64 = MONTHS * 12.0;
 // TODO(affo): this is not accurate, a duration value depends on the time in which it is calculated.
 // 1 month is different if now is the 1st of January, or the 1st of February.
 // Some days do not last 24 hours because of light savings.
-pub fn convert_duration(duration: &Vec<ast::Duration>) -> std::result::Result<Duration, String> {
+pub fn convert_duration(duration: &[ast::Duration]) -> std::result::Result<Duration, String> {
     let d = duration
         .iter()
         .try_fold(0 as i64, |acc, d| match d.unit.as_str() {

--- a/libflux/src/flux/semantic/parser/mod.rs
+++ b/libflux/src/flux/semantic/parser/mod.rs
@@ -284,15 +284,16 @@ impl Parser<'_> {
             return Err("Missing right square bracket");
         }
 
-        let mut cons = HashMap::new();
-        if self.peek().token_type == TokenType::WHERE {
+        let cons = if self.peek().token_type == TokenType::WHERE {
             self.next(); // move to where
-            cons = self.parse_constraints()?;
-        }
+            self.parse_constraints()?
+        } else {
+            HashMap::new()
+        };
 
         Ok(PolyType {
-            vars: vars,
-            cons: cons,
+            vars,
+            cons,
             expr: self.parse_monotype()?,
         })
     }
@@ -323,7 +324,7 @@ impl Parser<'_> {
     fn parse_type_var(&mut self, token: &Token) -> Result<Tvar, &'static str> {
         match &token.text {
             Some(text) => {
-                let num = text.trim_start_matches("t").parse::<u64>();
+                let num = text.trim_start_matches('t').parse::<u64>();
                 match num {
                     Err(_e) => Err("Not a valid type variable"),
                     Ok(num) => {

--- a/libflux/src/flux/semantic/sub.rs
+++ b/libflux/src/flux/semantic/sub.rs
@@ -18,7 +18,12 @@ impl From<HashMap<Tvar, MonoType>> for Substitution {
     }
 }
 
+// The `allow` attribute below is a side effect of the orphan impl rule as
+// well as the implicit_hasher lint. For more info, see
+// https://github.com/rust-lang/rfcs/issues/1856
+
 // Derive a hash map from a substitution.
+#[allow(clippy::implicit_hasher)]
 impl From<Substitution> for HashMap<Tvar, MonoType> {
     fn from(sub: Substitution) -> HashMap<Tvar, MonoType> {
         sub.0


### PR DESCRIPTION
The following clippy lints are addressed in this patch:

- [`single_char_pattern`](https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern)
- [`chars_last_cmp`](https://rust-lang.github.io/rust-clippy/master/index.html#chars_last_cmp)
- [`chars_next_cmp`](https://rust-lang.github.io/rust-clippy/master/index.html#chars_next_cmp)
- [`unnecessary_operation`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_operation)
- [`wrong_self_convention`](https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention)
- [`useless_let_if_seq`](https://rust-lang.github.io/rust-clippy/master/index.html#useless_let_if_seq)
- [`implicit_hasher`](https://rust-lang.github.io/rust-clippy/master/index.html#implicit_hasher)
- [`ptr_arg`](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg)
- [`single_match`](https://rust-lang.github.io/rust-clippy/master/index.html#single_match)
- [`unnecessary_fold`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fold)
- [`redundant_field_names`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names)
- [`new_without_default`](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default)

Additionally, as this work was done, I discovered that the generated
code's `allow` attributes were overly broad, and were accidentally
applying to the entire module. That issue was fixed, along with any lint
discovered as a result.

`clippy::unknown_clippy_lints` was promoted to being a library-wide lint
as a result of the `wrong_self_convention` issue. Using this lint allows
us to guard against changes in clippy, where a new version of clippy
may fail because it has no understanding of a lint name.

This patch is probably a bit larger than is preferred. However, the
division of work here makes some sense. At this point, the remaining lints
are a bit more involved, and are less shallow, so should be addressed in
individual patches.