### PR TITLE
fix(stdlib): better messaging for malformed csv

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -306,8 +306,7 @@ func readMetadata(r *csv.Reader, c ResultDecoderConfig, extraLine []string) (tab
 			if err != nil {
 				if err == io.EOF {
 					if datatypes == nil && groups == nil && defaults == nil {
-						// No, just pass the EOF up
-						return tableMetadata{}, err
+						return tableMetadata{}, fmt.Errorf("missing expected annotations datatype, group, and default")
 					}
 					switch {
 					case datatypes == nil:

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -684,6 +684,14 @@ func TestResultDecoder(t *testing.T) {
 				Err: errors.New("failed to create physical plan: query must specify explicit yields when there is more than one result."),
 			},
 		},
+		{
+			name:          "csv with no metadata",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded:       toCRLF(`1,2`),
+			result: &executetest.Result{
+				Err: errors.New("failed to read metadata: missing expected annotations datatype, group, and default"),
+			},
+		},
 	}
 	testCases = append(testCases, symmetricalTestCases...)
 	for _, tc := range testCases {


### PR DESCRIPTION
This patch provides a better error message for malformed CSV files.
Prior to this patch, if the metadata is missing from the CSV, an error
about EOF was returned, which was not helpful. A more helpful error
message is now returned (with test).

Fixes #2201 