### PR TITLE
test(semantic): add roundtrip testing for Flatbuffers serialization

### DIFF
--- a/internal/cmd/fbgen/cmd/semantic.go
+++ b/internal/cmd/fbgen/cmd/semantic.go
@@ -208,6 +208,9 @@ func doNamed(o types.Object, field *types.Var) ([]jen.Code, error) {
 		)
 	case "Expression", "Assignment":
 		helperFn := "from" + fieldType + "Table"
+		if isOptionalExpr(o.Name(), field.Name()) {
+			helperFn += "Optional"
+		}
 		fbField := toFBName(o.Name(), field.Name())
 		codes = append(codes,
 			ifErrorPropagate(
@@ -309,6 +312,18 @@ func fbConcat(s1, s2 string) string {
 
 	}
 	return s1 + s2
+}
+
+var optionalExprs map[[2]string]struct{} = map[[2]string]struct{}{
+	{"CallExpression", "Pipe"}: struct{}{},
+}
+
+// isOptionalExpr returns true if the given struct field (with type Expression)
+// is optional.
+func isOptionalExpr(structName, fieldName string) bool {
+	key := [2]string{structName, fieldName}
+	_, ok := optionalExprs[key]
+	return ok
 }
 
 // doBasic returns a slice of Go code that populates a field in a Go semantic graph struct,

--- a/libflux/src/flux/semantic/convert.rs
+++ b/libflux/src/flux/semantic/convert.rs
@@ -282,7 +282,7 @@ fn convert_block(block: ast::Block, fresher: &mut Fresher) -> Result<Block> {
     let block = if let Some(ast::Statement::Return(stmt)) = body.next() {
         let argument = convert_expression(stmt.argument, fresher)?;
         Block::Return(ReturnStmt {
-            loc: argument.loc().clone(),
+            loc: stmt.base.location.clone(),
             argument,
         })
     } else {

--- a/libflux/src/flux/semantic/flatbuffers/mod.rs
+++ b/libflux/src/flux/semantic/flatbuffers/mod.rs
@@ -512,8 +512,11 @@ impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
 
                 let mut block_len = 0;
                 let mut current = &func.body;
+                let body_start_pos = &current.loc().start;
+                let mut body_end_pos = &current.loc().end;
                 loop {
                     block_len += 1;
+                    body_end_pos = &current.loc().end;
                     match current {
                         semantic::nodes::Block::Expr(_, next) => {
                             current = next.as_ref();
@@ -526,6 +529,13 @@ impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
                         }
                     }
                 }
+                let body_loc = ast::SourceLocation {
+                    file: func.loc.file.clone(),
+                    start: body_start_pos.clone(),
+                    end: body_end_pos.clone(),
+                    source: None,
+                };
+                let body_loc = v.create_loc(&body_loc);
                 let body_vec = {
                     let stmt_vec = v.create_stmt_vector(block_len);
                     Some(v.builder.create_vector(&stmt_vec.as_slice()))
@@ -533,7 +543,7 @@ impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
                 let body = Some(fbsemantic::Block::create(
                     &mut v.builder,
                     &fbsemantic::BlockArgs {
-                        loc,
+                        loc: body_loc,
                         body: body_vec,
                     },
                 ));

--- a/semantic/analyze_libflux.go
+++ b/semantic/analyze_libflux.go
@@ -10,12 +10,13 @@ import (
 // using libflux.
 func AnalyzeSource(fluxSrc string) (*Package, error) {
 	ast := libflux.Parse(fluxSrc)
+	defer ast.Free()
 	sem, err := libflux.Analyze(ast)
 	if err != nil {
 		return nil, err
 	}
+	defer sem.Free()
 	fb, err := sem.MarshalFB()
-
 	if err != nil {
 		return nil, err
 	}

--- a/semantic/flatbuffers.go
+++ b/semantic/flatbuffers.go
@@ -113,6 +113,13 @@ func fromExpressionTable(getTable getTableFn, exprType fbsemantic.Expression) (E
 			return nil, errors.Newf(codes.Internal, "missing unknown expr type %v", exprType)
 		}
 	}
+	return fromExpressionTableOptional(getTable, exprType)
+}
+func fromExpressionTableOptional(getTable getTableFn, exprType fbsemantic.Expression) (Expression, error) {
+	tbl := new(flatbuffers.Table)
+	if !getTable(tbl) {
+		return nil, nil
+	}
 	switch exprType {
 	case fbsemantic.ExpressionStringExpression:
 		fbExpr := new(fbsemantic.StringExpression)
@@ -403,21 +410,23 @@ func fromFBDurationVector(fbDurLit *fbsemantic.DurationLiteral) ([]ast.Duration,
 		return nil, errors.New(codes.Internal, "missing duration vector")
 	}
 
-	durs := make([]ast.Duration, fbDurLit.ValueLength())
+	// Durations are represented as an array, but this seems
+	// unnecessary?
+	durs := make([]ast.Duration, 0, 2)
 	for i := 0; i < fbDurLit.ValueLength(); i++ {
 		fbDur := new(fbsemantic.Duration)
 		if !fbDurLit.Value(fbDur, i) {
 			return nil, errors.Newf(codes.Internal, "missing duration at position %v", i)
 		}
-		nano := ast.Duration{
-			Magnitude: fbDur.Nanoseconds(),
-			Unit:      "ns",
-		}
 		month := ast.Duration{
 			Magnitude: fbDur.Months(),
 			Unit:      "mo",
 		}
-		durs = append(durs, nano, month)
+		nano := ast.Duration{
+			Magnitude: fbDur.Nanoseconds(),
+			Unit:      "ns",
+		}
+		durs = append(durs, month, nano)
 	}
 	return durs, nil
 }
@@ -468,7 +477,7 @@ func fromFBStringExpressionPartVector(fbExpr *fbsemantic.StringExpression) ([]St
 			return nil, errors.New(codes.Internal, "expected to find either text or interpolated expression")
 		}
 
-		parts = append(parts, part)
+		parts[i] = part
 	}
 	return parts, nil
 }
@@ -530,7 +539,9 @@ func (e *FunctionExpression) FromBuf(fb *fbsemantic.FunctionExpression) error {
 				}
 			}
 		}
-		bl.Parameters = ps
+		if len(ps.List) > 0 {
+			bl.Parameters = ps
+		}
 
 		fbBlock := fb.Body(nil)
 		if fbBlock == nil {
@@ -544,9 +555,11 @@ func (e *FunctionExpression) FromBuf(fb *fbsemantic.FunctionExpression) error {
 	}
 	e.Block = bl
 
-	e.Defaults = &ObjectExpression{
-		loc:        e.loc,
-		Properties: defaults,
+	if len(defaults) > 0 {
+		e.Defaults = &ObjectExpression{
+			loc:        e.loc,
+			Properties: defaults,
+		}
 	}
 
 	return nil
@@ -603,10 +616,17 @@ func objectExprFromProperties(fb *fbsemantic.CallExpression) (*ObjectExpression,
 		if err := prop.FromBuf(fbProp); err != nil {
 			return nil, err
 		}
-		props = append(props, prop)
+		props[i] = prop
 	}
 
+	l := loc{}
+	if len(props) > 0 {
+		l = props[0].loc
+		l.End = props[len(props)-1].loc.End
+		l.Source = ""
+	}
 	obj := &ObjectExpression{
+		loc:        l,
 		Properties: props,
 	}
 	return obj, nil

--- a/semantic/flatbuffers_gen.go
+++ b/semantic/flatbuffers_gen.go
@@ -138,7 +138,7 @@ func (rcv *CallExpression) FromBuf(fb *fbsemantic.CallExpression) error {
 	if rcv.Arguments, err = objectExprFromProperties(fb); err != nil {
 		return errors.Wrap(err, codes.Inherit, "CallExpression.Arguments")
 	}
-	if rcv.Pipe, err = fromExpressionTable(fb.Pipe, fb.PipeType()); err != nil {
+	if rcv.Pipe, err = fromExpressionTableOptional(fb.Pipe, fb.PipeType()); err != nil {
 		return errors.Wrap(err, codes.Inherit, "CallExpression.Pipe")
 	}
 	if rcv.typ, err = getMonoType(fb); err != nil {

--- a/semantic/flatbuffers_test.go
+++ b/semantic/flatbuffers_test.go
@@ -3,6 +3,9 @@
 package semantic
 
 import (
+	"errors"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -17,7 +20,13 @@ import (
 
 var cmpOpts = []cmp.Option{
 	cmp.AllowUnexported(
+		ArrayExpression{},
+		BinaryExpression{},
 		Block{},
+		CallExpression{},
+		ConditionalExpression{},
+		DateTimeLiteral{},
+		DurationLiteral{},
 		ExpressionStatement{},
 		File{},
 		FloatLiteral{},
@@ -27,14 +36,30 @@ var cmpOpts = []cmp.Option{
 		FunctionParameter{},
 		IdentifierExpression{},
 		Identifier{},
+		ImportDeclaration{},
+		IndexExpression{},
 		IntegerLiteral{},
+		InterpolatedPart{},
+		LogicalExpression{},
+		MemberAssignment{},
+		MemberExpression{},
 		NativeVariableAssignment{},
 		ObjectExpression{},
+		OptionStatement{},
 		Package{},
+		PackageClause{},
+		RegexpLiteral{},
 		Property{},
 		ReturnStatement{},
+		StringExpression{},
+		StringLiteral{},
+		TestStatement{},
+		TextPart{},
 		UnaryExpression{},
 	),
+	cmp.Transformer("regexp", func(re *regexp.Regexp) string {
+		return re.String()
+	}),
 	// Just ignore types when comparing against Go semantic graph, since
 	// Go does not annotate expressions nodes with types directly.
 	cmp.Transformer("", func(ty *types.MonoType) int {
@@ -439,34 +464,491 @@ type MyAssignement struct {
 	Typ string
 }
 
-func TestRoundTrip(t *testing.T) {
+// transformGraph takes a semantic graph produced by Go, and modifies it
+// so it looks like something produced by Rust.
+// The differences do not affect program behavior at runtime.
+func transformGraph(pkg *Package) error {
+	Walk(&transformingVisitor{}, pkg)
+	return nil
+}
+
+type transformingVisitor struct{}
+
+func (tv *transformingVisitor) Visit(node Node) Visitor {
+	return tv
+}
+
+// toMonthsAndNanos takes a slice of durations,
+// and represents them as months and nanoseconds,
+// which is how durations are represented in a flatbuffer.
+func toMonthsAndNanos(ds []ast.Duration) []ast.Duration {
+	var ns int64
+	var mos int64
+	for _, d := range ds {
+		switch d.Unit {
+		case ast.NanosecondUnit:
+			ns += d.Magnitude
+		case ast.MicrosecondUnit:
+			ns += 1000 * d.Magnitude
+		case ast.MillisecondUnit:
+			ns += 1000000 * d.Magnitude
+		case ast.SecondUnit:
+			ns += 1000000000 * d.Magnitude
+		case ast.MinuteUnit:
+			ns += 60 * 1000000000 * d.Magnitude
+		case ast.HourUnit:
+			ns += 60 * 60 * 1000000000 * d.Magnitude
+		case ast.DayUnit:
+			ns += 24 * 60 * 60 * 1000000000 * d.Magnitude
+		case ast.WeekUnit:
+			ns += 7 * 24 * 60 * 60 * 1000000000 * d.Magnitude
+		case ast.MonthUnit:
+			mos += d.Magnitude
+		case ast.YearUnit:
+			mos += 12 * d.Magnitude
+		default:
+		}
+	}
+	outDurs := make([]ast.Duration, 2)
+	outDurs[0] = ast.Duration{Magnitude: mos, Unit: ast.MonthUnit}
+	outDurs[1] = ast.Duration{Magnitude: ns, Unit: ast.NanosecondUnit}
+	return outDurs
+}
+
+func (tv *transformingVisitor) Done(node Node) {
+	switch n := node.(type) {
+	case *CallExpression:
+		// Rust call expr args are just an array, so there's no location info.
+		n.Arguments.Source = ""
+	case *DurationLiteral:
+		// Rust duration literals use the months + nanos representation,
+		// Go uses AST units.
+		n.Values = toMonthsAndNanos(n.Values)
+	case *File:
+		if len(n.Body) == 0 {
+			n.Body = nil
+		}
+	case *FunctionBlock:
+		if e, ok := n.Body.(Expression); ok {
+			// The Rust semantic graph has only block-style function bodies
+			l := e.Location()
+			l.Source = ""
+			n.Body = &Block{
+				loc: loc(l),
+				Body: []Statement{
+					&ReturnStatement{
+						loc:      loc(e.Location()),
+						Argument: e,
+					},
+				},
+			}
+		} else {
+			// Blocks in Rust models blocks as linked lists, so we don't have a location for the
+			// entire block including the curly braces.  It uses location of the statements instead.
+			bl := n.Body.(*Block)
+			nStmts := len(bl.Body)
+			bl.Start = bl.Body[0].Location().Start
+			bl.End = bl.Body[nStmts-1].Location().End
+			bl.Source = ""
+		}
+	}
+}
+
+var tvarRegexp *regexp.Regexp = regexp.MustCompile("t[0-9]+")
+
+// canonicalizeType returns a string representation of the given type
+// that reindexes in the numbers in type variables starting from zero.
+func canonicalizeType(pt *types.PolyType) string {
+	tvm, err := pt.GetCanonicalMapping()
+	if err != nil {
+		panic(err)
+	}
+	tstr := pt.String()
+	return tvarRegexp.ReplaceAllStringFunc(tstr, func(in string) string {
+		n, err := strconv.Atoi(in[1:])
+		if err != nil {
+			panic(err)
+		}
+		nn, ok := tvm[uint64(n)]
+		if !ok {
+			panic(fmt.Sprintf("could not find tvar mapping for %v", in))
+		}
+		return fmt.Sprintf("t%v", nn)
+	})
+}
+
+// canonicalizeError reindexes type variable numbers in error messages
+// starting from zero, so that tests don't fail when the stdlib is updated.
+func canonicalizeError(errMsg string) string {
+	count := 0
+	tvm := make(map[int]int)
+	return tvarRegexp.ReplaceAllStringFunc(errMsg, func(in string) string {
+		n, err := strconv.Atoi(in[1:])
+		if err != nil {
+			panic(err)
+		}
+		var nn int
+		var ok bool
+		if nn, ok = tvm[n]; !ok {
+			nn = count
+			count++
+			tvm[n] = nn
+		}
+		t := fmt.Sprintf("t%v", nn)
+		return t
+	})
+}
+
+func TestFlatBuffersRoundTrip(t *testing.T) {
 	tcs := []struct {
 		name    string
 		fluxSrc string
+		err     error
 		// For each variable assignment, the expected inferred type of the variable
 		types map[string]string
 	}{
-		// TODO(cwolff): more testing to come
 		{
-			name:    "simple assignment",
+			name:    "package",
+			fluxSrc: `package foo`,
+		},
+		{
+			name: "import",
+			fluxSrc: `
+                import "math"
+                import c "csv"`,
+		},
+		{
+			name:    "option with assignment",
+			fluxSrc: `option o = "hello"`,
+			types: map[string]string{
+				"o": "forall [] string",
+			},
+		},
+		{
+			name:    "option with member assignment error",
+			fluxSrc: `option o.m = "hello"`,
+			err:     errors.New("undeclared variable o"),
+		},
+		{
+			name: "option with member assignment",
+			fluxSrc: `
+                import "influxdata/influxdb/monitor"
+                option monitor.log = (tables=<-) => tables`,
+		},
+		{
+			name:    "builtin statement",
+			fluxSrc: `builtin foo`,
+			err:     errors.New("builtin identifier foo not defined"),
+		},
+		{
+			name: "test statement",
+			fluxSrc: `
+                import "testing"
+                test t = () => ({input: testing.loadStorage(csv: ""), want: testing.loadMem(csv: ""), fn: (table=<-) => table})`,
+			types: map[string]string{
+				"t": "forall [t0, t1, t2] where t1: Row, t2: Row () -> {fn: (<-table: t0) -> t0 | input: [t2] | want: [t1]}",
+			},
+		},
+		{
+			name:    "expression statement",
+			fluxSrc: `42`,
+		},
+		{
+			name:    "native variable assignment",
 			fluxSrc: `x = 42`,
 			types: map[string]string{
 				"x": "forall [] int",
+			},
+		},
+		{
+			name: "string expression",
+			fluxSrc: `
+                str = "hello"
+                x = "${str} world"`,
+			types: map[string]string{
+				"str": "forall [] string",
+				"x":   "forall [] string",
+			},
+		},
+		{
+			name: "array expression/index expression",
+			fluxSrc: `
+                x = [1, 2, 3]
+                y = x[2]`,
+			types: map[string]string{
+				"x": "forall [] [int]",
+				"y": "forall [] int",
+			},
+		},
+		{
+			name:    "simple fn",
+			fluxSrc: `f = (x) => x`,
+			types: map[string]string{
+				"f": "forall [t0] (x: t0) -> t0",
+			},
+		},
+		{
+			name:    "simple fn with block (return statement)",
+			fluxSrc: `f = (x) => {return x}`,
+			types: map[string]string{
+				"f": "forall [t0] (x: t0) -> t0",
+			},
+		},
+		{
+			name: "simple fn with 2 stmts",
+			fluxSrc: `
+                f = (x) => {
+                    z = x + 1
+                    127 // expr statement
+                    return z
+                }`,
+			types: map[string]string{
+				"f": "forall [] (x: int) -> int",
+				"z": "forall [] int",
+			},
+		},
+		{
+			name:    "simple fn with 2 params",
+			fluxSrc: `f = (x, y) => x + y`,
+			types: map[string]string{
+				"f": "forall [t0] where t0: Addable (x: t0, y: t0) -> t0",
+			},
+		},
+		{
+			name:    "apply",
+			fluxSrc: `apply = (f, p) => f(param: p)`,
+			types: map[string]string{
+				"apply": "forall [t0, t1] (f: (param: t0) -> t1, p: t0) -> t1",
+			},
+		},
+		{
+			name:    "apply2",
+			fluxSrc: `apply2 = (f, p0, p1) => f(param0: p0, param1: p1)`,
+			types: map[string]string{
+				"apply2": "forall [t0, t1, t2] (f: (param0: t0, param1: t1) -> t2, p0: t0, p1: t1) -> t2",
+			},
+		},
+		{
+			name:    "default args",
+			fluxSrc: `f = (x=1, y) => x + y`,
+			types: map[string]string{
+				"f": "forall [] (?x: int, y: int) -> int",
+			},
+		},
+		{
+			name:    "two default args",
+			fluxSrc: `f = (x=1, y=10, z) => x + y + z`,
+			types: map[string]string{
+				"f": "forall [] (?x: int, ?y: int, z: int) -> int",
+			},
+		},
+		{
+			name:    "pipe args",
+			fluxSrc: `f = (x=<-, y) => x + y`,
+			types: map[string]string{
+				"f": "forall [t0] where t0: Addable (<-x: t0, y: t0) -> t0",
+			},
+		},
+		{
+			name: "binary expression",
+			fluxSrc: `
+                x = 1 * 2 / 3 - 1 + 7 % 8^9
+                lt = 1 < 3                
+                lte = 1 <= 3                
+                gt = 1 > 3                
+                gte = 1 >= 3                
+                eq = 1 == 3                
+                neq = 1 != 3
+                rem = "foo" =~ /foo/
+                renm = "food" !~ /foog/`,
+			types: map[string]string{
+				"x":    "forall [] int",
+				"lt":   "forall [] bool",
+				"lte":  "forall [] bool",
+				"gt":   "forall [] bool",
+				"gte":  "forall [] bool",
+				"eq":   "forall [] bool",
+				"neq":  "forall [] bool",
+				"rem":  "forall [] bool",
+				"renm": "forall [] bool",
+			},
+		},
+		{
+			name: "call expression",
+			fluxSrc: `
+                f = (x) => x + 1
+                y = f(x: 10)`,
+			types: map[string]string{
+				"f": "forall [] (x: int) -> int",
+				"y": "forall [] int",
+			},
+		},
+		{
+			name: "call expression two args",
+			fluxSrc: `
+                f = (x, y) => x + y
+                y = f(x: 10, y: 30)`,
+			types: map[string]string{
+				"f": "forall [t0] where t0: Addable (x: t0, y: t0) -> t0",
+				"y": "forall [] int",
+			},
+		},
+		{
+			name: "call expression two args with pipe",
+			fluxSrc: `
+                f = (x, y=<-) => x + y
+                y = 30 |> f(x: 10)`,
+			types: map[string]string{
+				"f": "forall [t0] where t0: Addable (x: t0, <-y: t0) -> t0",
+				"y": "forall [] int",
+			},
+		},
+		{
+			name: "conditional expression",
+			fluxSrc: `
+                ans = if 100 > 0 then "yes" else "no"`,
+			types: map[string]string{
+				"ans": "forall [] string",
+			},
+		},
+		{
+			name: "identifier expression",
+			fluxSrc: `
+                x = 34
+                y = x`,
+			types: map[string]string{
+				"x": "forall [] int",
+				"y": "forall [] int",
+			},
+		},
+		{
+			name:    "logical expression",
+			fluxSrc: `x = true and false or true`,
+			types: map[string]string{
+				"x": "forall [] bool",
+			},
+		},
+		{
+			name: "member expression/object expression",
+			fluxSrc: `
+                o = {temp: 30.0, loc: "FL"}
+                t = o.temp`,
+			types: map[string]string{
+				"o": "forall [] {loc: string | temp: float}",
+				"t": "forall [] float",
+			},
+		},
+		{
+			name: "object expression with",
+			fluxSrc: `
+                o = {temp: 30.0, loc: "FL"}
+                o2 = {o with city: "Tampa"}`,
+			types: map[string]string{
+				"o":  "forall [] {loc: string | temp: float}",
+				"o2": "forall [] {city: string | loc: string | temp: float}",
+			},
+		},
+		{
+			name: "object expression extends",
+			fluxSrc: `
+                f = (r) => ({r with val: 32})
+                o = f(r: {val: "thirty-two"})`,
+			types: map[string]string{
+				"f": "forall [t0] (r: t0) -> {val: int | t0}",
+				"o": "forall [] {val: int | val: string}",
+			},
+		},
+		{
+			name: "unary expression",
+			fluxSrc: `
+                x = -1
+                y = +1
+                b = not false`,
+			types: map[string]string{
+				"x": "forall [] int",
+				"y": "forall [] int",
+				"b": "forall [] bool",
+			},
+		},
+		{
+			name:    "exists operator",
+			fluxSrc: `e = exists {foo: 30}.bar`,
+			err:     errors.New("cannot unify {{}} with {bar:t0 | t1}"),
+		},
+		{
+			name:    "exists operator with tvar",
+			fluxSrc: `f = (r) => exists r.foo`,
+			types: map[string]string{
+				"f": "forall [t0, t1] (r: {foo: t0 | t1}) -> bool",
+			},
+		},
+		{
+			// This seems to be a bug: https://github.com/influxdata/flux/issues/2355
+			name: "exists operator with tvar and call",
+			fluxSrc: `
+                f = (r) => exists r.foo
+                ff = (r) => f(r: {r with bar: 1})`,
+			types: map[string]string{
+				"f": "forall [t0, t1] (r: {foo: t0 | t1}) -> bool",
+				// Note: t1 is unused in the monotype, and t2 is not quantified.
+				// Type of ff should be the same as f.
+				"ff": "forall [t0, t1] (r: {foo: t0 | t2}) -> bool",
+			},
+		},
+		{
+			name:    "datetime literal",
+			fluxSrc: `t = 2018-08-15T13:36:23-07:00`,
+			types: map[string]string{
+				"t": "forall [] time",
+			},
+		},
+		{
+			name:    "duration literal",
+			fluxSrc: `d = 1y1mo1w1d1h1m1s1ms1us1ns`,
+			types: map[string]string{
+				"d": "forall [] duration",
+			},
+		},
+		{
+			name:    "negative duration literal",
+			fluxSrc: `d = -1y1d`,
+			types: map[string]string{
+				"d": "forall [] duration",
+			},
+		},
+		{
+			name:    "zero duration literal",
+			fluxSrc: `d = 0d`,
+			types: map[string]string{
+				"d": "forall [] duration",
 			},
 		},
 	}
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := AnalyzeSource(tc.fluxSrc)
-			if err != nil {
-				t.Fatal(err)
-			}
-
+			t.Parallel()
 			astPkg := parser.ParseSource(tc.fluxSrc)
 			want, err := New(astPkg)
 			if err != nil {
 				t.Fatal(err)
+			}
+			if err := transformGraph(want); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := AnalyzeSource(tc.fluxSrc)
+			if err != nil {
+				if tc.err == nil {
+					t.Fatal(err)
+				}
+				if want, got := tc.err.Error(), canonicalizeError(err.Error()); want != got {
+					t.Fatalf("expected error %q, but got %q", want, got)
+				}
+				return
+			}
+			if tc.err != nil {
+				t.Fatalf("expected error %q, but got nothing", tc.err)
 			}
 
 			// Create a special comparison option to compare the types
@@ -483,7 +965,7 @@ func TestRoundTrip(t *testing.T) {
 					}
 				} else {
 					// This is the assignment from Rust.
-					typStr = nva.Typ.String()
+					typStr = canonicalizeType(nva.Typ)
 				}
 				return &MyAssignement{
 					loc:        nva.loc,

--- a/semantic/types/polytype.go
+++ b/semantic/types/polytype.go
@@ -140,7 +140,6 @@ func (pt *PolyType) String() string {
 
 		if needWhere {
 			sb.WriteString("where ")
-		} else {
 			needWhere = false
 		}
 		mtv := monoTypeFromVar(tv)
@@ -162,4 +161,31 @@ func (pt *PolyType) String() string {
 	sb.WriteString(mt.String())
 
 	return sb.String()
+}
+
+// GetCanonicalMapping returns a map of type variable numbers to
+// canonicalized numbers that start from 0.
+// Tests that do type inference will have type variables that are sensitive
+// to changes in the standard library, this helps to solve that problem.
+func (pt *PolyType) GetCanonicalMapping() (map[uint64]int, error) {
+	tvm := make(map[uint64]int)
+	counter := 0
+
+	svars, err := pt.SortedVars()
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range svars {
+		updateTVarMap(&counter, tvm, v.I())
+	}
+
+	mt, err := pt.Expr()
+	if err != nil {
+		return nil, err
+	}
+	if err := mt.getCanonicalMapping(&counter, tvm); err != nil {
+		return nil, err
+	}
+
+	return tvm, nil
 }


### PR DESCRIPTION
This PR adds roundtrip testing for FlatBuffers serialization of the semantic graph, and also fixes some issues that I found while writing these tests.

I also added some utilities that help with reindexing type variables starting from zero so that changes in the standard lib or the order that that expressions are analyzed do not make the test fail.