### PR TITLE
fix(libflux): handle invalid string literals

### DIFF
--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -1111,10 +1111,18 @@ impl Parser {
     }
     fn parse_string_literal(&mut self) -> StringLit {
         let t = self.expect(TOK_STRING);
-        let value = strconv::parse_string(t.lit.as_str()).unwrap();
-        StringLit {
-            base: self.base_node_from_token(&t),
-            value,
+        match strconv::parse_string(t.lit.as_str()) {
+            Ok(value) => StringLit {
+                base: self.base_node_from_token(&t),
+                value,
+            },
+            Err(err) => {
+                self.errs.push(err);
+                StringLit {
+                    base: self.base_node_from_token(&t),
+                    value: "".to_string(),
+                }
+            }
         }
     }
     fn parse_regexp_literal(&mut self) -> RegexpLit {

--- a/libflux/src/flux/parser/tests.rs
+++ b/libflux/src/flux/parser/tests.rs
@@ -2,9 +2,6 @@ use super::*;
 use crate::ast;
 
 use chrono;
-
-// This gives us a colorful diff.
-#[cfg(test)]
 use pretty_assertions::assert_eq;
 
 struct Locator<'a> {
@@ -10964,4 +10961,28 @@ fn integer_literal_overflow() {
             })]
         },
     )
+}
+
+#[test]
+fn parse_string_literal() {
+    let errors: Vec<String> = vec![];
+
+    let mut p = Parser::new(r#""Hello world""#);
+    let result = p.parse_string_literal();
+    assert_eq!("Hello world".to_string(), result.value);
+    assert_eq!(errors, result.base.errors);
+}
+
+#[test]
+fn parse_string_literal_invalid_string() {
+    let errors = vec![
+        "expected STRING, got QUOTE (\") at 1:1",
+        "expected STRING, got EOF",
+        "invalid string literal",
+    ];
+
+    let mut p = Parser::new(r#"""#);
+    let result = p.parse_string_literal();
+    assert_eq!("".to_string(), result.value);
+    assert_eq!(errors, result.base.errors);
 }


### PR DESCRIPTION
This patch addresses a panic discovered when an unclosed string literal
is passed to the parser.

Fixes #2375