### PR TITLE
fix(libflux): expose the builtin polytypes when analyzing a stdlib package

### DIFF
--- a/libflux/src/flux/semantic/bootstrap.rs
+++ b/libflux/src/flux/semantic/bootstrap.rs
@@ -91,18 +91,19 @@ pub fn infer_stdlib() -> Result<
 fn builtin_types() -> Result<(HashMap<String, HashMap<String, PolyType>>, Fresher), Error> {
     let mut tv = Tvar(0);
     let mut ty = HashMap::new();
-    for (mut path, expr) in builtins().iter() {
-        let name = path.pop().unwrap();
-        let expr = parse(expr)?;
+    for (path, values) in builtins().iter() {
+        for (name, expr) in values {
+            let expr = parse(expr)?;
 
-        let tvar = expr.max_tvar();
-        if tvar > tv {
-            tv = tvar;
+            let tvar = expr.max_tvar();
+            if tvar > tv {
+                tv = tvar;
+            }
+
+            ty.entry((*path).to_string())
+                .or_insert_with(HashMap::new)
+                .insert((*name).to_string(), expr);
         }
-
-        ty.entry(path.join("/"))
-            .or_insert_with(HashMap::new)
-            .insert(name.to_string(), expr);
     }
     Ok((ty, Fresher::from(tv.0 + 1)))
 }

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -1,183 +1,185 @@
+use crate::semantic::fresh::{Fresh, Fresher};
+use crate::semantic::import::Importer;
+use crate::semantic::parser::parse;
 use maplit::hashmap;
-use std::collections::hash_map;
+use std::collections::hash_map::Iter;
 use std::collections::HashMap;
-use std::iter::Iterator;
-use std::vec::Vec;
 
 pub struct Builtins<'a> {
-    pkgs: HashMap<&'a str, Node<'a>>,
+    pkgs: HashMap<&'a str, HashMap<&'a str, &'a str>>,
 }
 
 impl<'a> Builtins<'a> {
-    pub fn iter(&'a self) -> NodeIterator {
-        NodeIterator::new(self)
+    pub fn iter(&'a self) -> Iter<&'a str, HashMap<&'a str, &'a str>> {
+        self.pkgs.iter()
     }
-}
 
-enum Node<'a> {
-    Package(HashMap<&'a str, Node<'a>>),
-    Builtin(&'a str),
+    pub fn importer_for(&'a self, pkgpath: &str, f: &mut Fresher) -> impl Importer {
+        let mut h = HashMap::new();
+        if let Some(values) = self.pkgs.get(pkgpath) {
+            for (name, expr) in values {
+                let pty = parse(expr).unwrap().fresh(f, &mut HashMap::new());
+                h.insert((*name).to_string(), pty);
+            }
+        }
+        h
+    }
 }
 
 pub fn builtins() -> Builtins<'static> {
     Builtins {
         pkgs: hashmap! {
-            "csv" => Node::Package(maplit::hashmap! {
+            "csv" => maplit::hashmap! {
                 // This is a "provide exactly one argument" function
                 // https://github.com/influxdata/flux/issues/2249
-                "from" => Node::Builtin("forall [t0] where t0: Row (?csv: string, ?file: string) -> [t0]"),
-            }),
-            "date" => Node::Package(maplit::hashmap! {
-                 "second" => Node::Builtin("forall [] (t: time) -> int"),
-                 "minute" => Node::Builtin("forall [] (t: time) -> int"),
-                 "hour" => Node::Builtin("forall [] (t: time) -> int"),
-                 "weekDay" => Node::Builtin("forall [] (t: time) -> int"),
-                 "monthDay" => Node::Builtin("forall [] (t: time) -> int"),
-                 "yearDay" => Node::Builtin("forall [] (t: time) -> int"),
-                 "month" => Node::Builtin("forall [] (t: time) -> int"),
-                 "year" => Node::Builtin("forall [] (t: time) -> int"),
-                 "week" => Node::Builtin("forall [] (t: time) -> int"),
-                 "quarter" => Node::Builtin("forall [] (t: time) -> int"),
-                 "millisecond" => Node::Builtin("forall [] (t: time) -> int"),
-                 "microsecond" => Node::Builtin("forall [] (t: time) -> int"),
-                 "nanosecond" => Node::Builtin("forall [] (t: time) -> int"),
-                 "truncate" => Node::Builtin("forall [] (t: time, unit: duration) -> time"),
-            }),
-            "experimental" => Node::Package(maplit::hashmap! {
-                 "bigtable" => Node::Package(maplit::hashmap! {
-                     "from" => Node::Builtin("forall [t0] where t0: Row (token: string, project: string, instance: string, table: string) -> [t0]"),
-                 }),
-                 "http" => Node::Package(maplit::hashmap! {
-                     "get" => Node::Builtin(r#"
-                         forall [t0, t1] where t0: Row, t1: Row (
-                             url: string,
-                             ?headers: t0, 
-                             ?timeout: duration
-                         ) -> {statusCode: int | body: bytes | headers: t1}
-                     "#),
-                 }),
-                 "mqtt" => Node::Package(maplit::hashmap! {
-                     "to" => Node::Builtin(r#"
-                         forall [t0, t1] where t0: Row, t1: Row (
-                             <-tables: [t0],
-                             broker: string,
-                             ?topic: string,
-                             ?message: string,
-                             ?qos: int,
-                             ?clientid: string,
-                             ?username: string,
-                             ?password: string,
-                             ?name: string,
-                             ?timeout: duration,
-                             ?timeColumn: string,
-                             ?tagColumns: [string],
-                             ?valueColumns: [string]
-                         ) -> [t1]
-                     "#),
-                 }),
-                 "prometheus" => Node::Package(maplit::hashmap! {
-                     "scrape" => Node::Builtin("forall [t0] where t0: Row (url: string) -> [t0]"),
-                 }),
-                 "addDuration" => Node::Builtin("forall [] (d: duration, to: time) -> time"),
-                 "subDuration" => Node::Builtin("forall [] (d: duration, from: time) -> time"),
-                 "group" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], mode: string, columns: [string]) -> [t0]"),
-                 "objectKeys" => Node::Builtin("forall [t0] where t0: Row (o: t0) -> [string]"),
-                 "set" => Node::Builtin("forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (<-tables: [t0], o: t1) -> [t2]"),
+                "from" => "forall [t0] where t0: Row (?csv: string, ?file: string) -> [t0]",
+            },
+            "date" => maplit::hashmap! {
+                 "second" => "forall [] (t: time) -> int",
+                 "minute" => "forall [] (t: time) -> int",
+                 "hour" => "forall [] (t: time) -> int",
+                 "weekDay" => "forall [] (t: time) -> int",
+                 "monthDay" => "forall [] (t: time) -> int",
+                 "yearDay" => "forall [] (t: time) -> int",
+                 "month" => "forall [] (t: time) -> int",
+                 "year" => "forall [] (t: time) -> int",
+                 "week" => "forall [] (t: time) -> int",
+                 "quarter" => "forall [] (t: time) -> int",
+                 "millisecond" => "forall [] (t: time) -> int",
+                 "microsecond" => "forall [] (t: time) -> int",
+                 "nanosecond" => "forall [] (t: time) -> int",
+                 "truncate" => "forall [] (t: time, unit: duration) -> time",
+            },
+            "experimental/bigtable" => maplit::hashmap! {
+                     "from" => "forall [t0] where t0: Row (token: string, project: string, instance: string, table: string) -> [t0]",
+            },
+            "experimental/http" => maplit::hashmap! {
+                "get" => r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        url: string,
+                        ?headers: t0,
+                        ?timeout: duration
+                    ) -> {statusCode: int | body: bytes | headers: t1}
+                "#,
+            },
+            "experimental/mqtt" => maplit::hashmap! {
+                "to" => r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        broker: string,
+                        ?topic: string,
+                        ?message: string,
+                        ?qos: int,
+                        ?clientid: string,
+                        ?username: string,
+                        ?password: string,
+                        ?name: string,
+                        ?timeout: duration,
+                        ?timeColumn: string,
+                        ?tagColumns: [string],
+                        ?valueColumns: [string]
+                    ) -> [t1]
+                "#,
+            },
+            "experimental/prometheus" => maplit::hashmap! {
+                "scrape" => "forall [t0] where t0: Row (url: string) -> [t0]",
+            },
+            "experimental" => maplit::hashmap! {
+                 "addDuration" => "forall [] (d: duration, to: time) -> time",
+                 "subDuration" => "forall [] (d: duration, from: time) -> time",
+                 "group" => "forall [t0] where t0: Row (<-tables: [t0], mode: string, columns: [string]) -> [t0]",
+                 "objectKeys" => "forall [t0] where t0: Row (o: t0) -> [string]",
+                 "set" => "forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (<-tables: [t0], o: t1) -> [t2]",
                  // must specify exactly one of bucket, bucketID
                  // must specify exactly one of org, orgID
                  // if host is specified, token must be too.
                  // https://github.com/influxdata/flux/issues/1660
-                 "to" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string) -> [t0]"),
-            }),
-            "generate" => Node::Package(maplit::hashmap! {
-                "from" => Node::Builtin("forall [] (start: time, stop: time, count: int, fn: (n: int) -> int) -> [{ _start: time | _stop: time | _time: time | _value:int }]"),
-            }),
-            "http" => Node::Package(maplit::hashmap! {
-                "post" => Node::Builtin("forall [t0] where t0: Row (url: string, ?headers: t0, ?data: bytes) -> int"),
-                "basicAuth" => Node::Builtin("forall [] (u: string, p: string) -> string"),
-            }),
-            "influxdata" => Node::Package(maplit::hashmap! {
-                "influxdb" => Node::Package(maplit::hashmap! {
-                    "secrets" => Node::Package(maplit::hashmap! {
-                         "get" => Node::Builtin("forall [] (key: string) -> string"),
-                    }),
-                    "v1" => Node::Package(maplit::hashmap! {
-                        // exactly one of json and file must be specified
-                        // https://github.com/influxdata/flux/issues/2250
-                        "json" => Node::Builtin("forall [t0] where t0: Row (?json: string, ?file: string) -> [t0]"),
-                        "databases" => Node::Builtin(r#"
-                            forall [] () -> [{
-                                organizationID: string |
-                                databaseName: string |
-                                retentionPolicy: string |
-                                retentionPeriod: int |
-                                default: bool |
-                                bucketID: string
-                            }]
-                        "#),
-                    }),
-                    // This is a one-or-the-other parameters function
-                    // https://github.com/influxdata/flux/issues/1659
-                    "from" => Node::Builtin("forall [t0, t1] (?bucket: string, ?bucketID: string) -> [{_measurement: string | _field: string | _time: time | _value: t0 | t1}]"),
-                    // exactly one of (bucket, bucketID) must be specified
-                    // exactly one of (org, orgID) must be specified
-                    // https://github.com/influxdata/flux/issues/1660
-                    "to" => Node::Builtin(r#"
-                        forall [t0, t1] where t0: Row, t1: Row (
-                            <-tables: [t0],
-                            ?bucket: string,
-                            ?bucketID: string,
-                            ?org: string,
-                            ?orgID: string,
-                            ?token: string,
-                            ?timeColumn: string,
-                            ?measurementColumn: string,
-                            ?tagColumns: [string],
-                            ?fieldFn: (r: t0) -> t1
-                        ) -> [t0]
-                    "#),
-                    "buckets" => Node::Builtin(r#"
-                        forall [] () -> [{
-                            name: string |
-                            id: string |
-                            organizationID: string |
-                            retentionPolicy: string |
-                            retentionPeriod: int
-                        }]
-                    "#),
-                }),
-
-            }),
-            "internal" => Node::Package(maplit::hashmap! {
-                "gen" => Node::Package(maplit::hashmap! {
-                    "tables" => Node::Builtin("forall [t0] (n: int, tags: [{name: string | cardinality: int}]) -> [{_time: time | _value: float | t0}]"),
-                }),
-                "promql" => Node::Package(maplit::hashmap! {
-                    "changes" => Node::Builtin("forall [t0, t1] (<-tables: [{_value: float | t0}]) -> [{_value: float | t1}]"),
-                    "promqlDayOfMonth" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "promqlDayOfWeek" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "promqlDaysInMonth" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "emptyTable" => Node::Builtin("forall [] () -> [{_start: time | _stop: time | _time: time | _value: float}]"),
-                    "extrapolatedRate" => Node::Builtin("forall [t0, t1] (<-tables: [{_start: time | _stop: time | _time: time | _value: float | t0}], ?isCounter: bool, ?isRate: bool) -> [{_value: float | t1}]"),
-                    "holtWinters" => Node::Builtin("forall [t0, t1] (<-tables: [{_time: time | _value: float | t0}], ?smoothingFactor: float, ?trendFactor: float) -> [{_value: float | t1}]"),
-                    "promqlHour" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "instantRate" => Node::Builtin("forall [t0, t1] (<-tables: [{_time: time | _value: float | t0}], ?isRate: bool) -> [{_value: float | t1}]"),
-                    "labelReplace" => Node::Builtin("forall [t0, t1] (<-tables: [{_value: float | t0}], source: string, destination: string, regex: string, replacement: string) -> [{_value: float | t1}]"),
-                    "linearRegression" => Node::Builtin("forall [t0, t1] (<-tables: [{_time: time | _stop: time | _value: float | t0}], ?predict: bool, ?fromNow: float) -> [{_value: float | t1}]"),
-                    "promqlMinute" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "promqlMonth" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "promHistogramQuantile" => Node::Builtin("forall [t0, t1] where t0: Row, t1: Row (<-tables: [t0], ?quantile: float, ?countColumn: string, ?upperBoundColumn: string, ?valueColumn: string) -> [t1]"),
-                    "resets" => Node::Builtin("forall [t0, t1] (<-tables: [{_value: float | t0}]) -> [{_value: float | t1}]"),
-                    "timestamp" => Node::Builtin("forall [t0] (<-tables: [{_value: float | t0}]) -> [{_value: float | t0}]"),
-                    "promqlYear" => Node::Builtin("forall [] (timestamp: float) -> float"),
-                    "join" => Node::Builtin("forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (left: [t0], right: [t1], fn: (left: t0, right: t1) -> t2) -> [t2]"),
-                }),
-            }),
-            "json" => Node::Package(maplit::hashmap! {
-                "encode" => Node::Builtin("forall [t0] (v: t0) -> bytes"),
-            }),
-            "kafka" => Node::Package(maplit::hashmap! {
-                "to" => Node::Builtin(r#"
+                 "to" => "forall [t0] where t0: Row (<-tables: [t0], ?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string) -> [t0]",
+            },
+            "generate" => maplit::hashmap! {
+                "from" => "forall [] (start: time, stop: time, count: int, fn: (n: int) -> int) -> [{ _start: time | _stop: time | _time: time | _value:int }]",
+            },
+            "http" => maplit::hashmap! {
+                "post" => "forall [t0] where t0: Row (url: string, ?headers: t0, ?data: bytes) -> int",
+                "basicAuth" => "forall [] (u: string, p: string) -> string",
+            },
+            "influxdata/influxdb/secrets" => maplit::hashmap! {
+                "get" => "forall [] (key: string) -> string",
+            },
+            "influxdata/influxdb/v1" => maplit::hashmap! {
+                // exactly one of json and file must be specified
+                // https://github.com/influxdata/flux/issues/2250
+                "json" => "forall [t0] where t0: Row (?json: string, ?file: string) -> [t0]",
+                "databases" => r#"
+                    forall [] () -> [{
+                        organizationID: string |
+                        databaseName: string |
+                        retentionPolicy: string |
+                        retentionPeriod: int |
+                        default: bool |
+                        bucketID: string
+                    }]
+                "#,
+            },
+            "influxdata/influxdb" => maplit::hashmap! {
+                // This is a one-or-the-other parameters function
+                // https://github.com/influxdata/flux/issues/1659
+                "from" => "forall [t0, t1] (?bucket: string, ?bucketID: string) -> [{_measurement: string | _field: string | _time: time | _value: t0 | t1}]",
+                // exactly one of (bucket, bucketID) must be specified
+                // exactly one of (org, orgID) must be specified
+                // https://github.com/influxdata/flux/issues/1660
+                "to" => r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        ?bucket: string,
+                        ?bucketID: string,
+                        ?org: string,
+                        ?orgID: string,
+                        ?token: string,
+                        ?timeColumn: string,
+                        ?measurementColumn: string,
+                        ?tagColumns: [string],
+                        ?fieldFn: (r: t0) -> t1
+                    ) -> [t0]
+                "#,
+                "buckets" => r#"
+                    forall [] () -> [{
+                        name: string |
+                        id: string |
+                        organizationID: string |
+                        retentionPolicy: string |
+                        retentionPeriod: int
+                    }]
+                "#,
+            },
+            "internal/gen" => maplit::hashmap! {
+                "tables" => "forall [t0] (n: int, tags: [{name: string | cardinality: int}]) -> [{_time: time | _value: float | t0}]",
+            },
+            "internal/promql" => maplit::hashmap! {
+                "changes" => "forall [t0, t1] (<-tables: [{_value: float | t0}]) -> [{_value: float | t1}]",
+                "promqlDayOfMonth" => "forall [] (timestamp: float) -> float",
+                "promqlDayOfWeek" => "forall [] (timestamp: float) -> float",
+                "promqlDaysInMonth" => "forall [] (timestamp: float) -> float",
+                "emptyTable" => "forall [] () -> [{_start: time | _stop: time | _time: time | _value: float}]",
+                "extrapolatedRate" => "forall [t0, t1] (<-tables: [{_start: time | _stop: time | _time: time | _value: float | t0}], ?isCounter: bool, ?isRate: bool) -> [{_value: float | t1}]",
+                "holtWinters" => "forall [t0, t1] (<-tables: [{_time: time | _value: float | t0}], ?smoothingFactor: float, ?trendFactor: float) -> [{_value: float | t1}]",
+                "promqlHour" => "forall [] (timestamp: float) -> float",
+                "instantRate" => "forall [t0, t1] (<-tables: [{_time: time | _value: float | t0}], ?isRate: bool) -> [{_value: float | t1}]",
+                "labelReplace" => "forall [t0, t1] (<-tables: [{_value: float | t0}], source: string, destination: string, regex: string, replacement: string) -> [{_value: float | t1}]",
+                "linearRegression" => "forall [t0, t1] (<-tables: [{_time: time | _stop: time | _value: float | t0}], ?predict: bool, ?fromNow: float) -> [{_value: float | t1}]",
+                "promqlMinute" => "forall [] (timestamp: float) -> float",
+                "promqlMonth" => "forall [] (timestamp: float) -> float",
+                "promHistogramQuantile" => "forall [t0, t1] where t0: Row, t1: Row (<-tables: [t0], ?quantile: float, ?countColumn: string, ?upperBoundColumn: string, ?valueColumn: string) -> [t1]",
+                "resets" => "forall [t0, t1] (<-tables: [{_value: float | t0}]) -> [{_value: float | t1}]",
+                "timestamp" => "forall [t0] (<-tables: [{_value: float | t0}]) -> [{_value: float | t0}]",
+                "promqlYear" => "forall [] (timestamp: float) -> float",
+                "join" => "forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (left: [t0], right: [t1], fn: (left: t0, right: t1) -> t2) -> [t2]",
+            },
+            "json" => maplit::hashmap! {
+                "encode" => "forall [t0] (v: t0) -> bytes",
+            },
+            "kafka" => maplit::hashmap! {
+                "to" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         brokers: string,
@@ -188,206 +190,206 @@ pub fn builtins() -> Builtins<'static> {
                         ?timeColumn: string,
                         ?tagColumns: [string],
                         ?valueColumns: [string]
-                    ) -> [t0]"#),
-            }),
-            "math" => Node::Package(maplit::hashmap! {
-                "pi" => Node::Builtin("forall [] float"),
-                "e" => Node::Builtin("forall [] float"),
-                "phi" => Node::Builtin("forall [] float"),
-                "sqrt2" => Node::Builtin("forall [] float"),
-                "sqrte" => Node::Builtin("forall [] float"),
-                "sqrtpi" => Node::Builtin("forall [] float"),
-                "sqrtphi" => Node::Builtin("forall [] float"),
-                "log2e" => Node::Builtin("forall [] float"),
-                "ln2" => Node::Builtin("forall [] float"),
-                "ln10" => Node::Builtin("forall [] float"),
-                "log10e" => Node::Builtin("forall [] float"),
+                    ) -> [t0]"#,
+            },
+            "math" => maplit::hashmap! {
+                "pi" => "forall [] float",
+                "e" => "forall [] float",
+                "phi" => "forall [] float",
+                "sqrt2" => "forall [] float",
+                "sqrte" => "forall [] float",
+                "sqrtpi" => "forall [] float",
+                "sqrtphi" => "forall [] float",
+                "log2e" => "forall [] float",
+                "ln2" => "forall [] float",
+                "ln10" => "forall [] float",
+                "log10e" => "forall [] float",
 
-                "maxfloat" => Node::Builtin("forall [] float"),
-                "smallestNonzeroFloat" => Node::Builtin("forall [] float"),
-                "maxint" => Node::Builtin("forall [] int"),
-                "minint" => Node::Builtin("forall [] int"),
-                "maxuint" => Node::Builtin("forall [] uint"),
+                "maxfloat" => "forall [] float",
+                "smallestNonzeroFloat" => "forall [] float",
+                "maxint" => "forall [] int",
+                "minint" => "forall [] int",
+                "maxuint" => "forall [] uint",
 
-                "abs" => Node::Builtin("forall [] (x: float) -> float"),
-                "acos" => Node::Builtin("forall [] (x: float) -> float"),
-                "acosh" => Node::Builtin("forall [] (x: float) -> float"),
-                "asin" => Node::Builtin("forall [] (x: float) -> float"),
-                "asinh" => Node::Builtin("forall [] (x: float) -> float"),
-                "atan" => Node::Builtin("forall [] (x: float) -> float"),
-                "atan2" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "atanh" => Node::Builtin("forall [] (x: float) -> float"),
-                "cbrt" => Node::Builtin("forall [] (x: float) -> float"),
-                "ceil" => Node::Builtin("forall [] (x: float) -> float"),
-                "copysign" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "cos" => Node::Builtin("forall [] (x: float) -> float"),
-                "cosh" => Node::Builtin("forall [] (x: float) -> float"),
-                "dim" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "erf" => Node::Builtin("forall [] (x: float) -> float"),
-                "erfc" => Node::Builtin("forall [] (x: float) -> float"),
-                "erfcinv" => Node::Builtin("forall [] (x: float) -> float"),
-                "erfinv" => Node::Builtin("forall [] (x: float) -> float"),
-                "exp" => Node::Builtin("forall [] (x: float) -> float"),
-                "exp2" => Node::Builtin("forall [] (x: float) -> float"),
-                "expm1" => Node::Builtin("forall [] (x: float) -> float"),
-                "floor" => Node::Builtin("forall [] (x: float) -> float"),
-                "gamma" => Node::Builtin("forall [] (x: float) -> float"),
-                "hypot" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "j0" => Node::Builtin("forall [] (x: float) -> float"),
-                "j1" => Node::Builtin("forall [] (x: float) -> float"),
-                "log" => Node::Builtin("forall [] (x: float) -> float"),
-                "log10" => Node::Builtin("forall [] (x: float) -> float"),
-                "log1p" => Node::Builtin("forall [] (x: float) -> float"),
-                "log2" => Node::Builtin("forall [] (x: float) -> float"),
-                "logb" => Node::Builtin("forall [] (x: float) -> float"),
-                "mMax" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "mMin" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "mod" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "nextafter" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "pow" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "remainder" => Node::Builtin("forall [] (x: float, y: float) -> float"),
-                "round" => Node::Builtin("forall [] (x: float) -> float"),
-                "roundtoeven" => Node::Builtin("forall [] (x: float) -> float"),
-                "sin" => Node::Builtin("forall [] (x: float) -> float"),
-                "sinh" => Node::Builtin("forall [] (x: float) -> float"),
-                "sqrt" => Node::Builtin("forall [] (x: float) -> float"),
-                "tan" => Node::Builtin("forall [] (x: float) -> float"),
-                "tanh" => Node::Builtin("forall [] (x: float) -> float"),
-                "trunc" => Node::Builtin("forall [] (x: float) -> float"),
-                "y0" => Node::Builtin("forall [] (x: float) -> float"),
-                "y1" => Node::Builtin("forall [] (x: float) -> float"),
+                "abs" => "forall [] (x: float) -> float",
+                "acos" => "forall [] (x: float) -> float",
+                "acosh" => "forall [] (x: float) -> float",
+                "asin" => "forall [] (x: float) -> float",
+                "asinh" => "forall [] (x: float) -> float",
+                "atan" => "forall [] (x: float) -> float",
+                "atan2" => "forall [] (x: float, y: float) -> float",
+                "atanh" => "forall [] (x: float) -> float",
+                "cbrt" => "forall [] (x: float) -> float",
+                "ceil" => "forall [] (x: float) -> float",
+                "copysign" => "forall [] (x: float, y: float) -> float",
+                "cos" => "forall [] (x: float) -> float",
+                "cosh" => "forall [] (x: float) -> float",
+                "dim" => "forall [] (x: float, y: float) -> float",
+                "erf" => "forall [] (x: float) -> float",
+                "erfc" => "forall [] (x: float) -> float",
+                "erfcinv" => "forall [] (x: float) -> float",
+                "erfinv" => "forall [] (x: float) -> float",
+                "exp" => "forall [] (x: float) -> float",
+                "exp2" => "forall [] (x: float) -> float",
+                "expm1" => "forall [] (x: float) -> float",
+                "floor" => "forall [] (x: float) -> float",
+                "gamma" => "forall [] (x: float) -> float",
+                "hypot" => "forall [] (x: float, y: float) -> float",
+                "j0" => "forall [] (x: float) -> float",
+                "j1" => "forall [] (x: float) -> float",
+                "log" => "forall [] (x: float) -> float",
+                "log10" => "forall [] (x: float) -> float",
+                "log1p" => "forall [] (x: float) -> float",
+                "log2" => "forall [] (x: float) -> float",
+                "logb" => "forall [] (x: float) -> float",
+                "mMax" => "forall [] (x: float, y: float) -> float",
+                "mMin" => "forall [] (x: float, y: float) -> float",
+                "mod" => "forall [] (x: float, y: float) -> float",
+                "nextafter" => "forall [] (x: float, y: float) -> float",
+                "pow" => "forall [] (x: float, y: float) -> float",
+                "remainder" => "forall [] (x: float, y: float) -> float",
+                "round" => "forall [] (x: float) -> float",
+                "roundtoeven" => "forall [] (x: float) -> float",
+                "sin" => "forall [] (x: float) -> float",
+                "sinh" => "forall [] (x: float) -> float",
+                "sqrt" => "forall [] (x: float) -> float",
+                "tan" => "forall [] (x: float) -> float",
+                "tanh" => "forall [] (x: float) -> float",
+                "trunc" => "forall [] (x: float) -> float",
+                "y0" => "forall [] (x: float) -> float",
+                "y1" => "forall [] (x: float) -> float",
 
-                "float64bits" => Node::Builtin("forall [] (f: float) -> uint"),
-                "float64frombits" => Node::Builtin("forall [] (b: uint) -> float"),
-                "ilogb" => Node::Builtin("forall [] (x: float) -> int"),
-                "frexp" => Node::Builtin("forall [] (f: float) -> {frac: float | exp: int}"),
-                "lgamma" => Node::Builtin("forall [] (x: float) -> {lgamma: float | sign: int}"),
-                "modf" => Node::Builtin(r#"forall [] (f: float) -> {"int": float | frac: float}"#),
-                "sincos" => Node::Builtin("forall [] (x: float) -> {sin: float | cos: float}"),
-                "isInf" => Node::Builtin("forall [] (f: float, sign: int) -> bool"),
-                "isNaN" => Node::Builtin("forall [] (f: float) -> bool"),
-                "signbit" => Node::Builtin("forall [] (x: float) -> bool"),
-                "NaN" => Node::Builtin("forall [] () -> float"),
-                "mInf" => Node::Builtin("forall [] (sign: int) -> float"),
-                "jn" => Node::Builtin("forall [] (n: int, x: float) -> float"),
-                "yn" => Node::Builtin("forall [] (n: int, x: float) -> float"),
-                "ldexp" => Node::Builtin("forall [] (frac: float, exp: int) -> float"),
-                "pow10" => Node::Builtin("forall [] (n: int) -> float"),
-            }),
-            "pagerduty" => Node::Package(maplit::hashmap! {
-                "dedupKey" => Node::Builtin("forall [t0] (<-tables: [t0]) -> [{_pagerdutyDedupKey: string | t0}]"),
-            }),
-            "regexp" => Node::Package(maplit::hashmap! {
-                "compile" => Node::Builtin("forall [] (v: string) -> regexp"),
-                "quoteMeta" => Node::Builtin("forall [] (v: string) -> string"),
-                "findString" => Node::Builtin("forall [] (r: regexp, v: string) -> string"),
-                "findStringIndex" => Node::Builtin("forall [] (r: regexp, v: string) -> [int]"),
-                "matchRegexpString" => Node::Builtin("forall [] (r: regexp, v: string) -> bool"),
-                "replaceAllString" => Node::Builtin("forall [] (r: regexp, v: string, t: string) -> string"),
-                "splitRegexp" => Node::Builtin("forall [] (r: regexp, v: string, i: int) -> [string]"),
-                "getString" => Node::Builtin("forall [] (r: regexp) -> string"),
-            }),
-            "runtime" => Node::Package(maplit::hashmap! {
-                "version" => Node::Builtin("forall [] () -> string"),
-            }),
-            "slack" => Node::Package(maplit::hashmap! {
-                "validateColorString" => Node::Builtin("forall [] (color: string) -> string"),
-            }),
-            "socket" => Node::Package(maplit::hashmap! {
-                "from" => Node::Builtin("forall [t0] (url: string, ?decoder: string) -> [t0]"),
-            }),
-            "sql" => Node::Package(maplit::hashmap! {
-                "from" => Node::Builtin("forall [t0] (driverName: string, dataSourceName: string, query: string) -> [t0]"),
-                "to" => Node::Builtin("forall [t0] (<-tables: [t0], driverName: string, dataSourceName: string, table: string, ?batchSize: int) -> [t0]"),
-            }),
-            "strings" => Node::Package(maplit::hashmap! {
-                "title" => Node::Builtin("forall [] (v: string) -> string"),
-                "toUpper" => Node::Builtin("forall [] (v: string) -> string"),
-                "toLower" => Node::Builtin("forall [] (v: string) -> string"),
-                "trim" => Node::Builtin("forall [] (v: string, cutset: string) -> string"),
-                "trimPrefix" => Node::Builtin("forall [] (v: string, prefix: string) -> string"),
-                "trimSpace" => Node::Builtin("forall [] (v: string) -> string"),
-                "trimSuffix" => Node::Builtin("forall [] (v: string, suffix: string) -> string"),
-                "trimRight" => Node::Builtin("forall [] (v: string, cutset: string) -> string"),
-                "trimLeft" => Node::Builtin("forall [] (v: string, cutset: string) -> string"),
-                "toTitle" => Node::Builtin("forall [] (v: string) -> string"),
-                "hasPrefix" => Node::Builtin("forall [] (v: string, prefix: string) -> bool"),
-                "hasSuffix" => Node::Builtin("forall [] (v: string, suffix: string) -> bool"),
-                "containsStr" => Node::Builtin("forall [] (v: string, substr: string) -> bool"),
-                "containsAny" => Node::Builtin("forall [] (v: string, chars: string) -> bool"),
-                "equalFold" => Node::Builtin("forall [] (v: string, t: string) -> bool"),
-                "compare" => Node::Builtin("forall [] (v: string, t: string) -> int"),
-                "countStr" => Node::Builtin("forall [] (v: string, substr: string) -> int"),
-                "index" => Node::Builtin("forall [] (v: string, substr: string) -> int"),
-                "indexAny" => Node::Builtin("forall [] (v: string, chars: string) -> int"),
-                "lastIndex" => Node::Builtin("forall [] (v: string, substr: string) -> int"),
-                "lastIndexAny" => Node::Builtin("forall [] (v: string, chars: string) -> int"),
-                "isDigit" => Node::Builtin("forall [] (v: string) -> bool"),
-                "isLetter" => Node::Builtin("forall [] (v: string) -> bool"),
-                "isLower" => Node::Builtin("forall [] (v: string) -> bool"),
-                "isUpper" => Node::Builtin("forall [] (v: string) -> bool"),
-                "repeat" => Node::Builtin("forall [] (v: string, count: int) -> string"),
-                "replace" => Node::Builtin("forall [] (v: string, old: string, new: string, n: int) -> string"),
-                "replaceAll" => Node::Builtin("forall [] (v: string, old: string, new: string) -> string"),
-                "split" => Node::Builtin("forall [] (v: string, t: string) -> string"),
-                "splitAfter" => Node::Builtin("forall [] (v: string, t: string) -> string"),
-                "splitN" => Node::Builtin("forall [] (v: string, t: string, n: int) -> string"),
-                "splitAfterN" => Node::Builtin("forall [] (v: string, t: string, i: int) -> string"),
-                "joinStr" => Node::Builtin("forall [] (a: [string], v: string) -> {}"),
-                "strlen" => Node::Builtin("forall [] (v: string) -> int"),
-                "substring" => Node::Builtin("forall [] (v: string, start: int, end: int) -> string"),
-            }),
-            "system" => Node::Package(maplit::hashmap! {
-                "time" => Node::Builtin("forall [] () -> time"),
-            }),
-            "testing" => Node::Package(maplit::hashmap! {
-                "assertEquals" => Node::Builtin("forall [t0] (name: string, <-got: [t0], want: [t0]) -> [t0]"),
-                "assertEmpty" => Node::Builtin("forall [t0] (<-tables: [t0]) -> [t0]"),
-                "diff" => Node::Builtin("forall [t0] (<-got: [t0], want: [t0], ?verbose: bool) -> [{_diff: string | t0}]"),
-            }),
-            "universe" => Node::Package(maplit::hashmap! {
-                "bool" => Node::Builtin("forall [t0] (v: t0) -> bool"),
-                "bytes" => Node::Builtin("forall [t0] (v: t0) -> bytes"),
-                "chandeMomentumOscillator" => Node::Builtin(r#"
+                "float64bits" => "forall [] (f: float) -> uint",
+                "float64frombits" => "forall [] (b: uint) -> float",
+                "ilogb" => "forall [] (x: float) -> int",
+                "frexp" => "forall [] (f: float) -> {frac: float | exp: int}",
+                "lgamma" => "forall [] (x: float) -> {lgamma: float | sign: int}",
+                "modf" => r#"forall [] (f: float) -> {"int": float | frac: float}"#,
+                "sincos" => "forall [] (x: float) -> {sin: float | cos: float}",
+                "isInf" => "forall [] (f: float, sign: int) -> bool",
+                "isNaN" => "forall [] (f: float) -> bool",
+                "signbit" => "forall [] (x: float) -> bool",
+                "NaN" => "forall [] () -> float",
+                "mInf" => "forall [] (sign: int) -> float",
+                "jn" => "forall [] (n: int, x: float) -> float",
+                "yn" => "forall [] (n: int, x: float) -> float",
+                "ldexp" => "forall [] (frac: float, exp: int) -> float",
+                "pow10" => "forall [] (n: int) -> float",
+            },
+            "pagerduty" => maplit::hashmap! {
+                "dedupKey" => "forall [t0] (<-tables: [t0]) -> [{_pagerdutyDedupKey: string | t0}]",
+            },
+            "regexp" => maplit::hashmap! {
+                "compile" => "forall [] (v: string) -> regexp",
+                "quoteMeta" => "forall [] (v: string) -> string",
+                "findString" => "forall [] (r: regexp, v: string) -> string",
+                "findStringIndex" => "forall [] (r: regexp, v: string) -> [int]",
+                "matchRegexpString" => "forall [] (r: regexp, v: string) -> bool",
+                "replaceAllString" => "forall [] (r: regexp, v: string, t: string) -> string",
+                "splitRegexp" => "forall [] (r: regexp, v: string, i: int) -> [string]",
+                "getString" => "forall [] (r: regexp) -> string",
+            },
+            "runtime" => maplit::hashmap! {
+                "version" => "forall [] () -> string",
+            },
+            "slack" => maplit::hashmap! {
+                "validateColorString" => "forall [] (color: string) -> string",
+            },
+            "socket" => maplit::hashmap! {
+                "from" => "forall [t0] (url: string, ?decoder: string) -> [t0]",
+            },
+            "sql" => maplit::hashmap! {
+                "from" => "forall [t0] (driverName: string, dataSourceName: string, query: string) -> [t0]",
+                "to" => "forall [t0] (<-tables: [t0], driverName: string, dataSourceName: string, table: string, ?batchSize: int) -> [t0]",
+            },
+            "strings" => maplit::hashmap! {
+                "title" => "forall [] (v: string) -> string",
+                "toUpper" => "forall [] (v: string) -> string",
+                "toLower" => "forall [] (v: string) -> string",
+                "trim" => "forall [] (v: string, cutset: string) -> string",
+                "trimPrefix" => "forall [] (v: string, prefix: string) -> string",
+                "trimSpace" => "forall [] (v: string) -> string",
+                "trimSuffix" => "forall [] (v: string, suffix: string) -> string",
+                "trimRight" => "forall [] (v: string, cutset: string) -> string",
+                "trimLeft" => "forall [] (v: string, cutset: string) -> string",
+                "toTitle" => "forall [] (v: string) -> string",
+                "hasPrefix" => "forall [] (v: string, prefix: string) -> bool",
+                "hasSuffix" => "forall [] (v: string, suffix: string) -> bool",
+                "containsStr" => "forall [] (v: string, substr: string) -> bool",
+                "containsAny" => "forall [] (v: string, chars: string) -> bool",
+                "equalFold" => "forall [] (v: string, t: string) -> bool",
+                "compare" => "forall [] (v: string, t: string) -> int",
+                "countStr" => "forall [] (v: string, substr: string) -> int",
+                "index" => "forall [] (v: string, substr: string) -> int",
+                "indexAny" => "forall [] (v: string, chars: string) -> int",
+                "lastIndex" => "forall [] (v: string, substr: string) -> int",
+                "lastIndexAny" => "forall [] (v: string, chars: string) -> int",
+                "isDigit" => "forall [] (v: string) -> bool",
+                "isLetter" => "forall [] (v: string) -> bool",
+                "isLower" => "forall [] (v: string) -> bool",
+                "isUpper" => "forall [] (v: string) -> bool",
+                "repeat" => "forall [] (v: string, count: int) -> string",
+                "replace" => "forall [] (v: string, old: string, new: string, n: int) -> string",
+                "replaceAll" => "forall [] (v: string, old: string, new: string) -> string",
+                "split" => "forall [] (v: string, t: string) -> string",
+                "splitAfter" => "forall [] (v: string, t: string) -> string",
+                "splitN" => "forall [] (v: string, t: string, n: int) -> string",
+                "splitAfterN" => "forall [] (v: string, t: string, i: int) -> string",
+                "joinStr" => "forall [] (a: [string], v: string) -> {}",
+                "strlen" => "forall [] (v: string) -> int",
+                "substring" => "forall [] (v: string, start: int, end: int) -> string",
+            },
+            "system" => maplit::hashmap! {
+                "time" => "forall [] () -> time",
+            },
+            "testing" => maplit::hashmap! {
+                "assertEquals" => "forall [t0] (name: string, <-got: [t0], want: [t0]) -> [t0]",
+                "assertEmpty" => "forall [t0] (<-tables: [t0]) -> [t0]",
+                "diff" => "forall [t0] (<-got: [t0], want: [t0], ?verbose: bool) -> [{_diff: string | t0}]",
+            },
+            "universe" => maplit::hashmap! {
+                "bool" => "forall [t0] (v: t0) -> bool",
+                "bytes" => "forall [t0] (v: t0) -> bytes",
+                "chandeMomentumOscillator" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         n: int,
                         ?columns: [string]
                     ) -> [t1]
-                "#),
-                "columns" => Node::Builtin(r#"
+                "#,
+                "columns" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         column: string
                     ) -> [t1]
-                "#),
-                "contains" => Node::Builtin(r#"
+                "#,
+                "contains" => r#"
                     forall [t0] where t0: Nullable (
                         value: t0,
                         set: [t0]
                     ) -> bool
-                "#),
-                "count" => Node::Builtin(r#"
+                "#,
+                "count" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "covariance" => Node::Builtin(r#"
+                "#,
+                "covariance" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?pearsonr: bool,
                         ?valueDst: string,
                         columns: [string]
                     ) -> [t1]
-                "#),
-                "cumulativeSum" => Node::Builtin(r#"
+                "#,
+                "cumulativeSum" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?columns: [string]
                     ) -> [t1]
-                "#),
-                "derivative" => Node::Builtin(r#"
+                "#,
+                "derivative" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?unit: duration,
@@ -395,93 +397,93 @@ pub fn builtins() -> Builtins<'static> {
                         ?columns: [string],
                         ?timeColumn: string
                     ) -> [t1]
-                "#),
-                "difference" => Node::Builtin(r#"
+                "#,
+                "difference" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?nonNegative: bool,
                         ?columns: [string],
                         ?keepFirst: bool
                     ) -> [t1]
-                "#),
-                "distinct" => Node::Builtin(r#"
+                "#,
+                "distinct" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "drop" => Node::Builtin(r#"
+                "#,
+                "drop" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?fn: (column: string) -> bool,
                         ?columns: [string]
                     ) -> [t1]
-                "#),
-                "duplicate" => Node::Builtin(r#"
+                "#,
+                "duplicate" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         column: string,
                         as: string
                     ) -> [t1]
-                "#),
-                "duration" => Node::Builtin("forall [t0] (v: t0) -> duration"),
-                "elapsed" => Node::Builtin(r#"
+                "#,
+                "duration" => "forall [t0] (v: t0) -> duration",
+                "elapsed" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?unit: duration,
                         ?timeColumn: string,
                         ?columnName: string
                     ) -> [t1]
-                "#),
-                "exponentialMovingAverage" => Node::Builtin(r#"
+                "#,
+                "exponentialMovingAverage" => r#"
                     forall [t0, t1] where t0: Numeric (
                         <-tables: [{ _value: t0 | t1 }],
                         n: int
                     ) -> [{ _value: t0 | t1}]
-                "#),
-                "false" => Node::Builtin("forall [] bool"),
-                "fill" => Node::Builtin(r#"
+                "#,
+                "false" => "forall [] bool",
+                "fill" => r#"
                     forall [t0, t1, t2] where t0: Row, t2: Row (
                         <-tables: [t0],
                         ?column: string,
                         value: t1,
                         usePrevious: bool
                     ) -> [t2]
-                "#),
-                "filter" => Node::Builtin(r#"
+                "#,
+                "filter" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         fn: (r: t0) -> bool,
                         ?onEmpty: string
                     ) -> [t0]
-                "#),
-                "first" => Node::Builtin(r#"
+                "#,
+                "first" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t0]
-                "#),
-                "float" => Node::Builtin("forall [t0] (v: t0) -> float"),
-                "getColumn" => Node::Builtin(r#"
+                "#,
+                "float" => "forall [t0] (v: t0) -> float",
+                "getColumn" => r#"
                     forall [t0, t1] where t0: Row (
                         <-table: [t0],
                         column: string
                     ) -> [t1]
-                "#),
-                "getRecord" => Node::Builtin(r#"
+                "#,
+                "getRecord" => r#"
                     forall [t0] where t0: Row (
                         <-table: [t0],
                         idx: int
                     ) -> t0
-                "#),
-                "group" => Node::Builtin(r#"
+                "#,
+                "group" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         ?mode: string,
                         ?columns: [string]
                     ) -> [t0]
-                "#),
-                "histogram" => Node::Builtin(r#"
+                "#,
+                "histogram" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string,
@@ -490,8 +492,8 @@ pub fn builtins() -> Builtins<'static> {
                         bins: [float],
                         normalize: bool
                     ) -> [t1]
-                "#),
-                "histogramQuantile" => Node::Builtin(r#"
+                "#,
+                "histogramQuantile" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?quantile: float,
@@ -500,8 +502,8 @@ pub fn builtins() -> Builtins<'static> {
                         ?valueColumn: string,
                         ?minValue: float
                     ) -> [t1]
-                "#),
-                "holtWinters" => Node::Builtin(r#"
+                "#,
+                "holtWinters" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?withFit: bool,
@@ -511,109 +513,109 @@ pub fn builtins() -> Builtins<'static> {
                         seasonality: int,
                         interval: duration
                     ) -> [t1]
-                "#),
-                "hourSelection" => Node::Builtin(r#"
+                "#,
+                "hourSelection" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         start: int,
                         stop: int,
                         ?timeColumn: string
                     ) -> [t0]
-                "#),
-                "inf" => Node::Builtin("forall [] duration"),
-                "int" => Node::Builtin("forall [t0] (v: t0) -> int"),
-                "integral" => Node::Builtin(r#"
+                "#,
+                "inf" => "forall [] duration",
+                "int" => "forall [t0] (v: t0) -> int",
+                "integral" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?unit: duration,
                         ?timeColumn: string,
                         ?column: string
                     ) -> [t1]
-                "#),
-                "join" => Node::Builtin(r#"
+                "#,
+                "join" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: t0,
                         ?method: string,
                         ?on: [string]
                     ) -> [t1]
-                "#),
+                "#,
                 // This function would almost have input/output types that match, but:
                 // input column may start as int, uint or float, and always ends up as float.
                 // https://github.com/influxdata/flux/issues/2252
-                "kaufmansAMA" => Node::Builtin(r#"
+                "kaufmansAMA" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         n: int,
                         ?column: string
                     ) -> [t1]
-                "#),
+                "#,
                 // either column list or predicate must be provided
                 // https://github.com/influxdata/flux/issues/2248
-                "keep" => Node::Builtin(r#"
+                "keep" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?columns: [string],
                         ?fn: (column: string) -> bool
                     ) -> [t1]
-                "#),
-                "keyValues" => Node::Builtin(r#"
+                "#,
+                "keyValues" => r#"
                     forall [t0, t1, t2] where t0: Row, t2: Row (
                         <-tables: [t0],
                         ?keyColumns: [string]
                     ) -> [{_key: string | _value: t1 | t2}]
-                "#),
-                "keys" => Node::Builtin(r#"
+                "#,
+                "keys" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "last" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]"),
-                "length" => Node::Builtin("forall [t0] (arr: [t0]) -> int"),
-                "limit"  => Node::Builtin("forall [t0] (<-tables: [t0], n: int, ?offset: int) -> [t0]"),
-                "linearBins" => Node::Builtin(r#"
+                "#,
+                "last" => "forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]",
+                "length" => "forall [t0] (arr: [t0]) -> int",
+                "limit"  => "forall [t0] (<-tables: [t0], n: int, ?offset: int) -> [t0]",
+                "linearBins" => r#"
                     forall [] (
                         start: float,
                         width: float,
                         count: int,
                         ?infinity: bool
                     ) -> [float]
-                "#),
-                "logarithmicBins" => Node::Builtin(r#"
+                "#,
+                "logarithmicBins" => r#"
                     forall [] (
                         start: float,
                         factor: float,
                         count: int,
                         ?infinity: bool
                     ) -> [float]
-                "#),
+                "#,
                 // Note: mergeKey parameter could be removed from map once the transpiler is updated:
                 // https://github.com/influxdata/flux/issues/816
-                "map" => Node::Builtin("forall [t0, t1] (<-tables: [t0], fn: (r: t0) -> t1, ?mergeKey: bool) -> [t1]"),
-                "max" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]"),
-                "mean" => Node::Builtin(r#"
+                "map" => "forall [t0, t1] (<-tables: [t0], fn: (r: t0) -> t1, ?mergeKey: bool) -> [t1]",
+                "max" => "forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]",
+                "mean" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "min" => Node::Builtin("forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]"),
-                "mode" => Node::Builtin(r#"
+                "#,
+                "min" => "forall [t0] where t0: Row (<-tables: [t0], ?column: string) -> [t0]",
+                "mode" => r#"
                     forall [t0, t1, t2] where t0: Row, t2: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [{_value: t1 | t2}]
-                "#),
-                "movingAverage" => Node::Builtin("forall [t0, t1] where t0: Numeric (<-tables: [{_value: t0 | t1}], n: int) -> [{_value: float | t1}]"),
-                "pivot" => Node::Builtin(r#"
+                "#,
+                "movingAverage" => "forall [t0, t1] where t0: Numeric (<-tables: [{_value: t0 | t1}], n: int) -> [{_value: float | t1}]",
+                "pivot" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         rowKey: [string],
                         columnKey: [string],
                         valueColumn: string
                     ) -> [t1]
-                "#),
-                "quantile" => Node::Builtin(r#"
+                "#,
+                "quantile" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         ?column: string,
@@ -621,12 +623,12 @@ pub fn builtins() -> Builtins<'static> {
                         ?compression: float,
                         ?method: string
                     ) -> [t0]
-                "#),
+                "#,
                 // start and stop should be able to constrained to time or duration with a kind constraint:
                 //   https://github.com/influxdata/flux/issues/2243
                 // Also, we should remove the column arguments so we can reuse t0 in the return type:
                 //   https://github.com/influxdata/flux/issues/2253
-                "range" => Node::Builtin(r#"
+                "range" => r#"
                     forall [t0, t1, t2, t3] where t0: Row, t3: Row (
                         <-tables: [t0],
                         start: t1,
@@ -635,74 +637,74 @@ pub fn builtins() -> Builtins<'static> {
                         ?startColumn: string,
                         ?stopColumn: string
                     ) -> [t3]
-                "#),
+                "#,
                 // This function could be updated to get better type inference:
                 //   https://github.com/influxdata/flux/issues/2254
-                "reduce" => Node::Builtin(r#"
+                "reduce" => r#"
                     forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (
                         <-tables: [t0],
                         fn: (r: t0, accumulator: t1) -> t1,
                         identity: t1
                     ) -> [t2]
-                "#),
-                "relativeStrengthIndex" => Node::Builtin(r#"
+                "#,
+                "relativeStrengthIndex" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         n: int,
                         ?columns: [string]
                     ) -> [t1]
-                "#),
+                "#,
                 // Either fn or columns should be specified
                 // https://github.com/influxdata/flux/issues/2251
-                "rename" => Node::Builtin(r#"
+                "rename" => r#"
                     forall [t0, t1, t2] where t0: Row, t1: Row, t2: Row (
                         <-tables: [t0],
                         ?fn: (column: string) -> string,
                         ?columns: t1
                     ) -> [t2]
-                "#),
-                "sample" => Node::Builtin(r#"
+                "#,
+                "sample" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         n: int,
                         ?pos: int,
                         ?column: string
                     ) -> [t0]
-                "#),
-                "set" => Node::Builtin(r#"
+                "#,
+                "set" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         key: string,
                         value: string
                     ) -> [t0]
-                "#),
+                "#,
                 // This is an aggregate function, and may clobber value columns
-                "skew" => Node::Builtin(r#"
+                "skew" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "sleep" => Node::Builtin(r#"
+                "#,
+                "sleep" => r#"
                     forall [t0] (
                         <-v: t0,
                         "duration": duration
                     ) -> t0
-                "#),
-                "sort" => Node::Builtin(r#"
+                "#,
+                "sort" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         ?columns: [string],
                         ?desc: bool
                     ) -> [t0]
-                "#),
-                "spread" => Node::Builtin(r#"
+                "#,
+                "spread" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "stateTracking" => Node::Builtin(r#"
+                "#,
+                "stateTracking" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         fn: (r: t0) -> bool,
@@ -711,66 +713,66 @@ pub fn builtins() -> Builtins<'static> {
                         ?durationUnit: duration,
                         ?timeColumn: string
                     ) -> [t1]
-                "#),
-                "stddev" => Node::Builtin(r#"
+                "#,
+                "stddev" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string,
                         mode: string
                     ) -> [t1]
-                "#),
-                "string" => Node::Builtin("forall [t0] (v: t0) -> string"),
-                "sum" => Node::Builtin(r#"
+                "#,
+                "string" => "forall [t0] (v: t0) -> string",
+                "sum" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t1]
-                "#),
-                "tableFind" => Node::Builtin(r#"
+                "#,
+                "tableFind" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         fn: (key: t1) -> bool
                     ) -> [t0]
-                "#),
-                "tail" => Node::Builtin(r#"
+                "#,
+                "tail" => r#"
                     forall [t0] (
                         <-tables: [t0],
                         n: int,
                         ?offset: int
                     ) -> [t0]
-                "#),
-                "time" => Node::Builtin("forall [t0] (v: t0) -> time"),
-                "timeShift" => Node::Builtin(r#"
+                "#,
+                "time" => "forall [t0] (v: t0) -> time",
+                "timeShift" => r#"
                     forall [t0] (
                         <-tables: [t0],
                         "duration": duration,
                         ?columns: [string]
                     ) -> [t0]
-                "#),
-                "tripleExponentialDerivative" => Node::Builtin(r#"
+                "#,
+                "tripleExponentialDerivative" => r#"
                     forall [t0] where t0: Numeric, t1: Row (
                         <-tables: [{_value: t0 | t1}],
                         n: int
                     ) -> [{_value: float | t1}]
-                "#),
-                "true" => Node::Builtin("forall [] bool"),
-                "uint" => Node::Builtin("forall [t0] (v: t0) -> uint"),
-                "union" => Node::Builtin(r#"
+                "#,
+                "true" => "forall [] bool",
+                "uint" => "forall [t0] (v: t0) -> uint",
+                "union" => r#"
                     forall [t0] where t0: Row (
                         tables: [[t0]]
                     ) -> [t0]
-                "#),
-                "unique" => Node::Builtin(r#"
+                "#,
+                "unique" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         ?column: string
                     ) -> [t0]
-                "#),
+                "#,
                 // This would produce an output the same as the input,
                 // except that startColumn and stopColumn will be added if they don't
                 // already exist.
                 // https://github.com/influxdata/flux/issues/2255
-                "window" => Node::Builtin(r#"
+                "window" => r#"
                     forall [t0] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?every: duration,
@@ -781,60 +783,15 @@ pub fn builtins() -> Builtins<'static> {
                         ?stopColumn: string,
                         ?createEmpty: bool
                     ) -> [t1]
-                "#),
-                "yield" => Node::Builtin(r#"
+                "#,
+                "yield" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
                         ?name: string
                     ) -> [t0]
-                "#),
-            }),
+                "#,
+            },
         },
-    }
-}
-
-pub struct NodeIterator<'a> {
-    path_elems: Vec<&'a str>,
-    iter_stack: Vec<hash_map::Iter<'a, &'a str, Node<'a>>>,
-}
-
-impl<'a> NodeIterator<'a> {
-    pub fn new(builtins: &'a Builtins) -> NodeIterator<'a> {
-        NodeIterator {
-            path_elems: Vec::new(),
-            iter_stack: vec![builtins.pkgs.iter()],
-        }
-    }
-}
-
-impl<'a> Iterator for NodeIterator<'a> {
-    type Item = (std::vec::Vec<&'a str>, &'a str);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let mut it = self.iter_stack.pop()?;
-
-        match it.next() {
-            None => {
-                self.path_elems.pop();
-                self.next()
-            }
-            Some((name, item)) => {
-                self.path_elems.push(name);
-                match item {
-                    Node::Package(m) => {
-                        self.iter_stack.push(it);
-                        self.iter_stack.push(m.iter());
-                        self.next()
-                    }
-                    Node::Builtin(ty) => {
-                        let item = (self.path_elems.clone(), *ty);
-                        self.path_elems.pop();
-                        self.iter_stack.push(it);
-                        Some(item)
-                    }
-                }
-            }
-        }
     }
 }
 
@@ -845,12 +802,14 @@ mod test {
 
     #[test]
     fn parse_builtin_types() {
-        for (path, ty) in builtins().iter() {
-            match type_parser::parse(ty) {
-                Ok(_) => {}
-                Err(s) => {
-                    let msg = format!("{} type failed to parse: {}", path.join("/"), s);
-                    panic!(msg)
+        for (path, values) in builtins().iter() {
+            for (name, expr) in values {
+                match type_parser::parse(expr) {
+                    Ok(_) => {}
+                    Err(s) => {
+                        let msg = format!("{}.{} type failed to parse: {}", path, name, s);
+                        panic!(msg)
+                    }
                 }
             }
         }

--- a/libflux/src/flux/semantic/env.rs
+++ b/libflux/src/flux/semantic/env.rs
@@ -34,8 +34,11 @@ impl Substitutable for Environment {
 }
 
 impl Importer for Environment {
-    fn import(&self, name: &str) -> Option<&PolyType> {
-        self.lookup(name)
+    fn import(&self, name: &str) -> Option<PolyType> {
+        match self.lookup(name) {
+            Some(pty) => Some(pty.clone()),
+            None => None,
+        }
     }
 }
 

--- a/libflux/src/flux/semantic/import.rs
+++ b/libflux/src/flux/semantic/import.rs
@@ -2,13 +2,16 @@ use crate::semantic::types::PolyType;
 use std::collections::HashMap;
 
 pub trait Importer {
-    fn import(&self, _name: &str) -> Option<&PolyType> {
+    fn import(&self, _name: &str) -> Option<PolyType> {
         None
     }
 }
 
 impl Importer for HashMap<String, PolyType> {
-    fn import(&self, name: &str) -> Option<&PolyType> {
-        self.get(name)
+    fn import(&self, name: &str) -> Option<PolyType> {
+        match self.get(name) {
+            Some(pty) => Some(pty.clone()),
+            None => None,
+        }
     }
 }

--- a/libflux/src/flux/semantic/nodes.rs
+++ b/libflux/src/flux/semantic/nodes.rs
@@ -362,7 +362,7 @@ impl File {
             imports.push(name);
 
             match importer.import(path) {
-                Some(poly) => env.add(name.to_owned(), poly.clone()),
+                Some(poly) => env.add(name.to_owned(), poly),
                 None => return Err(Error::unknown_import_path(path)),
             };
         }
@@ -467,7 +467,7 @@ impl BuiltinStmt {
         importer: &I,
     ) -> std::result::Result<Environment, Error> {
         if let Some(ty) = importer.import(&self.id.name) {
-            env.add(self.id.name.clone(), ty.clone());
+            env.add(self.id.name.clone(), ty);
             Ok(env)
         } else {
             Err(Error::undefined_builtin(&self.id.name))

--- a/libflux/src/flux/semantic/tests.rs
+++ b/libflux/src/flux/semantic/tests.rs
@@ -76,8 +76,11 @@ fn parse_map(m: HashMap<&str, &str>) -> HashMap<String, PolyType> {
 }
 
 impl Importer for HashMap<&str, PolyType> {
-    fn import(&self, name: &str) -> Option<&PolyType> {
-        self.get(name)
+    fn import(&self, name: &str) -> Option<PolyType> {
+        match self.get(name) {
+            Some(pty) => Some(pty.clone()),
+            None => None,
+        }
     }
 }
 

--- a/libflux/src/libstd/lib.rs
+++ b/libflux/src/libstd/lib.rs
@@ -1,6 +1,7 @@
 use flatbuffers;
 use flux::ast;
 use flux::ctypes::*;
+use flux::semantic::builtins::builtins;
 use flux::semantic::env::Environment;
 use flux::semantic::flatbuffers::semantic_generated::fbsemantic as fb;
 use flux::semantic::fresh::Fresher;
@@ -47,6 +48,7 @@ pub unsafe extern "C" fn flux_analyze(
 /// that has been type-inferred.  This function is aware of the standard library
 /// and prelude.
 pub fn analyze(ast_pkg: ast::Package) -> Result<flux::semantic::nodes::Package, flux::Error> {
+    let pkgpath = ast_pkg.path.clone();
     let mut f = fresher();
     let mut sem_pkg = flux::semantic::convert::convert_with(ast_pkg, &mut f)?;
 
@@ -58,7 +60,8 @@ pub fn analyze(ast_pkg: ast::Package) -> Result<flux::semantic::nodes::Package, 
         Some(imports) => imports,
         None => return Err(flux::Error::from("missing stdlib imports")),
     };
-    let (_, sub) = infer_pkg_types(&mut sem_pkg, prelude, &mut f, &imports, &None)?;
+    let builtin_importer = builtins().importer_for(&pkgpath, &mut f);
+    let (_, sub) = infer_pkg_types(&mut sem_pkg, prelude, &mut f, &imports, &builtin_importer)?;
     sem_pkg = inject_pkg_types(sem_pkg, &sub);
     Ok(sem_pkg)
 }


### PR DESCRIPTION
This exposes the builtin polytypes when analyzing a package in the
standard library. It also flattens the builtin map to make it easier to
index. The old code that iterated through flattened the map anyway so it
is easier to read and index if we just refer to each package by their
full package name instead of by each component.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written