### PR TITLE
refactor(stdlib): fix reduce implementation for algorithm w

### DIFF
--- a/stdlib/universe/union.go
+++ b/stdlib/universe/union.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func createUnionOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
-	tables, err := args.GetRequiredArray("tables", semantic.Object)
+	tables, err := args.GetRequiredArray("tables", semantic.Array)
 	if err != nil {
 		return nil, err
 	}

--- a/values/values.go
+++ b/values/values.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"runtime/debug"
-	"strconv"
 
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
@@ -186,49 +185,6 @@ func NewNull(t semantic.MonoType) Value {
 		t: t,
 		v: nil,
 	}
-}
-
-func NewFromString(t semantic.MonoType, s string) (Value, error) {
-	var err error
-	v := value{t: t}
-	switch t.Nature() {
-	case semantic.String:
-		v.v = s
-	case semantic.Int:
-		v.v, err = strconv.ParseInt(s, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-	case semantic.UInt:
-		v.v, err = strconv.ParseUint(s, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-	case semantic.Float:
-		v.v, err = strconv.ParseFloat(s, 64)
-		if err != nil {
-			return nil, err
-		}
-	case semantic.Bool:
-		v.v, err = strconv.ParseBool(s)
-		if err != nil {
-			return nil, err
-		}
-	case semantic.Time:
-		v.v, err = ParseTime(s)
-		if err != nil {
-			return nil, err
-		}
-	case semantic.Duration:
-		v.v, err = ParseDuration(s)
-		if err != nil {
-			return nil, err
-		}
-
-	default:
-		return nil, errors.New(codes.Invalid, "invalid type for value stringer")
-	}
-	return v, nil
 }
 
 func NewString(v string) Value {


### PR DESCRIPTION
This fixes reduce so it works with the refactored row functions and
algorithm w.

This also changes union to expect an array of arrays instead of an array
of objects. This is because table streams are now represented in the
type system with arrays instead of table objects.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written