### PR TITLE
fix(stdlib): misc stdlib fixes

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -322,17 +322,17 @@ func FunctionValueWithSideEffect(name string, c CreateOperationSpec, ft semantic
 	return functionValue(name, c, ft, true)
 }
 
-func functionValue(name string, c CreateOperationSpec, ft semantic.MonoType, sideEffects bool) (values.Value, error) {
+func functionValue(name string, c CreateOperationSpec, mt semantic.MonoType, sideEffects bool) (values.Value, error) {
 	if c == nil {
 		c = func(args Arguments, a *Administration) (OperationSpec, error) {
 			return nil, errors.Newf(codes.Unimplemented, "function %q is not implemented", name)
 		}
 	}
-	if ft.Nature() != semantic.Function {
-		return nil, errors.Newf(codes.Invalid, "cannot implement function %q with value of type %v", name, ft)
+	if mt.Nature() != semantic.Function {
+		return nil, errors.Newf(codes.Invalid, "cannot implement function %q with value of type %v", name, mt)
 	}
 	return &function{
-		t:             ft,
+		t:             mt,
 		name:          name,
 		createOpSpec:  c,
 		hasSideEffect: sideEffects,

--- a/compile_internal_test.go
+++ b/compile_internal_test.go
@@ -42,7 +42,7 @@ func TestValidatePackageBuiltins(t *testing.T) {
 		},
 		{
 			name: "missing values",
-			pkg:  interpreter.NewPackageWithValues("test", values.NewObject()),
+			pkg:  interpreter.NewPackageWithValues("test", values.NewObjectWithValues(map[string]values.Value{})),
 			astPkg: &ast.Package{
 				Files: []*ast.File{{
 					Body: []ast.Statement{

--- a/result_test.go
+++ b/result_test.go
@@ -33,6 +33,7 @@ func TestColumnType(t *testing.T) {
 		{typ: semantic.NewArrayType(semantic.BasicString), want: flux.TInvalid},
 		{typ: semantic.NewObjectType(
 		// TODO(algow): determine how to create correct type
+		nil,
 		//	map[string]semantic.MonoType{
 		//	"foo": semantic.String,
 		//},

--- a/spec_test.go
+++ b/spec_test.go
@@ -358,7 +358,7 @@ func Example_overrideDefaultOptionInternally() {
 	timeValue := time.Date(2018, 7, 13, 0, 0, 0, 0, time.UTC)
 	functionName := "newTime"
 	// TODO (algow): determine correct type
-	functionType := semantic.NewFunctionType()
+	functionType := semantic.NewFunctionType(semantic.MonoType{}, nil)
 	functionCall := func(ctx context.Context, args values.Object) (values.Value, error) {
 		return values.NewTime(values.ConvertTime(timeValue)), nil
 	}

--- a/stdlib/generate/from.go
+++ b/stdlib/generate/from.go
@@ -193,8 +193,9 @@ func (s *GeneratorSource) Decode(ctx context.Context) (flux.Table, error) {
 	valueIdx := execute.ColIdx("_value", cols)
 	for i := 0; i < int(s.Count); i++ {
 		b.AppendTime(timeIdx, values.ConvertTime(s.Start.Add(time.Duration(i)*deltaT)))
-		in := values.NewObject()
-		in.Set("n", values.NewInt(int64(i)))
+		in := values.NewObjectWithValues(map[string]values.Value{
+			"n": values.NewInt(int64(i)),
+		})
 		v, err := s.Fn.Eval(ctx, in)
 		if err != nil {
 			return nil, err

--- a/stdlib/influxdata/influxdb/v1/databases.go
+++ b/stdlib/influxdata/influxdb/v1/databases.go
@@ -7,7 +7,7 @@ import (
 
 const DatabasesKind = "databases"
 
-var DatabasesSignature = semantic.MustLookupBuiltinType("influxdata/influxdb/v1", "databses")
+var DatabasesSignature = semantic.MustLookupBuiltinType("influxdata/influxdb/v1", "databases")
 
 func init() {
 	flux.RegisterPackageValue("influxdata/influxdb/v1", DatabasesKind, flux.MustValue(flux.FunctionValue(DatabasesKind, nil, DatabasesSignature)))

--- a/stdlib/internal/promql/join.go
+++ b/stdlib/internal/promql/join.go
@@ -520,6 +520,7 @@ func (fn *rowJoinFn) Prepare(left, right []flux.ColMeta) error {
 
 	f, err := fn.cache.Compile(semantic.NewObjectType(
 	// TODO (algow): determine the correct type
+	nil,
 	//map[string]semantic.MonoType{
 	//	"left":  semantic.NewObjectType(l),
 	//	"right": semantic.NewObjectType(r),

--- a/stdlib/math/math.go
+++ b/stdlib/math/math.go
@@ -114,8 +114,8 @@ func init() {
 	flux.RegisterPackageValue("math", "log2", generateMathFunctionX("log2", math.Log2))
 	flux.RegisterPackageValue("math", "logb", generateMathFunctionX("logb", math.Logb))
 	// TODO: change to max and min when we eliminate namespace collisions
-	flux.RegisterPackageValue("math", "mMax", generateMathFunctionXY("max", math.Max))
-	flux.RegisterPackageValue("math", "mMin", generateMathFunctionXY("min", math.Min))
+	flux.RegisterPackageValue("math", "mMax", generateMathFunctionXY("mMax", math.Max))
+	flux.RegisterPackageValue("math", "mMin", generateMathFunctionXY("mMin", math.Min))
 	flux.RegisterPackageValue("math", "mod", generateMathFunctionXY("mod", math.Mod))
 	flux.RegisterPackageValue("math", "nextafter", generateMathFunctionXY("nextafter", math.Nextafter))
 	flux.RegisterPackageValue("math", "pow", generateMathFunctionXY("pow", math.Pow))
@@ -314,7 +314,7 @@ func init() {
 		// (int) --> float
 		"mInf": values.NewFunction(
 			"inf",
-			semantic.MustLookupBuiltinType("math", "inf"),
+			semantic.MustLookupBuiltinType("math", "mInf"),
 			func(ctx context.Context, args values.Object) (values.Value, error) {
 
 				v1, ok := args.Get("sign")

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -27,7 +27,7 @@ type ToSQLOpSpec struct {
 }
 
 func init() {
-	toSQLSignature := semantic.MustLookupBuiltinType("sql", "ro")
+	toSQLSignature := semantic.MustLookupBuiltinType("sql", "to")
 	flux.RegisterPackageValue("sql", "to", flux.MustValue(flux.FunctionValueWithSideEffect(ToSQLKind, createToSQLOpSpec, toSQLSignature)))
 	flux.RegisterOpSpec(ToSQLKind, func() flux.OperationSpec { return &ToSQLOpSpec{} })
 	plan.RegisterProcedureSpecWithSideEffect(ToSQLKind, newToSQLProcedure, ToSQLKind)

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -145,7 +145,7 @@ func generateDualArgStringFunctionReturnInt(name string, argNames []string, stri
 func generateSplit(name string, argNames []string, fn func(string, string) []string) values.Function {
 	return values.NewFunction(
 		name,
-		semantic.MustLookupBuiltinType("string", name),
+		semantic.MustLookupBuiltinType("strings", name),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
 			var argVals = make([]values.Value, 2)
 

--- a/stdlib/universe/cumulative_sum.go
+++ b/stdlib/universe/cumulative_sum.go
@@ -17,7 +17,7 @@ type CumulativeSumOpSpec struct {
 }
 
 func init() {
-	cumulativeSumSignature := semantic.MustLookupBuiltinType("univsere", "cumulativeSum")
+	cumulativeSumSignature := semantic.MustLookupBuiltinType("universe", "cumulativeSum")
 
 	flux.RegisterPackageValue("universe", CumulativeSumKind, flux.MustValue(flux.FunctionValue(CumulativeSumKind, createCumulativeSumOpSpec, cumulativeSumSignature)))
 	flux.RegisterOpSpec(CumulativeSumKind, newCumulativeSumOp)

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -186,7 +186,8 @@ func (t *filterTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 
 	// Iterate through the properties and prefill a record
 	// with the values from the group key.
-	record := values.NewObject()
+	// TODO(algow): construct record properly
+	record := values.NewObject(semantic.MonoType{})
 	for name := range properties {
 		if idx := execute.ColIdx(name, tbl.Key().Cols()); idx >= 0 {
 			record.Set(name, tbl.Key().Value(idx))

--- a/stdlib/universe/histogram.go
+++ b/stdlib/universe/histogram.go
@@ -246,8 +246,7 @@ type linearBins struct{}
 var linearBinsType = semantic.MustLookupBuiltinType("universe", "linearBins")
 
 func (b linearBins) Type() semantic.MonoType {
-	t, _ := linearBinsType.Expr()
-	return t
+	return linearBinsType
 }
 
 func (b linearBins) IsNull() bool {
@@ -369,8 +368,7 @@ type logarithmicBins struct{}
 var logarithmicBinsType = semantic.MustLookupBuiltinType("universe", "logarithmicBins")
 
 func (b logarithmicBins) Type() semantic.MonoType {
-	t, _ := logarithmicBinsType.Expr()
-	return t
+	return logarithmicBinsType
 }
 
 func (b logarithmicBins) IsNull() bool {

--- a/stdlib/universe/holt_winters.go
+++ b/stdlib/universe/holt_winters.go
@@ -28,7 +28,7 @@ type HoltWintersOpSpec struct {
 }
 
 func init() {
-	hwSignature := semantic.MustLookupBuiltinType("univser", "holtWinter")
+	hwSignature := semantic.MustLookupBuiltinType("universe", "holtWinters")
 	flux.RegisterPackageValue("universe", HoltWintersKind, flux.MustValue(flux.FunctionValue(HoltWintersKind, createHoltWintersOpSpec, hwSignature)))
 	flux.RegisterOpSpec(HoltWintersKind, newHoltWintersOp)
 	plan.RegisterProcedureSpec(HoltWintersKind, newHoltWintersProcedure, HoltWintersKind)

--- a/stdlib/universe/relative_strength_index.go
+++ b/stdlib/universe/relative_strength_index.go
@@ -22,7 +22,7 @@ type RelativeStrengthIndexOpSpec struct {
 }
 
 func init() {
-	relativeStrengthIndexSignature := semantic.MustLookupBuiltinType("universe", "relativeStrenthIndex")
+	relativeStrengthIndexSignature := semantic.MustLookupBuiltinType("universe", "relativeStrengthIndex")
 	flux.RegisterPackageValue("universe", RelativeStrengthIndexKind, flux.MustValue(flux.FunctionValue(RelativeStrengthIndexKind, createRelativeStrengthIndexOpSpec, relativeStrengthIndexSignature)))
 	flux.RegisterOpSpec(RelativeStrengthIndexKind, newRelativeStrengthIndexOp)
 	plan.RegisterProcedureSpec(RelativeStrengthIndexKind, newRelativeStrengthIndexProcedure, RelativeStrengthIndexKind)

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -53,14 +53,14 @@ var SchemaMutationOps = []flux.OperationKind{}
 // should not have their own ProcedureSpec.
 type MutationRegistrar struct {
 	Kind   flux.OperationKind
-	Type   semantic.PolyType
+	Type   semantic.MonoType
 	Create flux.CreateOperationSpec
 	New    flux.NewOperationSpec
 }
 
 func (m MutationRegistrar) Register() {
-
-	flux.RegisterPackageValue("universe", string(m.Kind), flux.MustValue(flux.FunctionValue(string(m.Kind), m.Create, m.Type)))
+	t := semantic.MustLookupBuiltinType("universe", string(m.Kind))
+	flux.RegisterPackageValue("universe", string(m.Kind), flux.MustValue(flux.FunctionValue(string(m.Kind), m.Create, t)))
 	flux.RegisterOpSpec(m.Kind, m.New)
 
 	// Add to list of SchemaMutations which should map to a
@@ -73,61 +73,21 @@ func (m MutationRegistrar) Register() {
 var Registrars = []MutationRegistrar{
 	{
 		Kind: RenameKind,
-		// TODO (algow): determine correct types
-		//Args: map[string]semantic.PolyType{
-		//"columns": semantic.Object,
-		//"fn": semantic.NewFunctionType(
-		//	semantic.FunctionPolySignature{
-		//		Parameters: map[string]semantic.PolyType{
-		//			"column": semantic.String,
-		//		},
-		//		Required: semantic.LabelSet{"column"},
-		//		Return:   semantic.String,
-		//	},
-		//),
-		//},
 		Create: createRenameOpSpec,
 		New:    newRenameOp,
 	},
 	{
 		Kind: DropKind,
-		// TODO (algow): determine correct types
-		//Args: map[string]semantic.PolyType{
-		//"columns": semantic.NewArrayPolyType(semantic.String),
-		//"fn": semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
-		//	Parameters: map[string]semantic.PolyType{
-		//		"column": semantic.String,
-		//	},
-		//	Required: semantic.LabelSet{"column"},
-		//	Return:   semantic.Bool,
-		//}),
-		//},
 		Create: createDropOpSpec,
 		New:    newDropOp,
 	},
 	{
 		Kind: KeepKind,
-		// TODO (algow): determine correct types
-		//Args: map[string]semantic.PolyType{
-		//"columns": semantic.NewArrayPolyType(semantic.String),
-		//"fn": semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
-		//	Parameters: map[string]semantic.PolyType{
-		//		"column": semantic.String,
-		//	},
-		//	Required: semantic.LabelSet{"column"},
-		//	Return:   semantic.Bool,
-		//}),
-		//},
 		Create: createKeepOpSpec,
 		New:    newKeepOp,
 	},
 	{
 		Kind: DuplicateKind,
-		// TODO (algow): determine correct t
-		//Args: map[string]semantic.PolyType{
-		//"column": semantic.String,
-		//"as":     semantic.String,
-		//},
 		Create: createDuplicateOpSpec,
 		New:    newDuplicateOp,
 	},

--- a/stdlib/universe/schema_mutators.go
+++ b/stdlib/universe/schema_mutators.go
@@ -98,7 +98,8 @@ func NewRenameMutator(qs flux.OperationSpec) (*RenameMutator, error) {
 
 		m.Fn = compiledFn
 		m.ParamName = param
-		m.Input = values.NewObject()
+		// TODO(algow): initialize this properly
+		m.Input = values.NewObject(semantic.MonoType{})
 	}
 	return m, nil
 }
@@ -182,7 +183,8 @@ func NewDropKeepMutator(qs flux.OperationSpec) (*DropKeepMutator, error) {
 			}
 			m.Predicate = compiledFn
 			m.ParamName = param
-			m.Input = values.NewObject()
+			// TODO(algow): initialize this properly
+			m.Input = values.NewObject(semantic.MonoType{})
 		}
 	case *KeepOpSpec:
 		if s.Columns != nil {
@@ -197,7 +199,8 @@ func NewDropKeepMutator(qs flux.OperationSpec) (*DropKeepMutator, error) {
 			m.FlipPredicate = true
 
 			m.ParamName = param
-			m.Input = values.NewObject()
+			// TODO(algow): initialize this properly
+			m.Input = values.NewObject(semantic.MonoType{})
 		}
 	default:
 		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)


### PR DESCRIPTION
This fixes some miscellaneous typos in the `stdlib` code, and also lets code compile.

This commit will make it trivial to reproduce #2404 by running the test `TestValidatePackageBuiltins`.