### PR TITLE
fix(libflux/semantic): update count builtin type

### DIFF
--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -370,7 +370,7 @@ pub fn builtins() -> Builtins<'static> {
                 "count" => Node::Builtin(r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
-                        ?column: [string]
+                        ?column: string
                     ) -> [t1]
                 "#),
                 "covariance" => Node::Builtin(r#"


### PR DESCRIPTION
This change makes it so that count expects a single column instead of a list of columns

Fixes #2304 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
