### PR TITLE
chore(libflux): address needless_return lint

### DIFF
--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -54,7 +54,7 @@ impl From<&Position> for scanner::Position {
 
 impl Default for Position {
     fn default() -> Self {
-        return Self::invalid();
+        Self::invalid()
     }
 }
 

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -8,7 +8,7 @@
 #![allow(clippy::useless_let_if_seq, clippy::implicit_hasher, clippy::ptr_arg)]
 #![allow(clippy::large_enum_variant, clippy::single_match)]
 #![allow(clippy::unnecessary_fold, clippy::not_unsafe_ptr_arg_deref)]
-#![allow(clippy::needless_return, clippy::module_inception)]
+#![allow(clippy::module_inception)]
 #![allow(clippy::many_single_char_names, clippy::redundant_field_names)]
 #![allow(clippy::unknown_clippy_lints)]
 
@@ -52,7 +52,7 @@ pub extern "C" fn flux_parse(cstr: *mut c_char) -> *mut flux_ast_t {
     let s = String::from_utf8(buf.to_vec()).unwrap();
     let mut p = Parser::new(&s);
     let file = p.parse_file(String::from(""));
-    return Box::into_raw(Box::new(file)) as *mut flux_ast_t;
+    Box::into_raw(Box::new(file)) as *mut flux_ast_t
 }
 
 #[no_mangle]
@@ -82,10 +82,10 @@ pub extern "C" fn flux_parse_fb(src_ptr: *const c_char) -> *mut flux_buffer_t {
     match r {
         Ok((vec, offset)) => {
             let data = &vec[offset..];
-            return Box::into_raw(Box::new(flux_buffer_t {
+            Box::into_raw(Box::new(flux_buffer_t {
                 data: data.as_ptr(),
                 len: data.len(),
-            }));
+            }))
         }
         Err(_) => 1 as *mut flux_buffer_t,
     }
@@ -108,14 +108,14 @@ pub extern "C" fn flux_ast_marshal_json(
     let buffer = unsafe { &mut *buf };
     buffer.len = data.len();
     buffer.data = Box::into_raw(data.into_boxed_slice()) as *mut u8;
-    return std::ptr::null_mut();
+    std::ptr::null_mut()
 }
 
 #[no_mangle]
 pub extern "C" fn flux_error_str(err: *mut flux_error_t) -> *mut c_char {
     let e = unsafe { &*(err as *mut ErrorHandle) };
     let s = CString::new(e.err.description()).unwrap();
-    return s.into_raw();
+    s.into_raw()
 }
 
 #[no_mangle]

--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -16,7 +16,7 @@ pub fn parse(s: &str) -> JsValue {
     let mut p = Parser::new(s);
     let file = p.parse_file(String::from(""));
 
-    return JsValue::from_serde(&file).unwrap();
+    JsValue::from_serde(&file).unwrap()
 }
 
 // Parses a string of source code.
@@ -211,7 +211,7 @@ impl Parser {
         let t = self.expect(start);
         let n = self.blocks.entry(end).or_insert(0);
         *n += 1;
-        return t;
+        t
     }
 
     // more will check if we should continue reading tokens for the
@@ -271,7 +271,7 @@ impl Parser {
             format_token(end),
             format_token(tok.tok)
         ));
-        return tok;
+        tok
     }
 
     fn base_node(&mut self, location: SourceLocation) -> BaseNode {
@@ -365,7 +365,7 @@ impl Parser {
                 name: ident,
             });
         }
