### PR TITLE
fix(semantic): optimize lookup function using hashmap

### DIFF
--- a/semantic/lookup.go
+++ b/semantic/lookup.go
@@ -1,6 +1,7 @@
 package semantic
 
 import (
+	"fmt"
 	flatbuffers "github.com/google/flatbuffers/go"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
@@ -8,19 +9,16 @@ import (
 	"github.com/influxdata/flux/semantic/internal/fbsemantic"
 )
 
+var stdlibTypeEnvironment = TypeEnvMap(fbsemantic.GetRootAsTypeEnvironment(libflux.EnvStdlib(), 0))
+
 // LookupBuiltInType returns the type of the builtin value for a given
-// Flux stdlib package. Returns a empty MonoType if lookup fails.
+// Flux stdlib package. Returns an error if lookup fails.
 func LookupBuiltInType(pkg, name string) (MonoType, error) {
-	byteArr := libflux.EnvStdlib()
-	env := fbsemantic.GetRootAsTypeEnvironment(byteArr, 0)
 	var table flatbuffers.Table
-	// perform a lookup of package identifier in flatbuffers TypeEnvironment
-	prop, err := lookup(env, pkg, name)
-	if err != nil {
-		return MonoType{}, err
-	}
+	prop := stdlibTypeEnvironment[pkg][name] // query environment map for prop
+
 	if !prop.V(&table) {
-		return MonoType{}, errors.Newf(codes.Internal, "Prop value is not valid: %v", err)
+		return MonoType{}, errors.Newf(codes.Internal, "Prop value is not valid: pkg %v name %v", pkg, name)
 	}
 	monotype, err := NewMonoType(table, prop.VType())
 	if err != nil {
@@ -30,70 +28,40 @@ func LookupBuiltInType(pkg, name string) (MonoType, error) {
 	return monotype, nil
 }
 
-// lookup is a helper function that performs a lookup of a package identifier in
-// a flatbuffers TypeEnvironment. It first checks for the package using path string
-// and then checks for the package identifier, the "name" string in this case, returning
-// the corresponding MonoType if found
-func lookup(env *fbsemantic.TypeEnvironment, pkg, name string) (*fbsemantic.Prop, error) {
-	// Find package
-	typeAssign := new(fbsemantic.TypeAssignment)
-	if pkgErr := foundPackage(env, typeAssign, pkg); pkgErr != nil {
-		return nil, pkgErr
-	}
-
-	// Grab PolyType expr; expr should always be of type MonoTypeRow
-	polytype := typeAssign.Ty(nil)
-	if polytype.ExprType() != fbsemantic.MonoTypeRow {
-		return nil, errors.Newf(
-			codes.Internal,
-			"Expected PolyType expr to be fbsemantic.MonoTypeRow; found %v",
-			polytype.ExprType(),
-		)
-	}
+func TypeEnvMap(env *fbsemantic.TypeEnvironment) map[string]map[string]*fbsemantic.Prop {
+	envMap := make(map[string]map[string]*fbsemantic.Prop)
 	var table flatbuffers.Table
-	if !polytype.Expr(&table) {
-		return nil, errors.New(codes.Internal, "PolyType expr is not valid")
-	}
-
-	// check for package identifier in Row Props
-	row := new(fbsemantic.Row)
-	row.Init(table.Bytes, table.Pos)
-	prop := new(fbsemantic.Prop)
-	if propErr := foundProp(row, prop, name); propErr != nil {
-		return nil, propErr
-	}
-
-	return prop, nil
-}
-
-// foundPackage is a helper function that iterates over type assignments and checks
-// for a given package returning an error if the package is not found
-func foundPackage(env *fbsemantic.TypeEnvironment, obj *fbsemantic.TypeAssignment, pkg string) error {
 	l := env.AssignmentsLength()
-	for i := 0; i < l; i++ {
-		if !env.Assignments(obj, i) {
-			return errors.Newf(codes.Internal, "package %v not found; last position %v", pkg, i)
-		} else {
-			if string(obj.Id()) == pkg {
-				return nil
-			}
-		}
-	}
-	return errors.Newf(codes.Internal, "package not found %v", pkg)
-}
 
-// foundProp is a helper function that iterates over row properties and checks
-// for a given package identifier, returning an error if the identifier is not found
-func foundProp(row *fbsemantic.Row, obj *fbsemantic.Prop, name string) error {
-	l := row.PropsLength()
 	for i := 0; i < l; i++ {
-		if !row.Props(obj, i) {
-			return errors.Newf(codes.Internal, "package identifier %v not found; last position %v", name, i)
-		} else {
-			if string(obj.K()) == name {
-				return nil
-			}
+		newAssign := new(fbsemantic.TypeAssignment)
+		_ = env.Assignments(newAssign, i) // this call assigns a value to newAssign
+		assignId := string(newAssign.Id())
+		polytype := newAssign.Ty(nil)
+		if polytype.ExprType() != fbsemantic.MonoTypeRow {
+			panic(fmt.Errorf(
+				"Expected PolyType Expr of %v to be fbsemantic.MonoTypeRow; found fbsemantic.%v",
+				assignId,
+				fbsemantic.EnumNamesMonoType[polytype.ExprType()],
+			))
 		}
+		if !polytype.Expr(&table) {
+			panic(fmt.Errorf("PolyType does not have a MonoType; something went wrong %v", string(polytype.ExprType())))
+		}
+
+		// initialize table before use in row
+		row := new(fbsemantic.Row)
+		row.Init(table.Bytes, table.Pos)
+		propLen := row.PropsLength()
+		propMap := make(map[string]*fbsemantic.Prop)
+
+		for j := 0; j < propLen; j++ {
+			newProp := new(fbsemantic.Prop)
+			_ = row.Props(newProp, j) // this call assigns value to newProp
+			propKey := string(newProp.K())
+			propMap[propKey] = newProp
+		}
+		envMap[assignId] = propMap
 	}
-	return errors.Newf(codes.Internal, "package identifier not found %v", name)
+	return envMap
 }

--- a/semantic/lookup_test.go
+++ b/semantic/lookup_test.go
@@ -49,55 +49,55 @@ func TestLookupComplexTypes(t *testing.T) {
 			path: "date",
 			id:   "nanosecond",
 			name: "lookup date.nanosecond",
-			want: "(t: time) -> int", 
-		}, 
+			want: "(t: time) -> int",
+		},
 		{
 			path: "date",
 			id:   "truncate",
 			name: "lookup date.truncate",
-			want: "(t: time, unit: duration) -> time", 
+			want: "(t: time, unit: duration) -> time",
 		},
 		{
 			path: "experimental/bigtable",
 			id:   "from",
 			name: "lookup experimental/bigtable.from",
-			want: "(instance: string, project: string, table: string, token: string) -> [t0]", 
+			want: "(instance: string, project: string, table: string, token: string) -> [t0]",
 		},
 		{
 			path: "experimental",
 			id:   "to",
 			name: "lookup experimental.to",
-			want: "(?bucket: string, ?bucketID: string, ?host: string, ?org: string, ?orgID: string, <-tables: [t0], ?token: string) -> [t0]", 
+			want: "(?bucket: string, ?bucketID: string, ?host: string, ?org: string, ?orgID: string, <-tables: [t0], ?token: string) -> [t0]",
 		},
 		{
 			path: "http",
 			id:   "post",
 			name: "lookup http.post",
-			want: "(?data: bytes, ?headers: t0, url: string) -> int", 
+			want: "(?data: bytes, ?headers: t0, url: string) -> int",
 		},
 		{
 			path: "influxdata/influxdb/secrets",
 			id:   "get",
 			name: "lookup influxdata/influxdb/secrets.get",
-			want: "(key: string) -> string", 
+			want: "(key: string) -> string",
 		},
 		{
 			path: "json",
 			id:   "encode",
 			name: "lookup json.encode",
-			want: "(v: t0) -> bytes", 
+			want: "(v: t0) -> bytes",
 		},
 		{
 			path: "strings",
 			id:   "title",
 			name: "lookup strings.title",
-			want: "(v: string) -> string", 
+			want: "(v: string) -> string",
 		},
 		{
 			path: "system",
 			id:   "time",
 			name: "lookup system.time",
-			want: "() -> time", 
+			want: "() -> time",
 		},
 		{
 			path: "universe",
@@ -109,7 +109,7 @@ func TestLookupComplexTypes(t *testing.T) {
 			path: "internal/promql",
 			id:   "changes",
 			name: "lookup internal/promql.changes",
-			want: "(<-tables: [{_value: float | t0}]) -> [{_value: float | t1}]", 
+			want: "(<-tables: [{_value: float | t0}]) -> [{_value: float | t1}]",
 		},
 		{
 			path: "sql",
@@ -152,7 +152,7 @@ var tvarRegexp *regexp.Regexp = regexp.MustCompile("t[0-9]+")
 // that reindexes in the numbers in type variables starting from zero.
 func canonicalizeType(mt semantic.MonoType) string {
 	counter := 0
-	tvm := make(map[uint64]int) 
+	tvm := make(map[uint64]int)
 	err := mt.GetCanonicalMapping(&counter, tvm)
 
 	if err != nil {


### PR DESCRIPTION
`LookUpBuiltinType` was creating the entire TypeEnvironment and using linear search for every single lookup. This attempts to create the TypeEnvironment once and store it in a map. Then `LookUpBuiltinType` can be called for every stdlib builtin that needs to be looked up. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
