### PR TITLE
feat(libflux): add Go/Rust API for getting semantic graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ internal/scanner/unicode.rl: internal/scanner/unicode2ragel.rb
 internal/scanner/scanner.gen.go: internal/scanner/gen.go internal/scanner/scanner.rl internal/scanner/unicode.rl
 	$(GO_GENERATE) ./internal/scanner
 
-libflux: libflux/target/debug/libflux.a
+libflux: libflux/target/debug/libflux.a libflux/target/debug/liblibstd.a
 
 # Build the rust static library. Afterwards, fix the .d file that
 # rust generates so it references the correct targets.
@@ -78,6 +78,9 @@ libflux: libflux/target/debug/libflux.a
 # command line interface than the gnu equivalent.
 libflux/target/debug/libflux.a:
 	cd libflux && $(CARGO) build -p flux $(CARGO_ARGS)
+
+libflux/target/debug/liblibstd.a:
+	cd libflux && $(CARGO) build -p libstd $(CARGO_ARGS)
 
 libflux/go/libflux/flux.h: libflux/include/influxdata/flux.h
 	$(GO_GENERATE) ./libflux/go/libflux

--- a/ast/fbuffers.go
+++ b/ast/fbuffers.go
@@ -9,6 +9,13 @@ import (
 	"github.com/influxdata/flux/ast/internal/fbast"
 )
 
