### PR TITLE
fix: use LocalRange in compile tests

### DIFF
--- a/compile_test.go
+++ b/compile_test.go
@@ -25,7 +25,7 @@ func TestEval(t *testing.T) {
 			"f": "(x: int) -> int",
 			"y": "42",
 		}
-		scope.Range(func(k string, v values.Value) {
+		scope.LocalRange(func(k string, v values.Value) {
 			wantV, ok := want[k]
 			if !ok {
 				t.Errorf("did not find %q in scope", k)


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written