### PR TITLE
refactor(execute): execute tests are now passing

### DIFF
--- a/execute/executetest/compile.go
+++ b/execute/executetest/compile.go
@@ -1,0 +1,36 @@
+package executetest
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// FunctionExpression will take a function expression as a string
+// and return the *semantic.FunctionExpression.
+//
+// This will cause a fatal error in the test on failure.
+func FunctionExpression(t testing.TB, source string) *semantic.FunctionExpression {
+	t.Helper()
+
+	pkg, err := semantic.AnalyzeSource(source)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	file := pkg.Files[0]
+	if len(file.Body) != 1 {
+		t.Fatal("function expression must have exactly one statement")
+	}
+
+	stmt, ok := file.Body[0].(*semantic.ExpressionStatement)
+	if !ok {
+		t.Fatal("statement must be an expression statement with a function expression")
+	}
+
+	fn, ok := stmt.Expression.(*semantic.FunctionExpression)
+	if !ok {
+		t.Fatal("expression must be a function expression")
+	}
+	return fn
+}

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/ast"
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
@@ -17,7 +16,6 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
-	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
 	"go.uber.org/zap/zaptest"
 )
@@ -108,27 +106,7 @@ func TestExecutor_Execute(t *testing.T) {
 					)),
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
 						Fn: interpreter.ResolvedFunction{
-							Fn: &semantic.FunctionExpression{
-								Block: &semantic.FunctionBlock{
-									Parameters: &semantic.FunctionParameters{
-										List: []*semantic.FunctionParameter{
-											{
-												Key: &semantic.Identifier{Name: "r"},
-											},
-										},
-									},
-									Body: &semantic.BinaryExpression{
-										Operator: ast.LessThanOperator,
-										Left: &semantic.MemberExpression{
-											Property: "_value",
-											Object: &semantic.IdentifierExpression{
-												Name: "r",
-											},
-										},
-										Right: &semantic.FloatLiteral{Value: 2.5},
-									},
-								},
-							},
+							Fn:    executetest.FunctionExpression(t, "(r) => r._value < 2.5"),
 							Scope: flux.Prelude(),
 						},
 					}),
@@ -198,27 +176,7 @@ func TestExecutor_Execute(t *testing.T) {
 					plan.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
 						Fn: interpreter.ResolvedFunction{
 							Scope: flux.Prelude(),
-							Fn: &semantic.FunctionExpression{
-								Block: &semantic.FunctionBlock{
-									Parameters: &semantic.FunctionParameters{
-										List: []*semantic.FunctionParameter{
-											{
-												Key: &semantic.Identifier{Name: "r"},
-											},
-										},
-									},
-									Body: &semantic.BinaryExpression{
-										Operator: ast.LessThanOperator,
-										Left: &semantic.MemberExpression{
-											Property: "_value",
-											Object: &semantic.IdentifierExpression{
-												Name: "r",
-											},
-										},
-										Right: &semantic.FloatLiteral{Value: 7.5},
-									},
-								},
-							},
+							Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
 						},
 					}),
 					plan.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -229,25 +229,7 @@ func (f *RowPredicateFn) Prepare(cols []flux.ColMeta) error {
 // contain type variables and will only contain the properties that could be
 // inferred from type inference.
 func (f *RowPredicateFn) InferredInputType() semantic.MonoType {
-	t := f.preparedFn.Type()
-	narg, err := t.NumProperties()
-	if err != nil {
-		panic(err)
-	}
-
-	for i := 0; i < narg; i++ {
-		arg, err := t.Argument(i)
-		if err != nil {
-			panic(err)
-		} else if string(arg.Name()) == f.recordName {
-			inpType, err := arg.TypeOf()
-			if err != nil {
-				panic(err)
-			}
-			return inpType
-		}
-	}
-	return semantic.MonoType{}
+	return f.arg0.Type()
 }
 
 // InputType will return the prepared input type.


### PR DESCRIPTION
The unit tests for the execute package are now passing. This required
some fixes to filter which weren't previously capable of being tested
because the filter test cases couldn't be run because of the builtins
not being registered yet.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written