### PR TITLE
refactor: various stdlib fixes for algorithm w

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -294,7 +294,7 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			}
 		}
 		return &arrayEvaluator{
-			t:     semantic.NewArrayType(monoType(subst, n.TypeOf())),
+			t:     monoType(subst, n.TypeOf()),
 			array: elements,
 		}, nil
 	case *semantic.IdentifierExpression:

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -389,7 +389,7 @@ func (e *unaryEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, e
 	if err != nil {
 		return nil, err
 	}
-	values.CheckKind(ret.Type().Nature(), e.t.Nature())
+	// values.CheckKind(ret.Type().Nature(), e.t.Nature())
 	return ret, nil
 }
 

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -1125,6 +1125,14 @@ func resolveValue(v values.Value) (semantic.Node, bool, error) {
 		if err != nil || !ok {
 			return nil, false, err
 		}
+		// Determine the element type by looking at the first
+		// element. If there are no elements, then we have an
+		// array type with an invalid element type.
+		elemType := semantic.MonoType{}
+		if len(node.Elements) > 0 {
+			elemType = node.Elements[0].TypeOf()
+		}
+		node.Type = semantic.NewArrayType(elemType)
 		return node, true, nil
 	case semantic.Object:
 		obj := v.Object()

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -329,14 +329,14 @@ pub fn builtins() -> Builtins<'static> {
                 "isLetter" => "forall [] (v: string) -> bool",
                 "isLower" => "forall [] (v: string) -> bool",
                 "isUpper" => "forall [] (v: string) -> bool",
-                "repeat" => "forall [] (v: string, count: int) -> string",
-                "replace" => "forall [] (v: string, old: string, new: string, n: int) -> string",
-                "replaceAll" => "forall [] (v: string, old: string, new: string) -> string",
-                "split" => "forall [] (v: string, t: string) -> string",
-                "splitAfter" => "forall [] (v: string, t: string) -> string",
-                "splitN" => "forall [] (v: string, t: string, n: int) -> string",
-                "splitAfterN" => "forall [] (v: string, t: string, i: int) -> string",
-                "joinStr" => "forall [] (a: [string], v: string) -> {}",
+                "repeat" => "forall [] (v: string, i: int) -> string",
+                "replace" => "forall [] (v: string, t: string, u: string, i: int) -> string",
+                "replaceAll" => "forall [] (v: string, t: string, u: string) -> string",
+                "split" => "forall [] (v: string, t: string) -> [string]",
+                "splitAfter" => "forall [] (v: string, t: string) -> [string]",
+                "splitN" => "forall [] (v: string, t: string, n: int) -> [string]",
+                "splitAfterN" => "forall [] (v: string, t: string, i: int) -> [string]",
+                "joinStr" => "forall [] (arr: [string], v: string) -> {}",
                 "strlen" => "forall [] (v: string) -> int",
                 "substring" => "forall [] (v: string, start: int, end: int) -> string",
             },
@@ -361,7 +361,7 @@ pub fn builtins() -> Builtins<'static> {
                 "columns" => r#"
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
-                        column: string
+                        ?column: string
                     ) -> [t1]
                 "#,
                 "contains" => r#"
@@ -447,8 +447,8 @@ pub fn builtins() -> Builtins<'static> {
                     forall [t0, t1, t2] where t0: Row, t2: Row (
                         <-tables: [t0],
                         ?column: string,
-                        value: t1,
-                        usePrevious: bool
+                        ?value: t1,
+                        ?usePrevious: bool
                     ) -> [t2]
                 "#,
                 "filter" => r#"
@@ -491,7 +491,7 @@ pub fn builtins() -> Builtins<'static> {
                         ?upperBoundColumn: string,
                         ?countColumn: string,
                         bins: [float],
-                        normalize: bool
+                        ?normalize: bool
                     ) -> [t1]
                 "#,
                 "histogramQuantile" => r#"
@@ -719,7 +719,7 @@ pub fn builtins() -> Builtins<'static> {
                     forall [t0, t1] where t0: Row, t1: Row (
                         <-tables: [t0],
                         ?column: string,
-                        mode: string
+                        ?mode: string
                     ) -> [t1]
                 "#,
                 "string" => "forall [t0] (v: t0) -> string",