+// DeserializeFromFlatBuffer takes the given byte slice
+// that is an AST flatbuffer and deserializes it to an AST package.
+func DeserializeFromFlatBuffer(buf []byte) *Package {
+	pkg := Package{}
+	return pkg.FromBuf(buf)
+}
+
 func (p *Position) FromBuf(buf *fbast.Position) {
 	p.Line = int(buf.Line())
 	p.Column = int(buf.Column())

--- a/ast/flatbuffers_test.go
+++ b/ast/flatbuffers_test.go
@@ -102,7 +102,12 @@ bad_expr = 3 * / 1
 bad_expr = 3 * + 1
 `}
 	for _, src := range srcs {
-		astFbs := libflux.ParseIntoFbs(src)
+		a := libflux.Parse(src)
+		bs, err := a.MarshalFB()
+		if err != nil {
+			t.Fatal(err)
+		}
+		astFbs := ast.DeserializeFromFlatBuffer(bs)
 
 		srcb := []byte(src)
 		f := token.NewFile("", len(src))

--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -10,18 +10,20 @@ import "C"
 
 import (
 	"errors"
+	"runtime"
 	"unsafe"
 )
 
-// Analyze parses the given Flux source, performs type inference
-// (taking into account types from prelude and stldlib) and returns
-// a byte slice containing the FlatBuffer serialization of the semantic
-// graph.
-func Analyze(src string) ([]byte, error) {
-	var buf C.struct_flux_buffer_t
-	cstr := C.CString(src)
+// SemanticPkg is a Rust pointer to a semantic package.
+type SemanticPkg struct {
+	ptr *C.struct_flux_semantic_pkg_t
+}
 
-	if err := C.flux_semantic_analyze(cstr, &buf); err != nil {
+// MarshalFB serializes the given semantic package into a flatbuffer.
+func (p *SemanticPkg) MarshalFB() ([]byte, error) {
+	var buf C.struct_flux_buffer_t
+	if err := C.flux_semantic_marshal_fb(p.ptr, &buf); err != nil {
+		defer C.flux_free(unsafe.Pointer(err))
 		cstr := C.flux_error_str(err)
 		defer C.flux_free(unsafe.Pointer(cstr))
 
@@ -32,4 +34,37 @@ func Analyze(src string) ([]byte, error) {
 
 	data := C.GoBytes(buf.data, C.int(buf.len))
 	return data, nil
+}
+
+// Free frees the memory allocated by Rust for the semantic graph.
+func (p *SemanticPkg) Free() {
+	if p.ptr != nil {
+		C.flux_free(unsafe.Pointer(p.ptr))
+	}
+	p.ptr = nil
+}
+
+// Analyze parses the given Flux source, performs type inference
+// (taking into account types from prelude and stldlib) and returns
+// an a SemanticPkg containing an opaque pointer to the semantic graph.
+// The graph can be deserialized by calling MarshalFB.
+//
+// Note that Analyze will consume the AST, so astPkg.ptr will be set to nil,
+// even if there's an error in analysis.
+func Analyze(astPkg *ASTPkg) (*SemanticPkg, error) {
+	var semPkg *C.struct_flux_semantic_pkg_t
+	defer func() {
+		astPkg.ptr = nil
+	}()
+	if err := C.flux_analyze(astPkg.ptr, &semPkg); err != nil {
+		defer C.flux_free(unsafe.Pointer(err))
+		cstr := C.flux_error_str(err)
+		defer C.flux_free(unsafe.Pointer(cstr))
+
+		str := C.GoString(cstr)
+		return nil, errors.New(str)
+	}
+	p := &SemanticPkg{ptr: semPkg}
+	runtime.SetFinalizer(p, free)
+	return p, nil
 }

--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -1,0 +1,35 @@
+// +build libflux
+
+package libflux
+
+// #cgo CFLAGS: -I.
+// #cgo LDFLAGS: -L. -llibstd
+// #include "flux.h"
+// #include <stdlib.h>
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// Analyze parses the given Flux source, performs type inference
+// (taking into account types from prelude and stldlib) and returns
+// a byte slice containing the FlatBuffer serialization of the semantic
+// graph.
+func Analyze(src string) ([]byte, error) {
+	var buf C.struct_flux_buffer_t
+	cstr := C.CString(src)
+
+	if err := C.flux_semantic_analyze(cstr, &buf); err != nil {
+		cstr := C.flux_error_str(err)
+		defer C.flux_free(unsafe.Pointer(cstr))
+
+		str := C.GoString(cstr)
+		return nil, errors.New(str)
+	}
+	defer C.flux_free(buf.data)
+
+	data := C.GoBytes(buf.data, C.int(buf.len))
+	return data, nil
+}

--- a/libflux/go/libflux/analyze_test.go
+++ b/libflux/go/libflux/analyze_test.go
@@ -4,9 +4,9 @@ package libflux_test
 
 import (
 	"errors"
-	"github.com/google/go-cmp/cmp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/libflux/go/libflux"
 )
 

--- a/libflux/go/libflux/analyze_test.go
+++ b/libflux/go/libflux/analyze_test.go
@@ -1,0 +1,60 @@
+// +build libflux
+
+package libflux_test
+
+import (
+	"errors"
+	"github.com/google/go-cmp/cmp"
+	"testing"
+
+	"github.com/influxdata/flux/libflux/go/libflux"
+)
+
+func TestAnalyze(t *testing.T) {
+	tcs := []struct {
+		name string
+		flx  string
+		err  error
+	}{
+		{
+			name: "success",
+			flx: `
+                package main
+                from(bucket: "telegraf")
+	              |> range(start: -5m)
+	              |> mean()`,
+		},
+		{
+			name: "failure",
+			flx:  `x = "foo" + 10`,
+			err:  errors.New("cannot unify string with int"),
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ast := libflux.Parse(tc.flx)
+			defer ast.Free()
+
+			sem, err := libflux.Analyze(ast)
+			if err != nil {
+				if tc.err == nil {
+					t.Fatalf("expected no error, got: %q", err)
+				}
+				if diff := cmp.Diff(tc.err.Error(), err.Error()); diff != "" {
+					t.Fatalf("unexpected error: -want/+got: %v", diff)
+				}
+				return
+			}
+
+			if tc.err != nil {
+				t.Fatalf("got no error, expected: %q", tc.err)
+			}
+			fbBuf, err := sem.MarshalFB()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("flatbuffer has %v bytes\n", len(fbBuf))
+		})
+	}
+}

--- a/libflux/go/libflux/flux.h
+++ b/libflux/go/libflux/flux.h
@@ -52,8 +52,10 @@ struct flux_error_t *flux_ast_marshal_fb(struct flux_ast_pkg_t *, struct flux_bu
 struct flux_semantic_pkg_t;
 
 // flux_analyze analyzes the given AST and will populate the second pointer argument with
-// a pointer to the resulting semantic graph. It is the caller's responsibility to free the
-// resulting semantic graph with a call to flux_free().
+// a pointer to the resulting semantic graph.
+// It is the caller's responsibility to free the resulting semantic graph with a call to flux_free().
+// Note that the caller should free the pointer to the semantic graph, not the pointer to the pointer
+// to the semantic graph.  It is the former that references memory allocated by Rust.
 // If analysis fails, the second pointer argument wil be pointed at 0, and an error will be returned.
 // Any non-null error must be freed by calling flux_free.
 // Regardless of whether an error is returned, this function will consume and free its

--- a/libflux/go/libflux/flux.h
+++ b/libflux/go/libflux/flux.h
@@ -35,6 +35,9 @@ struct flux_buffer_t *flux_parse_fb(const char *);
 // using flux_free if it is non-null.
 struct flux_error_t *flux_ast_marshal_json(struct flux_ast_t *, struct flux_buffer_t *);
 
+// Take a Flux source program, analyze it, and return its flatbuffer.
+struct flux_error_t *flux_semantic_analyze(const char* src, struct flux_buffer_t *);
+
 // flux_buffer_free will free the memory that was allocated for a buffer.
 // This should only be called if the caller is the one who owns the data.
 void flux_buffer_free(struct flux_buffer_t *);

--- a/libflux/go/libflux/flux.h
+++ b/libflux/go/libflux/flux.h
@@ -7,9 +7,6 @@
 extern "C" {
 #endif
 
-// flux_ast_t is the AST representation of a flux query.
-struct flux_ast_t;
-
 // flux_buffer_t is a reference to a byte-slice.
 struct flux_buffer_t {
 	// data is a pointer to the data contained within the buffer.
@@ -22,32 +19,53 @@ struct flux_buffer_t {
 // flux_error_t represents a flux error.
 struct flux_error_t;
 
-// flux_parse will take in a string and return the AST representation
-// of the query.
-struct flux_ast_t *flux_parse(const char *);
-
-struct flux_buffer_t *flux_parse_fb(const char *);
-
-// flux_ast_marshal_json will marshal json and fill in the given buffer
-// with the data. If successful, memory will be allocated for the data
-// within the buffer and it is the caller's responsibility to free this
-// data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
-struct flux_error_t *flux_ast_marshal_json(struct flux_ast_t *, struct flux_buffer_t *);
-
-// Take a Flux source program, analyze it, and return its flatbuffer.
-struct flux_error_t *flux_semantic_analyze(const char* src, struct flux_buffer_t *);
-
-// flux_buffer_free will free the memory that was allocated for a buffer.
-// This should only be called if the caller is the one who owns the data.
-void flux_buffer_free(struct flux_buffer_t *);
-
 // flux_error_str will return a string representation of the error.
 // This will allocate memory for the returned string.
 const char *flux_error_str(struct flux_error_t *);
 
 // flux_free will free a resource.
 void flux_free(void *);
+
+// flux_ast_pkg_t is the AST representation of a flux query as a package.
+struct flux_ast_pkg_t;
+
+// flux_parse will take in a string and return the AST representation
+// of the query.
+struct flux_ast_pkg_t *flux_parse(const char *);
+
+// flux_ast_marshal_json will marshal json and fill in the given buffer
+// with the data. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_ast_marshal_json(struct flux_ast_pkg_t *, struct flux_buffer_t *);
+
+// flux_ast_marshal_fb will marshal the given AST as a flatbuffer into
+// the given buffer. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_ast_marshal_fb(struct flux_ast_pkg_t *, struct flux_buffer_t *);
+
+// flux_semantic_pkg_t represents a semantic graph package node, including all of its files
+// and their contents.
+struct flux_semantic_pkg_t;
+
+// flux_analyze analyzes the given AST and will populate the second pointer argument with
+// a pointer to the resulting semantic graph. It is the caller's responsibility to free the
+// resulting semantic graph with a call to flux_free().
+// If analysis fails, the second pointer argument wil be pointed at 0, and an error will be returned.
+// Any non-null error must be freed by calling flux_free.
+// Regardless of whether an error is returned, this function will consume and free its
+// flux_ast_pkg_t* argument, so it should not be reused after calling this function.
+struct flux_error_t *flux_analyze(struct flux_ast_pkg_t *, struct flux_semantic_pkg_t **);
+
+// flux_semantic_marshal_fb will marshal the given semantic graph as a flatbuffer into
+// the given buffer. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_semantic_marshal_fb(struct flux_semantic_pkg_t *, struct flux_buffer_t *);
 
 #ifdef __cplusplus
 }

--- a/libflux/go/libflux/liblibstd.a
+++ b/libflux/go/libflux/liblibstd.a
@@ -1,0 +1,1 @@
+../../target/debug/liblibstd.a

--- a/libflux/go/libflux/parser_test.go
+++ b/libflux/go/libflux/parser_test.go
@@ -18,10 +18,18 @@ from(bucket: "telegraf")
 	|> mean()
 `
 	ast := libflux.Parse(text)
-	buf, err := ast.MarshalJSON()
+
+	jsonBuf, err := ast.MarshalJSON()
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(string(buf))
+	fmt.Printf("json has %v bytes:\n%v\n", len(jsonBuf), string(jsonBuf))
+
+	fbBuf, err := ast.MarshalFB()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("flatbuffer has %v bytes\n", len(fbBuf))
+
 	ast.Free()
 }

