### PR TITLE
fix(semantic/analyze): update function block return statements to pro…

### DIFF
--- a/libflux/src/flux/semantic/analyze.rs
+++ b/libflux/src/flux/semantic/analyze.rs
@@ -262,7 +262,13 @@ fn analyze_function_params(
 
 fn analyze_function_body(body: ast::FunctionBody, fresher: &mut Fresher) -> Result<Block> {
     match body {
-        ast::FunctionBody::Expr(e) => Ok(Block::Return(analyze_expression(e, fresher)?)),
+        ast::FunctionBody::Expr(expr) => {
+            let argument = analyze_expression(expr, fresher)?;
+            Ok(Block::Return(ReturnStmt {
+                loc: argument.loc().clone(),
+                argument,
+            }))
+        }
         ast::FunctionBody::Block(block) => Ok(analyze_block(block, fresher)?),
     }
 }
@@ -271,7 +277,11 @@ fn analyze_block(block: ast::Block, fresher: &mut Fresher) -> Result<Block> {
     let mut body = block.body.into_iter().rev();
 
     let block = if let Some(ast::Statement::Return(stmt)) = body.next() {
-        Block::Return(analyze_expression(stmt.argument, fresher)?)
+        let argument = analyze_expression(stmt.argument, fresher)?;
+        Block::Return(ReturnStmt {
+            loc: argument.loc().clone(),
+            argument,
+        })
     } else {
         return Err("missing return statement in block".to_string());
     };
@@ -1499,21 +1509,24 @@ mod tests {
                                     default: None,
                                 },
                             ],
-                            body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+                            body: Block::Return(ReturnStmt {
                                 loc: b.location.clone(),
-                                typ: type_info(),
-                                operator: ast::Operator::AdditionOperator,
-                                left: Expression::Identifier(IdentifierExpr {
+                                argument: Expression::Binary(Box::new(BinaryExpr {
                                     loc: b.location.clone(),
                                     typ: type_info(),
-                                    name: "a".to_string(),
-                                }),
-                                right: Expression::Identifier(IdentifierExpr {
-                                    loc: b.location.clone(),
-                                    typ: type_info(),
-                                    name: "b".to_string(),
-                                }),
-                            }))),
+                                    operator: ast::Operator::AdditionOperator,
+                                    left: Expression::Identifier(IdentifierExpr {
+                                        loc: b.location.clone(),
+                                        typ: type_info(),
+                                        name: "a".to_string(),
+                                    }),
+                                    right: Expression::Identifier(IdentifierExpr {
+                                        loc: b.location.clone(),
+                                        typ: type_info(),
+                                        name: "b".to_string(),
+                                    }),
+                                })),
+                            }),
                         })),
                         b.location.clone(),
                     ))),
@@ -1722,31 +1735,34 @@ mod tests {
                                     default: None,
                                 },
                             ],
-                            body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+                            body: Block::Return(ReturnStmt {
                                 loc: b.location.clone(),
-                                typ: type_info(),
-                                operator: ast::Operator::AdditionOperator,
-                                left: Expression::Binary(Box::new(BinaryExpr {
+                                argument: Expression::Binary(Box::new(BinaryExpr {
                                     loc: b.location.clone(),
                                     typ: type_info(),
                                     operator: ast::Operator::AdditionOperator,
-                                    left: Expression::Identifier(IdentifierExpr {
+                                    left: Expression::Binary(Box::new(BinaryExpr {
                                         loc: b.location.clone(),
                                         typ: type_info(),
-                                        name: "a".to_string(),
-                                    }),
+                                        operator: ast::Operator::AdditionOperator,
+                                        left: Expression::Identifier(IdentifierExpr {
+                                            loc: b.location.clone(),
+                                            typ: type_info(),
+                                            name: "a".to_string(),
+                                        }),
+                                        right: Expression::Identifier(IdentifierExpr {
+                                            loc: b.location.clone(),
+                                            typ: type_info(),
+                                            name: "b".to_string(),
+                                        }),
+                                    })),
                                     right: Expression::Identifier(IdentifierExpr {
                                         loc: b.location.clone(),
                                         typ: type_info(),
-                                        name: "b".to_string(),
+                                        name: "c".to_string(),
                                     }),
                                 })),
-                                right: Expression::Identifier(IdentifierExpr {
-                                    loc: b.location.clone(),
-                                    typ: type_info(),
-                                    name: "c".to_string(),
-                                }),
-                            }))),
+                            }),
                         })),
                         b.location.clone(),
                     ))),
