### PR TITLE
feat(values): reduce memory allocations for operations in values

### DIFF
--- a/values/bool.go
+++ b/values/bool.go
@@ -1,0 +1,22 @@
+package values
+
+import "github.com/influxdata/flux/semantic"
+
+var (
+	trueValue Value = value{
+		t: semantic.Bool,
+		v: true,
+	}
+	falseValue Value = value{
+		t: semantic.Bool,
+		v: false,
+	}
+)
+
+func NewBool(v bool) Value {
+	if v {
+		return trueValue
+	} else {
+		return falseValue
+	}
+}

--- a/values/values.go
+++ b/values/values.go
@@ -263,12 +263,6 @@ func NewFloat(v float64) Value {
 		v: v,
 	}
 }
-func NewBool(v bool) Value {
-	return value{
-		t: semantic.Bool,
-		v: v,
-	}
-}
 func NewTime(v Time) Value {
 	return value{
 		t: semantic.Time,


### PR DESCRIPTION
An object will now cache the type for an object and not recompute it as
long as the type doesn't change. This includes a change to `Set` which
will check the old value's type and the new value's type and it will not
force the type to be recomputed as long as the type doesn't change. This
helps to reduce memory allocations when using `Set` to change the value
inside of functions like `filter()` where the type doesn't change.
Previously, it was using a lot of memory to recompute the type over and
over again.

This also changes `values.NewBool` to return one of two memoized values
for true and false. This avoids an interface allocation each time that a
boolean is created.

Fixes #2211.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written