### PR TITLE
refactor(libflux/semantic): remove convert() method that doesn't take a fresher

### DIFF
--- a/libflux/src/flux/semantic/convert.rs
+++ b/libflux/src/flux/semantic/convert.rs
@@ -7,7 +7,8 @@ use std::result;
 pub type SemanticError = String;
 pub type Result<T> = result::Result<T, SemanticError>;
 
-/// convert converts an AST package node to its semantic representation.
+/// convert_with converts an AST package node to its semantic representation using
+/// the provided fresher.
 ///
 /// Note: most external callers of this function will want to use the analyze()
 /// function in the libstd crate instead, which is aware of everything in the Flux stdlib and prelude.
@@ -17,11 +18,6 @@ pub type Result<T> = result::Result<T, SemanticError>;
 /// to the previous one. In other terms, once one converts an AST he should not use it anymore.
 /// If one wants to do so, he should explicitly pkg.clone() and incur consciously in the memory
 /// overhead involved.
-pub fn convert(pkg: ast::Package) -> Result<Package> {
-    convert_with(pkg, &mut Fresher::default())
-}
-
-// convert_with runs convert using the provided Fresher.
 pub fn convert_with(pkg: ast::Package, fresher: &mut Fresher) -> Result<Package> {
     convert_package(pkg, fresher)
     // TODO(affo): run checks on the semantic graph.
@@ -588,6 +584,7 @@ fn convert_date_time_literal(lit: ast::DateTimeLit, fresher: &mut Fresher) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::semantic::fresh;
     use crate::semantic::types::{MonoType, Tvar};
     use pretty_assertions::assert_eq;
 
@@ -598,7 +595,7 @@ mod tests {
     }
 
     fn test_convert(pkg: ast::Package) -> Result<Package> {
-        convert(pkg)
+        convert_with(pkg, &mut fresh::Fresher::default())
     }
 
     #[test]

--- a/libflux/src/flux/semantic/flatbuffers/tests.rs
+++ b/libflux/src/flux/semantic/flatbuffers/tests.rs
@@ -5,6 +5,7 @@ use super::semantic_generated::fbsemantic;
 use crate::ast;
 use crate::semantic;
 use crate::semantic::convert;
+use crate::semantic::fresh;
 use chrono::FixedOffset;
 
 #[test]
@@ -84,7 +85,7 @@ re !~ /foo/
         package: String::from("test"),
         files: f,
     };
-    let mut pkg = match convert::convert(pkg) {
+    let mut pkg = match convert::convert_with(pkg, &mut fresh::Fresher::default()) {
         Ok(pkg) => pkg,
         Err(e) => {
             assert!(false, e);

--- a/libflux/src/flux/semantic/walk/test_utils.rs
+++ b/libflux/src/flux/semantic/walk/test_utils.rs
@@ -1,6 +1,7 @@
 use crate::ast;
 use crate::parser::parse_string;
 use crate::semantic::convert;
+use crate::semantic::fresh::Fresher;
 use crate::semantic::nodes;
 
 pub fn compile(source: &str) -> nodes::Package {
@@ -15,5 +16,5 @@ pub fn compile(source: &str) -> nodes::Package {
         package: "main".to_string(),
         files: vec![file],
     };
-    convert::convert(ast_pkg).unwrap()
+    convert::convert_with(ast_pkg, &mut Fresher::default()).unwrap()
 }


### PR DESCRIPTION
The 0-argument method `convert()` uses a default fresher that starts from 0,
but that is generally not what most callers want, outside of special cases
like bootstrapping the standard library and testing.

If one tries to type-infer a flux program with the wrong fresher, strange
behavior can result.  This commit removes this method to make it more
difficult to make such a mistake.