@@ -2044,21 +2060,24 @@ mod tests {
                                     default: None,
                                 },
                             ],
-                            body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+                            body: Block::Return(ReturnStmt {
                                 loc: b.location.clone(),
-                                typ: type_info(),
-                                operator: ast::Operator::AdditionOperator,
-                                left: Expression::Identifier(IdentifierExpr {
+                                argument: Expression::Binary(Box::new(BinaryExpr {
                                     loc: b.location.clone(),
                                     typ: type_info(),
-                                    name: "a".to_string(),
-                                }),
-                                right: Expression::Identifier(IdentifierExpr {
-                                    loc: b.location.clone(),
-                                    typ: type_info(),
-                                    name: "piped".to_string(),
-                                }),
-                            }))),
+                                    operator: ast::Operator::AdditionOperator,
+                                    left: Expression::Identifier(IdentifierExpr {
+                                        loc: b.location.clone(),
+                                        typ: type_info(),
+                                        name: "a".to_string(),
+                                    }),
+                                    right: Expression::Identifier(IdentifierExpr {
+                                        loc: b.location.clone(),
+                                        typ: type_info(),
+                                        name: "piped".to_string(),
+                                    }),
+                                })),
+                            }),
                         })),
                         b.location.clone(),
                     ))),
@@ -2124,21 +2143,24 @@ mod tests {
                     default: None,
                 },
             ],
-            body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+            body: Block::Return(ReturnStmt {
                 loc: b.location.clone(),
-                typ: type_info(),
-                operator: ast::Operator::AdditionOperator,
-                left: Expression::Identifier(IdentifierExpr {
+                argument: Expression::Binary(Box::new(BinaryExpr {
                     loc: b.location.clone(),
                     typ: type_info(),
-                    name: "a".to_string(),
-                }),
-                right: Expression::Identifier(IdentifierExpr {
-                    loc: b.location.clone(),
-                    typ: type_info(),
-                    name: "b".to_string(),
-                }),
-            }))),
+                    operator: ast::Operator::AdditionOperator,
+                    left: Expression::Identifier(IdentifierExpr {
+                        loc: b.location.clone(),
+                        typ: type_info(),
+                        name: "a".to_string(),
+                    }),
+                    right: Expression::Identifier(IdentifierExpr {
+                        loc: b.location.clone(),
+                        typ: type_info(),
+                        name: "b".to_string(),
+                    }),
+                })),
+            }),
         };
         assert_eq!(Vec::<&FunctionParameter>::new(), f.defaults());
         assert_eq!(None, f.pipe());
@@ -2205,21 +2227,24 @@ mod tests {
                 default2.clone(),
                 no_default.clone(),
             ],
-            body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+            body: Block::Return(ReturnStmt {
                 loc: b.location.clone(),
-                typ: type_info(),
-                operator: ast::Operator::AdditionOperator,
-                left: Expression::Identifier(IdentifierExpr {
+                argument: Expression::Binary(Box::new(BinaryExpr {
                     loc: b.location.clone(),
                     typ: type_info(),
-                    name: "a".to_string(),
-                }),
-                right: Expression::Identifier(IdentifierExpr {
-                    loc: b.location.clone(),
-                    typ: type_info(),
-                    name: "b".to_string(),
-                }),
-            }))),
+                    operator: ast::Operator::AdditionOperator,
+                    left: Expression::Identifier(IdentifierExpr {
+                        loc: b.location.clone(),
+                        typ: type_info(),
+                        name: "a".to_string(),
+                    }),
+                    right: Expression::Identifier(IdentifierExpr {
+                        loc: b.location.clone(),
+                        typ: type_info(),
+                        name: "b".to_string(),
+                    }),
+                })),
+            }),
         };
         assert_eq!(defaults, f.defaults());
         assert_eq!(Some(&piped), f.pipe());

