### PR TITLE
fix(libflux): ensure stdlib directory is created

### DIFF
--- a/internal/cmd/flux-config/build.go
+++ b/internal/cmd/flux-config/build.go
@@ -167,17 +167,15 @@ func downloadSources(srcdir string, mod *Module) error {
 
 		if strings.HasPrefix(relpath, "libflux/") {
 			relpath = relpath[strings.Index(relpath, "/")+1:]
-			// Do not extract the symlink for the standard library.
-			if relpath == "stdlib" {
-				continue
-			}
-		} else if !strings.HasPrefix(relpath, "stdlib/") {
+		} else if relpath != "stdlib" && !strings.HasPrefix(relpath, "stdlib/") {
 			// Allow extracting the standard library.
 			continue
 		}
 
 		fpath := filepath.Join(srcdir, relpath)
 		if file.Mode().IsDir() {
+			// stdlib is a special exception. It is a symlink in the package,
+			// but we are going to use it as a directory.
 			if err := os.Mkdir(fpath, 0755); err != nil && !os.IsExist(err) {
 				return err
 			}


### PR DESCRIPTION
The stdlib directory didn't get created when extracting the archive in
flux config because the cleaned path didn't include an ending slash.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written