### PR TITLE
fix(builtins): add missing parameter to type of "to()"

### DIFF
--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -135,6 +135,7 @@ pub fn builtins() -> Builtins<'static> {
                         ?bucketID: string,
                         ?org: string,
                         ?orgID: string,
+                        ?host: string,
                         ?token: string,
                         ?timeColumn: string,
                         ?measurementColumn: string,


### PR DESCRIPTION
This just adds a parameter to the builtin `to()` that somehow got omitted.