--- a/libflux/src/flux/semantic/walk/walk.rs
+++ b/libflux/src/flux/semantic/walk/walk.rs
@@ -435,7 +435,7 @@ where
                     walk(v, Rc::new(Node::ExprStmt(estmt)));
                     walk(v, Rc::new(Node::Block(&*next)))
                 }
-                Block::Return(ref expr) => walk(v, Rc::new(Node::from_expr(expr))),
+                Block::Return(ref ret_stmt) => walk(v, Rc::new(Node::ReturnStmt(ret_stmt))),
             },
             Node::Property(ref n) => {
                 walk(v, Rc::new(Node::Identifier(&n.key)));
@@ -531,6 +531,7 @@ mod tests {
                     "ExprStmt",
                     "FunctionExpr",
                     "Block::Return",
+                    "ReturnStmt",
                     "IntegerLit",
                 ],
             )
@@ -564,6 +565,7 @@ mod tests {
                     "IdentifierExpr",
                     "IdentifierExpr",
                     "Block::Return",
+                    "ReturnStmt",
                     "IdentifierExpr",
                 ],
             )
@@ -580,6 +582,7 @@ mod tests {
                     "Identifier",
                     "IntegerLit",
                     "Block::Return",
+                    "ReturnStmt",
                     "IdentifierExpr",
                 ],
             )
@@ -761,6 +764,7 @@ mod tests {
                     "FunctionParameter",
                     "Identifier",
                     "Block::Return",
+                    "ReturnStmt",
                     "IdentifierExpr",
                 ],
             )
@@ -790,6 +794,7 @@ mod tests {
                     "ExprStmt",
                     "FunctionExpr",
                     "Block::Return",
+                    "ReturnStmt",
                     "IntegerLit",
                 ],
             )

--- a/libflux/src/flux/semantic/walk/walk_mut.rs
+++ b/libflux/src/flux/semantic/walk/walk_mut.rs
@@ -169,30 +169,6 @@ impl<'a> NodeMut<'a> {
         }
     }
     pub fn set_loc(&mut self, loc: SourceLocation) {
-        let mut_expr_loc = |expr: &mut Expression, loc: SourceLocation| {
-            match expr {
-                Expression::Identifier(ref mut e) => e.loc = loc,
-                Expression::Array(ref mut e) => e.loc = loc,
-                Expression::Function(ref mut e) => e.loc = loc,
-                Expression::Logical(ref mut e) => e.loc = loc,
-                Expression::Object(ref mut e) => e.loc = loc,
-                Expression::Member(ref mut e) => e.loc = loc,
-                Expression::Index(ref mut e) => e.loc = loc,
-                Expression::Binary(ref mut e) => e.loc = loc,
-                Expression::Unary(ref mut e) => e.loc = loc,
-                Expression::Call(ref mut e) => e.loc = loc,
-                Expression::Conditional(ref mut e) => e.loc = loc,
-                Expression::StringExpr(ref mut e) => e.loc = loc,
-                Expression::Integer(ref mut e) => e.loc = loc,
-                Expression::Float(ref mut e) => e.loc = loc,
-                Expression::StringLit(ref mut e) => e.loc = loc,
-                Expression::Duration(ref mut e) => e.loc = loc,
-                Expression::Uint(ref mut e) => e.loc = loc,
-                Expression::Boolean(ref mut e) => e.loc = loc,
-                Expression::DateTime(ref mut e) => e.loc = loc,
-                Expression::Regexp(ref mut e) => e.loc = loc,
-            };
-        };
         match self {
             NodeMut::Package(ref mut n) => n.loc = loc,
             NodeMut::File(ref mut n) => n.loc = loc,
@@ -225,11 +201,7 @@ impl<'a> NodeMut<'a> {
             NodeMut::ReturnStmt(ref mut n) => n.loc = loc,
             NodeMut::TestStmt(ref mut n) => n.loc = loc,
             NodeMut::BuiltinStmt(ref mut n) => n.loc = loc,
-            NodeMut::Block(Block::Variable(ref mut assgn, _)) => assgn.loc = loc,
-            NodeMut::Block(Block::Expr(ref mut estmt, _)) => {
-                mut_expr_loc(&mut estmt.expression, loc)
-            }
-            NodeMut::Block(Block::Return(ref mut expr)) => mut_expr_loc(expr, loc),
+            NodeMut::Block(_) => (),
             NodeMut::Property(ref mut n) => n.loc = loc,
             NodeMut::TextPart(ref mut n) => n.loc = loc,
             NodeMut::InterpolatedPart(ref mut n) => n.loc = loc,
@@ -477,7 +449,7 @@ where
                     walk_mut(v, &mut NodeMut::ExprStmt(estmt));
                     walk_mut(v, &mut NodeMut::Block(&mut *next))
                 }
-                Block::Return(ref mut expr) => walk_mut(v, &mut NodeMut::from_expr(expr)),
+                Block::Return(ref mut ret_stmt) => walk_mut(v, &mut NodeMut::ReturnStmt(ret_stmt)),
             },
             NodeMut::Property(ref mut n) => {
                 walk_mut(v, &mut NodeMut::Identifier(&mut n.key));
@@ -574,6 +546,7 @@ mod tests {
                     "ExprStmt",
                     "FunctionExpr",
                     "Block::Return",
+                    "ReturnStmt",
                     "IntegerLit",
                 ],
             )
@@ -607,6 +580,7 @@ mod tests {
                     "IdentifierExpr",
                     "IdentifierExpr",
                     "Block::Return",
+                    "ReturnStmt",
                     "IdentifierExpr",
                 ],
             )
