### PR TITLE
refactor(libflux): use runtime.KeepAlive to prevent finalizer race conditions

### DIFF
--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -30,6 +30,8 @@ func (p *SemanticPkg) MarshalFB() ([]byte, error) {
 		str := C.GoString(cstr)
 		return nil, errors.Newf(codes.Internal, "could not marshal semantic graph to FlatBuffer: %v", str)
 	}
+	// See MarshalFB in ASTPkg for why this is needed.
+	runtime.KeepAlive(p)
 	defer C.flux_free(buf.data)
 
 	data := C.GoBytes(buf.data, C.int(buf.len))
@@ -42,6 +44,10 @@ func (p *SemanticPkg) Free() {
 		C.flux_free(unsafe.Pointer(p.ptr))
 	}
 	p.ptr = nil
+
+	// See the equivalent method in ASTPkg for why
+	// this is needed.
+	runtime.KeepAlive(p)
 }
 
 // Analyze parses the given Flux source, performs type inference
@@ -64,6 +70,7 @@ func Analyze(astPkg *ASTPkg) (*SemanticPkg, error) {
 		str := C.GoString(cstr)
 		return nil, errors.New(codes.Invalid, str)
 	}
+	runtime.KeepAlive(astPkg)
 	p := &SemanticPkg{ptr: semPkg}
 	runtime.SetFinalizer(p, free)
 	return p, nil


### PR DESCRIPTION
The go docs for `SetFinalizer` indicate that an object can be garbage
collected even if it is currently within scope as long as the object
itself isn't used anymore. If the garbage collector runs in this
circumstance, it is possible for it to run the finalizer while a cgo
call is happening.

The `runtime.KeepAlive` function forces the compiler to have a reference
to the object until the method is called which forces the object to
remain alive. If this is placed after the call into the C library, it
prevents the handle from being freed while it is in use.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written