### PR TITLE
fix(csv): handled malformed data as well as eof

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -306,7 +306,7 @@ func readMetadata(r *csv.Reader, c ResultDecoderConfig, extraLine []string) (tab
 			if err != nil {
 				if err == io.EOF {
 					if datatypes == nil && groups == nil && defaults == nil {
-						return tableMetadata{}, fmt.Errorf("missing expected annotations datatype, group, and default")
+						return tableMetadata{}, err
 					}
 					switch {
 					case datatypes == nil:
@@ -340,7 +340,7 @@ func readMetadata(r *csv.Reader, c ResultDecoderConfig, extraLine []string) (tab
 			}
 			defaults = copyLine(line[recordStartIdx:])
 		default:
-			if annotation == "" {
+			if !strings.HasPrefix(line[annotationIdx], commentPrefix) {
 				switch {
 				case datatypes == nil:
 					return tableMetadata{}, fmt.Errorf("missing expected annotation datatype")
@@ -350,7 +350,7 @@ func readMetadata(r *csv.Reader, c ResultDecoderConfig, extraLine []string) (tab
 					return tableMetadata{}, fmt.Errorf("missing expected annotation default")
 				}
 			}
-			// Skip extra annotation
+			// Ignore unsupported/unknown annotations.
 		}
 	}
 

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -685,11 +685,64 @@ func TestResultDecoder(t *testing.T) {
 			},
 		},
 		{
+			name:          "csv with EOF",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded:       toCRLF(""),
+			result: &executetest.Result{
+				Err: errors.New("EOF"),
+			},
+		},
+		{
 			name:          "csv with no metadata",
 			encoderConfig: csv.DefaultEncoderConfig(),
 			encoded:       toCRLF(`1,2`),
 			result: &executetest.Result{
-				Err: errors.New("failed to read metadata: missing expected annotations datatype, group, and default"),
+				Err: errors.New("failed to read metadata: missing expected annotation datatype"),
+			},
+		},
+
+		{
+			name:          "single table with unknown annotations",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#unsupported,,,,,,,,
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							"cpu",
+							"A",
+							42.0,
+						},
+						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+							"cpu",
+							"A",
+							43.0,
+						},
+					},
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
This patch restores the original EOF functionality (and adds a test to
ensure that functionality doesn't break again). It also checks a line of
csv to see if the annotation actually is an annotation, rather than
data, before trying to parse it as an annotation. If it isn't an
annotation, and we're not expecting data yet, _then_ the "missing
expected annotations" error occurrs.

Additionally, another test for unsupported/ignored annotations was
added.
