### PR TITLE
fix(libflux): allow uint to be subtractable

### DIFF
--- a/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
+++ b/libflux/src/flux/semantic/flatbuffers/semantic_generated.rs
@@ -164,7 +164,7 @@ pub mod fbsemantic {
         Equatable = 5,
         Nullable = 6,
         Row = 7,
-        Signed = 8,
+        Negatable = 8,
     }
 
     const ENUM_MIN_KIND: u8 = 0;
@@ -211,7 +211,7 @@ pub mod fbsemantic {
         Kind::Equatable,
         Kind::Nullable,
         Kind::Row,
-        Kind::Signed,
+        Kind::Negatable,
     ];
 
     #[allow(non_camel_case_types)]
@@ -224,7 +224,7 @@ pub mod fbsemantic {
         "Equatable",
         "Nullable",
         "Row",
-        "Signed",
+        "Negatable",
     ];
 
     pub fn enum_name_kind(e: Kind) -> &'static str {

--- a/libflux/src/flux/semantic/flatbuffers/types.rs
+++ b/libflux/src/flux/semantic/flatbuffers/types.rs
@@ -87,7 +87,7 @@ impl From<fb::Kind> for Kind {
             fb::Kind::Equatable => Kind::Equatable,
             fb::Kind::Nullable => Kind::Nullable,
             fb::Kind::Row => Kind::Row,
-            fb::Kind::Signed => Kind::Signed,
+            fb::Kind::Negatable => Kind::Negatable,
         }
     }
 }
@@ -103,7 +103,7 @@ impl From<Kind> for fb::Kind {
             Kind::Equatable => fb::Kind::Equatable,
             Kind::Nullable => fb::Kind::Nullable,
             Kind::Row => fb::Kind::Row,
-            Kind::Signed => fb::Kind::Signed,
+            Kind::Negatable => fb::Kind::Negatable,
         }
     }
 }

--- a/libflux/src/flux/semantic/nodes.rs
+++ b/libflux/src/flux/semantic/nodes.rs
@@ -1338,7 +1338,7 @@ impl UnaryExpr {
             ast::Operator::AdditionOperator | ast::Operator::SubtractionOperator => {
                 Constraints::from(vec![
                     Constraint::Equal(self.argument.type_of().clone(), self.typ.clone()),
-                    Constraint::Kind(self.argument.type_of().clone(), Kind::Signed),
+                    Constraint::Kind(self.argument.type_of().clone(), Kind::Negatable),
                 ])
             }
             _ => return Err(Error::unsupported_unary_operator(&self.operator)),

--- a/libflux/src/flux/semantic/tests.rs
+++ b/libflux/src/flux/semantic/tests.rs
@@ -841,14 +841,17 @@ fn binary_expr_subtraction() {
             a - b
         "#,
     }
-    test_infer_err! {
+    test_infer! {
         env: map![
             "a" => "forall [] uint",
             "b" => "forall [] uint",
         ],
         src: r#"
-            a - b
+            c = a - b
         "#,
+        exp: map![
+            "c" => "forall [] uint",
+        ],
     }
     test_infer_err! {
         env: map![
@@ -2199,11 +2202,14 @@ fn unary_add() {
         ],
         src: "+a",
     }
-    test_infer_err! {
+    test_infer! {
         env: map![
             "a" => "forall [] uint",
         ],
-        src: "+a",
+        src: "b = +a",
+        exp: map![
+            "b" => "forall [] uint",
+        ],
     }
     test_infer_err! {
         env: map![
@@ -2271,11 +2277,14 @@ fn unary_sub() {
         ],
         src: "-a",
     }
-    test_infer_err! {
+    test_infer! {
         env: map![
             "a" => "forall [] uint",
         ],
-        src: "-a",
+        src: "b = -a",
+        exp: map![
+            "b" => "forall [] uint",
+        ],
     }
     test_infer_err! {
         env: map![

--- a/libflux/src/flux/semantic/types.rs
+++ b/libflux/src/flux/semantic/types.rs
@@ -174,7 +174,7 @@ pub enum Kind {
     Equatable,
     Nullable,
     Row,
-    Signed,
+    Negatable,
 }
 
 impl fmt::Display for Kind {
@@ -188,7 +188,7 @@ impl fmt::Display for Kind {
             Kind::Equatable => f.write_str("Equatable"),
             Kind::Nullable => f.write_str("Nullable"),
             Kind::Row => f.write_str("Row"),
-            Kind::Signed => f.write_str("Signed"),
+            Kind::Negatable => f.write_str("Negatable"),
         }
     }
 }
@@ -351,16 +351,18 @@ impl MonoType {
                 | Kind::Comparable
                 | Kind::Equatable
                 | Kind::Nullable
-                | Kind::Signed => Ok(Substitution::empty()),
+                | Kind::Negatable => Ok(Substitution::empty()),
                 _ => Err(Error::cannot_constrain(&self, with)),
             },
             MonoType::Uint => match with {
                 Kind::Addable
+                | Kind::Subtractable
                 | Kind::Divisible
                 | Kind::Numeric
                 | Kind::Comparable
                 | Kind::Equatable
-                | Kind::Nullable => Ok(Substitution::empty()),
+                | Kind::Nullable
+                | Kind::Negatable => Ok(Substitution::empty()),
                 _ => Err(Error::cannot_constrain(&self, with)),
             },
             MonoType::Float => match with {
@@ -371,7 +373,7 @@ impl MonoType {
                 | Kind::Comparable
                 | Kind::Equatable
                 | Kind::Nullable
-                | Kind::Signed => Ok(Substitution::empty()),
+                | Kind::Negatable => Ok(Substitution::empty()),
                 _ => Err(Error::cannot_constrain(&self, with)),
             },
             MonoType::String => match with {
@@ -381,7 +383,7 @@ impl MonoType {
                 _ => Err(Error::cannot_constrain(&self, with)),
             },
             MonoType::Duration => match with {
-                Kind::Comparable | Kind::Equatable | Kind::Nullable | Kind::Signed => {
+                Kind::Comparable | Kind::Equatable | Kind::Nullable | Kind::Negatable => {
                     Ok(Substitution::empty())
                 }
                 _ => Err(Error::cannot_constrain(&self, with)),

--- a/semantic/internal/fbsemantic/Kind.go
+++ b/semantic/internal/fbsemantic/Kind.go
@@ -13,7 +13,7 @@ const (
 	KindEquatable    Kind = 5
 	KindNullable     Kind = 6
 	KindRow          Kind = 7
-	KindSigned       Kind = 8
+	KindNegatable    Kind = 8
 )
 
 var EnumNamesKind = map[Kind]string{
@@ -25,5 +25,5 @@ var EnumNamesKind = map[Kind]string{
 	KindEquatable:    "Equatable",
 	KindNullable:     "Nullable",
 	KindRow:          "Row",
-	KindSigned:       "Signed",
+	KindNegatable:    "Negatable",
 }

--- a/semantic/semantic.fbs
+++ b/semantic/semantic.fbs
@@ -88,7 +88,7 @@ enum Kind : ubyte {
   Equatable,
   Nullable,
   Row,
-  Signed,
+  Negatable,
 }
 
 table Constraint {


### PR DESCRIPTION
This patch enables uints to be subtractable, both as a binary expression
and as a unary expression.

Fixes #2242