### PR TITLE
fix(semantic/libflux): removes unnecessary rc clone in semantic serializer

### DIFF
--- a/libflux/src/flux/semantic/flatbuffers/mod.rs
+++ b/libflux/src/flux/semantic/flatbuffers/mod.rs
@@ -39,7 +39,6 @@ impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
         if v.err.is_some() {
             return false;
         }
-        Rc::clone(&self.inner);
         true
     }
 


### PR DESCRIPTION
There was an unnecessary line of code cloning the reference counter in the semantic Flatbuffers serializer. This removes that line. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
