### PR TITLE
fix: create unique c files to force cgo to consider code changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,11 @@ libflux: libflux/target/debug/libflux.a libflux/target/debug/liblibstd.a
 # command line interface than the gnu equivalent.
 libflux/target/debug/libflux.a:
 	cd libflux && $(CARGO) build -p flux $(CARGO_ARGS)
+	echo "const char uniq_libflux[] = \"`cat $@ | md5sum | awk '{print $$1;}'`\";" > libflux/go/libflux/libflux.c
 
 libflux/target/debug/liblibstd.a:
 	cd libflux && $(CARGO) build -p libstd $(CARGO_ARGS)
+	echo "const char uniq_liblibstd[] = \"`cat $@ | md5sum | awk '{print $$1;}'`\";" > libflux/go/libflux/liblibstd.c
 
 libflux/go/libflux/flux.h: libflux/include/influxdata/flux.h
 	$(GO_GENERATE) ./libflux/go/libflux

--- a/libflux/go/libflux/.gitignore
+++ b/libflux/go/libflux/.gitignore
@@ -1,0 +1,2 @@
+/libflux.c
+/liblibstd.c


### PR DESCRIPTION
Please do not merge, looking for some feedback on this idea. I've been having a problem where cmd/flux/flux does not rebuild after the rust code changes. It seems cgo needs some source code changes to consider the package as changed. So I'm making a unique file using md5 sum. Wonder what others think of this idea ... or if there is a better solution. Seems to be the only thing that works for me, aside from a full blown clean.