### PR TITLE
docs(libflux): fail build when docs are missing

### DIFF
--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 pub mod check;
 
 pub mod flatbuffers;

--- a/libflux/src/flux/formatter/mod.rs
+++ b/libflux/src/flux/formatter/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use crate::ast::{self, walk::Node};
 use crate::Error;
 

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -1,6 +1,7 @@
-#![cfg_attr(feature = "strict", deny(warnings))]
+#![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
 #![allow(clippy::unknown_clippy_lints)]
-
+//! The flux crate handles the parsing and semantic analysis of flux source
+//! code.
 extern crate chrono;
 #[macro_use]
 extern crate serde_derive;
@@ -19,18 +20,23 @@ use std::os::raw::{c_char, c_void};
 
 use parser::Parser;
 
-pub const DEFAULT_PACKAGE_NAME: &str = "main";
+pub use ast::DEFAULT_PACKAGE_NAME;
 
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, missing_docs)]
 pub mod ctypes {
     include!(concat!(env!("OUT_DIR"), "/ctypes.rs"));
 }
 use ctypes::*;
 
+/// An error handle designed to allow passing `Error` instances to library
+/// consumers across language boundaries.
 pub struct ErrorHandle {
+    /// A heap-allocated `Error`
     pub err: Box<dyn error::Error>,
 }
 
+/// An error that can occur due to problems in ast generation or semantic
+/// analysis.
 #[derive(Debug)]
 pub struct Error {
     msg: String,
@@ -68,9 +74,12 @@ impl From<semantic::nodes::Error> for Error {
     }
 }
 
+/// A buffer of flux source.
 #[repr(C)]
 pub struct flux_buffer_t {
+    /// A pointer to a byte array.
     pub data: *const u8,
+    /// The length of the byte array.
     pub len: usize,
 }
 
@@ -169,9 +178,13 @@ pub unsafe extern "C" fn flux_semantic_marshal_fb(
     std::ptr::null_mut()
 }
 
+/// # Safety
+///
+/// This function is unsafe because it dereferences a raw pointer passed as a
+/// parameter
 #[no_mangle]
-pub extern "C" fn flux_error_str(err: *mut flux_error_t) -> *mut c_char {
-    let e = unsafe { &*(err as *mut ErrorHandle) };
+pub unsafe extern "C" fn flux_error_str(err: *mut flux_error_t) -> *mut c_char {
+    let e = &*(err as *mut ErrorHandle); // Unsafe
     let s = CString::new(format!("{}", e.err)).unwrap();
     s.into_raw()
 }

--- a/libflux/src/flux/parser/mod.rs
+++ b/libflux/src/flux/parser/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::str;

--- a/libflux/src/flux/scanner/mod.rs
+++ b/libflux/src/flux/scanner/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 pub type CChar = u8;

--- a/libflux/src/flux/semantic/mod.rs
+++ b/libflux/src/flux/semantic/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 pub mod convert;
 
 mod import;


### PR DESCRIPTION
This patch add `missing_docs` to the `strict` configuration attribute,
meaning the build will fail if the documentation is missing for any
function or type. As a result, more than 2400 errors were raised.

Additionally, this patch adds the ignore rules for all root modules, and
adds documentation for all functions and types in `lib.rs`.

Fixes #2099


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