--- a/libflux/src/flux/semantic/nodes.rs
+++ b/libflux/src/flux/semantic/nodes.rs
@@ -976,36 +976,50 @@ impl BinaryExpr {
                 Constraint::Kind(self.typ.clone(), Kind::Divisible),
             ]),
             ast::Operator::GreaterThanOperator => Constraints::from(vec![
-                Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
+                // https://github.com/influxdata/flux/issues/2393
+                // Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Comparable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Comparable),
             ]),
             ast::Operator::LessThanOperator => Constraints::from(vec![
-                Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
+                // https://github.com/influxdata/flux/issues/2393
+                // Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Comparable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Comparable),
             ]),
             ast::Operator::EqualOperator => Constraints::from(vec![
-                Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
+                // https://github.com/influxdata/flux/issues/2393
+                // Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Equatable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Equatable),
             ]),
             ast::Operator::NotEqualOperator => Constraints::from(vec![
-                Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
+                // https://github.com/influxdata/flux/issues/2393
+                // Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Equatable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Equatable),
             ]),
             ast::Operator::GreaterThanEqualOperator => Constraints::from(vec![
-                Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
+                // https://github.com/influxdata/flux/issues/2393
+                // Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Equatable),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Comparable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Equatable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Comparable),
             ]),
             ast::Operator::LessThanEqualOperator => Constraints::from(vec![
-                Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
+                // https://github.com/influxdata/flux/issues/2393
+                // Constraint::Equal(self.left.type_of().clone(), self.right.type_of().clone()),
                 Constraint::Equal(self.typ.clone(), MonoType::Bool),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Equatable),
                 Constraint::Kind(self.left.type_of().clone(), Kind::Comparable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Equatable),
+                Constraint::Kind(self.right.type_of().clone(), Kind::Comparable),
             ]),
             // Regular expression operators.
             ast::Operator::RegexpMatchOperator => Constraints::from(vec![

--- a/semantic/flatbuffers_gen.go
+++ b/semantic/flatbuffers_gen.go
@@ -30,7 +30,7 @@ func (rcv *ArrayExpression) FromBuf(fb *fbsemantic.ArrayExpression) error {
 			}
 		}
 	}
-	if rcv.typ, err = getMonoType(fb); err != nil {
+	if rcv.Type, err = getMonoType(fb); err != nil {
 		return errors.Wrap(err, codes.Inherit, "ArrayExpression.typ")
 	}
 	return nil

--- a/semantic/graph.go
+++ b/semantic/graph.go
@@ -499,7 +499,7 @@ type ArrayExpression struct {
 
 	Elements []Expression
 
-	typ MonoType
+	Type MonoType
 }
 
 func (*ArrayExpression) NodeType() string { return "ArrayExpression" }
@@ -521,7 +521,7 @@ func (e *ArrayExpression) Copy() Node {
 	return ne
 }
 func (e *ArrayExpression) TypeOf() MonoType {
-	return e.typ
+	return e.Type
 }
 
 // FunctionExpression represents the definition of a function
@@ -934,7 +934,7 @@ func (l *BooleanLiteral) Copy() Node {
 	return nl
 }
 func (e *BooleanLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicBool
 }
 
 type DateTimeLiteral struct {
@@ -957,7 +957,7 @@ func (l *DateTimeLiteral) Copy() Node {
 	return nl
 }
 func (e *DateTimeLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicTime
 }
 
 type DurationLiteral struct {
@@ -980,7 +980,7 @@ func (l *DurationLiteral) Copy() Node {
 	return nl
 }
 func (e *DurationLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicDuration
 }
 
 type IntegerLiteral struct {
@@ -1003,7 +1003,7 @@ func (l *IntegerLiteral) Copy() Node {
 	return nl
 }
 func (e *IntegerLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicInt
 }
 
 type FloatLiteral struct {
@@ -1026,7 +1026,7 @@ func (l *FloatLiteral) Copy() Node {
 	return nl
 }
 func (e *FloatLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicFloat
 }
 
 type RegexpLiteral struct {
@@ -1051,7 +1051,7 @@ func (l *RegexpLiteral) Copy() Node {
 	return nl
 }
 func (e *RegexpLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicRegexp
 }
 
 type StringLiteral struct {
@@ -1074,7 +1074,7 @@ func (l *StringLiteral) Copy() Node {
 	return nl
 }
 func (e *StringLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicString
 }
 
 type UnsignedIntegerLiteral struct {
@@ -1097,5 +1097,5 @@ func (l *UnsignedIntegerLiteral) Copy() Node {
 	return nl
 }
 func (e *UnsignedIntegerLiteral) TypeOf() MonoType {
-	return e.typ
+	return BasicUint
 }

--- a/values/values.go
+++ b/values/values.go
@@ -144,7 +144,7 @@ func (v value) String() string {
 var (
 	// InvalidValue is a non nil value who's type is semantic.Invalid
 	// TODO (algow): create a invalid monotype
-	InvalidValue = value{t: semantic.BasicBool}
+	InvalidValue = value{}
 
 	// Null is an untyped nil value.
 	Null = null{}


### PR DESCRIPTION
This contains various fixes to the stdlib to make the tests pass with
algorithm w. It updates some of the builtins with the correct type
signature. Some of them did not match the Go code.

It updates `map` to work with compiled functions.

It also updates an end to end test which relied on polymorphic literals.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written