### PR TITLE
fix(scanner): fix token location for scan_with_regex

### DIFF
--- a/ast/flatbuffers_test.go
+++ b/ast/flatbuffers_test.go
@@ -98,8 +98,8 @@ b = true
 dt = 2030-01-01T00:00:00Z
 re =~ /foo/
 re !~ /foo/
+bad_expr = 3 * / 1
 bad_expr = 3 * + 1
-// bad_expr = 3 * / 1
 `}
 	for _, src := range srcs {
 		astFbs := libflux.ParseIntoFbs(src)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -661,13 +661,25 @@ func (p *parser) parseMultiplicativeExpressionSuffix(expr *ast.Expression) func(
 			return false
 		}
 		rhs := p.parsePipeExpression()
+
+		var endPos ast.Position
+		// If we couldn't parse a RHS, use the buffered token to determine the
+		// end location of the binary expr.
+		if rhs == nil {
+			if p.buffered {
+				endPos = p.s.File().Position(p.pos + token.Pos(len(p.lit)))
+			}
+		} else {
+			endPos = locEnd(rhs)
+		}
+
 		*expr = &ast.BinaryExpression{
 			Operator: op,
 			Left:     *expr,
 			Right:    rhs,
 			BaseNode: p.baseNode(p.sourceLocation(
 				locStart(*expr),
-				locEnd(rhs),
+				endPos,
 			)),
 		}
 		return true

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -5604,9 +5604,8 @@ string"
 							BaseNode: base("1:1", "1:5"),
 							Expression: &ast.BinaryExpression{
 								Right: nil,
-								// TODO(affo): when one operand in the BinaryExpression is nil, the location is not reported.
-								//  This is because of locStart/locEnd implementation.
 								BaseNode: ast.BaseNode{
+									Loc: loc("1:2", "1:5"),
 									Errors: []ast.Error{
 										{Msg: "missing right hand side of expression"},
 									},

--- a/internal/token/fileset.go
+++ b/internal/token/fileset.go
@@ -29,6 +29,13 @@ func NewFile(name string, sz int) *File {
 }
 
 func (f *File) AddLine(offset int) {
+	// if we performed an unread then we may need to remove some lines to preserve
+	// the sortedness of the lines slice.
+	last := len(f.lines)
+	for last > 0 && f.lines[last-1] >= offset {
+		last--
+	}
+	f.lines = f.lines[0:last]
 	f.lines = append(f.lines, offset)
 }
 

--- a/libflux/scanner.c
+++ b/libflux/scanner.c
@@ -1872,6 +1872,17 @@ _again:
     *token_start_col = ts - last_newline_before_token + 1;
 
     *token_end = te - data;
+
+    if (*last_newline > te) {
+        // te (the token end pointer) will only be less than last_newline
+        // (pointer to the last newline the scanner saw) if we are trying
+        // to find a multi-line token (either string or regex literal)
+        // but don't find the closing `/` or `"`.
+        // In that case we need to reset last_newline and cur_line.
+        *cur_line = cur_line_token_start;
+        *last_newline = last_newline_before_token;
+    }
+
     *token_end_line = *cur_line;
     *token_end_col = te - *last_newline + 1;
 

--- a/libflux/src/flux/scanner/mod.rs
+++ b/libflux/src/flux/scanner/mod.rs
@@ -76,6 +76,16 @@ impl Scanner {
         self._scan(2)
     }
 
+    // unread will reset the Scanner to go back to the Scanner's location
+    // before the last scan_with_regex or scan call. If either of the scan_with_regex methods
+    // returned an EOF token, a call to unread will not unread the discarded whitespace.
+    // This method is a no-op if called multiple times.
+    pub fn unread(&mut self) {
+        self.p = self.checkpoint;
+        self.cur_line = self.checkpoint_line;
+        self.last_newline = self.checkpoint_last_newline;
+    }
+
     pub fn offset(&self, pos: &Position) -> u32 {
         *self.positions.get(pos).expect("position should be in map")
     }
@@ -207,16 +217,6 @@ impl Scanner {
             } => self.scan(),
             _ => t,
         }
-    }
-
-    // unread will reset the Scanner to go back to the Scanner's location
-    // before the last scan_with_regex or scan call. If either of the scan_with_regex methods
-    // returned an EOF token, a call to unread will not unread the discarded whitespace.
-    // This method is a no-op if called multiple times.
-    pub fn unread(&mut self) {
-        self.p = self.checkpoint;
-        self.cur_line = self.checkpoint_line;
-        self.last_newline = self.checkpoint_last_newline;
     }
 }
 

--- a/libflux/src/flux/scanner/scanner.rl
+++ b/libflux/src/flux/scanner/scanner.rl
@@ -192,6 +192,17 @@ int scan(
     *token_start_col = ts - last_newline_before_token + 1;
 
     *token_end = te - data;
+
+    if (*last_newline > te) {
+        // te (the token end pointer) will only be less than last_newline
+        // (pointer to the last newline the scanner saw) if we are trying
+        // to find a multi-line token (either string or regex literal)
+        // but don't find the closing `/` or `"`.
+        // In that case we need to reset last_newline and cur_line.
+        *cur_line = cur_line_token_start;
+        *last_newline = last_newline_before_token;
+    }
+
     *token_end_line = *cur_line;
     *token_end_col = te - *last_newline + 1;
 


### PR DESCRIPTION
If a flux program has a stray `/` in a place where a regexp literal might appear, the scanner will scan to the end of the input looking for the closing `/`.  During scanning we keep track of where newlines appear so we can determine the line/column info for the end of the token returned by the scanner.

In this situation we were getting the location wrong because the token was just TOKEN_DIV, not a regexp literal.  I updated the logic in the Rust scanner to reset the pointer to the last newline for this case.

I also made two changes to how Go parses Flux so that the roundtrip test can now pass:
- if we cannot parse the RHS of a binary expr, we use the location info of the buffered token, so we can propagate location info up the AST
- I added logic to preserve the sortedness of the lines slice maintained by the scanner.  We need to do this since the lines slice can become unordered when unreading multi-line tokens.  This is addressing the same problem that the Rust changes address, but on the Go side.