### PR TITLE
feat(stdlib): implement onEmpty parameter for filter

### DIFF
--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -743,11 +743,6 @@ func TestTableObjectCompiler(t *testing.T) {
 
 	filteredDataRaw := `#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
 #group,false,false,true,true,false,false,false,false,true,true
-#default,_result,0,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,,,,,host.local,disk0
-,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
-
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string
-#group,false,false,true,true,false,false,false,false,true,true
 #default,_result,,,,,,,,,
 ,result,table,_start,_stop,_time,_value,_field,_measurement,host,name
 ,,1,2017-10-10T00:00:00Z,2018-05-22T19:54:00Z,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -451,7 +451,8 @@ pub fn builtins() -> Builtins<'static> {
                 "filter" => Node::Builtin(r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
-                        fn: (r: t0) -> bool
+                        fn: (r: t0) -> bool,
+                        ?onEmpty: string
                     ) -> [t0]
                 "#),
                 "first" => Node::Builtin(r#"

--- a/stdlib/universe/filter_drop_empty_test.flux
+++ b/stdlib/universe/filter_drop_empty_test.flux
@@ -1,0 +1,42 @@
+package universe_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,host,name
+,,0,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
+,,1,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:06Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:16Z,648,io_time,diskio,host.local,disk2
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long
+#group,false,false,true,true,true,true,true,true,false
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_measurement,_field,host,name,_value
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,6
+"
+
+t_filter_drop_empty = (table=<-) =>
+  table
+  |> range(start: 2018-05-22T19:53:26Z)
+  |> filter(fn: (r) => r["_value"] > 1000)
+  |> count()
+
+test _filter_drop_empty = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_drop_empty})
+

--- a/stdlib/universe/filter_keep_empty_test.flux
+++ b/stdlib/universe/filter_keep_empty_test.flux
@@ -1,0 +1,43 @@
+package universe_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,host,name
+,,0,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
+,,1,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:06Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:16Z,648,io_time,diskio,host.local,disk2
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long
+#group,false,false,true,true,true,true,true,true,false
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_measurement,_field,host,name,_value
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,6
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk2,0
+"
+
+t_filter_keep_empty = (table=<-) =>
+  table
+  |> range(start: 2018-05-22T19:53:26Z)
+  |> filter(fn: (r) => r["_value"] > 1000, onEmpty: "keep")
+  |> count()
+
+test _filter_keep_empty = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_keep_empty})
+

--- a/stdlib/universe/filter_mixed_empty_test.flux
+++ b/stdlib/universe/filter_mixed_empty_test.flux
@@ -1,0 +1,67 @@
+package universe_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string
+#group,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,
+,result,table,_time,_value,_field,_measurement,host,name
+,,0,2018-05-22T19:53:26Z,15204688,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:36Z,15204894,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:46Z,15205102,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:53:56Z,15205226,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:06Z,15205499,io_time,diskio,host.local,disk0
+,,0,2018-05-22T19:54:16Z,15205755,io_time,diskio,host.local,disk0
+,,1,2018-05-22T19:53:26Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:36Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:46Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:53:56Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:06Z,648,io_time,diskio,host.local,disk2
+,,1,2018-05-22T19:54:16Z,648,io_time,diskio,host.local,disk2
+
+#datatype,string,long,dateTime:RFC3339,double,string,string,string
+#group,false,false,false,false,true,true,true
+#default,_result,,,,,,
+,result,table,_time,_value,_field,_measurement,host
+,,2,2018-05-22T19:53:26Z,1.83,load1,system,host.local
+,,2,2018-05-22T19:53:36Z,1.7,load1,system,host.local
+,,2,2018-05-22T19:53:46Z,1.74,load1,system,host.local
+,,2,2018-05-22T19:53:56Z,1.63,load1,system,host.local
+,,2,2018-05-22T19:54:06Z,1.91,load1,system,host.local
+,,2,2018-05-22T19:54:16Z,1.84,load1,system,host.local
+,,3,2018-05-22T19:53:26Z,1.98,load15,system,host.local
+,,3,2018-05-22T19:53:36Z,1.97,load15,system,host.local
+,,3,2018-05-22T19:53:46Z,1.97,load15,system,host.local
+,,3,2018-05-22T19:53:56Z,1.96,load15,system,host.local
+,,3,2018-05-22T19:54:06Z,1.98,load15,system,host.local
+,,3,2018-05-22T19:54:16Z,1.97,load15,system,host.local
+,,4,2018-05-22T19:53:26Z,1.95,load5,system,host.local
+,,4,2018-05-22T19:53:36Z,1.92,load5,system,host.local
+,,4,2018-05-22T19:53:46Z,1.92,load5,system,host.local
+,,4,2018-05-22T19:53:56Z,1.89,load5,system,host.local
+,,4,2018-05-22T19:54:06Z,1.94,load5,system,host.local
+,,4,2018-05-22T19:54:16Z,1.93,load5,system,host.local
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long
+#group,false,false,true,true,true,true,true,true,false
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_measurement,_field,host,name,_value
+,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk0,6
+,,1,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,diskio,io_time,host.local,disk2,0
+"
+
+t_filter_mixed_empty = (table=<-) =>
+  table
+  |> range(start: 2018-05-22T19:53:26Z)
+  |> filter(fn: (r) => r._measurement == "diskio")
+  |> filter(fn: (r) => r["_value"] > 1000, onEmpty: "keep")
+  |> count()
+
+test _filter_mixed_empty = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_filter_mixed_empty})
+

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -543,6 +543,79 @@ func TestFilter_NewQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "from with drop",
+			Raw:  `from(bucket:"mybucket") |> filter(fn: (r) => true, onEmpty: "drop")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: "mybucket",
+						},
+					},
+					{
+						ID: "filter1",
+						Spec: &universe.FilterOpSpec{
+							Fn: interpreter.ResolvedFunction{
+								Fn: &semantic.FunctionExpression{
+									Block: &semantic.FunctionBlock{
+										Parameters: &semantic.FunctionParameters{
+											List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+										},
+										Body: &semantic.BooleanLiteral{Value: true},
+									},
+								},
+								Scope: valuestest.NowScope(),
+							},
+							OnEmpty: "drop",
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "filter1"},
+				},
+			},
+		},
+		{
+			Name: "from with keep",
+			Raw:  `from(bucket:"mybucket") |> filter(fn: (r) => true, onEmpty: "keep")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: "mybucket",
+						},
+					},
+					{
+						ID: "filter1",
+						Spec: &universe.FilterOpSpec{
+							Fn: interpreter.ResolvedFunction{
+								Fn: &semantic.FunctionExpression{
+									Block: &semantic.FunctionBlock{
+										Parameters: &semantic.FunctionParameters{
+											List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
+										},
+										Body: &semantic.BooleanLiteral{Value: true},
+									},
+								},
+								Scope: valuestest.NowScope(),
+							},
+							OnEmpty: "keep",
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "filter1"},
+				},
+			},
+		},
+		{
+			Name:    "from with invalid parameter",
+			Raw:     `from(bucket:"mybucket") |> filter(fn: (r) => true, onEmpty: "invalid")`,
+			WantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc

--- a/stdlib/universe/join_missing_on_col_test.flux
+++ b/stdlib/universe/join_missing_on_col_test.flux
@@ -15,17 +15,17 @@ inData = "
 #group,false,false,false,false,true,true,true,true
 #default,_result,,,,,,,
 ,result,table,_time,_value,_field,_measurement,org_id,status
-,_result,1,2019-09-12T20:00:00Z,180654,resp_bytes,http_request,03b60149f6fb9000,200
-,_result,2,2019-09-12T20:00:00Z,144,resp_bytes,http_request,03b60149f6fb9000,500
-,_result,3,2019-09-12T20:00:00Z,152,resp_bytes,http_request,10603619cf2e665b,500
+,_result,0,2019-09-12T20:00:00Z,180654,resp_bytes,http_request,03b60149f6fb9000,200
+,_result,1,2019-09-12T20:00:00Z,144,resp_bytes,http_request,039e9eb802d3f000,500
+,_result,2,2019-09-12T20:00:00Z,152,resp_bytes,http_request,03a2c4456f0f5000,500
 
 #datatype,string,long,dateTime:RFC3339,long,string,string,string,long
 #group,false,false,false,false,true,true,true,true
 #default,_result,,,,,,,
 ,result,table,_time,_value,_field,_measurement,org_id,status
-,_result,0,2019-09-12T20:00:00Z,9654177,req_bytes,http_request,039e9eb802d3f000,204
-,_result,1,2019-09-12T20:00:00Z,33784154,req_bytes,http_request,03a2c4456f0f5000,204
-,_result,2,2019-09-12T20:00:00Z,870346480,req_bytes,http_request,03b60149f6fb9000,204
+,_result,0,2019-09-12T20:00:00Z,870346480,req_bytes,http_request,03b60149f6fb9000,204
+,_result,1,2019-09-12T20:00:00Z,9654177,req_bytes,http_request,039e9eb802d3f000,204
+,_result,2,2019-09-12T20:00:00Z,33784154,req_bytes,http_request,03a2c4456f0f5000,204
 ,_result,3,2019-09-12T20:00:00Z,48275,req_bytes,http_request,03c68af671227000,204
 "
 
@@ -34,11 +34,9 @@ outData = "
 #group,false,false,false,false,true
 #default,_result,,,,
 ,result,table,datain,dataout,org_id
-,_result,0,9654177,,039e9eb802d3f000
-,_result,1,33784154,,03a2c4456f0f5000
-,_result,2,870346480,180798,03b60149f6fb9000
-,_result,3,48275,,03c68af671227000
-,_result,4,,152,10603619cf2e665b
+,_result,0,870346480,180654,03b60149f6fb9000
+,_result,1,9654177,144,039e9eb802d3f000
+,_result,2,33784154,152,03a2c4456f0f5000
 "
 
 t_join_missing_on_col = (tables=<-) => {


### PR DESCRIPTION
The `filter()` function now accepts an `onEmpty` parameter that will
determine the behavior of filter when the filter causes all rows to be
filtered.

Fixes #2278.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written