@@ -623,6 +597,7 @@ mod tests {
                     "Identifier",
                     "IntegerLit",
                     "Block::Return",
+                    "ReturnStmt",
                     "IdentifierExpr",
                 ],
             )
@@ -804,6 +779,7 @@ mod tests {
                     "FunctionParameter",
                     "Identifier",
                     "Block::Return",
+                    "ReturnStmt",
                     "IdentifierExpr",
                 ],
             )
@@ -833,6 +809,7 @@ mod tests {
                     "ExprStmt",
                     "FunctionExpr",
                     "Block::Return",
+                    "ReturnStmt",
                     "IntegerLit",
                 ],
             )

--- a/libflux/src/flux/tests/analyze_test.rs
+++ b/libflux/src/flux/tests/analyze_test.rs
@@ -93,21 +93,24 @@ f(a: s)
                             },
                             default: None,
                         }],
-                        body: Block::Return(Expression::Binary(Box::new(BinaryExpr {
+                        body: Block::Return(ReturnStmt {
                             loc: ast::BaseNode::default().location,
-                            typ: MonoType::Var(Tvar(4)),
-                            operator: ast::Operator::AdditionOperator,
-                            left: Expression::Identifier(IdentifierExpr {
+                            argument: Expression::Binary(Box::new(BinaryExpr {
                                 loc: ast::BaseNode::default().location,
                                 typ: MonoType::Var(Tvar(4)),
-                                name: "a".to_string(),
-                            }),
-                            right: Expression::Identifier(IdentifierExpr {
-                                loc: ast::BaseNode::default().location,
-                                typ: MonoType::Var(Tvar(4)),
-                                name: "a".to_string(),
-                            }),
-                        }))),
+                                operator: ast::Operator::AdditionOperator,
+                                left: Expression::Identifier(IdentifierExpr {
+                                    loc: ast::BaseNode::default().location,
+                                    typ: MonoType::Var(Tvar(4)),
+                                    name: "a".to_string(),
+                                }),
+                                right: Expression::Identifier(IdentifierExpr {
+                                    loc: ast::BaseNode::default().location,
+                                    typ: MonoType::Var(Tvar(4)),
+                                    name: "a".to_string(),
+                                }),
+                            })),
+                        }),
                     })),
                     ast::BaseNode::default().location,
                 ))),


### PR DESCRIPTION
Previously, the Rust semantic graph represented `ReturnStmt` nodes within `Block` nodes as Expressions. This is because in the AST a `Block` node can be represented as a list of statements or as an expression with the return value being the value of the expression. This PR makes all function blocks in the semantic graph a list of statements. 

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
