### PR TITLE
refactor(semantic): new monotype should take a table struct not a pointer

### DIFF
--- a/semantic/flatbuffers.go
+++ b/semantic/flatbuffers.go
@@ -577,8 +577,8 @@ type fbTyper interface {
 // getMonoType produces an FBMonoType from the given FlatBuffers expression that has
 // a union "typ" field (which is all the different kinds of expressions).
 func getMonoType(fbExpr fbTyper) (MonoType, error) {
-	tbl := new(flatbuffers.Table)
-	if !fbExpr.Typ(tbl) {
+	var tbl flatbuffers.Table
+	if !fbExpr.Typ(&tbl) {
 		return MonoType{}, errors.Newf(codes.Internal, "missing monotype")
 	}
 

--- a/semantic/monotype.go
+++ b/semantic/monotype.go
@@ -23,7 +23,7 @@ type MonoType struct {
 }
 
 // NewMonoType constructs a new monotype from a FlatBuffers table and the given kind of monotype.
-func NewMonoType(tbl *flatbuffers.Table, t fbsemantic.MonoType) (MonoType, error) {
+func NewMonoType(tbl flatbuffers.Table, t fbsemantic.MonoType) (MonoType, error) {
 	var tbler fbTabler
 	switch t {
 	case fbsemantic.MonoTypeNONE:
@@ -103,8 +103,6 @@ func (mt MonoType) Kind() Kind {
 }
 
 var (
-	basicTable *flatbuffers.Table
-
 	BasicBool     MonoType
 	BasicInt      MonoType
 	BasicUint     MonoType
@@ -126,7 +124,7 @@ func init() {
 
 	// TODO (algow): this probably doesn't work...
 	builder.Finish(basicBool)
-	basicTable = &flatbuffers.Table{
+	basicTable := flatbuffers.Table{
 		Bytes: builder.FinishedBytes(),
 		Pos:   basicBool,
 	}
@@ -217,8 +215,8 @@ func (mt MonoType) ReturnType() (MonoType, error) {
 	if !ok {
 		return MonoType{}, errors.New(codes.Internal, "ReturnType() called on non-function MonoType")
 	}
-	tbl := new(flatbuffers.Table)
-	if !f.Retn(tbl) {
+	var tbl flatbuffers.Table
+	if !f.Retn(&tbl) {
 		return MonoType{}, errors.New(codes.Internal, "missing return type")
 	}
 	return NewMonoType(tbl, f.RetnType())
@@ -238,8 +236,8 @@ func (mt MonoType) ElemType() (MonoType, error) {
 	if err != nil {
 		return MonoType{}, err
 	}
-	tbl := new(flatbuffers.Table)
-	if !arr.T(tbl) {
+	var tbl flatbuffers.Table
+	if !arr.T(&tbl) {
 		return MonoType{}, errors.New(codes.Internal, "missing array type")
 	}
 	return NewMonoType(tbl, arr.TType())
@@ -307,8 +305,8 @@ func newArgument(fb *fbsemantic.Argument) (*Argument, error) {
 
 // TypeOf returns the type of the function argument.
 func (a *Argument) TypeOf() (MonoType, error) {
-	tbl := new(flatbuffers.Table)
-	if !a.T(tbl) {
+	var tbl flatbuffers.Table
+	if !a.T(&tbl) {
 		return MonoType{}, errors.New(codes.Internal, "missing argument type")
 	}
 	argTy, err := NewMonoType(tbl, a.TType())
@@ -330,8 +328,8 @@ func (p *RowProperty) Name() string {
 
 // TypeOf returns the type of the property.
 func (p *RowProperty) TypeOf() (MonoType, error) {
-	tbl := new(flatbuffers.Table)
-	if !p.fb.V(tbl) {
+	var tbl flatbuffers.Table
+	if !p.fb.V(&tbl) {
 		return MonoType{}, errors.Newf(codes.Internal, "missing property type")
 	}
 	return NewMonoType(tbl, p.fb.VType())

--- a/semantic/polytype.go
+++ b/semantic/polytype.go
@@ -60,8 +60,8 @@ func (pt PolyType) Constraint(i int) (*fbsemantic.Constraint, error) {
 
 // Expr returns the monotype expression for this polytype.
 func (pt PolyType) Expr() (MonoType, error) {
-	tbl := new(flatbuffers.Table)
-	if !pt.fb.Expr(tbl) {
+	var tbl flatbuffers.Table
+	if !pt.fb.Expr(&tbl) {
 		return MonoType{}, errors.New(codes.Internal, "missing a polytype expr")
 	}
 


### PR DESCRIPTION
The flatbuffers code sends the table struct as the struct itself and the
copy is largely inconsequential because the struct is composed of a
slice and an offset. This will simplify some of the APIs since it was
common to assign the table to a variable just to get a pointer value.
Now we can just pass the struct itself after the builder constructs the
table.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written