### PR TITLE
fix(semantic): annotate variable assignment with polytype (not monotype)

### DIFF
--- a/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
+++ b/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
@@ -4072,7 +4072,6 @@ pub mod fbsemantic {
             if let Some(x) = args.loc {
                 builder.add_loc(x);
             }
-            builder.add_typ_type(args.typ_type);
             builder.add_init__type(args.init__type);
             builder.finish()
         }
@@ -4081,8 +4080,7 @@ pub mod fbsemantic {
         pub const VT_IDENTIFIER: flatbuffers::VOffsetT = 6;
         pub const VT_INIT__TYPE: flatbuffers::VOffsetT = 8;
         pub const VT_INIT_: flatbuffers::VOffsetT = 10;
-        pub const VT_TYP_TYPE: flatbuffers::VOffsetT = 12;
-        pub const VT_TYP: flatbuffers::VOffsetT = 14;
+        pub const VT_TYP: flatbuffers::VOffsetT = 12;
 
         #[inline]
         pub fn loc(&self) -> Option<SourceLocation<'a>> {
@@ -4118,18 +4116,11 @@ pub mod fbsemantic {
                 )
         }
         #[inline]
-        pub fn typ_type(&self) -> MonoType {
-            self._tab
-                .get::<MonoType>(NativeVariableAssignment::VT_TYP_TYPE, Some(MonoType::NONE))
-                .unwrap()
-        }
-        #[inline]
-        pub fn typ(&self) -> Option<flatbuffers::Table<'a>> {
-            self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(
-                    NativeVariableAssignment::VT_TYP,
-                    None,
-                )
+        pub fn typ(&self) -> Option<PolyType<'a>> {
+            self._tab.get::<flatbuffers::ForwardsUOffset<PolyType<'a>>>(
+                NativeVariableAssignment::VT_TYP,
+                None,
+            )
         }
         #[inline]
         #[allow(non_snake_case)]
@@ -4333,56 +4324,6 @@ pub mod fbsemantic {
                 None
             }
         }
-
-        #[inline]
-        #[allow(non_snake_case)]
-        pub fn typ_as_basic(&self) -> Option<Basic<'a>> {
-            if self.typ_type() == MonoType::Basic {
-                self.typ().map(|u| Basic::init_from_table(u))
-            } else {
-                None
-            }
-        }
-
-        #[inline]
-        #[allow(non_snake_case)]
-        pub fn typ_as_var(&self) -> Option<Var<'a>> {
-            if self.typ_type() == MonoType::Var {
-                self.typ().map(|u| Var::init_from_table(u))
-            } else {
-                None
-            }
-        }
-
-        #[inline]
-        #[allow(non_snake_case)]
-        pub fn typ_as_arr(&self) -> Option<Arr<'a>> {
-            if self.typ_type() == MonoType::Arr {
-                self.typ().map(|u| Arr::init_from_table(u))
-            } else {
-                None
-            }
-        }
-
-        #[inline]
-        #[allow(non_snake_case)]
-        pub fn typ_as_row(&self) -> Option<Row<'a>> {
-            if self.typ_type() == MonoType::Row {
-                self.typ().map(|u| Row::init_from_table(u))
-            } else {
-                None
-            }
-        }
-
-        #[inline]
-        #[allow(non_snake_case)]
-        pub fn typ_as_fun(&self) -> Option<Fun<'a>> {
-            if self.typ_type() == MonoType::Fun {
-                self.typ().map(|u| Fun::init_from_table(u))
-            } else {
-                None
-            }
-        }
     }
 
     pub struct NativeVariableAssignmentArgs<'a> {
