### PR TITLE
fix: do not stall forever in flux-config when an error happens with verbose

### DIFF
--- a/internal/cmd/flux-config/build.go
+++ b/internal/cmd/flux-config/build.go
@@ -210,8 +210,8 @@ func runCargo(srcdir string) error {
 	cmd.Stderr = out
 	cmd.Dir = srcdir
 	if err := cmd.Run(); err != nil {
-		if r, ok := out.(io.Reader); ok {
-			_, _ = io.Copy(os.Stderr, r)
+		if !flags.Verbose {
+			_, _ = io.Copy(os.Stderr, out.(io.Reader))
 		}
 		return err
 	}


### PR DESCRIPTION
The verbose flag would set the output to be `os.Stderr`. The code
assumed that this wouldn't be usable as an `io.Reader` and so the
`io.Copy` would only occur when the output was not verbose. But,
`os.Stderr` uses `*os.File` and `*os.File` does implement `io.Reader`,
but blocks forever because `os.Stderr` doesn't have anything to read.

This removes the incorrect code and replaces it by just checking to see
if verbose is set. If verbose is set, there is no need to copy the
buffer to stderr because it already is on stderr.

Fixes influxdata/influxdb#16267.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written