### PR TITLE
refactor(runtime): refactor the builtin registration

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -1,0 +1,185 @@
+package flux
+
+import (
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/values"
+)
+
+// defaultRuntime contains the preregistered packages and builtin values
+// required to execute a flux script.
+var defaultRuntime = &runtime{}
+
+// runtimeBuilder is used to construct the runtime before it is finalized.
+type runtimeBuilder struct {
+	pkgs     map[string]*ast.Package
+	builtins map[string]map[string]values.Value
+}
+
+func (b *runtimeBuilder) RegisterPackage(pkg *ast.Package) error {
+	if b == nil {
+		return errors.New(codes.Internal, "already finalized, cannot register builtin package")
+	}
+
+	if b.pkgs == nil {
+		b.pkgs = make(map[string]*ast.Package)
+	}
+
+	if _, ok := b.pkgs[pkg.Path]; ok {
+		return errors.Newf(codes.Internal, "duplicate builtin package %q", pkg.Path)
+	}
+	b.pkgs[pkg.Path] = pkg
+	return nil
+}
+
+func (b *runtimeBuilder) RegisterPackageValue(pkgpath, name string, value values.Value) error {
+	return b.registerPackageValue(pkgpath, name, value, false)
+}
+
+func (b *runtimeBuilder) ReplacePackageValue(pkgpath, name string, value values.Value) error {
+	return b.registerPackageValue(pkgpath, name, value, true)
+}
+
+func (b *runtimeBuilder) registerPackageValue(pkgpath, name string, value values.Value, replace bool) error {
+	if b == nil {
+		return errors.Newf(codes.Internal, "already finalized, cannot register builtin package value")
+	}
+
+	if b.builtins == nil {
+		b.builtins = make(map[string]map[string]values.Value)
+	}
+
+	pkg, ok := b.builtins[pkgpath]
+	if !ok {
+		pkg = make(map[string]values.Value)
+		b.builtins[pkgpath] = pkg
+	}
+
+	if _, ok := pkg[name]; ok && !replace {
+		return errors.Newf(codes.Internal, "duplicate builtin package value %q %q", pkgpath, name)
+	} else if !ok && replace {
+		return errors.Newf(codes.Internal, "missing builtin package value %q %q", pkgpath, name)
+	}
+	pkg[name] = value
+	return nil
+}
+
+// runtime contains the flux runtime for interpreting and
+// executing queries.
+type runtime struct {
+	pkgs      map[string]*interpreter.Package
+	prelude   *scopeSet
+	rbuilder  *runtimeBuilder
+	finalized bool
+}
+
+// builder returns the runtime builder for this runtime
+// or constructs one if the runtime hasn't been finalized.
+func (r *runtime) builder() *runtimeBuilder {
+	if r.rbuilder == nil {
+		if r.finalized {
+			return nil
+		}
+		r.rbuilder = &runtimeBuilder{}
+	}
+	return r.rbuilder
+}
+
+func (r *runtime) RegisterPackage(pkg *ast.Package) error {
+	return r.builder().RegisterPackage(pkg)
+}
+
+func (r *runtime) RegisterPackageValue(pkgpath, name string, value values.Value) error {
+	return r.builder().RegisterPackageValue(pkgpath, name, value)
+}
+
+func (r *runtime) ReplacePackageValue(pkgpath, name string, value values.Value) error {
+	return r.builder().ReplacePackageValue(pkgpath, name, value)
+}
+
+func (r *runtime) Prelude() values.Scope {
+	if !r.finalized {
+		panic("builtins not finalized")
+	}
+	return r.prelude.Nest(nil)
+}
+
+func (r *runtime) Stdlib() interpreter.Importer {
+	importer := importer{pkgs: r.pkgs}
+	return importer.Copy()
+}
+
+func (r *runtime) Finalize() error {
+	if r.finalized {
+		return errors.New(codes.Internal, "already finalized")
+	}
+	r.finalized = true
+
+	b := r.builder()
+	order, err := packageOrder(prelude, b.pkgs)
+	if err != nil {
+		return err
+	}
+
+	r.prelude = &scopeSet{
+		packages: make([]*interpreter.Package, 0, len(prelude)),
+	}
+	r.pkgs = make(map[string]*interpreter.Package, len(order))
+	for _, astPkg := range order {
+		if ast.Check(astPkg) > 0 {
+			err := ast.GetError(astPkg)
+			return errors.Wrapf(err, codes.Inherit, "failed to parse builtin package %q", astPkg.Path)
+		}
+		pkgpath := astPkg.Path
+
+		// TODO(algow): Need to semantically analyze the AST package to
+		// run it through the interpreter, but the AST gets deserialized
+		// incorrectly in Rust.
+		// ap, err := parser.ToHandle(astPkg)
+		// if err != nil {
+		// 	return err
+		// }
+		//
+		// root, err := semantic.AnalyzePackage(ap)
+		// if err != nil {
+		// 	return err
+		// }
+
+		// Build an object with the initial set of identifiers
+		// from the known builtin values.
+		object, _ := values.BuildObject(func(set values.ObjectSetter) error {
+			for k, v := range b.builtins[pkgpath] {
+				set(k, v)
+			}
+			return nil
+		})
+		scope := r.prelude.Nest(object)
+
+		// TODO(algow): Need to run the interpreter on the package, but the
+		// Rust code doesn't perform type inference correctly on builtins at
+		// the moment.
+		// importer := importer{pkgs: r.pkgs}
+		// // Construct an initial package using the builtins.
+		// itrp := interpreter.NewInterpreter(nil)
+		// if _, err := itrp.Eval(context.Background(), root, scope, &importer); err != nil {
+		// 	return err
+		// }
+		packageName := astPkg.Path
+		obj, _ := values.BuildObject(func(set values.ObjectSetter) error {
+			scope.LocalRange(set)
+			return nil
+		})
+		r.pkgs[pkgpath] = interpreter.NewPackageWithValues(packageName, obj)
+		for _, ppath := range prelude {
+			if ppath == pkgpath {
+				r.prelude.packages = append(r.prelude.packages, r.pkgs[pkgpath])
+				break
+			}
+		}
+	}
+
+	r.rbuilder = nil
+	return nil
+}

--- a/values/option.go
+++ b/values/option.go
@@ -1,0 +1,15 @@
+package values
+
+// Option is a value that has been declared as an option within the
+// package. An option can be modified by another package from outside
+// of the scope that the option was originally defined in, but it will
+// affect the original scope it was defined in.
+type Option struct {
+	Value
+}
+
+// IsOption checks if the current value is defined as an option.
+func IsOption(v Value) bool {
+	_, ok := v.(Option)
+	return ok
+}


### PR DESCRIPTION
The builtin registration was previously happening incrementally so the
order of how things got registered was uncertain. The registration has
now been changed so it encapsulates the work in a runtime builder struct
and it constructs the final runtime when finalize is called instead of
gradually as the packages are registered.

This also modifies the scope so there is a special `values.Option` which
wraps another value. This signals that a variable was defined in a
package as an option. This allows us to evaluate a flux file and
determine from the scope which values were defined as options and which
as normal variables.

The refactor removes most of the need for the global variables by
encapsulating those globals into a single struct which can be used as if
it were not a global variable.

Unfortunately, this is not completely done due to a few other pieces
that need to be fixed before evaluating standard library packages works
correctly.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written