@@ -4390,8 +4331,7 @@ pub mod fbsemantic {
         pub identifier: Option<flatbuffers::WIPOffset<Identifier<'a>>>,
         pub init__type: Expression,
         pub init_: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-        pub typ_type: MonoType,
-        pub typ: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+        pub typ: Option<flatbuffers::WIPOffset<PolyType<'a>>>,
     }
     impl<'a> Default for NativeVariableAssignmentArgs<'a> {
         #[inline]
@@ -4401,7 +4341,6 @@ pub mod fbsemantic {
                 identifier: None,
                 init__type: Expression::NONE,
                 init_: None,
-                typ_type: MonoType::NONE,
                 typ: None,
             }
         }
@@ -4443,19 +4382,12 @@ pub mod fbsemantic {
             );
         }
         #[inline]
-        pub fn add_typ_type(&mut self, typ_type: MonoType) {
-            self.fbb_.push_slot::<MonoType>(
-                NativeVariableAssignment::VT_TYP_TYPE,
-                typ_type,
-                MonoType::NONE,
-            );
-        }
-        #[inline]
-        pub fn add_typ(&mut self, typ: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
-            self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
-                NativeVariableAssignment::VT_TYP,
-                typ,
-            );
+        pub fn add_typ(&mut self, typ: flatbuffers::WIPOffset<PolyType<'b>>) {
+            self.fbb_
+                .push_slot_always::<flatbuffers::WIPOffset<PolyType>>(
+                    NativeVariableAssignment::VT_TYP,
+                    typ,
+                );
         }
         #[inline]
         pub fn new(

--- a/semantic/internal/fbsemantic/NativeVariableAssignment.go
+++ b/semantic/internal/fbsemantic/NativeVariableAssignment.go
@@ -73,29 +73,21 @@ func (rcv *NativeVariableAssignment) Init_(obj *flatbuffers.Table) bool {
 	return false
 }
 
-func (rcv *NativeVariableAssignment) TypType() byte {
+func (rcv *NativeVariableAssignment) Typ(obj *PolyType) *PolyType {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(12))
 	if o != 0 {
-		return rcv._tab.GetByte(o + rcv._tab.Pos)
+		x := rcv._tab.Indirect(o + rcv._tab.Pos)
+		if obj == nil {
+			obj = new(PolyType)
+		}
+		obj.Init(rcv._tab.Bytes, x)
+		return obj
 	}
-	return 0
-}
-
-func (rcv *NativeVariableAssignment) MutateTypType(n byte) bool {
-	return rcv._tab.MutateByteSlot(12, n)
-}
-
-func (rcv *NativeVariableAssignment) Typ(obj *flatbuffers.Table) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(14))
-	if o != 0 {
-		rcv._tab.Union(obj, o)
-		return true
-	}
-	return false
+	return nil
 }
 
 func NativeVariableAssignmentStart(builder *flatbuffers.Builder) {
-	builder.StartObject(6)
+	builder.StartObject(5)
 }
 func NativeVariableAssignmentAddLoc(builder *flatbuffers.Builder, loc flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(loc), 0)
@@ -109,11 +101,8 @@ func NativeVariableAssignmentAddInit_type(builder *flatbuffers.Builder, init_typ
 func NativeVariableAssignmentAddInit_(builder *flatbuffers.Builder, init_ flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(init_), 0)
 }
-func NativeVariableAssignmentAddTypType(builder *flatbuffers.Builder, typType byte) {
-	builder.PrependByteSlot(4, typType, 0)
-}
 func NativeVariableAssignmentAddTyp(builder *flatbuffers.Builder, typ flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(5, flatbuffers.UOffsetT(typ), 0)
+	builder.PrependUOffsetTSlot(4, flatbuffers.UOffsetT(typ), 0)
 }
 func NativeVariableAssignmentEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/semantic/semantic.fbs
+++ b/semantic/semantic.fbs
@@ -200,7 +200,7 @@ table NativeVariableAssignment {
   loc:SourceLocation;
   identifier:Identifier;
   init_:Expression;
-  typ:MonoType;
+  typ:PolyType;
 }
 
 table MemberAssignment {


### PR DESCRIPTION
This is just a very simple change to the flatbuffer schema for the semantic graph.  It's not actually used anywhere on master yet, so there are no test changes.