### PR TITLE
fix(libflux/semantic): update fill builtin type

### DIFF
--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -444,7 +444,7 @@ pub fn builtins() -> Builtins<'static> {
                     forall [t0, t1, t2] where t0: Row, t2: Row (
                         <-tables: [t0],
                         ?column: string,
-                        value: [t1],
+                        value: t1,
                         usePrevious: bool
                     ) -> [t2]
                 "#),


### PR DESCRIPTION
This change makes fill expect a single value to fill instead of a list of values

Fixes #2306 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
