### PR TITLE
fix: libflux json deserialization uses type properly

### DIFF
--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -101,34 +101,56 @@ where
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum Expression {
     Identifier(Identifier),
-
+    #[serde(rename = "ArrayExpression")]
     Array(Box<ArrayExpr>),
+    #[serde(rename = "FunctionExpression")]
     Function(Box<FunctionExpr>),
+    #[serde(rename = "LogicalExpression")]
     Logical(Box<LogicalExpr>),
+    #[serde(rename = "ObjectExpression")]
     Object(Box<ObjectExpr>),
+    #[serde(rename = "MemberExpression")]
     Member(Box<MemberExpr>),
+    #[serde(rename = "IndexExpression")]
     Index(Box<IndexExpr>),
+    #[serde(rename = "BinaryExpression")]
     Binary(Box<BinaryExpr>),
+    #[serde(rename = "UnaryExpression")]
     Unary(Box<UnaryExpr>),
+    #[serde(rename = "PipeExpression")]
     PipeExpr(Box<PipeExpr>),
+    #[serde(rename = "CallExpression")]
     Call(Box<CallExpr>),
+    #[serde(rename = "ConditionalExpression")]
     Conditional(Box<ConditionalExpr>),
+    #[serde(rename = "StringExpression")]
     StringExpr(Box<StringExpr>),
+    #[serde(rename = "ParenExpression")]
     Paren(Box<ParenExpr>),
 
+    #[serde(rename = "IntegerLiteral")]
     Integer(IntegerLit),
+    #[serde(rename = "FloatLiteral")]
     Float(FloatLit),
+    #[serde(rename = "StringLiteral")]
     StringLit(StringLit),
+    #[serde(rename = "DurationLiteral")]
     Duration(DurationLit),
+    #[serde(rename = "UnsignedIntegerLiteral")]
     Uint(UintLit),
+    #[serde(rename = "BooleanLiteral")]
     Boolean(BooleanLit),
+    #[serde(rename = "DateTimeLiteral")]
     DateTime(DateTimeLit),
+    #[serde(rename = "RegexpLiteral")]
     Regexp(RegexpLit),
+    #[serde(rename = "PipeLiteral")]
     PipeLit(PipeLit),
 
+    #[serde(rename = "BadExpression")]
     Bad(Box<BadExpr>),
 }
 