-        return None;
+        None
     }
 
     fn parse_import_list(&mut self) -> Vec<ImportDeclaration> {
@@ -387,11 +387,11 @@ impl Parser {
             None
         };
         let path = self.parse_string_literal();
-        return ImportDeclaration {
+        ImportDeclaration {
             base: self.base_node_from_other_end(&t, &path.base),
             alias: alias,
             path: path,
-        };
+        }
     }
 
     fn parse_statement_list(&mut self) -> Vec<Statement> {
@@ -448,7 +448,7 @@ impl Parser {
                 self.consume();
                 let prop = self.parse_identifier();
                 let init = self.parse_assign_statement();
-                return Assignment::Member(MemberAssgn {
+                Assignment::Member(MemberAssgn {
                     base: self.base_node_from_others(&id.base, init.base()),
                     member: MemberExpr {
                         base: self.base_node_from_others(&id.base, &prop.base),
@@ -456,7 +456,7 @@ impl Parser {
                         property: PropertyKey::Identifier(prop),
                     },
                     init,
-                });
+                })
             }
             _ => panic!("invalid option assignment suffix"),
         }
@@ -488,11 +488,11 @@ impl Parser {
         match t.tok {
             TOK_ASSIGN => {
                 let init = self.parse_assign_statement();
-                return Statement::Variable(VariableAssgn {
+                Statement::Variable(VariableAssgn {
                     base: self.base_node_from_others(&id.base, init.base()),
                     id,
                     init,
-                });
+                })
             }
             _ => {
                 let expr = self.parse_expression_suffix(Expression::Identifier(id));
@@ -505,7 +505,7 @@ impl Parser {
     }
     fn parse_assign_statement(&mut self) -> Expression {
         self.expect(TOK_ASSIGN);
-        return self.parse_expression();
+        self.parse_expression()
     }
     fn parse_return_statement(&mut self) -> Statement {
         let t = self.expect(TOK_RETURN);
@@ -527,10 +527,10 @@ impl Parser {
         let start = self.open(TOK_LBRACE, TOK_RBRACE);
         let stmts = self.parse_statement_list();
         let end = self.close(TOK_RBRACE);
-        return Block {
+        Block {
             base: self.base_node_from_tokens(&start, &end),
             body: stmts,
-        };
+        }
     }
     fn parse_expression(&mut self) -> Expression {
         self.parse_conditional_expression()
@@ -585,7 +585,7 @@ impl Parser {
                 }
             }
         }
-        return expr;
+        expr
     }
     fn parse_expression_suffix(&mut self, expr: Expression) -> Expression {
         let expr = self.parse_postfix_operator_suffix(expr);
@@ -631,11 +631,11 @@ impl Parser {
                 alternate: alt,
             }));
         }
-        return self.parse_logical_or_expression();
+        self.parse_logical_or_expression()
     }
     fn parse_logical_or_expression(&mut self) -> Expression {
         let expr = self.parse_logical_and_expression();
-        return self.parse_logical_or_expression_suffix(expr);
+        self.parse_logical_or_expression_suffix(expr)
     }
     fn parse_logical_or_expression_suffix(&mut self, expr: Expression) -> Expression {
         let mut res = expr;
@@ -667,7 +667,7 @@ impl Parser {
     }
     fn parse_logical_and_expression(&mut self) -> Expression {
         let expr = self.parse_logical_unary_expression();
-        return self.parse_logical_and_expression_suffix(expr);
+        self.parse_logical_and_expression_suffix(expr)
     }
     fn parse_logical_and_expression_suffix(&mut self, expr: Expression) -> Expression {
         let mut res = expr;
@@ -728,7 +728,7 @@ impl Parser {
     }
     fn parse_comparison_expression(&mut self) -> Expression {
         let expr = self.parse_additive_expression();
-        return self.parse_comparison_expression_suffix(expr);
+        self.parse_comparison_expression_suffix(expr)
     }
     fn parse_comparison_expression_suffix(&mut self, expr: Expression) -> Expression {
         let mut res = expr;
@@ -771,7 +771,7 @@ impl Parser {
     }
     fn parse_additive_expression(&mut self) -> Expression {
         let expr = self.parse_multiplicative_expression();
-        return self.parse_additive_expression_suffix(expr);
+        self.parse_additive_expression_suffix(expr)
     }
     fn parse_additive_expression_suffix(&mut self, expr: Expression) -> Expression {
         let mut res = expr;
@@ -808,7 +808,7 @@ impl Parser {
     }
     fn parse_multiplicative_expression(&mut self) -> Expression {
         let expr = self.parse_pipe_expression();
-        return self.parse_multiplicative_expression_suffix(expr);
+        self.parse_multiplicative_expression_suffix(expr)
     }
     fn parse_multiplicative_expression_suffix(&mut self, expr: Expression) -> Expression {
         let mut res = expr;
@@ -847,7 +847,7 @@ impl Parser {
     }
     fn parse_pipe_expression(&mut self) -> Expression {
         let expr = self.parse_unary_expression();
-        return self.parse_pipe_expression_suffix(expr);
+        self.parse_pipe_expression_suffix(expr)
     }
     fn parse_pipe_expression_suffix(&mut self, expr: Expression) -> Expression {
         let mut res = expr;
@@ -1090,10 +1090,10 @@ impl Parser {
     }
     fn parse_identifier(&mut self) -> Identifier {
         let t = self.expect(TOK_IDENT);
-        return Identifier {
+        Identifier {
             base: self.base_node_from_token(&t),
             name: t.lit,
-        };
+        }
     }
     fn parse_int_literal(&mut self) -> IntegerLit {
         let t = self.expect(TOK_INT);
@@ -1116,10 +1116,10 @@ impl Parser {
     }
     fn parse_float_literal(&mut self) -> FloatLit {
         let t = self.expect(TOK_FLOAT);
-        return FloatLit {
+        FloatLit {
             base: self.base_node_from_token(&t),
             value: (&t.lit).parse::<f64>().unwrap(),
-        };
+        }
     }
     fn parse_string_literal(&mut self) -> StringLit {
         let t = self.expect(TOK_STRING);

--- a/libflux/src/flux/parser/strconv.rs
+++ b/libflux/src/flux/parser/strconv.rs
@@ -11,7 +11,7 @@ pub fn parse_string(lit: &str) -> Result<String, String> {
     if lit.len() < 2 || lit.chars().next().unwrap() != '"' || lit.chars().last().unwrap() != '"' {
         return Err("invalid string literal".to_string());
     }
-    return parse_text(&lit[1..lit.len() - 1]);
+    parse_text(&lit[1..lit.len() - 1])
 }
 
 pub fn parse_text(lit: &str) -> Result<String, String> {

--- a/libflux/src/flux/scanner/mod.rs
+++ b/libflux/src/flux/scanner/mod.rs
@@ -45,7 +45,7 @@ impl Scanner {
         let ptr = data.as_ptr();
         let bytes = data.as_bytes();
         let end = ((ptr as usize) + bytes.len()) as *const CChar;
-        return Scanner {
+        Scanner {
             data,
             ps: ptr as *const CChar,
             p: ptr as *const CChar,
@@ -58,7 +58,7 @@ impl Scanner {
             checkpoint_line: 1,
             checkpoint_last_newline: ptr as *const CChar,
             positions: HashMap::new(),
-        };
+        }
     }
 
     // scan produces the next token from the input.

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -10,7 +10,7 @@ pub struct Builtins<'a> {
 
 impl<'a> Builtins<'a> {
     pub fn iter(&'a self) -> NodeIterator {
-        return NodeIterator::new(self);
+        NodeIterator::new(self)
     }
 }
 
@@ -581,10 +581,10 @@ pub struct NodeIterator<'a> {
 
 impl<'a> NodeIterator<'a> {
     pub fn new(builtins: &'a Builtins) -> NodeIterator<'a> {
-        return NodeIterator {
+        NodeIterator {
             path_elems: Vec::new(),
             iter_stack: vec![builtins.pkgs.iter()],
-        };
+        }
     }
 }
 

--- a/libflux/src/flux/semantic/nodes.rs
+++ b/libflux/src/flux/semantic/nodes.rs
@@ -590,7 +590,7 @@ impl StringExpr {
             }
         }
         constraints.push(Constraint::Equal(self.typ.clone(), MonoType::String));
-        return Ok((env, Constraints::from(constraints)));
+        Ok((env, Constraints::from(constraints)))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);
@@ -661,7 +661,7 @@ impl ArrayExpr {
         }
         let at = MonoType::Arr(Box::new(Array(elt)));
         cons.push(Constraint::Equal(at, self.typ.clone()));
-        return Ok((env, cons.into()));
+        Ok((env, cons.into()))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);
@@ -754,7 +754,7 @@ impl FunctionExpr {
         }));
         cons = cons + bcons;
         cons.add(Constraint::Equal(func, self.typ.clone()));
-        return Ok((env, cons));
+        Ok((env, cons))
     }
     pub fn pipe(&self) -> Option<&FunctionParameter> {
         for p in &self.params {
@@ -966,7 +966,7 @@ impl BinaryExpr {
         };
 
         // Otherwise, add the constraints together and return them.
-        return Ok((env, lcons + rcons + cons));
+        Ok((env, lcons + rcons + cons))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);
@@ -1084,7 +1084,7 @@ impl ConditionalExpr {
                 ),
                 Constraint::Equal(self.consequent.type_of().clone(), self.typ.clone()),
             ]);
-        return Ok((env, cons));
+        Ok((env, cons))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);
@@ -1118,7 +1118,7 @@ impl LogicalExpr {
                 Constraint::Equal(self.right.type_of().clone(), MonoType::Bool),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
             ]);
-        return Ok((env, cons));
+        Ok((env, cons))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);
@@ -1190,7 +1190,7 @@ impl IndexExpr {
                     MonoType::Arr(Box::new(Array(self.typ.clone()))),
                 ),
             ]);
-        return Ok((env, cons));
+        Ok((env, cons))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);
@@ -1289,7 +1289,7 @@ impl UnaryExpr {
             ]),
             _ => return Err(Error::unsupported_unary_operator(&self.operator)),
         };
-        return Ok((env, acons + cons));
+        Ok((env, acons + cons))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);


### PR DESCRIPTION
This patch addresses the [`needless_return`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return) lint.
