### PR TITLE
perf(stdlib): optimize window transformation

### DIFF
--- a/internal/execute/table/buffered_builder.go
+++ b/internal/execute/table/buffered_builder.go
@@ -38,9 +38,10 @@ func GetBufferedBuilder(key flux.GroupKey, cache *BuilderCache) (builder *Buffer
 // It ensures the schemas are compatible and will backfill previous
 // buffers with nil for new columns that didn't previously exist.
 func (b *BufferedBuilder) AppendBuffer(cr flux.ColReader) error {
-	if len(b.Buffers) == 0 {
-		// If there are no buffers, then take the columns
-		// from the column reader and append the buffer directly.
+	if b.Columns == nil {
+		// If the columns have not been set, then take the columns
+		// from the column reader and append the buffer directly
+		// since we know it matches the table schema.
 		b.Columns = cr.Cols()
 		buffer := &arrow.TableBuffer{
 			GroupKey: b.GroupKey,

--- a/internal/execute/table/builder_cache.go
+++ b/internal/execute/table/builder_cache.go
@@ -21,6 +21,34 @@ type Builder interface {
 	Release()
 }
 
+// KeyLookup is an interface for storing and retrieving
+// items by their group key.
+type KeyLookup interface {
+	// Lookup will retrieve the value associated with the given key if it exists.
+	Lookup(key flux.GroupKey) (interface{}, bool)
+
+	// LookupOrCreate will retrieve the value associated with the given key or,
+	// if it does not exist, will invoke the function to create one and set
+	// it in the group lookup.
+	LookupOrCreate(key flux.GroupKey, fn func() interface{}) interface{}
+
+	// Set will set the value for the given key.
+	// It will overwrite an existing value.
+	Set(key flux.GroupKey, value interface{})
+
+	// Delete will remove the key from this KeyLookup.
+	// It will return the same thing as a call to Lookup.
+	Delete(key flux.GroupKey) (v interface{}, found bool)
+
+	// Range will iterate over all groups keys in a stable ordering.
+	// Range must not be called within another call to Range.
+	// It is safe to call Set/Delete while ranging.
+	Range(f func(key flux.GroupKey, value interface{}))
+
+	// Clear will clear the lookup and reset it to contain nothing.
+	Clear()
+}
+
 // BuilderCache hold a mapping of group keys to Builder.
 // When a Builder is requested for a specific group key,
 // the BuilderCache will return a Builder that is unique
@@ -31,7 +59,12 @@ type BuilderCache struct {
 	// requested. The returned Builder should be empty.
 	New func(key flux.GroupKey) Builder
 
-	tables *execute.GroupLookup
+	// Tables contains the cached builders.
+	// This can be set before use to customize the
+	// method for storing data. If this is null,
+	// the default execute.GroupLookup is initialized
+	// when the cache is first used.
+	Tables KeyLookup
 }
 
 // Get retrieves the Builder for this group key.
@@ -45,11 +78,11 @@ type BuilderCache struct {
 func (d *BuilderCache) Get(key flux.GroupKey, b interface{}) bool {
 	builder, ok := d.lookupState(key)
 	if !ok {
-		if d.tables == nil {
-			d.tables = execute.NewGroupLookup()
+		if d.Tables == nil {
+			d.Tables = execute.NewGroupLookup()
 		}
 		builder = d.New(key)
-		d.tables.Set(key, builder)
+		d.Tables.Set(key, builder)
 	}
 	r := reflect.ValueOf(b)
 	r.Elem().Set(reflect.ValueOf(builder))
@@ -67,11 +100,11 @@ func (d *BuilderCache) Table(key flux.GroupKey) (flux.Table, error) {
 }
 
 func (d *BuilderCache) ForEach(f func(key flux.GroupKey, builder Builder) error) error {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return nil
 	}
 	var err error
-	d.tables.Range(func(key flux.GroupKey, value interface{}) {
+	d.Tables.Range(func(key flux.GroupKey, value interface{}) {
 		if err != nil {
 			return
 		}
@@ -82,10 +115,10 @@ func (d *BuilderCache) ForEach(f func(key flux.GroupKey, builder Builder) error)
 }
 
 func (d *BuilderCache) lookupState(key flux.GroupKey) (Builder, bool) {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return nil, false
 	}
-	v, ok := d.tables.Lookup(key)
+	v, ok := d.Tables.Lookup(key)
 	if !ok {
 		return nil, false
 	}
@@ -93,7 +126,7 @@ func (d *BuilderCache) lookupState(key flux.GroupKey) (Builder, bool) {
 }
 
 func (d *BuilderCache) DiscardTable(key flux.GroupKey) {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return
 	}
 
@@ -106,16 +139,16 @@ func (d *BuilderCache) DiscardTable(key flux.GroupKey) {
 		} else {
 			// Release the table and construct a new one.
 			b.Release()
-			d.tables.Set(key, d.New(key))
+			d.Tables.Set(key, d.New(key))
 		}
 	}
 }
 
 func (d *BuilderCache) ExpireTable(key flux.GroupKey) {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return
 	}
-	ts, ok := d.tables.Delete(key)
+	ts, ok := d.Tables.Delete(key)
 	if ok {
 		ts.(Builder).Release()
 	}

--- a/internal/execute/table/dataset.go
+++ b/internal/execute/table/dataset.go
@@ -32,11 +32,11 @@ func (d *dataset) SetTriggerSpec(spec plan.TriggerSpec) {
 }
 
 func (d *dataset) UpdateWatermark(mark execute.Time) error {
-	return nil
+	return d.ts.UpdateWatermark(d.id, mark)
 }
 
 func (d *dataset) UpdateProcessingTime(time execute.Time) error {
-	return nil
+	return d.ts.UpdateProcessingTime(d.id, time)
 }
 
 func (d *dataset) RetractTable(key flux.GroupKey) error {

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -2,11 +2,16 @@ package universe
 
 import (
 	"math"
+	"sort"
 
+	"github.com/apache/arrow/go/arrow/array"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/internal/execute/table"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -167,8 +172,6 @@ func createWindowTransformation(id execute.DatasetID, mode execute.AccumulationM
 	if !ok {
 		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
 	}
-	cache := execute.NewTableBuilderCache(a.Allocator())
-	d := execute.NewDataset(id, mode, cache)
 
 	bounds := a.StreamContext().Bounds()
 	if bounds == nil {
@@ -183,223 +186,33 @@ func createWindowTransformation(id execute.DatasetID, mode execute.AccumulationM
 	if err != nil {
 		return nil, nil, err
 	}
-	t := NewFixedWindowTransformation(
-		d,
-		cache,
+	t, d := NewFixedWindowTransformation(
+		id,
 		*bounds,
 		w,
 		s.TimeColumn,
 		s.StartColumn,
 		s.StopColumn,
 		s.CreateEmpty,
+		a.Allocator(),
 	)
 	return t, d, nil
 }
 
-type fixedWindowTransformation struct {
-	d         execute.Dataset
-	cache     execute.TableBuilderCache
-	w         execute.Window
-	bounds    execute.Bounds
-	allBounds []execute.Bounds
-
-	timeCol,
-	startCol,
-	stopCol string
-	createEmpty bool
-}
-
 func NewFixedWindowTransformation(
-	d execute.Dataset,
-	cache execute.TableBuilderCache,
+	id execute.DatasetID,
 	bounds execute.Bounds,
 	w execute.Window,
 	timeCol,
 	startCol,
 	stopCol string,
 	createEmpty bool,
-) execute.Transformation {
-	t := &fixedWindowTransformation{
-		d:           d,
-		cache:       cache,
-		w:           w,
-		bounds:      bounds,
-		timeCol:     timeCol,
-		startCol:    startCol,
-		stopCol:     stopCol,
-		createEmpty: createEmpty,
+	mem *memory.Allocator,
+) (execute.Transformation, execute.Dataset) {
+	if w.Every == infinityVar.Duration() {
+		return newInfinityWindowTransformation(id, bounds, timeCol, startCol, stopCol, mem)
 	}
-
-	if createEmpty {
-		t.generateWindowsWithinBounds()
-	}
-
-	return t
-}
-
-func (t *fixedWindowTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) (err error) {
-	panic("not implemented")
-}
-
-func (t *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
-	timeIdx := execute.ColIdx(t.timeCol, tbl.Cols())
-	if timeIdx < 0 {
-		return errors.Newf(codes.FailedPrecondition, "missing time column %q", t.timeCol)
-	}
-
-	newCols := make([]flux.ColMeta, 0, len(tbl.Cols())+2)
-	keyCols := make([]flux.ColMeta, 0, len(tbl.Cols())+2)
-	keyColMap := make([]int, 0, len(tbl.Cols())+2)
-	startColIdx := -1
-	stopColIdx := -1
-	for j, c := range tbl.Cols() {
-		keyIdx := execute.ColIdx(c.Label, tbl.Key().Cols())
-		keyed := keyIdx >= 0
-		if c.Label == t.startCol {
-			startColIdx = j
-			keyed = true
-		}
-		if c.Label == t.stopCol {
-			stopColIdx = j
-			keyed = true
-		}
-		newCols = append(newCols, c)
-		if keyed {
-			keyCols = append(keyCols, c)
-			keyColMap = append(keyColMap, keyIdx)
-		}
-	}
-	if startColIdx == -1 {
-		startColIdx = len(newCols)
-		c := flux.ColMeta{
-			Label: t.startCol,
-			Type:  flux.TTime,
-		}
-		newCols = append(newCols, c)
-		keyCols = append(keyCols, c)
-		keyColMap = append(keyColMap, len(keyColMap))
-	}
-	if stopColIdx == -1 {
-		stopColIdx = len(newCols)
-		c := flux.ColMeta{
-			Label: t.stopCol,
-			Type:  flux.TTime,
-		}
-		newCols = append(newCols, c)
-		keyCols = append(keyCols, c)
-		keyColMap = append(keyColMap, len(keyColMap))
-	}
-
-	// Abort processing if no data will match bounds
-	if t.bounds.IsEmpty() {
-		return nil
-	}
-
-	for _, bnds := range t.allBounds {
-		key := t.newWindowGroupKey(tbl, keyCols, bnds, keyColMap)
-		builder, created := t.cache.TableBuilder(key)
-		if created {
-			for _, c := range newCols {
-				_, err := builder.AddCol(c)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return tbl.Do(func(cr flux.ColReader) error {
-		l := cr.Len()
-		for i := 0; i < l; i++ {
-			tm := values.Time(cr.Times(timeIdx).Value(i))
-			bounds := t.getWindowBounds(tm)
-
-			for _, bnds := range bounds {
-				key := t.newWindowGroupKey(tbl, keyCols, bnds, keyColMap)
-				builder, created := t.cache.TableBuilder(key)
-				if created {
-					for _, c := range newCols {
-						_, err := builder.AddCol(c)
-						if err != nil {
-							return err
-						}
-					}
-				}
-
-				for j, c := range builder.Cols() {
-					switch c.Label {
-					case t.startCol:
-						if err := builder.AppendTime(startColIdx, bnds.Start); err != nil {
-							return err
-						}
-					case t.stopCol:
-						if err := builder.AppendTime(stopColIdx, bnds.Stop); err != nil {
-							return err
-						}
-					default:
-						if err := builder.AppendValue(j, execute.ValueForRow(cr, i, j)); err != nil {
-							return err
-						}
-					}
-				}
-			}
-		}
-		return nil
-	})
-}
-
-func (t *fixedWindowTransformation) newWindowGroupKey(tbl flux.Table, keyCols []flux.ColMeta, bnds execute.Bounds, keyColMap []int) flux.GroupKey {
-	cols := make([]flux.ColMeta, len(keyCols))
-	vs := make([]values.Value, len(keyCols))
-	for j, c := range keyCols {
-		cols[j] = c
-		switch c.Label {
-		case t.startCol:
-			vs[j] = values.NewTime(bnds.Start)
-		case t.stopCol:
-			vs[j] = values.NewTime(bnds.Stop)
-		default:
-			vs[j] = tbl.Key().Value(keyColMap[j])
-		}
-	}
-	return execute.NewGroupKey(cols, vs)
-}
-
-func (t *fixedWindowTransformation) clipBounds(bs []execute.Bounds) {
-	for i := range bs {
-		bs[i] = t.bounds.Intersect(bs[i])
-	}
-}
-
-func (t *fixedWindowTransformation) getWindowBounds(tm execute.Time) []execute.Bounds {
-	if t.w.Every == infinityVar.Duration() {
-		return []execute.Bounds{t.bounds}
-	}
-	bs := t.w.GetOverlappingBounds(execute.Bounds{Start: tm, Stop: tm + 1})
-	t.clipBounds(bs)
-	return bs
-}
-
-func (t *fixedWindowTransformation) generateWindowsWithinBounds() {
-	if t.w.Every == infinityVar.Duration() {
-		t.allBounds = []execute.Bounds{
-			{Start: execute.MinTime, Stop: execute.MaxTime},
-		}
-		return
-	}
-	bs := t.w.GetOverlappingBounds(t.bounds)
-	t.clipBounds(bs)
-	t.allBounds = bs
-}
-
-func (t *fixedWindowTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
-	return t.d.UpdateWatermark(mark)
-}
-func (t *fixedWindowTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
-	return t.d.UpdateProcessingTime(pt)
-}
-func (t *fixedWindowTransformation) Finish(id execute.DatasetID, err error) {
-	t.d.Finish(err)
+	return newFixedWindowTransformation(id, bounds, w, timeCol, startCol, stopCol, createEmpty, mem)
 }
 
 // WindowTriggerPhysicalRule rewrites a physical window operation
@@ -481,4 +294,458 @@ func hasValidPredecessors(node plan.Node) bool {
 		return hasValidPredecessors(pred[0])
 	}
 	return false
+}
+
+type windowTransformationBase struct {
+	d      execute.Dataset
+	cache  table.BuilderCache
+	bounds execute.Bounds
+	mem    *memory.Allocator
+
+	timeCol,
+	startCol,
+	stopCol string
+}
+
+// newWindowGroupKey will return a new group key that either adds or modifies the existing start
+// and stop column to match the bounds of the window.
+func (w *windowTransformationBase) newWindowGroupKey(key flux.GroupKey, bnds execute.Bounds) flux.GroupKey {
+	// Construct the group key schema.
+	cols, startIdx, stopIdx := w.createSchema(key.Cols())
+
+	// Make a copy of the values and replace the start and stop.
+	vs := make([]values.Value, len(cols))
+	for j := range cols {
+		if j == startIdx {
+			vs[j] = values.NewTime(bnds.Start)
+		} else if j == stopIdx {
+			vs[j] = values.NewTime(bnds.Stop)
+		} else {
+			// This will always be the same index as the old location
+			// since the key is always additive.
+			vs[j] = key.Value(j)
+		}
+	}
+	return execute.NewGroupKey(cols, vs)
+}
+
+// createSchema will create a compatible schema for the given column metadata.
+func (w *windowTransformationBase) createSchema(cols []flux.ColMeta) ([]flux.ColMeta, int, int) {
+	startIdx := execute.ColIdx(w.startCol, cols)
+	stopIdx := execute.ColIdx(w.stopCol, cols)
+	if (startIdx < 0 || cols[startIdx].Type != flux.TTime) ||
+		(stopIdx < 0 || cols[stopIdx].Type != flux.TTime) {
+		newCols := make([]flux.ColMeta, len(cols), len(cols)+2)
+		copy(newCols, cols)
+		cols = newCols
+		if startIdx < 0 {
+			cols = append(cols, flux.ColMeta{
+				Label: w.startCol,
+				Type:  flux.TTime,
+			})
+			startIdx = len(cols) - 1
+		} else {
+			cols[startIdx].Type = flux.TTime
+		}
+		if stopIdx < 0 {
+			cols = append(cols, flux.ColMeta{
+				Label: w.stopCol,
+				Type:  flux.TTime,
+			})
+			stopIdx = len(cols) - 1
+		} else {
+			cols[stopIdx].Type = flux.TTime
+		}
+	}
+	return cols, startIdx, stopIdx
+}
+
+func (w *windowTransformationBase) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	return w.d.RetractTable(key)
+}
+
+func (w *windowTransformationBase) UpdateWatermark(id execute.DatasetID, t execute.Time) error {
+	return w.d.UpdateWatermark(t)
+}
+
+func (w *windowTransformationBase) UpdateProcessingTime(id execute.DatasetID, t execute.Time) error {
+	return w.d.UpdateProcessingTime(t)
+}
+
+func (w *windowTransformationBase) Finish(id execute.DatasetID, err error) {
+	w.d.Finish(err)
+}
+
+type infinityWindowTransformation struct {
+	windowTransformationBase
+}
+
+func newInfinityWindowTransformation(id execute.DatasetID, bounds execute.Bounds, timeCol, startCol, stopCol string, mem *memory.Allocator) (execute.Transformation, execute.Dataset) {
+	t := &infinityWindowTransformation{
+		windowTransformationBase: windowTransformationBase{
+			cache: table.BuilderCache{
+				New: func(key flux.GroupKey) table.Builder {
+					return table.NewBufferedBuilder(key, mem)
+				},
+			},
+			bounds:   bounds,
+			mem:      mem,
+			timeCol:  timeCol,
+			startCol: startCol,
+			stopCol:  stopCol,
+		},
+	}
+	t.d = table.NewDataset(id, &t.cache)
+	return t, t.d
+}
+
+func (w *infinityWindowTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	key := w.newWindowGroupKey(tbl.Key(), w.bounds)
+	b, _ := table.GetBufferedBuilder(key, &w.cache)
+
+	cols, startIdx, stopIdx := w.createSchema(tbl.Cols())
+	return tbl.Do(func(cr flux.ColReader) error {
+		buffer := &arrow.TableBuffer{
+			GroupKey: key,
+			Columns:  cols,
+			Values:   make([]array.Interface, len(cols)),
+		}
+
+		l := cr.Len()
+		for j := range cols {
+			var vs array.Interface
+			// TODO(jsternberg): These created arrays can be cached and shared.
+			if j == startIdx {
+				ts := values.NewTime(w.bounds.Start)
+				vs = arrow.Repeat(ts, l, w.mem)
+			} else if j == stopIdx {
+				ts := values.NewTime(w.bounds.Stop)
+				vs = arrow.Repeat(ts, l, w.mem)
+			} else {
+				vs = table.Values(cr, j)
+				vs.Retain()
+			}
+			buffer.Values[j] = vs
+		}
+		return b.AppendBuffer(buffer)
+	})
+}
+
+type fixedWindowTransformation struct {
+	windowTransformationBase
+	w           execute.Window
+	createEmpty bool
+}
+
+func newFixedWindowTransformation(id execute.DatasetID, bounds execute.Bounds, w execute.Window, timeCol, startCol, stopCol string, createEmpty bool, mem *memory.Allocator) (execute.Transformation, execute.Dataset) {
+	t := &fixedWindowTransformation{
+		windowTransformationBase: windowTransformationBase{
+			cache: table.BuilderCache{
+				New: func(key flux.GroupKey) table.Builder {
+					return table.NewBufferedBuilder(key, mem)
+				},
+				Tables: execute.NewRandomAccessGroupLookup(),
+			},
+			bounds:   bounds,
+			mem:      mem,
+			timeCol:  timeCol,
+			startCol: startCol,
+			stopCol:  stopCol,
+		},
+		w:           w,
+		createEmpty: createEmpty,
+	}
+	t.d = table.NewDataset(id, &t.cache)
+	return t, t.d
+}
+
+func (w *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	timeIdx := execute.ColIdx(w.timeCol, tbl.Cols())
+	if timeIdx < 0 {
+		return errors.Newf(codes.FailedPrecondition, "missing time column %q", w.timeCol)
+	} else if col := tbl.Cols()[timeIdx]; col.Type != flux.TTime {
+		return errors.Newf(codes.FailedPrecondition, "time column %q must be of type time, is %s", col.Label, col.Type)
+	}
+
+	// Generate the window boundaries if we have been told to create
+	// empty windows.
+	var bounds []execute.Bounds
+	if w.createEmpty {
+		bounds = w.getAllWindowBounds()
+	}
+
+	// Precreate the tables if create empty is true.
+	for _, bnds := range bounds {
+		key := w.newWindowGroupKey(tbl.Key(), bnds)
+		if b, created := table.GetBufferedBuilder(key, &w.cache); created {
+			b.Columns, _, _ = w.createSchema(tbl.Cols())
+		}
+	}
+
+	// Process the table and insert rows into the appropriate boundaries.
+	return tbl.Do(func(cr flux.ColReader) error {
+		// If the buffer is empty, skip it.
+		if cr.Len() == 0 {
+			return nil
+		}
+
+		// Retrieve the time index and sort the time input by the indices.
+		ts := cr.Times(timeIdx)
+		indices := w.getSortedIndices(ts)
+
+		// Create the window boundaries encountered in this buffer
+		// if we are not creating empty boundaries.
+		if !w.createEmpty {
+			bounds = w.getWindowBoundsFromTimes(ts, indices)
+		}
+
+		// Iterate through each of the window boundaries
+		// and create a new table for each one.
+		// The algorithm will create one boundary at a time to
+		// reduce the number of table lookups required to be created.
+		// The start location is where we believe the first element
+		// for the boundary starts. We iterate until we find the first
+		// and final element that fit into the boundary. We then
+		// record the start so that we can speed up the next iteration.
+		// This is possible because both the times and the boundaries
+		// are sorted.
+		start := 0
+		for _, b := range bounds {
+			// If the current start index is after the first
+			// boundary, we will never find a time that is within
+			// the current boundary so abandon this boundary.
+			if tm := execute.Time(ts.Value(indices[start])); tm >= b.Stop {
+				continue
+			}
+
+			// Find the start index.
+			for l := len(indices); start < l; start++ {
+				tm := execute.Time(ts.Value(indices[start]))
+				if b.Contains(tm) {
+					break
+				}
+			}
+
+			// If the start index is after the index, exit here.
+			// This shouldn't be possible.
+			if start >= len(indices) {
+				break
+			}
+
+			// Determine the first index that is not in the
+			// boundary.
+			end := start + 1
+			for l := len(indices); end < l; end++ {
+				tm := execute.Time(ts.Value(indices[end]))
+				if !b.Contains(tm) {
+					break
+				}
+			}
+
+			// Append the rows to the appropriate table buffer.
+			if err := w.appendRows(cr, b, indices, start, end); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// getSortedIndices will return a list of sorted indices for the array.
+func (w *fixedWindowTransformation) getSortedIndices(vs *array.Int64) []int {
+	indices := make([]int, vs.Len())
+
+	// Add all of the valid indices to the array in order.
+	// While we are doing this, check to see if we are sorted.
+	sorted := true
+	for i, l := 0, vs.Len(); i < l; i++ {
+		// TODO(jsternberg): The original window function didn't differentiate
+		// between null values so we're keeping that same behavior, but that
+		// is obviously not correct.
+		indices[i] = i
+		if i >= 1 && sorted {
+			if vs.Value(i-1) > vs.Value(i) {
+				sorted = false
+			}
+		}
+	}
+
+	// If we are not sorted, then sort the indices by their value.
+	if !sorted {
+		sort.SliceStable(indices, func(i, j int) bool {
+			idx, jdx := indices[i], indices[j]
+			return vs.Value(idx) < vs.Value(jdx)
+		})
+	}
+
+	// Return the indices in sorted order.
+	return indices
+}
+
+func (w *fixedWindowTransformation) getAllWindowBounds() (bounds []execute.Bounds) {
+	bs := w.w.GetOverlappingBounds(w.bounds)
+	w.clipBounds(bs)
+	return bs
+}
+
+func (w *fixedWindowTransformation) getWindowBoundsFromTimes(ts *array.Int64, indices []int) (bounds []execute.Bounds) {
+	// TODO(jsternberg): Implement create empty.
+	// Iterate through each time and generate window boundaries.
+	seen := make(map[execute.Bounds]bool)
+	for _, i := range indices {
+		tm := execute.Time(ts.Value(i))
+		for _, b := range w.getWindowBounds(tm) {
+			if seen[b] {
+				continue
+			}
+			bounds = append(bounds, b)
+			seen[b] = true
+		}
+	}
+	return bounds
+}
+
+func (w *fixedWindowTransformation) clipBounds(bs []execute.Bounds) {
+	for i := range bs {
+		bs[i] = w.bounds.Intersect(bs[i])
+	}
+}
+
+func (w *fixedWindowTransformation) getWindowBounds(tm execute.Time) []execute.Bounds {
+	bs := w.w.GetOverlappingBounds(execute.Bounds{Start: tm, Stop: tm + 1})
+	w.clipBounds(bs)
+	return bs
+}
+
+func (w *fixedWindowTransformation) appendRows(cr flux.ColReader, bnds execute.Bounds, indices []int, start, stop int) error {
+	// Construct the group key and the columns.
+	key := w.newWindowGroupKey(cr.Key(), bnds)
+	cols, startIdx, stopIdx := w.createSchema(cr.Cols())
+
+	buffer := &arrow.TableBuffer{
+		GroupKey: key,
+		Columns:  cols,
+		Values:   make([]array.Interface, len(cols)),
+	}
+
+	l := stop - start
+	for j, c := range buffer.Columns {
+		var vs array.Interface
+		if l == 0 {
+			vs = arrow.NewBuilder(c.Type, w.mem).NewArray()
+		} else if j == startIdx {
+			ts := values.NewTime(bnds.Start)
+			vs = arrow.Repeat(ts, l, w.mem)
+		} else if j == stopIdx {
+			ts := values.NewTime(bnds.Stop)
+			vs = arrow.Repeat(ts, l, w.mem)
+		} else {
+			vs = w.appendRowsForColumn(cr, j, indices, start, stop)
+		}
+		buffer.Values[j] = vs
+	}
+
+	// Find the buffered table builder in the cache and append this buffer.
+	b, _ := table.GetBufferedBuilder(key, &w.cache)
+	return b.AppendBuffer(buffer)
+}
+
+func (w *fixedWindowTransformation) appendRowsForColumn(cr flux.ColReader, j int, indices []int, start, stop int) array.Interface {
+	col := cr.Cols()[j]
+	if idx := execute.ColIdx(col.Label, cr.Key().Cols()); idx >= 0 {
+		// If this is part of the group key, all of the values are
+		// the same and the indices don't matter. Just create a slice
+		// because this doesn't matter.
+		return arrow.Slice(table.Values(cr, j), int64(start), int64(stop))
+	}
+
+	l := stop - start
+	switch col.Type {
+	case flux.TInt:
+		b := array.NewInt64Builder(w.mem)
+		b.Resize(l)
+
+		vs := cr.Ints(j)
+		for i := start; i < stop; i++ {
+			idx := indices[i]
+			if vs.IsNull(idx) {
+				b.AppendNull()
+				continue
+			}
+			b.Append(vs.Value(idx))
+		}
+		return b.NewArray()
+	case flux.TUInt:
+		b := array.NewUint64Builder(w.mem)
+		b.Resize(l)
+
+		vs := cr.UInts(j)
+		for i := start; i < stop; i++ {
+			idx := indices[i]
+			if vs.IsNull(idx) {
+				b.AppendNull()
+				continue
+			}
+			b.Append(vs.Value(idx))
+		}
+		return b.NewArray()
+	case flux.TFloat:
+		b := array.NewFloat64Builder(w.mem)
+		b.Resize(l)
+
+		vs := cr.Floats(j)
+		for i := start; i < stop; i++ {
+			idx := indices[i]
+			if vs.IsNull(idx) {
+				b.AppendNull()
+				continue
+			}
+			b.Append(vs.Value(idx))
+		}
+		return b.NewArray()
+	case flux.TString:
+		b := arrow.NewStringBuilder(w.mem)
+		b.Resize(l)
+
+		vs := cr.Strings(j)
+		for i := start; i < stop; i++ {
+			idx := indices[i]
+			if vs.IsNull(idx) {
+				b.AppendNull()
+				continue
+			}
+			b.Append(vs.Value(idx))
+		}
+		return b.NewArray()
+	case flux.TBool:
+		b := array.NewBooleanBuilder(w.mem)
+		b.Resize(l)
+
+		vs := cr.Bools(j)
+		for i := start; i < stop; i++ {
+			idx := indices[i]
+			if vs.IsNull(idx) {
+				b.AppendNull()
+				continue
+			}
+			b.Append(vs.Value(idx))
+		}
+		return b.NewArray()
+	case flux.TTime:
+		b := array.NewInt64Builder(w.mem)
+		b.Resize(l)
+
+		vs := cr.Times(j)
+		for i := start; i < stop; i++ {
+			idx := indices[i]
+			if vs.IsNull(idx) {
+				b.AppendNull()
+				continue
+			}
+			b.Append(vs.Value(idx))
+		}
+		return b.NewArray()
+	default:
+		panic(errors.Newf(codes.Internal, "unknown column type: %s", col.Type))
+	}
 }


### PR DESCRIPTION
This optimizes the window transformation to be more efficient than the 
current window transformation. It changes the access pattern so the time 
values are iterated over in sorted order and the windows are created in 
sorted order. This reduces the amount of random access used when iterating
over values so memory is more efficient.

It also adds a new `RandomAccessGroupLookup` that uses another method for
storing values based on their group key. The window method had a bad access
pattern for the standard `GroupLookup` because the `_start` and
`_stop` values changing would commonly result in an access pattern like 
this:

    1 2 3 4 5 6 -> 1 4 2 5 3 6

This hit one of the group lookups worst access patterns and caused a lot of
time to be spent copying memory to maintain the sorted order of the data
structure.

The window transformation still likely has more room to improve, but this
will at least cause some small amount of improvement over the old 
implementation.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written