### PR TITLE
refactor(values): mutable object values with the new semantic object

### DIFF
--- a/interpreter/package.go
+++ b/interpreter/package.go
@@ -18,11 +18,11 @@ type Package struct {
 
 func NewPackageWithValues(name string, obj values.Object) *Package {
 	if obj == nil {
-		obj = values.NewObject()
+		obj = values.NewObjectWithValues(nil)
 	}
 	return &Package{
 		name:    name,
-		options: values.NewObject(),
+		options: values.NewObjectWithValues(nil),
 		object:  obj,
 	}
 }
@@ -32,11 +32,11 @@ func NewPackage(name string) *Package {
 }
 
 func (p *Package) Copy() *Package {
-	object := values.NewObjectWithBacking(p.object.Len())
+	object := values.NewObject(p.object.Type())
 	p.object.Range(func(k string, v values.Value) {
 		object.Set(k, v)
 	})
-	options := values.NewObjectWithBacking(p.options.Len())
+	options := values.NewObject(p.options.Type())
 	p.options.Range(func(k string, v values.Value) {
 		options.Set(k, v)
 	})

--- a/semantic/monotype.go
+++ b/semantic/monotype.go
@@ -421,8 +421,11 @@ func (mt MonoType) String() string {
 }
 
 func (l MonoType) Equal(r MonoType) bool {
-	// TODO (algow): Remove this method, we will not support comparing types for equality.
-	return false
+	if l.mt != r.mt {
+		return false
+	}
+	// TODO(algow): We might need this we might not.
+	return true
 }
 
 func newBasicType(t fbsemantic.Type) MonoType {

--- a/stdlib/experimental/set.go
+++ b/stdlib/experimental/set.go
@@ -67,7 +67,7 @@ func (s *SetProcedureSpec) Kind() plan.ProcedureKind {
 }
 func (s *SetProcedureSpec) Copy() plan.ProcedureSpec {
 	ns := new(SetProcedureSpec)
-	ns.Object = values.NewObjectWithBacking(s.Object.Len())
+	ns.Object = values.NewObject(s.Object.Type())
 	s.Object.Range(func(k string, v values.Value) {
 		ns.Object.Set(k, v)
 	})

--- a/stdlib/experimental/set_test.go
+++ b/stdlib/experimental/set_test.go
@@ -1,28 +1,31 @@
 package experimental_test
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/experimental"
 	"github.com/influxdata/flux/values"
 )
 
 // newOrderedObject creates a object with sorted keys order
 func newOrderedObject(vs map[string]values.Value) values.Object {
-	obj := values.NewObjectWithBacking(len(vs))
-	keys := make([]string, 0, len(vs))
-	for k := range vs {
-		keys = append(keys, k)
+	properties := make([]semantic.PropertyType, 0, len(vs))
+	for key, value := range vs {
+		properties = append(properties, semantic.PropertyType{
+			Key:   []byte(key),
+			Value: value.Type(),
+		})
 	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		obj.Set(k, vs[k])
-	}
-	return obj
+
+	object := values.NewObject(semantic.NewObjectType(properties))
+	object.Range(func(name string, _ values.Value) {
+		object.Set(name, vs[name])
+	})
+	return object
 }
 
 func TestSet_Process(t *testing.T) {

--- a/values/object_test.go
+++ b/values/object_test.go
@@ -3,14 +3,17 @@ package values_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/values"
 )
 
 func TestObjectEqual(t *testing.T) {
-	r := values.NewObject()
-	r.Set("a", values.NewInt(1))
-	l := values.NewObject()
-	l.Set("a", values.NewInt(1))
+	r := values.NewObjectWithValues(map[string]values.Value{
+		"a": values.NewInt(1),
+	})
+	l := values.NewObjectWithValues(map[string]values.Value{
+		"a": values.NewInt(1),
+	})
 
 	if !l.Equal(r) {
 		t.Fatal("expected objects to be equal")
@@ -25,8 +28,43 @@ func TestObjectEqual(t *testing.T) {
 	if !l.Equal(r) {
 		t.Fatal("expected objects to be equal")
 	}
-	l.Set("b", values.NewInt(1))
+
+	l, _ = values.BuildObject(func(set values.ObjectSetter) error {
+		l.Range(func(name string, v values.Value) {
+			set(name, v)
+		})
+		set("b", values.NewInt(1))
+		return nil
+	})
 	if l.Equal(r) {
 		t.Fatal("expected objects to be unequal")
+	}
+}
+
+func TestBuildObject(t *testing.T) {
+	object, err := values.BuildObject(func(set values.ObjectSetter) error {
+		set("b", values.NewInt(2))
+		set("a", values.NewString("foo"))
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := 2, object.Len(); want != got {
+		t.Fatalf("unexpected length -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	got := make(map[string]values.Value)
+	object.Range(func(name string, v values.Value) {
+		got[name] = v
+	})
+
+	want := map[string]values.Value{
+		"b": values.NewInt(2),
+		"a": values.NewString("foo"),
+	}
+	if !cmp.Equal(want, got) {
+		t.Fatalf("unexpected values -want/+got:\n%s", cmp.Diff(want, got))
 	}
 }


### PR DESCRIPTION
This modifies the API for creating object values since the object's type
needs to be known before we create the object now. It also adds a
utility method for building an object that is easier for creating an
object.

Fixes #2318.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written