### PR TITLE
fix(valuestest): replace ScopeComparer with ScopeTransformer

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -125,9 +125,7 @@ func SetNowOption(now time.Time) ScopeMutator {
 
 func generateNowFunc(now time.Time) values.Function {
 	timeVal := values.NewTime(values.ConvertTime(now))
-	// TODO(jsternberg): Replace with proper function type.
-	// ftype := semantic.NewFunctionType()
-	var ftype semantic.MonoType
+	ftype := semantic.MustLookupBuiltinType("universe", "now")
 	call := func(ctx context.Context, args values.Object) (values.Value, error) {
 		return timeVal, nil
 	}

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -183,7 +183,7 @@ pub fn builtins() -> Builtins<'static> {
                 "to" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],
-                        brokers: string,
+                        brokers: [string],
                         topic: string,
                         ?balancer: string,
                         ?name: string,

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -83,7 +83,13 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 								},
 							},
 						},
-						Body: &semantic.BooleanLiteral{Value: true},
+						Body: &semantic.Block{
+							Body: []semantic.Statement{
+								&semantic.ReturnStatement{
+									Argument: &semantic.BooleanLiteral{Value: true},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/plan/plantest/cmp.go
+++ b/plan/plantest/cmp.go
@@ -23,7 +23,7 @@ var CmpOptions = append(
 	cmpopts.IgnoreUnexported(universe.JoinOpSpec{}),
 	cmp.AllowUnexported(kafka.ToKafkaProcedureSpec{}),
 	cmpopts.IgnoreUnexported(kafka.ToKafkaProcedureSpec{}),
-	valuestest.ScopeComparer,
+	valuestest.ScopeTransformer,
 )
 
 // ComparePlans compares two query plans using an arbitrary comparator function f

--- a/querytest/compile.go
+++ b/querytest/compile.go
@@ -31,7 +31,7 @@ var opts = append(
 	cmp.AllowUnexported(universe.JoinOpSpec{}),
 	cmpopts.IgnoreUnexported(flux.Spec{}),
 	cmpopts.IgnoreUnexported(universe.JoinOpSpec{}),
-	valuestest.ScopeComparer,
+	valuestest.ScopeTransformer,
 )
 
 func NewQueryTestHelper(t *testing.T, tc NewQueryTestCase) {

--- a/semantic/semantictest/cmp.go
+++ b/semantic/semantictest/cmp.go
@@ -128,6 +128,11 @@ func TransformValue(v values.Value) map[string]interface{} {
 			"type":     semantic.Object.String(),
 			"elements": elements,
 		}
+	case semantic.Function:
+		// Just use the function type when comparing functions
+		return map[string]interface{}{
+			"type": v.Type().String(),
+		}
 	default:
 		panic(fmt.Errorf("unexpected value type %v", v.Type()))
 	}


### PR DESCRIPTION
When comparing `ProcedureSpec` objects as we do in planner tests, we need to compare `ResolvedFn` members for stream functions that use lambdas.  `ResolvedFn` contains a scope that has all of the `universe` and `influxdb` packages.  Comparing scopes works just fine, but when there are differences, producing the human-readable diff takes a long time, and this was causing some of the planner and `QueryTest` tests to appear to hang.