@@ -165,14 +187,21 @@ impl Expression {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum Statement {
+    #[serde(rename = "ExpressionStatement")]
     Expr(ExprStmt),
+    #[serde(rename = "VariableAssignment")]
     Variable(Box<VariableAssgn>),
+    #[serde(rename = "OptionStatement")]
     Option(Box<OptionStmt>),
+    #[serde(rename = "ReturnStatement")]
     Return(ReturnStmt),
+    #[serde(rename = "BadStatement")]
     Bad(BadStmt),
+    #[serde(rename = "TestStatement")]
     Test(Box<TestStmt>),
+    #[serde(rename = "BuiltinStatement")]
     Builtin(BuiltinStmt),
 }
 
@@ -205,9 +234,11 @@ impl Statement {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum Assignment {
+    #[serde(rename = "VariableAssignment")]
     Variable(Box<VariableAssgn>),
+    #[serde(rename = "MemberAssignment")]
     Member(Box<MemberAssgn>),
 }
 
@@ -222,9 +253,10 @@ impl Assignment {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum PropertyKey {
     Identifier(Identifier),
+    #[serde(rename = "StringLiteral")]
     StringLit(StringLit),
 }
 
@@ -395,7 +427,6 @@ pub struct BadStmt {
 
 // ExprStmt may consist of an expression that does not return a value and is executed solely for its side-effects.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "ExpressionStatement", tag = "type")]
 pub struct ExprStmt {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -406,7 +437,6 @@ pub struct ExprStmt {
 
 // ReturnStmt defines an Expression to return
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "ReturnStatement", tag = "type")]
 pub struct ReturnStmt {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -417,7 +447,6 @@ pub struct ReturnStmt {
 
 // OptionStmt syntactically is a single variable declaration
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "OptionStatement", tag = "type")]
 pub struct OptionStmt {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -428,7 +457,6 @@ pub struct OptionStmt {
 
 // BuiltinStmt declares a builtin identifier and its struct
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "BuiltinStatement", tag = "type")]
 pub struct BuiltinStmt {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -439,7 +467,6 @@ pub struct BuiltinStmt {
 
 // TestStmt declares a Flux test case
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "TestStatement", tag = "type")]
 pub struct TestStmt {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -450,7 +477,6 @@ pub struct TestStmt {
 
 // VariableAssgn represents the declaration of a variable
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "VariableAssignment", tag = "type")]
 pub struct VariableAssgn {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -462,7 +488,6 @@ pub struct VariableAssgn {
 
 // MemberAssgn represents an assignement into a member of an object.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "MemberAssignment", tag = "type")]
 pub struct MemberAssgn {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -474,7 +499,6 @@ pub struct MemberAssgn {
 
 // StringExpr represents an interpolated string
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "StringExpression", tag = "type")]
 pub struct StringExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -485,15 +509,16 @@ pub struct StringExpr {
 
 // StringExprPart represents part of an interpolated string
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum StringExprPart {
+    #[serde(rename = "TextPart")]
     Text(TextPart),
+    #[serde(rename = "InterpolatedPart")]
     Interpolated(InterpolatedPart),
 }
 
 // TextPart represents the text part of an interpolated string
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
 pub struct TextPart {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -504,7 +529,6 @@ pub struct TextPart {
 
 // InterpolatedPart represents the expression part of an interpolated string
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
 pub struct InterpolatedPart {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -515,7 +539,6 @@ pub struct InterpolatedPart {
 
 // ParenExpr represents an expression wrapped in parenthesis
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "ParenExpression", tag = "type")]
 pub struct ParenExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -526,7 +549,6 @@ pub struct ParenExpr {
 
 // CallExpr represents a function call
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "CallExpression", tag = "type")]
 pub struct CallExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -540,7 +562,6 @@ pub struct CallExpr {
 
 // PipeExpr represents a call expression using the pipe forward syntax.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "PipeExpression", tag = "type")]
 pub struct PipeExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -552,7 +573,6 @@ pub struct PipeExpr {
 
 // MemberExpr represents calling a property of a Call
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "MemberExpression", tag = "type")]
 pub struct MemberExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -564,7 +584,6 @@ pub struct MemberExpr {
 
 // IndexExpr represents indexing into an array
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "IndexExpression", tag = "type")]
 pub struct IndexExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -575,13 +594,12 @@ pub struct IndexExpr {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "FunctionExpression", tag = "type")]
 pub struct FunctionExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
     #[serde(flatten)]
     pub base: BaseNode,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(deserialize_with = "deserialize_default_from_null")]
     pub params: Vec<Property>,
     pub body: FunctionBody,
 }
@@ -813,7 +831,6 @@ impl<'de> Deserialize<'de> for LogicalOperator {
 // `or` expressions compute the disjunction of two boolean expressions and return boolean values.
 // `and`` expressions compute the conjunction of two boolean expressions and return boolean values.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "LogicalExpression", tag = "type")]
 pub struct LogicalExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -826,7 +843,6 @@ pub struct LogicalExpr {
 
 // ArrayExpr is used to create and directly specify the elements of an array object
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "ArrayExpression", tag = "type")]
 pub struct ArrayExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -837,13 +853,13 @@ pub struct ArrayExpr {
 
 // ObjectExpr allows the declaration of an anonymous object within a declaration.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "ObjectExpression", tag = "type")]
 pub struct ObjectExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
     #[serde(flatten)]
     pub base: BaseNode,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub with: Option<Identifier>,
     pub properties: Vec<Property>,
 }
@@ -851,7 +867,6 @@ pub struct ObjectExpr {
 // ConditionalExpr selects one of two expressions, `Alternate` or `Consequent`
 // depending on a third, boolean, expression, `Test`.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "ConditionalExpression", tag = "type")]
 pub struct ConditionalExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -865,7 +880,6 @@ pub struct ConditionalExpr {
 // BadExpr is a malformed expression that contains the reason why in `text`.
 // It can contain another expression, so that the parser can make a chained list of bad expressions.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "BadExpression", tag = "type")]
 pub struct BadExpr {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -891,7 +905,6 @@ pub struct Property {
 
 // Identifier represents a name that identifies a unique Node
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
 pub struct Identifier {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -902,7 +915,6 @@ pub struct Identifier {
 
 // PipeLit represents an specialized literal value, indicating the left hand value of a pipe expression.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "PipeLiteral", tag = "type")]
 pub struct PipeLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -912,7 +924,6 @@ pub struct PipeLit {
 
 // StringLit expressions begin and end with double quote marks.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "StringLiteral", tag = "type")]
 pub struct StringLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -923,7 +934,6 @@ pub struct StringLit {
 
 // Boolean represent boolean values
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "BooleanLiteral", tag = "type")]
 pub struct BooleanLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -934,7 +944,6 @@ pub struct BooleanLit {
 
 // FloatLit represent floating point numbers according to the double representations defined by the IEEE-754-1985
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "FloatLiteral", tag = "type")]
 pub struct FloatLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -945,7 +954,6 @@ pub struct FloatLit {
 
 // IntegerLit represent integer numbers.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "IntegerLiteral", tag = "type")]
 pub struct IntegerLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -958,7 +966,6 @@ pub struct IntegerLit {
 
 // UintLit represent integer numbers.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "UnsignedIntegerLiteral", tag = "type")]
 pub struct UintLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -1037,7 +1044,6 @@ where
 
 // RegexpLit expressions begin and end with `/` and are regular expressions with syntax accepted by RE2
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "RegexpLiteral", tag = "type")]
 pub struct RegexpLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -1060,7 +1066,6 @@ pub struct Duration {
 // TODO: this may be better as a class initialization
 // All magnitudes in Duration vector should have the same sign
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "DurationLiteral", tag = "type")]
 pub struct DurationLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]
@@ -1075,7 +1080,6 @@ pub struct DurationLit {
 // the syntax of golang's RFC3339 Nanosecond variant
 // TODO: this may be better as a class initialization
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-#[serde(rename = "DateTimeLiteral", tag = "type")]
 pub struct DateTimeLit {
     #[serde(skip_serializing_if = "BaseNode::is_empty")]
     #[serde(default)]

--- a/libflux/src/flux/ast/tests.rs
+++ b/libflux/src/flux/ast/tests.rs
@@ -23,7 +23,7 @@ use chrono::TimeZone;
 */
 #[test]
 fn test_string_interpolation() {
-    let n = StringExpr {
+    let n = Expression::StringExpr(Box::new(StringExpr {
         base: BaseNode::default(),
         parts: vec![
             StringExprPart::Text(TextPart {
@@ -38,13 +38,13 @@ fn test_string_interpolation() {
                 }),
             }),
         ],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"StringExpression","parts":[{"type":"TextPart","value":"a = "},{"type":"InterpolatedPart","expression":{"type":"Identifier","name":"a"}}]}"#
     );
-    let deserialized: StringExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -69,7 +69,7 @@ fn test_string_interpolation() {
 */
 #[test]
 fn test_paren_expression() {
-    let n = ParenExpr {
+    let n = Expression::Paren(Box::new(ParenExpr {
         base: BaseNode::default(),
         expression: Expression::StringExpr(Box::new(StringExpr {
             base: BaseNode::default(),
@@ -87,13 +87,13 @@ fn test_paren_expression() {
                 }),
             ],
         })),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ParenExpression","expression":{"type":"StringExpression","parts":[{"type":"TextPart","value":"a = "},{"type":"InterpolatedPart","expression":{"type":"Identifier","name":"a"}}]}}"#
     );
-    let deserialized: ParenExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -239,7 +239,7 @@ fn test_json_file() {
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"File","metadata":"parser-type=none","package":{"type":"PackageClause","name":{"type":"Identifier","name":"foo"}},"imports":[{"type":"ImportDeclaration","as":{"type":"Identifier","name":"b"},"path":{"type":"StringLiteral","value":"path/bar"}}],"body":[{"type":"ExpressionStatement","expression":{"type":"StringLiteral","value":"hello"}}]}"#
+        r#"{"type":"File","metadata":"parser-type=none","package":{"type":"PackageClause","name":{"name":"foo"}},"imports":[{"type":"ImportDeclaration","as":{"name":"b"},"path":{"value":"path/bar"}}],"body":[{"type":"ExpressionStatement","expression":{"type":"StringLiteral","value":"hello"}}]}"#
     );
     let deserialized: File = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
@@ -288,19 +288,19 @@ fn test_json_block() {
 */
 #[test]
 fn test_json_expression_statement() {
-    let n = ExprStmt {
+    let n = Statement::Expr(ExprStmt {
         base: BaseNode::default(),
         expression: Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         }),
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ExpressionStatement","expression":{"type":"StringLiteral","value":"hello"}}"#
     );
-    let deserialized: ExprStmt = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -314,19 +314,19 @@ fn test_json_expression_statement() {
 */
 #[test]
 fn test_json_return_statement() {
-    let n = ReturnStmt {
+    let n = Statement::Return(ReturnStmt {
         base: BaseNode::default(),
         argument: Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         }),
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ReturnStatement","argument":{"type":"StringLiteral","value":"hello"}}"#
     );
-    let deserialized: ReturnStmt = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -361,7 +361,7 @@ fn test_json_return_statement() {
 */
 #[test]
 fn test_json_option_statement() {
-    let n = OptionStmt {
+    let n = Statement::Option(Box::new(OptionStmt {
         base: BaseNode::default(),
         assignment: Assignment::Variable(Box::new(VariableAssgn {
             base: BaseNode::default(),
@@ -401,13 +401,13 @@ fn test_json_option_statement() {
                 ],
             })),
         })),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"OptionStatement","assignment":{"type":"VariableAssignment","id":{"type":"Identifier","name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","values":[{"magnitude":1,"unit":"h"}]}}]}}}"#
+        r#"{"type":"OptionStatement","assignment":{"type":"VariableAssignment","id":{"name":"task"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"name"},"value":{"type":"StringLiteral","value":"foo"}},{"type":"Property","key":{"type":"Identifier","name":"every"},"value":{"type":"DurationLiteral","values":[{"magnitude":1,"unit":"h"}]}}]}}}"#
     );
-    let deserialized: OptionStmt = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -421,19 +421,19 @@ fn test_json_option_statement() {
 */
 #[test]
 fn test_json_builtin_statement() {
-    let n = BuiltinStmt {
+    let n = Statement::Builtin(BuiltinStmt {
         base: BaseNode::default(),
         id: Identifier {
             base: BaseNode::default(),
             name: "task".to_string(),
         },
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"BuiltinStatement","id":{"type":"Identifier","name":"task"}}"#
+        r#"{"type":"BuiltinStatement","id":{"name":"task"}}"#
     );
-    let deserialized: BuiltinStmt = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -469,7 +469,7 @@ fn test_json_builtin_statement() {
 */
 #[test]
 fn test_json_test_statement() {
-    let n = TestStmt {
+    let n = Statement::Test(Box::new(TestStmt {
         base: BaseNode::default(),
         assignment: VariableAssgn {
             base: BaseNode::default(),
@@ -506,13 +506,13 @@ fn test_json_test_statement() {
                 ],
             })),
         },
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"TestStatement","assignment":{"type":"VariableAssignment","id":{"type":"Identifier","name":"mean"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"want"},"value":{"type":"IntegerLiteral","value":"0"}},{"type":"Property","key":{"type":"Identifier","name":"got"},"value":{"type":"IntegerLiteral","value":"0"}}]}}}"#
+        r#"{"type":"TestStatement","assignment":{"id":{"name":"mean"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"want"},"value":{"type":"IntegerLiteral","value":"0"}},{"type":"Property","key":{"type":"Identifier","name":"got"},"value":{"type":"IntegerLiteral","value":"0"}}]}}}"#
     );
-    let deserialized: TestStmt = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -538,7 +538,7 @@ fn test_json_test_statement() {
 */
 #[test]
 fn test_json_qualified_option_statement() {
-    let n = OptionStmt {
+    let n = Statement::Option(Box::new(OptionStmt {
         base: BaseNode::default(),
         assignment: Assignment::Member(Box::new(MemberAssgn {
             base: BaseNode::default(),
@@ -558,13 +558,13 @@ fn test_json_qualified_option_statement() {
                 value: "Warning".to_string(),
             }),
         })),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"OptionStatement","assignment":{"type":"MemberAssignment","member":{"type":"MemberExpression","object":{"type":"Identifier","name":"alert"},"property":{"type":"Identifier","name":"state"}},"init":{"type":"StringLiteral","value":"Warning"}}}"#
+        r#"{"type":"OptionStatement","assignment":{"type":"MemberAssignment","member":{"object":{"type":"Identifier","name":"alert"},"property":{"type":"Identifier","name":"state"}},"init":{"type":"StringLiteral","value":"Warning"}}}"#
     );
-    let deserialized: OptionStmt = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -579,7 +579,7 @@ fn test_json_qualified_option_statement() {
 */
 #[test]
 fn test_json_variable_assignment() {
-    let n = VariableAssgn {
+    let n = Statement::Variable(Box::new(VariableAssgn {
         base: BaseNode::default(),
         id: Identifier {
             base: BaseNode::default(),
@@ -589,13 +589,13 @@ fn test_json_variable_assignment() {
             base: BaseNode::default(),
             value: "hello".to_string(),
         }),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"VariableAssignment","id":{"type":"Identifier","name":"a"},"init":{"type":"StringLiteral","value":"hello"}}"#
+        r#"{"type":"VariableAssignment","id":{"name":"a"},"init":{"type":"StringLiteral","value":"hello"}}"#
     );
-    let deserialized: VariableAssgn = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -610,7 +610,7 @@ fn test_json_variable_assignment() {
 */
 #[test]
 fn test_json_call_expression() {
-    let n = CallExpr {
+    let n = Expression::Call(Box::new(CallExpr {
         base: BaseNode::default(),
         callee: Expression::Identifier(Identifier {
             base: BaseNode::default(),
@@ -620,13 +620,13 @@ fn test_json_call_expression() {
             base: BaseNode::default(),
             value: "hello".to_string(),
         })],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"CallExpression","callee":{"type":"Identifier","name":"a"},"arguments":[{"type":"StringLiteral","value":"hello"}]}"#
     );
-    let deserialized: CallExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -641,20 +641,20 @@ fn test_json_call_expression() {
 */
 #[test]
 fn test_json_call_expression_empty_arguments() {
-    let n = CallExpr {
+    let n = Expression::Call(Box::new(CallExpr {
         base: BaseNode::default(),
         callee: Expression::Identifier(Identifier {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
         arguments: vec![],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"CallExpression","callee":{"type":"Identifier","name":"a"}}"#
     );
-    let deserialized: CallExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -672,7 +672,7 @@ fn test_json_call_expression_empty_arguments() {
 */
 #[test]
 fn test_json_pipe_expression() {
-    let n = PipeExpr {
+    let n = Expression::PipeExpr(Box::new(PipeExpr {
         base: BaseNode::default(),
         argument: Expression::Identifier(Identifier {
             base: BaseNode::default(),
@@ -689,13 +689,13 @@ fn test_json_pipe_expression() {
                 value: "hello".to_string(),
             })],
         },
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"PipeExpression","argument":{"type":"Identifier","name":"a"},"call":{"type":"CallExpression","callee":{"type":"Identifier","name":"a"},"arguments":[{"type":"StringLiteral","value":"hello"}]}}"#
+        r#"{"type":"PipeExpression","argument":{"type":"Identifier","name":"a"},"call":{"callee":{"type":"Identifier","name":"a"},"arguments":[{"type":"StringLiteral","value":"hello"}]}}"#
     );
-    let deserialized: PipeExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -710,7 +710,7 @@ fn test_json_pipe_expression() {
 */
 #[test]
 fn test_json_member_expression_with_identifier() {
-    let n = MemberExpr {
+    let n = Expression::Member(Box::new(MemberExpr {
         base: BaseNode::default(),
         object: Expression::Identifier(Identifier {
             base: BaseNode::default(),
@@ -720,13 +720,13 @@ fn test_json_member_expression_with_identifier() {
             base: BaseNode::default(),
             name: "b".to_string(),
         }),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"MemberExpression","object":{"type":"Identifier","name":"a"},"property":{"type":"Identifier","name":"b"}}"#
     );
-    let deserialized: MemberExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -741,7 +741,7 @@ fn test_json_member_expression_with_identifier() {
 */
 #[test]
 fn test_json_member_expression_with_string_literal() {
-    let n = MemberExpr {
+    let n = Expression::Member(Box::new(MemberExpr {
         base: BaseNode::default(),
         object: Expression::Identifier(Identifier {
             base: BaseNode::default(),
@@ -751,13 +751,13 @@ fn test_json_member_expression_with_string_literal() {
             base: BaseNode::default(),
             value: "b".to_string(),
         }),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"MemberExpression","object":{"type":"Identifier","name":"a"},"property":{"type":"StringLiteral","value":"b"}}"#
     );
-    let deserialized: MemberExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -772,7 +772,7 @@ fn test_json_member_expression_with_string_literal() {
 */
 #[test]
 fn test_json_index_expression() {
-    let n = IndexExpr {
+    let n = Expression::Index(Box::new(IndexExpr {
         base: BaseNode::default(),
         array: Expression::Identifier(Identifier {
             base: BaseNode::default(),
@@ -782,13 +782,13 @@ fn test_json_index_expression() {
             base: BaseNode::default(),
             value: 3,
         }),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"IndexExpression","array":{"type":"Identifier","name":"a"},"index":{"type":"IntegerLiteral","value":"3"}}"#
     );
-    let deserialized: IndexExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -803,7 +803,7 @@ fn test_json_index_expression() {
 */
 #[test]
 fn test_json_arrow_function_expression() {
-    let n = FunctionExpr {
+    let n = Expression::Function(Box::new(FunctionExpr {
         base: BaseNode::default(),
         params: vec![Property {
             base: BaseNode::default(),
@@ -817,13 +817,13 @@ fn test_json_arrow_function_expression() {
             base: BaseNode::default(),
             value: "hello".to_string(),
         })),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"FunctionExpression","params":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":null}],"body":{"type":"StringLiteral","value":"hello"}}"#
     );
-    let deserialized: FunctionExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -900,7 +900,7 @@ fn test_json_unary_expression() {
 */
 #[test]
 fn test_json_logical_expression() {
-    let n = LogicalExpr {
+    let n = Expression::Logical(Box::new(LogicalExpr {
         base: BaseNode::default(),
         operator: LogicalOperator::OrOperator,
         left: Expression::Boolean(BooleanLit {
@@ -911,13 +911,13 @@ fn test_json_logical_expression() {
             base: BaseNode::default(),
             value: true,
         }),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"LogicalExpression","operator":"or","left":{"type":"BooleanLiteral","value":false},"right":{"type":"BooleanLiteral","value":true}}"#
     );
-    let deserialized: LogicalExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -931,19 +931,19 @@ fn test_json_logical_expression() {
 */
 #[test]
 fn test_json_array_expression() {
-    let n = ArrayExpr {
+    let n = Expression::Array(Box::new(ArrayExpr {
         base: BaseNode::default(),
         elements: vec![Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         })],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ArrayExpression","elements":[{"type":"StringLiteral","value":"hello"}]}"#
     );
-    let deserialized: ArrayExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -960,7 +960,7 @@ fn test_json_array_expression() {
 */
 #[test]
 fn test_json_object_expression() {
-    let n = ObjectExpr {
+    let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
         with: None,
         properties: vec![Property {
@@ -974,13 +974,13 @@ fn test_json_object_expression() {
                 value: "hello".to_string(),
             })),
         }],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":{"type":"StringLiteral","value":"hello"}}]}"#
     );
-    let deserialized: ObjectExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -997,7 +997,7 @@ fn test_json_object_expression() {
 */
 #[test]
 fn test_json_object_expression_with_string_literal_key() {
-    let n = ObjectExpr {
+    let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
         with: None,
         properties: vec![Property {
@@ -1011,13 +1011,13 @@ fn test_json_object_expression_with_string_literal_key() {
                 value: "hello".to_string(),
             })),
         }],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"StringLiteral","value":"a"},"value":{"type":"StringLiteral","value":"hello"}}]}"#
     );
-    let deserialized: ObjectExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1033,7 +1033,7 @@ fn test_json_object_expression_with_string_literal_key() {
 */
 #[test]
 fn test_json_object_expression_implicit_keys() {
-    let n = ObjectExpr {
+    let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
         with: None,
         properties: vec![Property {
@@ -1044,19 +1044,19 @@ fn test_json_object_expression_implicit_keys() {
             }),
             value: None,
         }],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":null}]}"#
     );
-    let deserialized: ObjectExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 
 #[test]
 fn test_json_object_expression_implicit_keys_and_with() {
-    let n = ObjectExpr {
+    let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
         with: Some(Identifier {
             base: BaseNode::default(),
@@ -1070,13 +1070,13 @@ fn test_json_object_expression_implicit_keys_and_with() {
             }),
             value: None,
         }],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
-        r#"{"type":"ObjectExpression","with":{"type":"Identifier","name":"a"},"properties":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":null}]}"#
+        r#"{"type":"ObjectExpression","with":{"name":"a"},"properties":[{"type":"Property","key":{"type":"Identifier","name":"a"},"value":null}]}"#
     );
-    let deserialized: ObjectExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1092,7 +1092,7 @@ fn test_json_object_expression_implicit_keys_and_with() {
 */
 #[test]
 fn test_json_conditional_expression() {
-    let n = ConditionalExpr {
+    let n = Expression::Conditional(Box::new(ConditionalExpr {
         base: BaseNode::default(),
         test: Expression::Boolean(BooleanLit {
             base: BaseNode::default(),
@@ -1106,13 +1106,13 @@ fn test_json_conditional_expression() {
             base: BaseNode::default(),
             value: "true".to_string(),
         }),
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"ConditionalExpression","test":{"type":"BooleanLiteral","value":true},"consequent":{"type":"StringLiteral","value":"true"},"alternate":{"type":"StringLiteral","value":"false"}}"#
     );
-    let deserialized: ConditionalExpr = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1157,13 +1157,13 @@ fn test_json_property() {
 */
 #[test]
 fn test_json_identifier() {
-    let n = Identifier {
+    let n = Expression::Identifier(Identifier {
         base: BaseNode::default(),
         name: "a".to_string(),
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(serialized, r#"{"type":"Identifier","name":"a"}"#);
-    let deserialized: Identifier = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1177,13 +1177,13 @@ fn test_json_identifier() {
 */
 #[test]
 fn test_json_string_literal() {
-    let n = StringLit {
+    let n = Expression::StringLit(StringLit {
         base: BaseNode::default(),
         value: "hello".to_string(),
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(serialized, r#"{"type":"StringLiteral","value":"hello"}"#);
-    let deserialized: StringLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1197,13 +1197,13 @@ fn test_json_string_literal() {
 */
 #[test]
 fn test_json_boolean_literal() {
-    let n = BooleanLit {
+    let n = Expression::Boolean(BooleanLit {
         base: BaseNode::default(),
         value: true,
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(serialized, r#"{"type":"BooleanLiteral","value":true}"#);
-    let deserialized: BooleanLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1217,13 +1217,13 @@ fn test_json_boolean_literal() {
 */
 #[test]
 fn test_json_float_literal() {
-    let n = FloatLit {
+    let n = Expression::Float(FloatLit {
         base: BaseNode::default(),
         value: 42.1,
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(serialized, r#"{"type":"FloatLiteral","value":42.1}"#);
-    let deserialized: FloatLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1237,16 +1237,16 @@ fn test_json_float_literal() {
 */
 #[test]
 fn test_json_integer_literal() {
-    let n = IntegerLit {
+    let n = Expression::Integer(IntegerLit {
         base: BaseNode::default(),
         value: 9223372036854775807,
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"IntegerLiteral","value":"9223372036854775807"}"#
     );
-    let deserialized: IntegerLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1260,16 +1260,16 @@ fn test_json_integer_literal() {
 */
 #[test]
 fn test_json_unsigned_integer_literal() {
-    let n = UintLit {
+    let n = Expression::Uint(UintLit {
         base: BaseNode::default(),
         value: 18446744073709551615,
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"UnsignedIntegerLiteral","value":"18446744073709551615"}"#
     );
-    let deserialized: UintLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1283,13 +1283,13 @@ fn test_json_unsigned_integer_literal() {
 */
 #[test]
 fn test_json_regexp_literal() {
-    let n = RegexpLit {
+    let n = Expression::Regexp(RegexpLit {
         base: BaseNode::default(),
         value: ".*".to_string(),
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(serialized, r#"{"type":"RegexpLiteral","value":".*"}"#);
-    let deserialized: RegexpLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1312,7 +1312,7 @@ fn test_json_regexp_literal() {
 */
 #[test]
 fn test_json_duration_literal() {
-    let n = DurationLit {
+    let n = Expression::Duration(DurationLit {
         base: BaseNode::default(),
         values: vec![
             Duration {
@@ -1324,13 +1324,13 @@ fn test_json_duration_literal() {
                 unit: "h".to_string(),
             },
         ],
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"DurationLiteral","values":[{"magnitude":1,"unit":"h"},{"magnitude":1,"unit":"h"}]}"#
     );
-    let deserialized: DurationLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 /*
@@ -1347,24 +1347,24 @@ fn test_json_duration_literal() {
 // and it will be parsed by the Go backend.
 #[test]
 fn test_json_datetime_literal() {
-    let n = DateTimeLit {
+    let n = Expression::DateTime(DateTimeLit {
         base: BaseNode::default(),
         value: FixedOffset::east(0)
             .ymd(2017, 8, 8)
             .and_hms_nano(8, 8, 8, 8),
-    };
+    });
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
         r#"{"type":"DateTimeLiteral","value":"2017-08-08T08:08:08.000000008+00:00"}"#
     );
-    let deserialized: DateTimeLit = serde_json::from_str(serialized.as_str()).unwrap();
+    let deserialized: Expression = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
 
 #[test]
 fn test_object_expression_with_source_locations_and_errors() {
-    let n = ObjectExpr {
+    let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode {
             location: SourceLocation {
                 file: Some("foo.flux".to_string()),
@@ -1419,7 +1419,7 @@ fn test_object_expression_with_source_locations_and_errors() {
                 value: "hello".to_string(),
             })),
         }],
-    };
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,


### PR DESCRIPTION
The libflux json deserialization now uses type properly instead of the
untagged property. That causes the enums to consult the type of the enum
instead of trying to do pattern matching.

A consequence of this though is that parts of the AST that hard-code a
specific type, not the enum, won't have their type serialized. But, this
doesn't matter because since the type is hard-coded in both the Go and
Rust AST's, the correct type gets deserialized anyway. The type was
only needed for interfaces anyway.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written