--- a/libflux/include/influxdata/flux.h
+++ b/libflux/include/influxdata/flux.h
@@ -7,9 +7,6 @@
 extern "C" {
 #endif
 
-// flux_ast_t is the AST representation of a flux query.
-struct flux_ast_t;
-
 // flux_buffer_t is a reference to a byte-slice.
 struct flux_buffer_t {
 	// data is a pointer to the data contained within the buffer.
@@ -22,29 +19,53 @@ struct flux_buffer_t {
 // flux_error_t represents a flux error.
 struct flux_error_t;
 
-// flux_parse will take in a string and return the AST representation
-// of the query.
-struct flux_ast_t *flux_parse(const char *);
-
-struct flux_buffer_t *flux_parse_fb(const char *);
-
-// flux_ast_marshal_json will marshal json and fill in the given buffer
-// with the data. If successful, memory will be allocated for the data
-// within the buffer and it is the caller's responsibility to free this
-// data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
-struct flux_error_t *flux_ast_marshal_json(struct flux_ast_t *, struct flux_buffer_t *);
-
-// flux_buffer_free will free the memory that was allocated for a buffer.
-// This should only be called if the caller is the one who owns the data.
-void flux_buffer_free(struct flux_buffer_t *);
-
 // flux_error_str will return a string representation of the error.
 // This will allocate memory for the returned string.
 const char *flux_error_str(struct flux_error_t *);
 
 // flux_free will free a resource.
 void flux_free(void *);
+
+// flux_ast_pkg_t is the AST representation of a flux query as a package.
+struct flux_ast_pkg_t;
+
+// flux_parse will take in a string and return the AST representation
+// of the query.
+struct flux_ast_pkg_t *flux_parse(const char *);
+
+// flux_ast_marshal_json will marshal json and fill in the given buffer
+// with the data. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_ast_marshal_json(struct flux_ast_pkg_t *, struct flux_buffer_t *);
+
+// flux_ast_marshal_fb will marshal the given AST as a flatbuffer into
+// the given buffer. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_ast_marshal_fb(struct flux_ast_pkg_t *, struct flux_buffer_t *);
+
+// flux_semantic_pkg_t represents a semantic graph package node, including all of its files
+// and their contents.
+struct flux_semantic_pkg_t;
+
+// flux_analyze analyzes the given AST and will populate the second pointer argument with
+// a pointer to the resulting semantic graph. It is the caller's responsibility to free the
+// resulting semantic graph with a call to flux_free().
+// If analysis fails, the second pointer argument wil be pointed at 0, and an error will be returned.
+// Any non-null error must be freed by calling flux_free.
+// Regardless of whether an error is returned, this function will consume and free its
+// flux_ast_pkg_t* argument, so it should not be reused after calling this function.
+struct flux_error_t *flux_analyze(struct flux_ast_pkg_t *, struct flux_semantic_pkg_t **);
+
+// flux_semantic_marshal_fb will marshal the given semantic graph as a flatbuffer into
+// the given buffer. If successful, memory will be allocated for the data
+// within the buffer and it is the caller's responsibility to free this
+// data. If an error happens it will be returned. The error must be freed
+// using flux_free if it is non-null.
+struct flux_error_t *flux_semantic_marshal_fb(struct flux_semantic_pkg_t *, struct flux_buffer_t *);
 
 #ifdef __cplusplus
 }

--- a/libflux/include/influxdata/flux.h
+++ b/libflux/include/influxdata/flux.h
@@ -52,8 +52,10 @@ struct flux_error_t *flux_ast_marshal_fb(struct flux_ast_pkg_t *, struct flux_bu
 struct flux_semantic_pkg_t;
 
 // flux_analyze analyzes the given AST and will populate the second pointer argument with
-// a pointer to the resulting semantic graph. It is the caller's responsibility to free the
-// resulting semantic graph with a call to flux_free().
+// a pointer to the resulting semantic graph.
+// It is the caller's responsibility to free the resulting semantic graph with a call to flux_free().
+// Note that the caller should free the pointer to the semantic graph, not the pointer to the pointer
+// to the semantic graph.  It is the former that references memory allocated by Rust.
 // If analysis fails, the second pointer argument wil be pointed at 0, and an error will be returned.
 // Any non-null error must be freed by calling flux_free.
 // Regardless of whether an error is returned, this function will consume and free its

--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -292,9 +292,9 @@ pub struct Package {
 
 impl From<File> for Package {
     fn from(file: File) -> Self {
-        Package{
-            base: BaseNode{
-              ..BaseNode::default()
+        Package {
+            base: BaseNode {
+                ..BaseNode::default()
             },
             path: String::from(""),
             package: String::from(file.get_package()),

--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -16,6 +16,8 @@ use serde::de::{Deserialize, Deserializer, Error, Visitor};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use serde_aux::prelude::*;
 
+pub const DEFAULT_PACKAGE_NAME: &str = "main";
+
 // Position is the AST counterpart of Scanner's Position.
 // It adds serde capabilities.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -288,6 +290,19 @@ pub struct Package {
     pub files: Vec<File>,
 }
 
+impl From<File> for Package {
+    fn from(file: File) -> Self {
+        Package{
+            base: BaseNode{
+              ..BaseNode::default()
+            },
+            path: String::from(""),
+            package: String::from(file.get_package()),
+            files: vec![file],
+        }
+    }
+}
+
 // File represents a source from a single file
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
@@ -306,6 +321,15 @@ pub struct File {
     #[serde(deserialize_with = "deserialize_default_from_null")]
     pub imports: Vec<ImportDeclaration>,
     pub body: Vec<Statement>,
+}
+
+impl File {
+    fn get_package(self: &File) -> &str {
+        match &self.package {
+            Some(pkg_clause) => pkg_clause.name.name.as_str(),
+            None => DEFAULT_PACKAGE_NAME,
+        }
+    }
 }
 
 // PackageClause defines the current package identifier.

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -55,7 +55,9 @@ impl From<String> for Error {
 
 impl From<&str> for Error {
     fn from(msg: &str) -> Self {
-        Error { msg: String::from(msg) }
+        Error {
+            msg: String::from(msg),
+        }
     }
 }
 

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn flux_semantic_marshal_fb(
 #[no_mangle]
 pub extern "C" fn flux_error_str(err: *mut flux_error_t) -> *mut c_char {
     let e = unsafe { &*(err as *mut ErrorHandle) };
-    let s = CString::new(e.err.description()).unwrap();
+    let s = CString::new(format!("{}", e.err)).unwrap();
     s.into_raw()
 }
 

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -11,8 +11,9 @@ pub mod parser;
 pub mod scanner;
 pub mod semantic;
 
-use std::error::Error;
+use std::error;
 use std::ffi::*;
+use std::fmt;
 use std::os::raw::{c_char, c_void};
 
 use parser::Parser;
@@ -25,8 +26,37 @@ pub mod ctypes {
 }
 use ctypes::*;
 
-struct ErrorHandle {
-    err: Box<dyn Error>,
+pub struct ErrorHandle {
+    pub err: Box<dyn error::Error>,
+}
+
+#[derive(Debug)]
+pub struct Error {
+    msg: String,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
+    }
+}
+
+impl From<String> for Error {
+    fn from(msg: String) -> Self {
+        Error { msg }
+    }
+}
+
+impl From<semantic::nodes::Error> for Error {
+    fn from(sn_err: semantic::nodes::Error) -> Self {
+        Error { msg: sn_err.msg }
+    }
 }
 
 #[repr(C)]

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -53,6 +53,12 @@ impl From<String> for Error {
     }
 }
 
+impl From<&str> for Error {
+    fn from(msg: &str) -> Self {
+        Error { msg: String::from(msg) }
+    }
+}
+
 impl From<semantic::nodes::Error> for Error {
     fn from(sn_err: semantic::nodes::Error) -> Self {
         Error { msg: sn_err.msg }
@@ -67,71 +73,30 @@ pub struct flux_buffer_t {
 
 /// # Safety
 ///
-/// This function is unsafe because it takes a dereferences a raw pointer passed
+/// This function is unsafe because it dereferences a raw pointer passed
 /// in as a parameter. For example, if that pointer is NULL, undefined behavior
 /// could occur.
 #[no_mangle]
-pub unsafe extern "C" fn flux_parse(cstr: *mut c_char) -> *mut flux_ast_t {
+pub unsafe extern "C" fn flux_parse(cstr: *mut c_char) -> *mut flux_ast_pkg_t {
     let buf = CStr::from_ptr(cstr).to_bytes(); // Unsafe
     let s = String::from_utf8(buf.to_vec()).unwrap();
     let mut p = Parser::new(&s);
-    let file = p.parse_file(String::from(""));
-    Box::into_raw(Box::new(file)) as *mut flux_ast_t
+    let pkg: ast::Package = p.parse_file(String::from("")).into();
+    Box::into_raw(Box::new(pkg)) as *mut flux_ast_pkg_t
 }
 
 /// # Safety
 ///
-/// This function is unsafe because it takes a dereferences a raw pointer passed
-/// in as a parameter. For example, if that pointer is NULL, undefined behavior
-/// could occur.
-#[no_mangle]
-pub unsafe extern "C" fn flux_parse_fb(src_ptr: *const c_char) -> *mut flux_buffer_t {
-    let src_bytes = CStr::from_ptr(src_ptr).to_bytes(); // Unsafe
-    let src = String::from_utf8(src_bytes.to_vec()).unwrap();
-    let mut p = Parser::new(&src);
-    let file = p.parse_file(String::from(""));
-    let package_name: String;
-    match &file.package {
-        Some(p) => {
-            package_name = p.name.name.clone();
-        }
-        _ => {
-            package_name = DEFAULT_PACKAGE_NAME.to_string();
-        }
-    }
-    let pkg = ast::Package {
-        base: ast::BaseNode {
-            ..ast::BaseNode::default()
-        },
-        path: String::from(""),
-        package: package_name,
-        files: vec![file],
-    };
-    let r = ast::flatbuffers::serialize(&pkg);
-    match r {
-        Ok((vec, offset)) => {
-            let data = &vec[offset..];
-            Box::into_raw(Box::new(flux_buffer_t {
-                data: data.as_ptr(),
-                len: data.len(),
-            }))
-        }
-        Err(_) => 1 as *mut flux_buffer_t,
-    }
-}
-
-/// # Safety
-///
-/// This function is unsafe because it takes a dereferences raw pointers passed
+/// This function is unsafe because it dereferences raw pointers passed
 /// in as parameters. For example, if that pointer is NULL, undefined behavior
 /// could occur.
 #[no_mangle]
 pub unsafe extern "C" fn flux_ast_marshal_json(
-    ast: *mut flux_ast_t,
+    ast_pkg: *mut flux_ast_pkg_t,
     buf: *mut flux_buffer_t,
 ) -> *mut flux_error_t {
-    let self_ = &*(ast as *mut ast::File) as &ast::File; // Unsafe
-    let data = match serde_json::to_vec(self_) {
+    let ast_pkg = &*(ast_pkg as *mut ast::Package) as &ast::Package; // Unsafe
+    let data = match serde_json::to_vec(ast_pkg) {
         Ok(v) => v,
         Err(err) => {
             let errh = ErrorHandle { err: Box::new(err) };
@@ -139,6 +104,62 @@ pub unsafe extern "C" fn flux_ast_marshal_json(
         }
     };
 
+    let buffer = &mut *buf; // Unsafe
+    buffer.len = data.len();
+    buffer.data = Box::into_raw(data.into_boxed_slice()) as *mut u8;
+    std::ptr::null_mut()
+}
+
+/// # Safety
+///
+/// This function is unsafe because it takes a dereferences a raw pointer passed
+/// in as a parameter. For example, if that pointer is NULL, undefined behavior
+/// could occur.
+#[no_mangle]
+pub unsafe extern "C" fn flux_ast_marshal_fb(
+    ast: *mut flux_ast_pkg_t,
+    buf: *mut flux_buffer_t,
+) -> *mut flux_error_t {
+    let pkg = &*(ast as *mut ast::Package) as &ast::Package; // Unsafe
+    let (mut vec, offset) = match ast::flatbuffers::serialize(&pkg) {
+        Ok(vec_offset) => vec_offset,
+        Err(err) => {
+            let err: Error = err.into();
+            let errh = ErrorHandle { err: Box::new(err) };
+            return Box::into_raw(Box::new(errh)) as *mut flux_error_t;
+        }
+    };
+
+    // Note, split_off() does a copy: https://github.com/influxdata/flux/issues/2194
+    let data = vec.split_off(offset);
+    let buffer = &mut *buf; // Unsafe
+    buffer.len = data.len();
+    buffer.data = Box::into_raw(data.into_boxed_slice()) as *mut u8;
+    std::ptr::null_mut()
+}
+
+/// # Safety
+///
+/// This function is unsafe because it takes a dereferences a raw pointer passed
+/// in as a parameter. For example, if that pointer is NULL, undefined behavior
+/// could occur.
+#[no_mangle]
+pub unsafe extern "C" fn flux_semantic_marshal_fb(
+    ast: *mut flux_semantic_pkg_t,
+    buf: *mut flux_buffer_t,
+) -> *mut flux_error_t {
+    let pkg = &*(ast as *mut semantic::nodes::Package) as &semantic::nodes::Package; // Unsafe
+    let (mut vec, offset) = match semantic::flatbuffers::serialize(&pkg) {
+        Ok(vec_offset) => vec_offset,
+        Err(err) => {
+            let err: Error = err.into();
+            let errh = ErrorHandle { err: Box::new(err) };
+            return Box::into_raw(Box::new(errh)) as *mut flux_error_t;
+        }
+    };
+
+    // Note, split_off() does a copy: https://github.com/influxdata/flux/issues/2194
+    let data = vec.split_off(offset);
     let buffer = &mut *buf; // Unsafe
     buffer.len = data.len();
     buffer.data = Box::into_raw(data.into_boxed_slice()) as *mut u8;

--- a/libflux/src/flux/semantic/analyze.rs
+++ b/libflux/src/flux/semantic/analyze.rs
@@ -7,12 +7,16 @@ use std::result;
 pub type SemanticError = String;
 pub type Result<T> = result::Result<T, SemanticError>;
 
-// analyze analyzes an AST package node and returns its semantic analysis.
-// The function explicitly moves the ast::Package because it adds information to it.
-// We follow here the principle that every compilation step should be isolated and should add meaning
-// to the previous one. In other terms, once one analyzes an AST he should not use it anymore.
-// If one wants to do so, he should explicitly pkg.clone() and incur consciously in the memory
-// overhead involved.
+/// analyze analyzes an AST package node and returns its semantic analysis.
+/// 
+/// Note: most external callers of this function will want to use the analyze()
+/// function in the libstd crate instead, which is aware of everything in the Flux stdlib and prelude.
+///
+/// The function explicitly moves the ast::Package because it adds information to it.
+/// We follow here the principle that every compilation step should be isolated and should add meaning
+/// to the previous one. In other terms, once one analyzes an AST he should not use it anymore.
+/// If one wants to do so, he should explicitly pkg.clone() and incur consciously in the memory
+/// overhead involved.
 pub fn analyze(pkg: ast::Package) -> Result<Package> {
     analyze_with(pkg, &mut Fresher::default())
 }

--- a/libflux/src/flux/semantic/bootstrap.rs
+++ b/libflux/src/flux/semantic/bootstrap.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use crate::ast;
 use crate::parser;
-use crate::semantic::analyze::analyze_file;
+use crate::semantic::convert::convert_file;
 use crate::semantic::builtins::builtins;
 use crate::semantic::env::Environment;
 use crate::semantic::fresh::Fresher;
@@ -289,7 +289,7 @@ fn infer_pkg<I: Importer>(
 
             let env = if let Some(builtins) = builtin.get(pkg) {
                 infer_file(
-                    &mut analyze_file(file, f)?,
+                    &mut convert_file(file, f)?,
                     Environment::new(prelude.clone().into()),
                     f,
                     &imports,
@@ -298,7 +298,7 @@ fn infer_pkg<I: Importer>(
                 .0
             } else {
                 infer_file(
-                    &mut analyze_file(file, f)?,
+                    &mut convert_file(file, f)?,
                     Environment::new(prelude.clone().into()),
                     f,
                     &imports,
@@ -321,7 +321,7 @@ fn infer_pkg<I: Importer>(
 
     let env = if let Some(builtins) = builtin.get(name) {
         infer_file(
-            &mut analyze_file(file, f)?,
+            &mut convert_file(file, f)?,
             Environment::new(prelude.into()),
             f,
             &imports,
@@ -330,7 +330,7 @@ fn infer_pkg<I: Importer>(
         .0
     } else {
         infer_file(
-            &mut analyze_file(file, f)?,
+            &mut convert_file(file, f)?,
             Environment::new(prelude.into()),
             f,
             &imports,

--- a/libflux/src/flux/semantic/bootstrap.rs
+++ b/libflux/src/flux/semantic/bootstrap.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use crate::ast;
 use crate::parser;
-use crate::semantic::convert::convert_file;
 use crate::semantic::builtins::builtins;
+use crate::semantic::convert::convert_file;
 use crate::semantic::env::Environment;
 use crate::semantic::fresh::Fresher;
 use crate::semantic::import::Importer;

--- a/libflux/src/flux/semantic/flatbuffers/mod.rs
+++ b/libflux/src/flux/semantic/flatbuffers/mod.rs
@@ -15,7 +15,7 @@ use semantic_generated::fbsemantic;
 extern crate chrono;
 use chrono::Duration as ChronoDuration;
 
-pub fn serialize(semantic_pkg: &mut semantic::nodes::Package) -> Result<(Vec<u8>, usize), String> {
+pub fn serialize(semantic_pkg: &semantic::nodes::Package) -> Result<(Vec<u8>, usize), String> {
     let mut v = new_serializing_visitor_with_capacity(1024);
     walk::walk(&mut v, Rc::new(walk::Node::Package(semantic_pkg)));
     v.finish()

--- a/libflux/src/flux/semantic/flatbuffers/tests.rs
+++ b/libflux/src/flux/semantic/flatbuffers/tests.rs
@@ -4,7 +4,7 @@ extern crate walkdir;
 use super::semantic_generated::fbsemantic;
 use crate::ast;
 use crate::semantic;
-use crate::semantic::analyze;
+use crate::semantic::convert;
 use chrono::FixedOffset;
 
 #[test]
@@ -84,7 +84,7 @@ re !~ /foo/
         package: String::from("test"),
         files: f,
     };
-    let mut pkg = match analyze(pkg) {
+    let mut pkg = match convert::convert(pkg) {
         Ok(pkg) => pkg,
         Err(e) => {
             assert!(false, e);

--- a/libflux/src/flux/semantic/tests.rs
+++ b/libflux/src/flux/semantic/tests.rs
@@ -23,7 +23,7 @@
 //!
 use std::collections::HashMap;
 
-use crate::semantic::analyze::analyze_with;
+use crate::semantic::convert::convert_with;
 use crate::semantic::bootstrap::build_polytype;
 use crate::semantic::env::Environment;
 use crate::semantic::fresh::Fresher;
@@ -118,7 +118,7 @@ fn infer_types(
     let pkg = parse_program(src);
 
     let got = match nodes::infer_pkg_types(
-        &mut analyze_with(pkg, &mut f).expect("analysis failed"),
+        &mut convert_with(pkg, &mut f).expect("analysis failed"),
         Environment::new(env.into()),
         &mut f,
         &importer,

--- a/libflux/src/flux/semantic/tests.rs
+++ b/libflux/src/flux/semantic/tests.rs
@@ -23,8 +23,8 @@
 //!
 use std::collections::HashMap;
 
-use crate::semantic::convert::convert_with;
 use crate::semantic::bootstrap::build_polytype;
+use crate::semantic::convert::convert_with;
 use crate::semantic::env::Environment;
 use crate::semantic::fresh::Fresher;
 use crate::semantic::import::Importer;

--- a/libflux/src/flux/semantic/walk/test_utils.rs
+++ b/libflux/src/flux/semantic/walk/test_utils.rs
@@ -1,6 +1,6 @@
 use crate::ast;
 use crate::parser::parse_string;
-use crate::semantic::analyze;
+use crate::semantic::convert;
 use crate::semantic::nodes;
 
 pub fn compile(source: &str) -> nodes::Package {
@@ -15,5 +15,5 @@ pub fn compile(source: &str) -> nodes::Package {
         package: "main".to_string(),
         files: vec![file],
     };
-    analyze(ast_pkg).unwrap()
+    convert::convert(ast_pkg).unwrap()
 }

--- a/libflux/src/flux/tests/analyze_test.rs
+++ b/libflux/src/flux/tests/analyze_test.rs
@@ -1,5 +1,5 @@
 use flux::ast;
-use flux::semantic::analyze_source;
+use flux::semantic::convert_source;
 use flux::semantic::nodes::*;
 use flux::semantic::types::{Function, MonoType, Tvar};
 use flux::semantic::walk::{walk_mut, NodeMut};
@@ -10,7 +10,7 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn analyze_end_to_end() {
-    let mut got = analyze_source(
+    let mut got = convert_source(
         r#"
 n = 1
 s = "string"

--- a/libflux/src/libstd/Cargo.toml
+++ b/libflux/src/libstd/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [lib]
 name = "libstd"
 path = "lib.rs"
+crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
 flux = { path = "../flux" }

--- a/libflux/src/libstd/lib.rs
+++ b/libflux/src/libstd/lib.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn flux_analyze(
 /// that has been type-inferred.  This function is aware of the standard library
 /// and prelude.
 pub fn analyze(ast_pkg: ast::Package) -> Result<flux::semantic::nodes::Package, flux::Error> {
-    let mut sem_pkg = flux::semantic::analyze::analyze(ast_pkg)?;
+    let mut sem_pkg = flux::semantic::convert::convert(ast_pkg)?;
 
     let mut f = fresher();
     let prelude = match prelude() {
@@ -66,7 +66,7 @@ pub fn analyze(ast_pkg: ast::Package) -> Result<flux::semantic::nodes::Package, 
 #[cfg(test)]
 mod tests {
     use flux::semantic;
-    use flux::semantic::analyze::analyze_file;
+    use flux::semantic::convert::convert_file;
     use flux::semantic::env::Environment;
     use flux::semantic::nodes::infer_file;
 
@@ -84,7 +84,7 @@ mod tests {
         let ast = flux::parser::parse_string("main.flux", src);
         let mut f = super::fresher();
 
-        let mut file = analyze_file(ast, &mut f).unwrap();
+        let mut file = convert_file(ast, &mut f).unwrap();
         let (got, _) = infer_file(&mut file, prelude, &mut f, &imports, &None).unwrap();
 
         let want = semantic::parser::parse(

--- a/libflux/src/libstd/lib.rs
+++ b/libflux/src/libstd/lib.rs
@@ -1,13 +1,10 @@
 use flatbuffers;
+use flux::ast;
 use flux::ctypes::*;
-use flux::flux_buffer_t;
-use flux::semantic::analyze::analyze_file;
 use flux::semantic::env::Environment;
 use flux::semantic::flatbuffers::semantic_generated::fbsemantic as fb;
 use flux::semantic::fresh::Fresher;
 use flux::semantic::nodes::{infer_pkg_types, inject_pkg_types};
-use std::ffi::*;
-use std::os::raw::c_char;
 
 pub fn prelude() -> Option<Environment> {
     let buf = include_bytes!(concat!(env!("OUT_DIR"), "/prelude.data"));
@@ -24,48 +21,46 @@ pub fn fresher() -> Fresher {
     flatbuffers::get_root::<fb::Fresher>(buf).into()
 }
 
+/// # Safety
+///
+/// Ths function is unsafe because it dereferences a raw pointer.
 #[no_mangle]
-pub unsafe extern "C" fn flux_semantic_analyze(
-    src_ptr: *const c_char,
-    flux_buf: *mut flux_buffer_t,
+pub unsafe extern "C" fn flux_analyze(
+    ast_pkg: *mut flux_ast_pkg_t,
+    out_sem_pkg: *mut*const flux_semantic_pkg_t,
 ) -> *mut flux_error_t {
-    let buf = CStr::from_ptr(src_ptr).to_bytes(); // Unsafe
-    let s = String::from_utf8(buf.to_vec()).unwrap();
-    match analyze(s.as_str()) {
-        Ok(vec) => {
-            let flux_buf = &mut *flux_buf;
-            flux_buf.data = vec.as_ptr();
-            flux_buf.len = vec.len();
-            std::mem::forget(vec);
+    let ast_pkg = *Box::from_raw(ast_pkg as *mut ast::Package);
+    match analyze(ast_pkg) {
+        Ok(sem_pkg) => {
+            let sem_pkg = Box::into_raw(Box::new(sem_pkg)) as *const flux_semantic_pkg_t;
+            *out_sem_pkg = sem_pkg;
             std::ptr::null_mut()
-        }
+        },
         Err(err) => {
             let errh = flux::ErrorHandle { err: Box::new(err) };
-            return Box::into_raw(Box::new(errh)) as *mut flux_error_t;
+            Box::into_raw(Box::new(errh)) as *mut flux_error_t
         }
     }
 }
 
-fn analyze(src: &str) -> Result<Vec<u8>, flux::Error> {
+/// analyze consumes the given AST package and returns a semantic package
+/// that has been type-inferred.  This function is aware of the standard library
+/// and prelude.
+pub fn analyze(ast_pkg: ast::Package) -> Result<flux::semantic::nodes::Package, flux::Error> {
+    let mut sem_pkg = flux::semantic::analyze::analyze(ast_pkg)?;
+
     let mut f = fresher();
-
-    let ast_file = flux::parser::parse_string("", src);
-    let sem_file = analyze_file(ast_file, &mut f).unwrap();
-    let mut sem_pkg = flux::semantic::nodes::Package {
-        loc: flux::ast::SourceLocation {
-            ..flux::ast::SourceLocation::default()
-        },
-        package: String::from(flux::DEFAULT_PACKAGE_NAME),
-        files: vec![sem_file],
+    let prelude = match prelude() {
+        Some(prelude) => Environment::new(prelude),
+        None => return Err(flux::Error::from("missing prelude")),
     };
-
-    let prelude = Environment::new(prelude().unwrap());
-    let imports = imports().unwrap();
+    let imports = match imports() {
+        Some(imports) => imports,
+        None => return Err(flux::Error::from("missing stdlib imports")),
+    };
     let (_, sub) = infer_pkg_types(&mut sem_pkg, prelude, &mut f, &imports, &None)?;
     sem_pkg = inject_pkg_types(sem_pkg, &sub);
-
-    let (mut vec, offset) = flux::semantic::flatbuffers::serialize(&mut sem_pkg)?;
-    Ok(vec.split_off(offset))
+    Ok(sem_pkg)
 }
 
 #[cfg(test)]

--- a/libflux/src/libstd/lib.rs
+++ b/libflux/src/libstd/lib.rs
@@ -47,9 +47,9 @@ pub unsafe extern "C" fn flux_analyze(
 /// that has been type-inferred.  This function is aware of the standard library
 /// and prelude.
 pub fn analyze(ast_pkg: ast::Package) -> Result<flux::semantic::nodes::Package, flux::Error> {
-    let mut sem_pkg = flux::semantic::convert::convert(ast_pkg)?;
-
     let mut f = fresher();
+    let mut sem_pkg = flux::semantic::convert::convert_with(ast_pkg, &mut f)?;
+
     let prelude = match prelude() {
         Some(prelude) => Environment::new(prelude),
         None => return Err(flux::Error::from("missing prelude")),

--- a/libflux/src/libstd/lib.rs
+++ b/libflux/src/libstd/lib.rs
@@ -27,7 +27,7 @@ pub fn fresher() -> Fresher {
 #[no_mangle]
 pub unsafe extern "C" fn flux_analyze(
     ast_pkg: *mut flux_ast_pkg_t,
-    out_sem_pkg: *mut*const flux_semantic_pkg_t,
+    out_sem_pkg: *mut *const flux_semantic_pkg_t,
 ) -> *mut flux_error_t {
     let ast_pkg = *Box::from_raw(ast_pkg as *mut ast::Package);
     match analyze(ast_pkg) {
@@ -35,7 +35,7 @@ pub unsafe extern "C" fn flux_analyze(
             let sem_pkg = Box::into_raw(Box::new(sem_pkg)) as *const flux_semantic_pkg_t;
             *out_sem_pkg = sem_pkg;
             std::ptr::null_mut()
-        },
+        }
         Err(err) => {
             let errh = flux::ErrorHandle { err: Box::new(err) };
             Box::into_raw(Box::new(errh)) as *mut flux_error_t

--- a/parser/libflux_parser.go
+++ b/parser/libflux_parser.go
@@ -3,8 +3,6 @@
 package parser
 
 import (
-	"encoding/json"
-
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/internal/parser"
 	"github.com/influxdata/flux/internal/token"
@@ -24,10 +22,7 @@ func parseFile(f *token.File, src []byte) (*ast.File, error) {
 		return nil, err
 	}
 
-	var pkg ast.Package
-	if err := json.Unmarshal(data, &pkg); err != nil {
-		return nil, err
-	}
+	pkg := ast.DeserializeFromFlatBuffer(data)
 	file := pkg.Files[0]
 	file.Name = f.Name()
 

--- a/parser/libflux_parser.go
+++ b/parser/libflux_parser.go
@@ -19,15 +19,16 @@ func parseFile(f *token.File, src []byte) (*ast.File, error) {
 	astFile := libflux.Parse(string(src))
 	defer astFile.Free()
 
-	data, err := astFile.MarshalJSON()
+	data, err := astFile.MarshalFB()
 	if err != nil {
 		return nil, err
 	}
 
-	var file ast.File
-	if err := json.Unmarshal(data, &file); err != nil {
+	var pkg ast.Package
+	if err := json.Unmarshal(data, &pkg); err != nil {
 		return nil, err
 	}
+	file := pkg.Files[0]
 	file.Name = f.Name()
 
 	// The go parser will not fill in the imports if there are
@@ -35,7 +36,7 @@ func parseFile(f *token.File, src []byte) (*ast.File, error) {
 	if len(file.Imports) == 0 {
 		file.Imports = nil
 	}
-	return &file, nil
+	return file, nil
 }
 
 func isLibfluxBuild() bool {

--- a/semantic/analyze_libflux.go
+++ b/semantic/analyze_libflux.go
@@ -9,9 +9,12 @@ import (
 // AnalyzeSource parses and analyzes the given Flux source,
 // using libflux.
 func AnalyzeSource(fluxSrc string) (*Package, error) {
-	data, err := libflux.Analyze(fluxSrc)
+	ast := libflux.Parse(fluxSrc)
+	sem, err := libflux.Analyze(ast)
+	fb, err := sem.MarshalFB()
+
 	if err != nil {
 		return nil, err
 	}
-	return DeserializeFromFlatBuffer(data)
+	return DeserializeFromFlatBuffer(fb)
 }

--- a/semantic/analyze_libflux.go
+++ b/semantic/analyze_libflux.go
@@ -1,0 +1,17 @@
+// +build libflux
+
+package semantic
+
+import (
+	"github.com/influxdata/flux/libflux/go/libflux"
+)
+
+// AnalyzeSource parses and analyzes the given Flux source,
+// using libflux.
+func AnalyzeSource(fluxSrc string) (*Package, error) {
+	data, err := libflux.Analyze(fluxSrc)
+	if err != nil {
+		return nil, err
+	}
+	return DeserializeFromFlatBuffer(data)
+}

--- a/semantic/analyze_libflux.go
+++ b/semantic/analyze_libflux.go
@@ -11,6 +11,9 @@ import (
 func AnalyzeSource(fluxSrc string) (*Package, error) {
 	ast := libflux.Parse(fluxSrc)
 	sem, err := libflux.Analyze(ast)
+	if err != nil {
+		return nil, err
+	}
 	fb, err := sem.MarshalFB()
 
 	if err != nil {

--- a/semantic/analyze_libflux_test.go
+++ b/semantic/analyze_libflux_test.go
@@ -1,0 +1,45 @@
+// +build libflux
+
+package semantic_test
+
+import (
+	"errors"
+	"github.com/influxdata/flux/semantic"
+	"testing"
+)
+
+func TestAnalyzeSource(t *testing.T) {
+	tcs := []struct {
+		name string
+		flx  string
+		err  error
+	}{
+		{
+			name: "success",
+			flx:  `x = 10`,
+		},
+		{
+			name: "failure",
+			flx:  `x = 10 + "foo"`,
+			err:  errors.New("cannot unify int with string"),
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := semantic.AnalyzeSource(tc.flx)
+			if err != nil {
+				if tc.err == nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				if want, got := tc.err.Error(), err.Error(); want != got {
+					t.Fatalf("wanted error %q, got %q", want, got)
+				}
+				return
+			}
+			if tc.err != nil {
+				t.Fatalf("expected error %q, got none", tc.err)
+			}
+		})
+	}
+}

--- a/semantic/flatbuffers_test.go
+++ b/semantic/flatbuffers_test.go
@@ -1,3 +1,5 @@
+// +build libflux
+
 package semantic
 
 import (
@@ -12,9 +14,6 @@ import (
 	"github.com/influxdata/flux/semantic/internal/fbsemantic"
 	"github.com/influxdata/flux/semantic/types"
 )
-
-// TODO(cwolff): There needs to be more testing here.  Once we can serialize an arbitrary semantic graph
-//   in Rust, we can get more complete coverage without having to create FlatBuffers by hand.
 
 var cmpOpts = []cmp.Option{
 	cmp.AllowUnexported(
@@ -68,8 +67,8 @@ func TestDeserializeFromFlatBuffer(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			src, fb := tc.fbFn()
-			ast := parser.ParseSource(src)
-			want, err := New(ast)
+			astPkg := parser.ParseSource(src)
+			want, err := New(astPkg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -426,4 +425,80 @@ func source(src string, loc *ast.SourceLocation) string {
 		return "<invalid offsets>"
 	}
 	return src[soffset:eoffset]
+}
+
+// MyAssignment is a special struct used only
+// for comparing NativeVariableAssignments with
+// PolyTypes provided by a test case.
+type MyAssignement struct {
+	loc
+
+	Identifier *Identifier
+	Init       Expression
+
+	Typ string
+}
+
+func TestRoundTrip(t *testing.T) {
+	tcs := []struct {
+		name    string
+		fluxSrc string
+		// For each variable assignment, the expected inferred type of the variable
+		types map[string]string
+	}{
+		// TODO(cwolff): more testing to come
+		{
+			name:    "simple assignment",
+			fluxSrc: `x = 42`,
+			types: map[string]string{
+				"x": "forall [] int",
+			},
+		},
+	}
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AnalyzeSource(tc.fluxSrc)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			astPkg := parser.ParseSource(tc.fluxSrc)
+			want, err := New(astPkg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create a special comparison option to compare the types
+			// of NativeVariableAssignments using the expected types in the map
+			// provided by the test case.
+			assignCmp := cmp.Transformer("assign", func(nva *NativeVariableAssignment) *MyAssignement {
+				var typStr string
+				if nva.Typ == nil {
+					// This is the assignment from Go.
+					var ok bool
+					typStr, ok = tc.types[nva.Identifier.Name]
+					if !ok {
+						typStr = "*** missing type ***"
+					}
+				} else {
+					// This is the assignment from Rust.
+					typStr = nva.Typ.String()
+				}
+				return &MyAssignement{
+					loc:        nva.loc,
+					Identifier: nva.Identifier,
+					Init:       nva.Init,
+					Typ:        typStr,
+				}
+			})
+
+			opts := make(cmp.Options, len(cmpOpts), len(cmpOpts)+2)
+			copy(opts, cmpOpts)
+			opts = append(opts, assignCmp, cmp.AllowUnexported(MyAssignement{}))
+			if diff := cmp.Diff(want, got, opts...); diff != "" {
+				t.Fatalf("differences in semantic graph: -want/+got:\n%v", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
I also added a simple (to be expanded) test case for calling type inference from Go.

I wanted to be able to have access to types from the builtins, standard library and prelude, so I had to implement `analyze` in libflux and make that linkable from CGO.  This API lets Go pass in Flux source and get a type-inferred semantic graph (that uses types from the stdlib and prelude).

I think that we'll want to refine the Go/Rust API a bit more than what's on this branch:
- It seems strange that Go needs to call into both `liblibstd` and `libflux`.   Seems like we should encapsulate everything we need from Go into a single crate.
- We'll somehow want to avoid having to copy the prelude and stdlib types very time we type-infer a program.

