### PR TITLE
fix(semantic): require successful lookup of stdlib builtins or panic

### DIFF
--- a/semantic/lookup_test.go
+++ b/semantic/lookup_test.go
@@ -20,7 +20,7 @@ func TestLookupSimpleTypes(t *testing.T) {
 		{path: "math", id: "maxint", name: "lookup math.maxint", want: "int"},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			got, _ := semantic.LookupBuiltInType(testCase.path, testCase.id)
+			got, _ := semantic.LookupBuiltinType(testCase.path, testCase.id)
 			if want, got := testCase.want, got.String(); want != got {
 				t.Fatalf("unexpected result -want/+got\n\t- %s\n\t+ %s", want, got)
 			}
@@ -138,7 +138,7 @@ func TestLookupComplexTypes(t *testing.T) {
 	} {
 
 		t.Run(testCase.name, func(t *testing.T) {
-			got, _ := semantic.LookupBuiltInType(testCase.path, testCase.id)
+			got, _ := semantic.LookupBuiltinType(testCase.path, testCase.id)
 			if want, got := testCase.want, canonicalizeType(got); want != got {
 				t.Fatalf("unexpected result -want/+got\n\t- %s\n\t+ %s", want, got)
 			}

--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const FromCSVKind = "fromCSV"
@@ -22,7 +23,7 @@ type FromCSVOpSpec struct {
 }
 
 func init() {
-	fromCSVSignature := semantic.LookupBuiltInType("csv", "from")
+	fromCSVSignature := semantic.MustLookupBuiltinType("csv", "from")
 	flux.RegisterPackageValue("csv", "from", flux.MustValue(flux.FunctionValue(FromCSVKind, createFromCSVOpSpec, fromCSVSignature)))
 	flux.RegisterOpSpec(FromCSVKind, newFromCSVOp)
 	plan.RegisterProcedureSpec(FromCSVKind, newFromCSVProcedure, FromCSVKind)

--- a/stdlib/date/date.go
+++ b/stdlib/date/date.go
@@ -20,7 +20,7 @@ func init() {
 	SpecialFns = map[string]values.Function{
 		"second": values.NewFunction(
 			"second",
-			semantic.LookupBuiltInType("date", "second"),
+			semantic.MustLookupBuiltinType("date", "second"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -35,7 +35,7 @@ func init() {
 		),
 		"minute": values.NewFunction(
 			"minute",
-			semantic.LookupBuiltInType("date", "minute"),
+			semantic.MustLookupBuiltinType("date", "minute"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -50,7 +50,7 @@ func init() {
 		),
 		"hour": values.NewFunction(
 			"hour",
-			semantic.LookupBuiltInType("date", "hour"),
+			semantic.MustLookupBuiltinType("date", "hour"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -65,7 +65,7 @@ func init() {
 		),
 		"weekDay": values.NewFunction(
 			"weekDay",
-			semantic.LookupBuiltInType("date", "weekDay"),
+			semantic.MustLookupBuiltinType("date", "weekDay"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -80,7 +80,7 @@ func init() {
 		),
 		"monthDay": values.NewFunction(
 			"monthDay",
-			semantic.LookupBuiltInType("date", "monthDay"),
+			semantic.MustLookupBuiltinType("date", "monthDay"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -95,7 +95,7 @@ func init() {
 		),
 		"yearDay": values.NewFunction(
 			"yearDay",
-			semantic.LookupBuiltInType("date", "yearDay"),
+			semantic.MustLookupBuiltinType("date", "yearDay"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -110,7 +110,7 @@ func init() {
 		),
 		"month": values.NewFunction(
 			"month",
-			semantic.LookupBuiltInType("date", "month"),
+			semantic.MustLookupBuiltinType("date", "month"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -125,7 +125,7 @@ func init() {
 		),
 		"year": values.NewFunction(
 			"year",
-			semantic.LookupBuiltInType("date", "year"),
+			semantic.MustLookupBuiltinType("date", "year"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -140,7 +140,7 @@ func init() {
 		),
 		"week": values.NewFunction(
 			"week",
-			semantic.LookupBuiltInType("date", "week"),
+			semantic.MustLookupBuiltinType("date", "week"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -156,7 +156,7 @@ func init() {
 		),
 		"quarter": values.NewFunction(
 			"quarter",
-			semantic.LookupBuiltInType("date", "quarter"),
+			semantic.MustLookupBuiltinType("date", "quarter"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -172,7 +172,7 @@ func init() {
 		),
 		"millisecond": values.NewFunction(
 			"millisecond",
-			semantic.LookupBuiltInType("date", "millisecond"),
+			semantic.MustLookupBuiltinType("date", "millisecond"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -188,7 +188,7 @@ func init() {
 		),
 		"microsecond": values.NewFunction(
 			"microsecond",
-			semantic.LookupBuiltInType("date", "microsecond"),
+			semantic.MustLookupBuiltinType("date", "microsecond"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -204,7 +204,7 @@ func init() {
 		),
 		"nanosecond": values.NewFunction(
 			"nanosecond",
-			semantic.LookupBuiltInType("date", "nanosecond"),
+			semantic.MustLookupBuiltinType("date", "nanosecond"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("t")
 				if !ok {
@@ -219,7 +219,7 @@ func init() {
 		),
 		"truncate": values.NewFunction(
 			"truncate",
-			semantic.LookupBuiltInType("date", "truncate"),
+			semantic.MustLookupBuiltinType("date", "truncate"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("t")
 				if !ok {

--- a/stdlib/experimental/bigtable/from.go
+++ b/stdlib/experimental/bigtable/from.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 	"google.golang.org/api/option"
@@ -23,7 +24,7 @@ type FromBigtableOpSpec struct {
 }
 
 func init() {
-	fromBigtableSignature := semantic.LookupBuiltInType("experimental/bigtable", "from")
+	fromBigtableSignature := semantic.MustLookupBuiltinType("experimental/bigtable", "from")
 	flux.RegisterPackageValue("experimental/bigtable", "from", flux.MustValue(flux.FunctionValue(FromBigtableKind, createFromBigtableOpSpec, fromBigtableSignature)))
 	flux.RegisterOpSpec(FromBigtableKind, newFromBigtableOp)
 	plan.RegisterProcedureSpec(FromBigtableKind, newFromBigtableProcedure, FromBigtableKind)

--- a/stdlib/experimental/durations.go
+++ b/stdlib/experimental/durations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -19,7 +20,7 @@ func init() {
 }
 
 func addDuration(name string) values.Value {
-	tp := semantic.LookupBuiltInType("experimental", "addDuration")
+	tp := semantic.MustLookupBuiltinType("experimental", "addDuration")
 	fn := func(ctx context.Context, args values.Object) (values.Value, error) {
 		d, ok := args.Get("d")
 		if !ok {
@@ -35,7 +36,7 @@ func addDuration(name string) values.Value {
 }
 
 func subDuration(name string) values.Value {
-	tp := semantic.LookupBuiltInType("experimental", "subDuration")
+	tp := semantic.MustLookupBuiltinType("experimental", "subDuration")
 	fn := func(ctx context.Context, args values.Object) (values.Value, error) {
 		d, ok := args.Get("d")
 		if !ok {

--- a/stdlib/experimental/group.go
+++ b/stdlib/experimental/group.go
@@ -30,7 +30,7 @@ type GroupOpSpec struct {
 }
 
 func init() {
-	groupSignature := semantic.LookupBuiltInType("experimental", "group")
+	groupSignature := semantic.MustLookupBuiltinType("experimental", "group")
 	flux.RegisterPackageValue("experimental", "group", flux.MustValue(flux.FunctionValue("group", createGroupOpSpec, groupSignature)))
 	flux.RegisterOpSpec(ExperimentalGroupKind, newGroupOp)
 	plan.RegisterProcedureSpec(ExperimentalGroupKind, newGroupProcedure, ExperimentalGroupKind)

--- a/stdlib/experimental/http/http_experimental.go
+++ b/stdlib/experimental/http/http_experimental.go
@@ -25,7 +25,7 @@ const maxResponseBody = 512 * 1024 // 512 KB
 // http get mirrors the http post originally completed for alerts & notifications
 var get = values.NewFunction(
 	"get",
-	semantic.LookupBuiltInType("experimental/http", "get"),
+	semantic.MustLookupBuiltinType("experimental/http", "get"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		// Get and validate URL
 		uV, ok := args.Get("url")

--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -26,7 +26,7 @@ const (
 )
 
 func init() {
-	toMQTTSignature := semantic.LookupBuiltInType("experimental/mqtt", "to")
+	toMQTTSignature := semantic.MustLookupBuiltinType("experimental/mqtt", "to")
 
 	flux.RegisterPackageValue("experimental/mqtt", "to", flux.MustValue(flux.FunctionValueWithSideEffect(ToMQTTKind, createToMQTTOpSpec, toMQTTSignature)))
 	flux.RegisterOpSpec(ToMQTTKind, func() flux.OperationSpec { return &ToMQTTOpSpec{} })

--- a/stdlib/experimental/object_keys.go
+++ b/stdlib/experimental/object_keys.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	flux.RegisterPackageValue("experimental", "objectKeys", values.NewFunction(
 		"objectKeys",
-		semantic.LookupBuiltInType("experimental", "objectKeys"),
+		semantic.MustLookupBuiltinType("experimental", "objectKeys"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			o, ok := args.Get("o")
 			if !ok {

--- a/stdlib/experimental/prometheus/scrape.go
+++ b/stdlib/experimental/prometheus/scrape.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 
 	// Prometheus packages
@@ -34,7 +35,7 @@ type ScrapePrometheusOpSpec struct {
 }
 
 func init() {
-	scrapePrometheusSignature := semantic.LookupBuiltInType("experimental/prometheus", "scrape")
+	scrapePrometheusSignature := semantic.MustLookupBuiltinType("experimental/prometheus", "scrape")
 	flux.RegisterPackageValue("experimental/prometheus", "scrape", flux.MustValue(flux.FunctionValue(ScrapePrometheusKind, createScrapePrometheusOpSpec, scrapePrometheusSignature)))
 	flux.RegisterOpSpec(ScrapePrometheusKind, newScrapePrometheusOp)
 	plan.RegisterProcedureSpec(ScrapePrometheusKind, newScrapePrometheusProcedure, ScrapePrometheusKind)

--- a/stdlib/experimental/set.go
+++ b/stdlib/experimental/set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -16,7 +17,7 @@ type SetOpSpec struct {
 }
 
 func init() {
-	setSignature := semantic.LookupBuiltInType("experimental", "set")
+	setSignature := semantic.MustLookupBuiltinType("experimental", "set")
 
 	flux.RegisterPackageValue("experimental", "set", flux.MustValue(flux.FunctionValue(SetKind, createSetOpSpec, setSignature)))
 	flux.RegisterOpSpec(SetKind, newSetOp)

--- a/stdlib/experimental/to.go
+++ b/stdlib/experimental/to.go
@@ -2,12 +2,13 @@ package experimental
 
 import (
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
 )
 
 // ToKind is the kind for the experimental `to` flux function
 const ExperimentalToKind = "experimental-to"
 
-var ToSignature = semantic.LookupBuiltInType("experimental", "to")
+var ToSignature = semantic.MustLookupBuiltinType("experimental", "to")
 
 func init() {
 	flux.RegisterPackageValue("experimental", "to", flux.MustValue(flux.FunctionValueWithSideEffect("to", nil, ToSignature)))

--- a/stdlib/generate/from.go
+++ b/stdlib/generate/from.go
@@ -25,7 +25,7 @@ type FromGeneratorOpSpec struct {
 }
 
 func init() {
-	fromGeneratorSignature := semantic.LookupBuiltInType("generate", "from")
+	fromGeneratorSignature := semantic.MustLookupBuiltinType("generate", "from")
 	flux.RegisterPackageValue("generate", "from", flux.MustValue(flux.FunctionValue(FromGeneratorKind, createFromGeneratorOpSpec, fromGeneratorSignature)))
 	flux.RegisterOpSpec(FromGeneratorKind, newFromGeneratorOp)
 	plan.RegisterProcedureSpec(FromGeneratorKind, newFromGeneratorProcedure, FromGeneratorKind)

--- a/stdlib/http/basic_auth.go
+++ b/stdlib/http/basic_auth.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -21,7 +22,7 @@ const (
 
 var basicAuthFunc = values.NewFunction(
 	"basicAuth",
-	semantic.LookupBuiltInType("http", "basicAuth"),
+	semantic.MustLookupBuiltinType("http", "basicAuth"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		return interpreter.DoFunctionCall(BasicAuth, args)
 	},

--- a/stdlib/http/post.go
+++ b/stdlib/http/post.go
@@ -25,7 +25,7 @@ const maxResponseBody = 512 * 1024 // 512 KB
 func init() {
 	flux.RegisterPackageValue("http", "post", values.NewFunction(
 		"post",
-		semantic.LookupBuiltInType("http", "post"),
+		semantic.MustLookupBuiltinType("http", "post"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			// Get and validate URL
 			uV, ok := args.Get("url")

--- a/stdlib/influxdata/influxdb/buckets.go
+++ b/stdlib/influxdata/influxdb/buckets.go
@@ -5,6 +5,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const BucketsKind = "buckets"
@@ -13,7 +14,7 @@ type BucketsOpSpec struct {
 }
 
 func init() {
-	bucketsSignature := semantic.LookupBuiltInType("influxdata/influxdb", "buckets")
+	bucketsSignature := semantic.MustLookupBuiltinType("influxdata/influxdb", "buckets")
 
 	flux.RegisterPackageValue("influxdata/influxdb", BucketsKind, flux.MustValue(flux.FunctionValue(BucketsKind, createBucketsOpSpec, bucketsSignature)))
 	flux.RegisterOpSpec(BucketsKind, newBucketsOp)

--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const FromKind = "from"
@@ -17,7 +18,7 @@ type FromOpSpec struct {
 }
 
 func init() {
-	fromSignature := semantic.LookupBuiltInType("influxdata/influxdb", "from")
+	fromSignature := semantic.MustLookupBuiltinType("influxdata/influxdb", "from")
 
 	flux.RegisterPackageValue("influxdata/influxdb", FromKind, flux.MustValue(flux.FunctionValue(FromKind, createFromOpSpec, fromSignature)))
 	flux.RegisterOpSpec(FromKind, newFromOp)

--- a/stdlib/influxdata/influxdb/secrets/get.go
+++ b/stdlib/influxdata/influxdb/secrets/get.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -20,7 +21,7 @@ func init() {
 var GetFunc = makeGetFunc()
 
 func makeGetFunc() values.Function {
-	sig := semantic.LookupBuiltInType("influxdata/influxdb/secrets", "get")
+	sig := semantic.MustLookupBuiltinType("influxdata/influxdb/secrets", "get")
 	return values.NewFunction("get", sig, Get, false)
 }
 

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -2,12 +2,13 @@ package influxdb
 
 import (
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
 )
 
 // ToKind is the kind for the `to` flux function
 const ToKind = "to"
 
-var ToSignature = semantic.LookupBuiltInType("influxdata/influxdb", "to")
+var ToSignature = semantic.MustLookupBuiltinType("influxdata/influxdb", "to")
 
 func init() {
 	flux.RegisterPackageValue("influxdata/influxdb", ToKind, flux.MustValue(flux.FunctionValueWithSideEffect(ToKind, nil, ToSignature)))

--- a/stdlib/influxdata/influxdb/v1/databases.go
+++ b/stdlib/influxdata/influxdb/v1/databases.go
@@ -2,11 +2,12 @@ package v1
 
 import (
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
 )
 
 const DatabasesKind = "databases"
 
-var DatabasesSignature = semantic.LookupBuiltInType("influxdata/influxdb/v1", "databses")
+var DatabasesSignature = semantic.MustLookupBuiltinType("influxdata/influxdb/v1", "databses")
 
 func init() {
 	flux.RegisterPackageValue("influxdata/influxdb/v1", DatabasesKind, flux.MustValue(flux.FunctionValue(DatabasesKind, nil, DatabasesSignature)))

--- a/stdlib/influxdata/influxdb/v1/from_influx_json.go
+++ b/stdlib/influxdata/influxdb/v1/from_influx_json.go
@@ -16,13 +16,14 @@ import (
 	"github.com/influxdata/flux/influxql"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const FromInfluxJSONKind = "fromInfluxJSON"
 const bufferSize = 8192
 
 func init() {
-	fromInfluxJSONSignature := semantic.LookupBuiltInType("influxdata/influxdb/v1", "json")
+	fromInfluxJSONSignature := semantic.MustLookupBuiltinType("influxdata/influxdb/v1", "json")
 	flux.RegisterPackageValue("influxdata/influxdb/v1", "json", flux.MustValue(flux.FunctionValue(FromInfluxJSONKind, createFromInfluxJSONOpSpec, fromInfluxJSONSignature)))
 	flux.RegisterOpSpec(FromInfluxJSONKind, newFromInfluxJSONOp)
 	plan.RegisterProcedureSpec(FromInfluxJSONKind, newFromInfluxJSONProcedure, FromInfluxJSONKind)

--- a/stdlib/internal/gen/tables.go
+++ b/stdlib/internal/gen/tables.go
@@ -27,7 +27,7 @@ type TablesOpSpec struct {
 }
 
 func init() {
-	tablesSignature := semantic.LookupBuiltInType("internal/gen", "tables")
+	tablesSignature := semantic.MustLookupBuiltinType("internal/gen", "tables")
 	flux.RegisterPackageValue("internal/gen", "tables", flux.MustValue(flux.FunctionValue(TablesKind, createTablesOpSpec, tablesSignature)))
 	flux.RegisterOpSpec(TablesKind, newTablesOp)
 	plan.RegisterProcedureSpec(TablesKind, newTablesProcedure, TablesKind)

--- a/stdlib/internal/promql/changes.go
+++ b/stdlib/internal/promql/changes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const ChangesKind = "changes"
@@ -14,7 +15,7 @@ const ChangesKind = "changes"
 type ChangesOpSpec struct{}
 
 func init() {
-	changesSignature := semantic.LookupBuiltInType("internal/promql", "changes")
+	changesSignature := semantic.MustLookupBuiltinType("internal/promql", "changes")
 
 	flux.RegisterPackageValue("internal/promql", ChangesKind, flux.MustValue(flux.FunctionValue(ChangesKind, createChangesOpSpec, changesSignature)))
 	flux.RegisterOpSpec(ChangesKind, newChangesOp)

--- a/stdlib/internal/promql/date_functions.go
+++ b/stdlib/internal/promql/date_functions.go
@@ -14,7 +14,7 @@ import (
 func generateDateFunction(name string, dateFn func(time.Time) int) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("internal/promql", name),
+		semantic.MustLookupBuiltinType("internal/promql", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("timestamp")
 			if !ok {

--- a/stdlib/internal/promql/empty_table.go
+++ b/stdlib/internal/promql/empty_table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/values"
+	"github.com/influxdata/flux/semantic"
 	"github.com/pkg/errors"
 )
 
@@ -19,7 +20,7 @@ const EmptyTableKind = "emptyTable"
 type EmptyTableOpSpec struct{}
 
 func init() {
-	emptyTableSignature := semantic.LookupBuiltInType("internal/promql", "emptyTable")
+	emptyTableSignature := semantic.MustLookupBuiltinType("internal/promql", "emptyTable")
 	flux.RegisterPackageValue("internal/promql", "emptyTable", flux.MustValue(flux.FunctionValue(EmptyTableKind, createEmptyTableOpSpec, emptyTableSignature)))
 	flux.RegisterOpSpec(EmptyTableKind, newEmptyTableOp)
 	plan.RegisterProcedureSpec(EmptyTableKind, newEmptyTableProcedure, EmptyTableKind)

--- a/stdlib/internal/promql/extrapolated_rate.go
+++ b/stdlib/internal/promql/extrapolated_rate.go
@@ -22,7 +22,7 @@ type ExtrapolatedRateOpSpec struct {
 }
 
 func init() {
-	extrapolatedRateSignature := semantic.LookupBuiltInType("internal/promql", ExtrapolatedRateKind)
+	extrapolatedRateSignature := semantic.MustLookupBuiltinType("internal/promql", ExtrapolatedRateKind)
 
 	flux.RegisterPackageValue("internal/promql", ExtrapolatedRateKind, flux.MustValue(flux.FunctionValue(ExtrapolatedRateKind, createExtrapolatedRateOpSpec, extrapolatedRateSignature)))
 	flux.RegisterOpSpec(ExtrapolatedRateKind, newExtrapolatedRateOp)

--- a/stdlib/internal/promql/histogram_quantile.go
+++ b/stdlib/internal/promql/histogram_quantile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 // TODO: Added "prom" prefix to avoid duplicate registration error. Decide whether to
@@ -25,7 +26,7 @@ type HistogramQuantileOpSpec struct {
 }
 
 func init() {
-	histogramQuantileSignature := semantic.LookupBuiltInType("internal/promql", HistogramQuantileKind)
+	histogramQuantileSignature := semantic.MustLookupBuiltinType("internal/promql", HistogramQuantileKind)
 
 	flux.RegisterPackageValue("internal/promql", HistogramQuantileKind, flux.MustValue(flux.FunctionValue(HistogramQuantileKind, createHistogramQuantileOpSpec, histogramQuantileSignature)))
 	flux.RegisterOpSpec(HistogramQuantileKind, newHistogramQuantileOp)

--- a/stdlib/internal/promql/holt_winters.go
+++ b/stdlib/internal/promql/holt_winters.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const HoltWintersKind = "promHoltWinters"
@@ -19,7 +20,7 @@ type HoltWintersOpSpec struct {
 }
 
 func init() {
-	holtWintersSignature := semantic.LookupBuiltInType("internal/promql", "holtWinters")
+	holtWintersSignature := semantic.MustLookupBuiltinType("internal/promql", "holtWinters")
 
 	flux.RegisterPackageValue("internal/promql", "holtWinters", flux.MustValue(flux.FunctionValue(HoltWintersKind, createHoltWintersOpSpec, holtWintersSignature)))
 	flux.RegisterOpSpec(HoltWintersKind, newHoltWintersOp)

--- a/stdlib/internal/promql/instant_rate.go
+++ b/stdlib/internal/promql/instant_rate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/values"
+	"github.com/influxdata/flux/semantic"
 )
 
 const InstantRateKind = "instantRate"
@@ -20,7 +21,7 @@ type InstantRateOpSpec struct {
 }
 
 func init() {
-	instantRateSignature := semantic.LookupBuiltInType("internal/promql", InstantRateKind)
+	instantRateSignature := semantic.MustLookupBuiltinType("internal/promql", InstantRateKind)
 
 	flux.RegisterPackageValue("internal/promql", InstantRateKind, flux.MustValue(flux.FunctionValue(InstantRateKind, createInstantRateOpSpec, instantRateSignature)))
 	flux.RegisterOpSpec(InstantRateKind, newInstantRateOp)

--- a/stdlib/internal/promql/join.go
+++ b/stdlib/internal/promql/join.go
@@ -20,7 +20,7 @@ import (
 const joinKind = "internal/promql.join"
 
 func init() {
-	signature := semantic.LookupBuiltInType("internal/promql", "join")
+	signature := semantic.MustLookupBuiltinType("internal/promql", "join")
 	flux.RegisterPackageValue("internal/promql", "join", flux.MustValue(flux.FunctionValue("join", createJoinOpSpec, signature)))
 	flux.RegisterOpSpec(joinKind, newJoinOp)
 	plan.RegisterProcedureSpec(joinKind, newMergeJoinProcedure, joinKind)

--- a/stdlib/internal/promql/label_replace.go
+++ b/stdlib/internal/promql/label_replace.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const (
@@ -24,7 +25,7 @@ type LabelReplaceOpSpec struct {
 }
 
 func init() {
-	labelReplaceSignature := semantic.LookupBuiltInType("internal/promql", "labelReplace")
+	labelReplaceSignature := semantic.MustLookupBuiltinType("internal/promql", "labelReplace")
 	flux.RegisterPackageValue("internal/promql", "labelReplace", flux.MustValue(flux.FunctionValue(LabelReplaceKind, createLabelReplaceOpSpec, labelReplaceSignature)))
 	flux.RegisterOpSpec(LabelReplaceKind, func() flux.OperationSpec { return &LabelReplaceOpSpec{} })
 	plan.RegisterProcedureSpec(LabelReplaceKind, newLabelReplaceProcedure, LabelReplaceKind)

--- a/stdlib/internal/promql/linear_regression.go
+++ b/stdlib/internal/promql/linear_regression.go
@@ -20,7 +20,7 @@ type LinearRegressionOpSpec struct {
 }
 
 func init() {
-	linearRegressionSignature := semantic.LookupBuiltInType("internal/promql", LinearRegressionKind)
+	linearRegressionSignature := semantic.MustLookupBuiltinType("internal/promql", LinearRegressionKind)
 
 	flux.RegisterPackageValue("internal/promql", LinearRegressionKind, flux.MustValue(flux.FunctionValue(LinearRegressionKind, createLinearRegressionOpSpec, linearRegressionSignature)))
 	flux.RegisterOpSpec(LinearRegressionKind, newLinearRegressionOp)

--- a/stdlib/internal/promql/resets.go
+++ b/stdlib/internal/promql/resets.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const ResetsKind = "resets"
@@ -13,7 +14,7 @@ const ResetsKind = "resets"
 type ResetsOpSpec struct{}
 
 func init() {
-	resetsSignature := semantic.LookupBuiltInType("internal/promql", ResetsKind)
+	resetsSignature := semantic.MustLookupBuiltinType("internal/promql", ResetsKind)
 
 	flux.RegisterPackageValue("internal/promql", ResetsKind, flux.MustValue(flux.FunctionValue(ResetsKind, createResetsOpSpec, resetsSignature)))
 	flux.RegisterOpSpec(ResetsKind, newResetsOp)

--- a/stdlib/internal/promql/timestamp.go
+++ b/stdlib/internal/promql/timestamp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 type TimestampOpSpec struct{}
 
 func init() {
-	timestampSignature := semantic.LookupBuiltInType("internal/promql", "timestamp")
+	timestampSignature := semantic.MustLookupBuiltinType("internal/promql", "timestamp")
 	flux.RegisterPackageValue("internal/promql", "timestamp", flux.MustValue(flux.FunctionValue(TimestampKind, createTimestampOpSpec, timestampSignature)))
 	flux.RegisterOpSpec(TimestampKind, func() flux.OperationSpec { return &TimestampOpSpec{} })
 	plan.RegisterProcedureSpec(TimestampKind, newTimestampProcedure, TimestampKind)

--- a/stdlib/json/encode.go
+++ b/stdlib/json/encode.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	flux.RegisterPackageValue("json", "encode", values.NewFunction(
 		"encode",
-		semantic.LookupBuiltInType("json", "encode"),
+		semantic.MustLookupBuiltinType("json", "encode"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("v")
 			if !ok {

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -40,7 +40,7 @@ type ToKafkaOpSpec struct {
 }
 
 func init() {
-	toKafkaSignature := semantic.LookupBuiltInType("kafka", "to")
+	toKafkaSignature := semantic.MustLookupBuiltinType("kafka", "to")
 	flux.RegisterPackageValue("kafka", "to", flux.MustValue(flux.FunctionValueWithSideEffect(ToKafkaKind, createToKafkaOpSpec, toKafkaSignature)))
 	flux.RegisterOpSpec(ToKafkaKind, func() flux.OperationSpec { return &ToKafkaOpSpec{} })
 	plan.RegisterProcedureSpecWithSideEffect(ToKafkaKind, newToKafkaProcedure, ToKafkaKind)

--- a/stdlib/math/math.go
+++ b/stdlib/math/math.go
@@ -17,7 +17,7 @@ var SpecialFns map[string]values.Function
 func generateMathFunctionX(name string, mathFn func(float64) float64) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("math", name),
+		semantic.MustLookupBuiltinType("math", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v, ok := args.Get("x")
 			if !ok {
@@ -39,7 +39,7 @@ func generateMathFunctionXY(name string, mathFn func(float64, float64) float64, 
 	}
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("math", name),
+		semantic.MustLookupBuiltinType("math", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			v1, ok := args.Get(argNames[0])
 			if !ok {
@@ -135,7 +135,7 @@ func init() {
 		// float --> uint
 		"float64bits": values.NewFunction(
 			"float64bits",
-			semantic.LookupBuiltInType("math", "float64bits"),
+			semantic.MustLookupBuiltinType("math", "float64bits"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
@@ -150,7 +150,7 @@ func init() {
 		),
 		"float64frombits": values.NewFunction(
 			"float64frombits",
-			semantic.LookupBuiltInType("math", "float64frombits"),
+			semantic.MustLookupBuiltinType("math", "float64frombits"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("b")
 				if !ok {
@@ -166,7 +166,7 @@ func init() {
 		// float --> int
 		"ilogb": values.NewFunction(
 			"ilogb",
-			semantic.LookupBuiltInType("math", "ilogb"),
+			semantic.MustLookupBuiltinType("math", "ilogb"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
@@ -182,7 +182,7 @@ func init() {
 		// float --> {frac: float, exp: int}
 		"frexp": values.NewFunction(
 			"frexp",
-			semantic.LookupBuiltInType("math", "frexp"),
+			semantic.MustLookupBuiltinType("math", "frexp"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
@@ -199,7 +199,7 @@ func init() {
 		// float --> {lgamma: float, sign: int}
 		"lgamma": values.NewFunction(
 			"lgamma",
-			semantic.LookupBuiltInType("math", "lgamma"),
+			semantic.MustLookupBuiltinType("math", "lgamma"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
@@ -216,7 +216,7 @@ func init() {
 		// float --> {int: float, frac: float}
 		"modf": values.NewFunction(
 			"modf",
-			semantic.LookupBuiltInType("math", "modf"),
+			semantic.MustLookupBuiltinType("math", "modf"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
@@ -233,7 +233,7 @@ func init() {
 		// float --> {sin: float, cos: float}
 		"sincos": values.NewFunction(
 			"sincos",
-			semantic.LookupBuiltInType("math", "sincos"),
+			semantic.MustLookupBuiltinType("math", "sincos"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
@@ -250,7 +250,7 @@ func init() {
 		// float, int --> bool
 		"isInf": values.NewFunction(
 			"isInf",
-			semantic.LookupBuiltInType("math", "isInf"),
+			semantic.MustLookupBuiltinType("math", "isInf"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
@@ -274,7 +274,7 @@ func init() {
 		// float --> bool
 		"isNaN": values.NewFunction(
 			"isNaN",
-			semantic.LookupBuiltInType("math", "isNaN"),
+			semantic.MustLookupBuiltinType("math", "isNaN"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("f")
 				if !ok {
@@ -290,7 +290,7 @@ func init() {
 		// float --> bool
 		"signbit": values.NewFunction(
 			"signbit",
-			semantic.LookupBuiltInType("math", "signbit"),
+			semantic.MustLookupBuiltinType("math", "signbit"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("x")
 				if !ok {
@@ -306,7 +306,7 @@ func init() {
 		// () --> float
 		"NaN": values.NewFunction(
 			"NaN",
-			semantic.LookupBuiltInType("math", "NaN"),
+			semantic.MustLookupBuiltinType("math", "NaN"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				return values.NewFloat(math.NaN()), nil
 			}, false,
@@ -314,7 +314,7 @@ func init() {
 		// (int) --> float
 		"mInf": values.NewFunction(
 			"inf",
-			semantic.LookupBuiltInType("math", "inf"),
+			semantic.MustLookupBuiltinType("math", "inf"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 
 				v1, ok := args.Get("sign")
@@ -331,7 +331,7 @@ func init() {
 		// (int, float) --> float
 		"jn": values.NewFunction(
 			"jn",
-			semantic.LookupBuiltInType("math", "jn"),
+			semantic.MustLookupBuiltinType("math", "jn"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("n")
 				if !ok {
@@ -355,7 +355,7 @@ func init() {
 		// (int, float) --> float
 		"yn": values.NewFunction(
 			"yn",
-			semantic.LookupBuiltInType("math", "yn"),
+			semantic.MustLookupBuiltinType("math", "yn"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("n")
 				if !ok {
@@ -379,7 +379,7 @@ func init() {
 		// (float, int) --> float
 		"ldexp": values.NewFunction(
 			"ldexp",
-			semantic.LookupBuiltInType("math", "ldexp"),
+			semantic.MustLookupBuiltinType("math", "ldexp"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("frac")
 				if !ok {
@@ -403,7 +403,7 @@ func init() {
 		// int --> float
 		"pow10": values.NewFunction(
 			"pow10",
-			semantic.LookupBuiltInType("math", "pow10"),
+			semantic.MustLookupBuiltinType("math", "pow10"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v1, ok := args.Get("n")
 				if !ok {

--- a/stdlib/pagerduty/pagerduty.go
+++ b/stdlib/pagerduty/pagerduty.go
@@ -25,7 +25,7 @@ func (s *DedupKeyOpSpec) Kind() flux.OperationKind {
 }
 
 func init() {
-	dedupKeySignature := semantic.LookupBuiltInType("pagerduty", "dedupKey")
+	dedupKeySignature := semantic.MustLookupBuiltinType("pagerduty", "dedupKey")
 	flux.RegisterPackageValue("pagerduty", "dedupKey", flux.MustValue(flux.FunctionValue(DedupKeyKind, createDedupKeyOpSpec, dedupKeySignature)))
 	flux.RegisterOpSpec(DedupKeyKind, newDedupKeyOp)
 	plan.RegisterProcedureSpec(DedupKeyKind, newDedupKeyProcedure, DedupKeyKind)

--- a/stdlib/regexp/regexp.go
+++ b/stdlib/regexp/regexp.go
@@ -18,7 +18,7 @@ func init() {
 	SpecialFns = map[string]values.Function{
 		"compile": values.NewFunction(
 			"compile",
-			semantic.LookupBuiltInType("regexp", "compile"),
+			semantic.MustLookupBuiltinType("regexp", "compile"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				if !ok {
@@ -38,7 +38,7 @@ func init() {
 		),
 		"quoteMeta": values.NewFunction(
 			"quoteMeta",
-			semantic.LookupBuiltInType("regexp", "quoteMeta"),
+			semantic.MustLookupBuiltinType("regexp", "quoteMeta"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				if !ok {
@@ -55,7 +55,7 @@ func init() {
 		),
 		"findString": values.NewFunction(
 			"findString",
-			semantic.LookupBuiltInType("regexp", "findString"),
+			semantic.MustLookupBuiltinType("regexp", "findString"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				r, okk := args.Get("r")
@@ -73,7 +73,7 @@ func init() {
 		),
 		"findStringIndex": values.NewFunction(
 			"findStringIndex",
-			semantic.LookupBuiltInType("regexp", "findStringIndex"),
+			semantic.MustLookupBuiltinType("regexp", "findStringIndex"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				r, okk := args.Get("r")
@@ -95,7 +95,7 @@ func init() {
 		),
 		"matchRegexpString": values.NewFunction(
 			"matchRegexpString",
-			semantic.LookupBuiltInType("regexp", "matchRegexpString"),
+			semantic.MustLookupBuiltinType("regexp", "matchRegexpString"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				v, ok := args.Get("v")
 				r, okk := args.Get("r")
@@ -113,7 +113,7 @@ func init() {
 		),
 		"replaceAllString": values.NewFunction(
 			"replaceAllString",
-			semantic.LookupBuiltInType("regexp", "replaceAllString"),
+			semantic.MustLookupBuiltinType("regexp", "replaceAllString"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				r, ok := args.Get("r")
 				v, okk := args.Get("v")
@@ -132,7 +132,7 @@ func init() {
 		),
 		"splitRegexp": values.NewFunction(
 			"splitRegexp",
-			semantic.LookupBuiltInType("regexp", "splitRegexp"),
+			semantic.MustLookupBuiltinType("regexp", "splitRegexp"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				r, ok := args.Get("r")
 				v, okk := args.Get("v")
@@ -155,7 +155,7 @@ func init() {
 		),
 		"getString": values.NewFunction(
 			"getString",
-			semantic.LookupBuiltInType("regexp", "getString"),
+			semantic.MustLookupBuiltinType("regexp", "getString"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				r, ok := args.Get("r")
 				if !ok {

--- a/stdlib/runtime/runtime.go
+++ b/stdlib/runtime/runtime.go
@@ -4,6 +4,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -14,7 +15,7 @@ var errBuildInfoNotPresent = errors.New(codes.NotFound, "build info is not prese
 func init() {
 	flux.RegisterPackageValue("runtime", versionFuncName, values.NewFunction(
 		versionFuncName,
-		semantic.LookupBuiltInType("runtime", versionFuncName),
+		semantic.MustLookupBuiltinType("runtime", versionFuncName),
 		Version,
 		false,
 	))

--- a/stdlib/slack/slack.go
+++ b/stdlib/slack/slack.go
@@ -40,7 +40,7 @@ func validateColorString(color string) error {
 
 var validateColorStringFluxFn = values.NewFunction(
 	"validateColorString",
-	semantic.LookupBuiltInType("slack", "validateColorString"),
+	semantic.MustLookupBuiltinType("slack", "validateColorString"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, ok := args.Get("color")
 

--- a/stdlib/socket/from.go
+++ b/stdlib/socket/from.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/line"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -29,7 +30,7 @@ type FromSocketOpSpec struct {
 }
 
 func init() {
-	fromSocketSignature := semantic.LookupBuiltInType("socket", "from")
+	fromSocketSignature := semantic.MustLookupBuiltinType("socket", "from")
 
 	flux.RegisterPackageValue("socket", "from", flux.MustValue(flux.FunctionValue(FromSocketKind, createFromSocketOpSpec, fromSocketSignature)))
 	flux.RegisterOpSpec(FromSocketKind, newFromSocketOp)

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	_ "github.com/lib/pq"
 )
 
@@ -25,7 +26,7 @@ type FromSQLOpSpec struct {
 }
 
 func init() {
-	fromSQLSignature := semantic.LookupBuiltInType("sql", "from")
+	fromSQLSignature := semantic.MustLookupBuiltinType("sql", "from")
 	flux.RegisterPackageValue("sql", "from", flux.MustValue(flux.FunctionValue(FromSQLKind, createFromSQLOpSpec, fromSQLSignature)))
 	flux.RegisterOpSpec(FromSQLKind, newFromSQLOp)
 	plan.RegisterProcedureSpec(FromSQLKind, newFromSQLProcedure, FromSQLKind)

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -26,7 +27,7 @@ type ToSQLOpSpec struct {
 }
 
 func init() {
-	toSQLSignature := semantic.LookupBuiltInType("sql", "ro")
+	toSQLSignature := semantic.MustLookupBuiltinType("sql", "ro")
 	flux.RegisterPackageValue("sql", "to", flux.MustValue(flux.FunctionValueWithSideEffect(ToSQLKind, createToSQLOpSpec, toSQLSignature)))
 	flux.RegisterOpSpec(ToSQLKind, func() flux.OperationSpec { return &ToSQLOpSpec{} })
 	plan.RegisterProcedureSpecWithSideEffect(ToSQLKind, newToSQLProcedure, ToSQLKind)

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -31,7 +31,7 @@ const (
 func generateSingleArgStringFunction(name string, stringFn func(string) string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var str string
 
@@ -59,7 +59,7 @@ func generateDualArgStringFunction(name string, argNames []string, stringFn func
 
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
@@ -89,7 +89,7 @@ func generateDualArgStringFunctionReturnBool(name string, argNames []string, str
 
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
@@ -119,7 +119,7 @@ func generateDualArgStringFunctionReturnInt(name string, argNames []string, stri
 
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
@@ -145,7 +145,7 @@ func generateDualArgStringFunctionReturnInt(name string, argNames []string, stri
 func generateSplit(name string, argNames []string, fn func(string, string) []string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("string", name),
+		semantic.MustLookupBuiltinType("string", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 
@@ -176,7 +176,7 @@ func generateSplit(name string, argNames []string, fn func(string, string) []str
 func generateSplitN(name string, argNames []string, fn func(string, string, int) []string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 3)
 			var argTypes = []semantic.Nature{semantic.String, semantic.String, semantic.Int}
@@ -208,7 +208,7 @@ func generateSplitN(name string, argNames []string, fn func(string, string, int)
 func generateRepeat(name string, argNames []string, fn func(string, int) string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 			var argType = []semantic.Nature{semantic.String, semantic.Int}
@@ -235,7 +235,7 @@ func generateRepeat(name string, argNames []string, fn func(string, int) string)
 func generateReplace(name string, argNames []string, fn func(string, string, string, int) string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 4)
 			var argType = []semantic.Nature{semantic.String, semantic.String, semantic.String, semantic.Int}
@@ -262,7 +262,7 @@ func generateReplace(name string, argNames []string, fn func(string, string, str
 func generateReplaceAll(name string, argNames []string, fn func(string, string, string) string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 3)
 
@@ -288,7 +288,7 @@ func generateReplaceAll(name string, argNames []string, fn func(string, string, 
 func generateUnicodeIsFunction(name string, Fn func(rune) bool) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.LookupBuiltInType("strings", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var str string
 
@@ -320,7 +320,7 @@ func generateUnicodeIsFunction(name string, Fn func(rune) bool) values.Function 
 
 var strlen = values.NewFunction(
 	"strlen",
-	semantic.LookupBuiltInType("strings", "strlen"),
+	semantic.MustLookupBuiltinType("strings", "strlen"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, ok := args.Get(stringArgV)
 		if !ok {
@@ -337,7 +337,7 @@ var strlen = values.NewFunction(
 
 var substring = values.NewFunction(
 	"substring",
-	semantic.LookupBuiltInType("strings", "substring"),
+	semantic.MustLookupBuiltinType("strings", "substring"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, vOk := args.Get(stringArgV)
 		a, aOk := args.Get(start)
@@ -446,7 +446,7 @@ func init() {
 	SpecialFns = map[string]values.Function{
 		"joinStr": values.NewFunction(
 			"joinStr",
-			semantic.LookupBuiltInType("strings", "joinStr"),
+			semantic.MustLookupBuiltinType("strings", "joinStr"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 				var argVals = make([]values.Value, 2)
 

--- a/stdlib/system/time.go
+++ b/stdlib/system/time.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -13,7 +14,7 @@ var systemTimeFuncName = "time"
 func init() {
 	flux.RegisterPackageValue("system", systemTimeFuncName, values.NewFunction(
 		systemTimeFuncName,
-		semantic.LookupBuiltInType("system", systemTimeFuncName),
+		semantic.MustLookupBuiltinType("system", systemTimeFuncName),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			return values.NewTime(values.ConvertTime(time.Now().UTC())), nil
 		},

--- a/stdlib/testing/assert_empty.go
+++ b/stdlib/testing/assert_empty.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const AssertEmptyKind = "assertEmpty"
@@ -17,7 +18,7 @@ func (s *AssertEmptyOpSpec) Kind() flux.OperationKind {
 }
 
 func init() {
-	assertEmptySignature := semantic.LookupBuiltInType("testing", "assertEmpty")
+	assertEmptySignature := semantic.MustLookupBuiltinType("testing", "assertEmpty")
 
 	flux.RegisterPackageValue("testing", "assertEmpty", flux.MustValue(flux.FunctionValue(AssertEmptyKind, createAssertEmptyOpSpec, assertEmptySignature)))
 	flux.RegisterOpSpec(AssertEmptyKind, newAssertEmptyOp)

--- a/stdlib/testing/assert_equals.go
+++ b/stdlib/testing/assert_equals.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const AssertEqualsKind = "assertEquals"
@@ -23,7 +24,7 @@ func (s *AssertEqualsOpSpec) Kind() flux.OperationKind {
 }
 
 func init() {
-	assertEqualsSignature := semantic.LookupBuiltInType("testing", "assertEquals")
+	assertEqualsSignature := semantic.MustLookupBuiltinType("testing", "assertEquals")
 
 	flux.RegisterPackageValue("testing", "assertEquals", flux.MustValue(flux.FunctionValue(AssertEqualsKind, createAssertEqualsOpSpec, assertEqualsSignature)))
 	flux.RegisterOpSpec(AssertEqualsKind, newAssertEqualsOp)

--- a/stdlib/testing/diff.go
+++ b/stdlib/testing/diff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const DiffKind = "diff"
@@ -26,7 +27,7 @@ func (s *DiffOpSpec) Kind() flux.OperationKind {
 }
 
 func init() {
-	diffSignature := semantic.LookupBuiltInType("testing", "diff")
+	diffSignature := semantic.MustLookupBuiltinType("testing", "diff")
 
 	flux.RegisterPackageValue("testing", "diff", flux.MustValue(flux.FunctionValue(DiffKind, createDiffOpSpec, diffSignature)))
 	flux.RegisterOpSpec(DiffKind, newDiffOp)

--- a/stdlib/universe/chande_momentum_oscillator.go
+++ b/stdlib/universe/chande_momentum_oscillator.go
@@ -18,7 +18,7 @@ type ChandeMomentumOscillatorOpSpec struct {
 }
 
 func init() {
-	chandeMomentumOscillatorSignature := semantic.LookupBuiltInType("universe", ChandeMomentumOscillatorKind)
+	chandeMomentumOscillatorSignature := semantic.MustLookupBuiltinType("universe", ChandeMomentumOscillatorKind)
 
 	flux.RegisterPackageValue("universe", ChandeMomentumOscillatorKind, flux.MustValue(flux.FunctionValue(ChandeMomentumOscillatorKind, createChandeMomentumOscillatorOpSpec, chandeMomentumOscillatorSignature)))
 	flux.RegisterOpSpec(ChandeMomentumOscillatorKind, newChandeMomentumOscillatorOp)

--- a/stdlib/universe/columns.go
+++ b/stdlib/universe/columns.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const ColumnsKind = "columns"
@@ -16,7 +17,7 @@ type ColumnsOpSpec struct {
 }
 
 func init() {
-	columnsSignature := semantic.LookupBuiltInType("universe", "columns")
+	columnsSignature := semantic.MustLookupBuiltinType("universe", "columns")
 	flux.RegisterPackageValue("universe", ColumnsKind, flux.MustValue(flux.FunctionValue(ColumnsKind, createColumnsOpSpec, columnsSignature)))
 	flux.RegisterOpSpec(ColumnsKind, newColumnsOp)
 	plan.RegisterProcedureSpec(ColumnsKind, newColumnsProcedure, ColumnsKind)

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -16,7 +17,7 @@ import (
 func MakeContainsFunc() values.Function {
 	return values.NewFunction(
 		"contains",
-		semantic.LookupBuiltInType("universe", "contains"),
+		semantic.MustLookupBuiltinType("universe", "contains"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			a := interpreter.NewArguments(args)
 			v, err := a.GetRequired("value")

--- a/stdlib/universe/count.go
+++ b/stdlib/universe/count.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const CountKind = "count"
@@ -16,7 +17,7 @@ type CountOpSpec struct {
 }
 
 func init() {
-	countSignature := semantic.LookupBuiltInType("universe", "count")
+	countSignature := semantic.MustLookupBuiltinType("universe", "count")
 	flux.RegisterPackageValue("universe", CountKind, flux.MustValue(flux.FunctionValue(CountKind, createCountOpSpec, countSignature)))
 	flux.RegisterOpSpec(CountKind, newCountOp)
 	plan.RegisterProcedureSpec(CountKind, newCountProcedure, CountKind)

--- a/stdlib/universe/covariance.go
+++ b/stdlib/universe/covariance.go
@@ -22,7 +22,7 @@ type CovarianceOpSpec struct {
 }
 
 func init() {
-	var covarianceSignature = semantic.LookupBuiltInType("universe", "covariance")
+	var covarianceSignature = semantic.MustLookupBuiltinType("universe", "covariance")
 	flux.RegisterPackageValue("universe", CovarianceKind, flux.MustValue(flux.FunctionValue(CovarianceKind, createCovarianceOpSpec, covarianceSignature)))
 	flux.RegisterOpSpec(CovarianceKind, newCovarianceOp)
 	plan.RegisterProcedureSpec(CovarianceKind, newCovarianceProcedure, CovarianceKind)

--- a/stdlib/universe/cumulative_sum.go
+++ b/stdlib/universe/cumulative_sum.go
@@ -17,7 +17,7 @@ type CumulativeSumOpSpec struct {
 }
 
 func init() {
-	cumulativeSumSignature := semantic.LookupBuiltInType("univsere", "cumulativeSum")
+	cumulativeSumSignature := semantic.MustLookupBuiltinType("univsere", "cumulativeSum")
 
 	flux.RegisterPackageValue("universe", CumulativeSumKind, flux.MustValue(flux.FunctionValue(CumulativeSumKind, createCumulativeSumOpSpec, cumulativeSumSignature)))
 	flux.RegisterOpSpec(CumulativeSumKind, newCumulativeSumOp)

--- a/stdlib/universe/derivative.go
+++ b/stdlib/universe/derivative.go
@@ -24,7 +24,7 @@ type DerivativeOpSpec struct {
 }
 
 func init() {
-	derivativeSignature := semantic.LookupBuiltInType("universe", "derivative")
+	derivativeSignature := semantic.MustLookupBuiltinType("universe", "derivative")
 
 	flux.RegisterPackageValue("universe", DerivativeKind, flux.MustValue(flux.FunctionValue(DerivativeKind, createDerivativeOpSpec, derivativeSignature)))
 	flux.RegisterOpSpec(DerivativeKind, newDerivativeOp)

--- a/stdlib/universe/difference.go
+++ b/stdlib/universe/difference.go
@@ -22,7 +22,7 @@ type DifferenceOpSpec struct {
 }
 
 func init() {
-	differenceSignature := semantic.LookupBuiltInType("universe", "difference")
+	differenceSignature := semantic.MustLookupBuiltinType("universe", "difference")
 
 	flux.RegisterPackageValue("universe", DifferenceKind, flux.MustValue(flux.FunctionValue(DifferenceKind, createDifferenceOpSpec, differenceSignature)))
 	flux.RegisterOpSpec(DifferenceKind, newDifferenceOp)

--- a/stdlib/universe/distinct.go
+++ b/stdlib/universe/distinct.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -16,7 +17,7 @@ type DistinctOpSpec struct {
 }
 
 func init() {
-	distinctSignature := semantic.LookupBuiltInType("universe", "distinct")
+	distinctSignature := semantic.MustLookupBuiltinType("universe", "distinct")
 
 	flux.RegisterPackageValue("universe", DistinctKind, flux.MustValue(flux.FunctionValue(DistinctKind, createDistinctOpSpec, distinctSignature)))
 	flux.RegisterOpSpec(DistinctKind, newDistinctOp)

--- a/stdlib/universe/elapsed.go
+++ b/stdlib/universe/elapsed.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -20,7 +21,7 @@ type ElapsedOpSpec struct {
 }
 
 func init() {
-	elapsedSignature := semantic.LookupBuiltInType("universe", "elapsed")
+	elapsedSignature := semantic.MustLookupBuiltinType("universe", "elapsed")
 
 	flux.RegisterPackageValue("universe", ElapsedKind, flux.MustValue(flux.FunctionValue(ElapsedKind, createElapsedOpSpec, elapsedSignature)))
 	flux.RegisterOpSpec(ElapsedKind, newElapsedOp)

--- a/stdlib/universe/exponential_moving_average.go
+++ b/stdlib/universe/exponential_moving_average.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/moving_average"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const ExponentialMovingAverageKind = "exponentialMovingAverage"
@@ -16,7 +17,7 @@ type ExponentialMovingAverageOpSpec struct {
 }
 
 func init() {
-	exponentialMovingAverageSignature := semantic.LookupBuiltInType("universe", "exponentialMovingAverage")
+	exponentialMovingAverageSignature := semantic.MustLookupBuiltinType("universe", "exponentialMovingAverage")
 
 	flux.RegisterPackageValue("universe", ExponentialMovingAverageKind, flux.MustValue(flux.FunctionValue(ExponentialMovingAverageKind, createExponentialMovingAverageOpSpec, exponentialMovingAverageSignature)))
 	flux.RegisterOpSpec(ExponentialMovingAverageKind, newExponentialMovingAverageOp)

--- a/stdlib/universe/fill.go
+++ b/stdlib/universe/fill.go
@@ -22,7 +22,7 @@ type FillOpSpec struct {
 }
 
 func init() {
-	fillSignature := semantic.LookupBuiltInType("universe", "fill")
+	fillSignature := semantic.MustLookupBuiltinType("universe", "fill")
 
 	flux.RegisterPackageValue("universe", FillKind, flux.MustValue(flux.FunctionValue(FillKind, createFillOpSpec, fillSignature)))
 	flux.RegisterOpSpec(FillKind, newFillOp)

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -30,7 +30,7 @@ type FilterOpSpec struct {
 }
 
 func init() {
-	filterSignature := semantic.LookupBuiltInType("universe", "filter")
+	filterSignature := semantic.MustLookupBuiltinType("universe", "filter")
 
 	flux.RegisterPackageValue("universe", FilterKind, flux.MustValue(flux.FunctionValue(FilterKind, createFilterOpSpec, filterSignature)))
 	flux.RegisterOpSpec(FilterKind, newFilterOp)

--- a/stdlib/universe/first.go
+++ b/stdlib/universe/first.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const FirstKind = "first"
@@ -16,7 +17,7 @@ type FirstOpSpec struct {
 }
 
 func init() {
-	firstSignature := semantic.LookupBuiltInType("universe", "first")
+	firstSignature := semantic.MustLookupBuiltinType("universe", "first")
 
 	flux.RegisterPackageValue("universe", FirstKind, flux.MustValue(flux.FunctionValue(FirstKind, createFirstOpSpec, firstSignature)))
 	flux.RegisterOpSpec(FirstKind, newFirstOp)

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -29,7 +29,7 @@ type GroupOpSpec struct {
 }
 
 func init() {
-	groupSignature := semantic.LookupBuiltInType("universe", "group")
+	groupSignature := semantic.MustLookupBuiltinType("universe", "group")
 
 	flux.RegisterPackageValue("universe", GroupKind, flux.MustValue(flux.FunctionValue(GroupKind, createGroupOpSpec, groupSignature)))
 	flux.RegisterOpSpec(GroupKind, newGroupOp)

--- a/stdlib/universe/histogram.go
+++ b/stdlib/universe/histogram.go
@@ -28,7 +28,7 @@ type HistogramOpSpec struct {
 }
 
 func init() {
-	histogramSignature := semantic.LookupBuiltInType("universe", "histogram")
+	histogramSignature := semantic.MustLookupBuiltinType("universe", "histogram")
 
 	flux.RegisterPackageValue("universe", HistogramKind, flux.MustValue(flux.FunctionValue(HistogramKind, createHistogramOpSpec, histogramSignature)))
 	flux.RegisterPackageValue("universe", "linearBins", linearBins{})
@@ -243,7 +243,7 @@ func (t *histogramTransformation) Finish(id execute.DatasetID, err error) {
 // linearBins is a helper function for creating bins spaced linearly
 type linearBins struct{}
 
-var linearBinsType = semantic.LookupBuiltInType("universe", "linearBins")
+var linearBinsType = semantic.MustLookupBuiltinType("universe", "linearBins")
 
 func (b linearBins) Type() semantic.MonoType {
 	t, _ := linearBinsType.Expr()
@@ -366,7 +366,7 @@ func (b linearBins) Call(ctx context.Context, args values.Object) (values.Value,
 // logarithmicBins is a helper function for creating bins spaced by an logarithmic factor.
 type logarithmicBins struct{}
 
-var logarithmicBinsType = semantic.LookupBuiltInType("universe", "logarithmicBins")
+var logarithmicBinsType = semantic.MustLookupBuiltinType("universe", "logarithmicBins")
 
 func (b logarithmicBins) Type() semantic.MonoType {
 	t, _ := logarithmicBinsType.Expr()

--- a/stdlib/universe/histogram_quantile.go
+++ b/stdlib/universe/histogram_quantile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const HistogramQuantileKind = "histogramQuantile"
@@ -24,7 +25,7 @@ type HistogramQuantileOpSpec struct {
 }
 
 func init() {
-	histogramQuantileSignature := semantic.LookupBuiltInType("universe", "histogramQuantile")
+	histogramQuantileSignature := semantic.MustLookupBuiltinType("universe", "histogramQuantile")
 
 	flux.RegisterPackageValue("universe", HistogramQuantileKind, flux.MustValue(flux.FunctionValue(HistogramQuantileKind, createHistogramQuantileOpSpec, histogramQuantileSignature)))
 	flux.RegisterOpSpec(HistogramQuantileKind, newHistogramQuantileOp)

--- a/stdlib/universe/holt_winters.go
+++ b/stdlib/universe/holt_winters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	fluxmemory "github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe/holt_winters"
 	"github.com/influxdata/flux/values"
 )
@@ -27,7 +28,7 @@ type HoltWintersOpSpec struct {
 }
 
 func init() {
-	hwSignature := semantic.LookupBuiltInType("univser", "holtWinter")
+	hwSignature := semantic.MustLookupBuiltinType("univser", "holtWinter")
 	flux.RegisterPackageValue("universe", HoltWintersKind, flux.MustValue(flux.FunctionValue(HoltWintersKind, createHoltWintersOpSpec, hwSignature)))
 	flux.RegisterOpSpec(HoltWintersKind, newHoltWintersOp)
 	plan.RegisterProcedureSpec(HoltWintersKind, newHoltWintersProcedure, HoltWintersKind)

--- a/stdlib/universe/hour_selection.go
+++ b/stdlib/universe/hour_selection.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const HourSelectionKind = "hourSelection"
@@ -17,7 +18,7 @@ type HourSelectionOpSpec struct {
 }
 
 func init() {
-	hourSelectionSignature := semantic.LookupBuiltInType("universe", "hourSelection")
+	hourSelectionSignature := semantic.MustLookupBuiltinType("universe", "hourSelection")
 
 	flux.RegisterPackageValue("universe", HourSelectionKind, flux.MustValue(flux.FunctionValue(HourSelectionKind, createHourSelectionOpSpec, hourSelectionSignature)))
 	flux.RegisterOpSpec(HourSelectionKind, newHourSelectionOp)

--- a/stdlib/universe/integral.go
+++ b/stdlib/universe/integral.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -20,7 +21,7 @@ type IntegralOpSpec struct {
 }
 
 func init() {
-	integralSignature := semantic.LookupBuiltInType("universe", "integral")
+	integralSignature := semantic.MustLookupBuiltinType("universe", "integral")
 
 	flux.RegisterPackageValue("universe", IntegralKind, flux.MustValue(flux.FunctionValue(IntegralKind, createIntegralOpSpec, integralSignature)))
 	flux.RegisterOpSpec(IntegralKind, newIntegralOp)

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -21,7 +21,7 @@ const JoinKind = "join"
 const MergeJoinKind = "merge-join"
 
 func init() {
-	joinSignature := semantic.LookupBuiltInType("universe", "join")
+	joinSignature := semantic.MustLookupBuiltinType("universe", "join")
 	flux.RegisterPackageValue("universe", JoinKind, flux.MustValue(flux.FunctionValue(JoinKind, createJoinOpSpec, joinSignature)))
 	flux.RegisterOpSpec(JoinKind, newJoinOp)
 	//TODO(nathanielc): Allow for other types of join implementations

--- a/stdlib/universe/kaufmansAMA.go
+++ b/stdlib/universe/kaufmansAMA.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const kamaKind = "kaufmansAMA"
@@ -18,7 +19,7 @@ type KamaOpSpec struct {
 }
 
 func init() {
-	kamaSignature := semantic.LookupBuiltInType("universe", "kaufmansAMA")
+	kamaSignature := semantic.MustLookupBuiltinType("universe", "kaufmansAMA")
 
 	flux.RegisterPackageValue("universe", kamaKind, flux.MustValue(flux.FunctionValue(kamaKind, createkamaOpSpec, kamaSignature)))
 	flux.RegisterOpSpec(kamaKind, newkamaOp)

--- a/stdlib/universe/key_values.go
+++ b/stdlib/universe/key_values.go
@@ -18,7 +18,7 @@ type KeyValuesOpSpec struct {
 }
 
 func init() {
-	keyValuesSignature := semantic.LookupBuiltInType("universe", "keyValues")
+	keyValuesSignature := semantic.MustLookupBuiltinType("universe", "keyValues")
 
 	flux.RegisterPackageValue("universe", KeyValuesKind, flux.MustValue(flux.FunctionValue(KeyValuesKind, createKeyValuesOpSpec, keyValuesSignature)))
 	flux.RegisterOpSpec(KeyValuesKind, newKeyValuesOp)

--- a/stdlib/universe/keys.go
+++ b/stdlib/universe/keys.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const KeysKind = "keys"
@@ -16,7 +17,7 @@ type KeysOpSpec struct {
 }
 
 func init() {
-	keysSignature := semantic.LookupBuiltInType("universe", "keys")
+	keysSignature := semantic.MustLookupBuiltinType("universe", "keys")
 
 	flux.RegisterPackageValue("universe", KeysKind, flux.MustValue(flux.FunctionValue(KeysKind, createKeysOpSpec, keysSignature)))
 	flux.RegisterOpSpec(KeysKind, newKeysOp)

--- a/stdlib/universe/last.go
+++ b/stdlib/universe/last.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const LastKind = "last"
@@ -16,7 +17,7 @@ type LastOpSpec struct {
 }
 
 func init() {
-	lastSignature := semantic.LookupBuiltInType("universe", "last")
+	lastSignature := semantic.MustLookupBuiltinType("universe", "last")
 
 	flux.RegisterPackageValue("universe", LastKind, flux.MustValue(flux.FunctionValue(LastKind, createLastOpSpec, lastSignature)))
 	flux.RegisterOpSpec(LastKind, newLastOp)

--- a/stdlib/universe/length.go
+++ b/stdlib/universe/length.go
@@ -17,7 +17,7 @@ import (
 func MakeLengthFunc() values.Function {
 	return values.NewFunction(
 		"length",
-		semantic.LookupBuiltInType("universe", "length"),
+		semantic.MustLookupBuiltinType("universe", "length"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			a := interpreter.NewArguments(args)
 			v, err := a.GetRequired("arr")

--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/execute/table"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const LimitKind = "limit"
@@ -22,7 +23,7 @@ type LimitOpSpec struct {
 }
 
 func init() {
-	limitSignature := semantic.LookupBuiltInType("universe", "limit")
+	limitSignature := semantic.MustLookupBuiltinType("universe", "limit")
 
 	flux.RegisterPackageValue("universe", LimitKind, flux.MustValue(flux.FunctionValue(LimitKind, createLimitOpSpec, limitSignature)))
 	flux.RegisterOpSpec(LimitKind, newLimitOp)

--- a/stdlib/universe/map.go
+++ b/stdlib/universe/map.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -21,7 +22,7 @@ type MapOpSpec struct {
 }
 
 func init() {
-	mapSignature := semantic.LookupBuiltInType("universe", "map")
+	mapSignature := semantic.MustLookupBuiltinType("universe", "map")
 
 	flux.RegisterPackageValue("universe", MapKind, flux.MustValue(flux.FunctionValue(MapKind, createMapOpSpec, mapSignature)))
 	flux.RegisterOpSpec(MapKind, newMapOp)

--- a/stdlib/universe/max.go
+++ b/stdlib/universe/max.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const MaxKind = "max"
@@ -16,7 +17,7 @@ type MaxOpSpec struct {
 }
 
 func init() {
-	maxSignature := semantic.LookupBuiltInType("universe", "max")
+	maxSignature := semantic.MustLookupBuiltinType("universe", "max")
 
 	flux.RegisterPackageValue("universe", MaxKind, flux.MustValue(flux.FunctionValue(MaxKind, createMaxOpSpec, maxSignature)))
 	flux.RegisterOpSpec(MaxKind, newMaxOp)

--- a/stdlib/universe/mean.go
+++ b/stdlib/universe/mean.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const MeanKind = "mean"
@@ -19,7 +20,7 @@ type MeanOpSpec struct {
 }
 
 func init() {
-	meanSignature := semantic.LookupBuiltInType("universe", "mean")
+	meanSignature := semantic.MustLookupBuiltinType("universe", "mean")
 
 	flux.RegisterPackageValue("universe", MeanKind, flux.MustValue(flux.FunctionValue(MeanKind, createMeanOpSpec, meanSignature)))
 	flux.RegisterOpSpec(MeanKind, newMeanOp)

--- a/stdlib/universe/min.go
+++ b/stdlib/universe/min.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const MinKind = "min"
@@ -16,7 +17,7 @@ type MinOpSpec struct {
 }
 
 func init() {
-	minSignature := semantic.LookupBuiltInType("universe", "min")
+	minSignature := semantic.MustLookupBuiltinType("universe", "min")
 
 	flux.RegisterPackageValue("universe", MinKind, flux.MustValue(flux.FunctionValue(MinKind, createMinOpSpec, minSignature)))
 	flux.RegisterOpSpec(MinKind, newMinOp)

--- a/stdlib/universe/mode.go
+++ b/stdlib/universe/mode.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -18,7 +19,7 @@ type ModeOpSpec struct {
 }
 
 func init() {
-	modeSignature := semantic.LookupBuiltInType("universe", "mode")
+	modeSignature := semantic.MustLookupBuiltinType("universe", "mode")
 
 	flux.RegisterPackageValue("universe", ModeKind, flux.MustValue(flux.FunctionValue(ModeKind, createModeOpSpec, modeSignature)))
 	flux.RegisterOpSpec(ModeKind, newModeOp)

--- a/stdlib/universe/moving_average.go
+++ b/stdlib/universe/moving_average.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/moving_average"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -18,7 +19,7 @@ type MovingAverageOpSpec struct {
 }
 
 func init() {
-	movingAverageSignature := semantic.LookupBuiltInType("universe", "movingAverage")
+	movingAverageSignature := semantic.MustLookupBuiltinType("universe", "movingAverage")
 
 	flux.RegisterPackageValue("universe", MovingAverageKind, flux.MustValue(flux.FunctionValue(MovingAverageKind, createMovingAverageOpSpec, movingAverageSignature)))
 	flux.RegisterOpSpec(MovingAverageKind, newMovingAverageOp)

--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -36,7 +36,7 @@ type PivotOpSpec struct {
 }
 
 func init() {
-	pivotSignature := semantic.LookupBuiltInType("universe", "pivot")
+	pivotSignature := semantic.MustLookupBuiltinType("universe", "pivot")
 
 	flux.RegisterPackageValue("universe", PivotKind, flux.MustValue(flux.FunctionValue(PivotKind, createPivotOpSpec, pivotSignature)))
 	flux.RegisterOpSpec(PivotKind, newPivotOp)

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/tdigest"
 )
@@ -35,7 +36,7 @@ type QuantileOpSpec struct {
 }
 
 func init() {
-	quantileSignature := semantic.LookupBuiltInType("universe", "quantile")
+	quantileSignature := semantic.MustLookupBuiltinType("universe", "quantile")
 
 	flux.RegisterPackageValue("universe", QuantileKind, flux.MustValue(flux.FunctionValue(QuantileKind, createQuantileOpSpec, quantileSignature)))
 

--- a/stdlib/universe/range.go
+++ b/stdlib/universe/range.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -20,7 +21,7 @@ type RangeOpSpec struct {
 }
 
 func init() {
-	rangeSignature := semantic.LookupBuiltInType("universe", "range")
+	rangeSignature := semantic.MustLookupBuiltinType("universe", "range")
 
 	flux.RegisterPackageValue("universe", RangeKind, flux.MustValue(flux.FunctionValue(RangeKind, createRangeOpSpec, rangeSignature)))
 	flux.RegisterOpSpec(RangeKind, newRangeOp)

--- a/stdlib/universe/reduce.go
+++ b/stdlib/universe/reduce.go
@@ -23,7 +23,7 @@ type ReduceOpSpec struct {
 }
 
 func init() {
-	reduceSignature := semantic.LookupBuiltInType("universe", "reduce")
+	reduceSignature := semantic.MustLookupBuiltinType("universe", "reduce")
 
 	flux.RegisterPackageValue("universe", ReduceKind, flux.MustValue(flux.FunctionValue(ReduceKind, createReduceOpSpec, reduceSignature)))
 	flux.RegisterOpSpec(ReduceKind, newReduceOp)

--- a/stdlib/universe/relative_strength_index.go
+++ b/stdlib/universe/relative_strength_index.go
@@ -22,7 +22,7 @@ type RelativeStrengthIndexOpSpec struct {
 }
 
 func init() {
-	relativeStrengthIndexSignature := semantic.LookupBuiltInType("universe", "relativeStrenthIndex")
+	relativeStrengthIndexSignature := semantic.MustLookupBuiltinType("universe", "relativeStrenthIndex")
 	flux.RegisterPackageValue("universe", RelativeStrengthIndexKind, flux.MustValue(flux.FunctionValue(RelativeStrengthIndexKind, createRelativeStrengthIndexOpSpec, relativeStrengthIndexSignature)))
 	flux.RegisterOpSpec(RelativeStrengthIndexKind, newRelativeStrengthIndexOp)
 	plan.RegisterProcedureSpec(RelativeStrengthIndexKind, newRelativeStrengthIndexProcedure, RelativeStrengthIndexKind)

--- a/stdlib/universe/sample.go
+++ b/stdlib/universe/sample.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const SampleKind = "sample"
@@ -20,7 +21,7 @@ type SampleOpSpec struct {
 }
 
 func init() {
-	sampleSignature := semantic.LookupBuiltInType("universe", "sample")
+	sampleSignature := semantic.MustLookupBuiltinType("universe", "sample")
 
 	flux.RegisterPackageValue("universe", SampleKind, flux.MustValue(flux.FunctionValue(SampleKind, createSampleOpSpec, sampleSignature)))
 	flux.RegisterOpSpec(SampleKind, newSampleOp)

--- a/stdlib/universe/set.go
+++ b/stdlib/universe/set.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -17,7 +18,7 @@ type SetOpSpec struct {
 }
 
 func init() {
-	setSignature := semantic.LookupBuiltInType("universe", "set")
+	setSignature := semantic.MustLookupBuiltinType("universe", "set")
 
 	flux.RegisterPackageValue("universe", SetKind, flux.MustValue(flux.FunctionValue(SetKind, createSetOpSpec, setSignature)))
 	flux.RegisterOpSpec(SetKind, newSetOp)

--- a/stdlib/universe/shift.go
+++ b/stdlib/universe/shift.go
@@ -21,7 +21,7 @@ type ShiftOpSpec struct {
 }
 
 func init() {
-	shiftSignature := semantic.LookupBuiltInType("universe", "timeShift")
+	shiftSignature := semantic.MustLookupBuiltinType("universe", "timeShift")
 
 	flux.RegisterPackageValue("universe", ShiftKind, flux.MustValue(flux.FunctionValue(ShiftKind, createShiftOpSpec, shiftSignature)))
 	flux.RegisterOpSpec(ShiftKind, newShiftOp)

--- a/stdlib/universe/skew.go
+++ b/stdlib/universe/skew.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const SkewKind = "skew"
@@ -18,7 +19,7 @@ type SkewOpSpec struct {
 }
 
 func init() {
-	skewSignature := semantic.LookupBuiltInType("universe", "skew")
+	skewSignature := semantic.MustLookupBuiltinType("universe", "skew")
 
 	flux.RegisterPackageValue("universe", SkewKind, flux.MustValue(flux.FunctionValue(SkewKind, createSkewOpSpec, skewSignature)))
 	flux.RegisterOpSpec(SkewKind, newSkewOp)

--- a/stdlib/universe/sleep.go
+++ b/stdlib/universe/sleep.go
@@ -23,7 +23,7 @@ const (
 
 var sleepFunc = values.NewFunction(
 	"sleep",
-	semantic.LookupBuiltInType("universe", "sleep"),
+	semantic.MustLookupBuiltinType("universe", "sleep"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		return interpreter.DoFunctionCallContext(sleep, ctx, args)
 	},

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -19,7 +19,7 @@ type SortOpSpec struct {
 }
 
 func init() {
-	sortSignature := semantic.LookupBuiltInType("universe", "sort")
+	sortSignature := semantic.MustLookupBuiltinType("universe", "sort")
 
 	flux.RegisterPackageValue("universe", SortKind, flux.MustValue(flux.FunctionValue(SortKind, createSortOpSpec, sortSignature)))
 	flux.RegisterOpSpec(SortKind, newSortOp)

--- a/stdlib/universe/spread.go
+++ b/stdlib/universe/spread.go
@@ -7,13 +7,14 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 // SpreadKind is the registration name for Flux, query, plan, and execution.
 const SpreadKind = "spread"
 
 func init() {
-	spreadSignature := semantic.LookupBuiltInType("universe", "spread")
+	spreadSignature := semantic.MustLookupBuiltinType("universe", "spread")
 
 	flux.RegisterPackageValue("universe", SpreadKind, flux.MustValue(flux.FunctionValue(SpreadKind, createSpreadOpSpec, spreadSignature)))
 	flux.RegisterOpSpec(SpreadKind, newSpreadOp)

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -26,7 +27,7 @@ type StateTrackingOpSpec struct {
 }
 
 func init() {
-	stateTrackingSignature := semantic.LookupBuiltInType("universe", "stateTracking")
+	stateTrackingSignature := semantic.MustLookupBuiltinType("universe", "stateTracking")
 
 	flux.RegisterPackageValue("universe", StateTrackingKind, flux.MustValue(flux.FunctionValue(StateTrackingKind, createStateTrackingOpSpec, stateTrackingSignature)))
 	flux.RegisterOpSpec(StateTrackingKind, newStateTrackingOp)

--- a/stdlib/universe/stddev.go
+++ b/stdlib/universe/stddev.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const (
@@ -24,7 +25,7 @@ type StddevOpSpec struct {
 }
 
 func init() {
-	stddevSignature := semantic.LookupBuiltInType("universe", "stddev")
+	stddevSignature := semantic.MustLookupBuiltinType("universe", "stddev")
 
 	flux.RegisterPackageValue("universe", StddevKind, flux.MustValue(flux.FunctionValue(StddevKind, createStddevOpSpec, stddevSignature)))
 	flux.RegisterOpSpec(StddevKind, newStddevOp)

--- a/stdlib/universe/sum.go
+++ b/stdlib/universe/sum.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const SumKind = "sum"
@@ -17,7 +18,7 @@ type SumOpSpec struct {
 }
 
 func init() {
-	sumSignature := semantic.LookupBuiltInType("universe", "sum")
+	sumSignature := semantic.MustLookupBuiltinType("universe", "sum")
 
 	flux.RegisterPackageValue("universe", SumKind, flux.MustValue(flux.FunctionValue(SumKind, createSumOpSpec, sumSignature)))
 	flux.RegisterOpSpec(SumKind, newSumOp)

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -34,7 +34,7 @@ func init() {
 
 func NewTableFindFunction() values.Value {
 	return values.NewFunction("tableFind",
-		semantic.LookupBuiltInType("universe", "tableFind"),
+		semantic.MustLookupBuiltinType("universe", "tableFind"),
 		tableFindCall,
 		false)
 }
@@ -127,7 +127,7 @@ func tableFindCall(ctx context.Context, args values.Object) (values.Value, error
 
 func NewGetColumnFunction() values.Value {
 	return values.NewFunction("getColumn",
-		semantic.LookupBuiltInType("universe", "getColumn"),
+		semantic.MustLookupBuiltinType("universe", "getColumn"),
 		getColumnCall,
 		false)
 }
@@ -212,7 +212,7 @@ func arrayFromColumn(idx int, cr flux.ColReader) values.Array {
 
 func NewGetRecordFunction() values.Value {
 	return values.NewFunction("getRecord",
-		semantic.LookupBuiltInType("universe", "getRecord"),
+		semantic.MustLookupBuiltinType("universe", "getRecord"),
 		getRecordCall,
 		false)
 }

--- a/stdlib/universe/tail.go
+++ b/stdlib/universe/tail.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const TailKind = "tail"
@@ -17,7 +18,7 @@ type TailOpSpec struct {
 }
 
 func init() {
-	tailSignature := semantic.LookupBuiltInType("universe", "tail")
+	tailSignature := semantic.MustLookupBuiltinType("universe", "tail")
 
 	flux.RegisterPackageValue("universe", TailKind, flux.MustValue(flux.FunctionValue(TailKind, createTailOpSpec, tailSignature)))
 	flux.RegisterOpSpec(TailKind, newTailOp)

--- a/stdlib/universe/triple_exponential_derivative.go
+++ b/stdlib/universe/triple_exponential_derivative.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/flux/internal/moving_average"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -22,7 +23,7 @@ type TripleExponentialDerivativeOpSpec struct {
 }
 
 func init() {
-	tripleExponentialDerivativeSignature := semantic.LookupBuiltInType("universe", "tripleExponentialDerivative")
+	tripleExponentialDerivativeSignature := semantic.MustLookupBuiltinType("universe", "tripleExponentialDerivative")
 
 	flux.RegisterPackageValue("universe", TripleExponentialDerivativeKind, flux.MustValue(flux.FunctionValue(TripleExponentialDerivativeKind, createTripleExponentialDerivativeOpSpec, tripleExponentialDerivativeSignature)))
 	flux.RegisterOpSpec(TripleExponentialDerivativeKind, newTripleExponentialDerivativeOp)

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -670,7 +670,7 @@ func (c *durationConv) Call(ctx context.Context, args values.Object) (values.Val
 
 var bytes = values.NewFunction(
 	"bytes",
-	semantic.LookupBuiltInType("universe", "bytes"),
+	semantic.MustLookupBuiltinType("universe", "bytes"),
 	func(ctx context.Context, args values.Object) (values.Value, error) {
 		v, ok := args.Get(conversionArg)
 		if !ok {

--- a/stdlib/universe/union.go
+++ b/stdlib/universe/union.go
@@ -23,7 +23,7 @@ func (s *UnionOpSpec) Kind() flux.OperationKind {
 }
 
 func init() {
-	unionSignature := semantic.LookupBuiltInType("universe", "union")
+	unionSignature := semantic.MustLookupBuiltinType("universe", "union")
 
 	flux.RegisterPackageValue("universe", UnionKind, flux.MustValue(flux.FunctionValue(UnionKind, createUnionOpSpec, unionSignature)))
 	flux.RegisterOpSpec(UnionKind, newUnionOp)

--- a/stdlib/universe/unique.go
+++ b/stdlib/universe/unique.go
@@ -6,6 +6,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const UniqueKind = "unique"
@@ -15,7 +16,7 @@ type UniqueOpSpec struct {
 }
 
 func init() {
-	uniqueSignature := semantic.LookupBuiltInType("universe", "unique")
+	uniqueSignature := semantic.MustLookupBuiltinType("universe", "unique")
 
 	flux.RegisterPackageValue("universe", UniqueKind, flux.MustValue(flux.FunctionValue(UniqueKind, createUniqueOpSpec, uniqueSignature)))
 	flux.RegisterOpSpec(UniqueKind, newUniqueOp)

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux/internal/execute/table"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -31,7 +32,7 @@ type WindowOpSpec struct {
 var infinityVar = values.NewDuration(values.ConvertDuration(math.MaxInt64))
 
 func init() {
-	windowSignature := semantic.LookupBuiltInType("universe", "window")
+	windowSignature := semantic.MustLookupBuiltinType("universe", "window")
 
 	flux.RegisterPackageValue("universe", WindowKind, flux.MustValue(flux.FunctionValue(WindowKind, createWindowOpSpec, windowSignature)))
 	flux.RegisterOpSpec(WindowKind, newWindowOp)

--- a/stdlib/universe/yield.go
+++ b/stdlib/universe/yield.go
@@ -5,6 +5,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/semantic"
 )
 
 const YieldKind = "yield"
@@ -14,7 +15,7 @@ type YieldOpSpec struct {
 }
 
 func init() {
-	yieldSignature := semantic.LookupBuiltInType("universe", "yield")
+	yieldSignature := semantic.MustLookupBuiltinType("universe", "yield")
 
 	flux.RegisterPackageValue("universe", YieldKind, flux.MustValue(flux.FunctionValueWithSideEffect(YieldKind, createYieldOpSpec, yieldSignature)))
 	flux.RegisterOpSpec(YieldKind, newYieldOp)

--- a/values/valuestest/scope.go
+++ b/values/valuestest/scope.go
@@ -51,7 +51,7 @@ func NowScope() values.Scope {
 	scope := flux.Prelude()
 	scope.SetOption("universe", "now", values.NewFunction(
 		"now",
-		semantic.LookupBuiltInType("universe", "now"),
+		semantic.MustLookupBuiltinType("universe", "now"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			//Functions are only compared by type so the function body here is not important
 			return nil, errors.New("NowScope was called")


### PR DESCRIPTION
`LookupBuiltinType` should panic if lookup fails. This issue adds a validation wrapper that panics if there is a failure. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
