### PR TITLE
fix(libflux/semantic): update the type of influxdb.to to be a passthrough

### DIFF
--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -134,7 +134,7 @@ pub fn builtins() -> Builtins<'static> {
                             ?measurementColumn: string,
                             ?tagColumns: [string],
                             ?fieldFn: (r: t0) -> t1
-                        ) -> [t1]
+                        ) -> [t0]
                     "#),
                     "buckets" => Node::Builtin(r#"
                         forall [] () -> [{


### PR DESCRIPTION
The `to` function is a passthrough, the `t1` from the `fieldFn` parameter does not effect the return type of the `to` function. 


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
