### PR TITLE
refactor(values): ensure that setting an invalid key in the object panics

### DIFF
--- a/values/object.go
+++ b/values/object.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 )
 
@@ -152,6 +154,7 @@ func (o *object) Set(k string, v Value) {
 			return
 		}
 	}
+	panic(errors.Newf(codes.Internal, "key %q not defined in object", k))
 }
 
 func (o *object) Get(name string) (Value, bool) {


### PR DESCRIPTION
Previously, attempting to set an invalid key in an object would result
in it silently ignoring the failure. This makes it explicitly a problem
that must be addressed because it will panic if the key could not be
found.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written