### PR TITLE
fix(monitor): remove default value from notify data as it is required

### DIFF
--- a/stdlib/influxdata/influxdb/monitor/monitor.flux
+++ b/stdlib/influxdata/influxdb/monitor/monitor.flux
@@ -54,7 +54,7 @@ stateChanges = (fromLevel="any", toLevel, tables=<-) => {
 }
 
 // Notify will call the endpoint and log the results.
-notify = (tables=<-, endpoint, data={}) =>
+notify = (tables=<-, endpoint, data) =>
     tables
         |> experimental.set(o: data)
         |> experimental.group(mode: "extend", columns: experimental.objectKeys(o: data))


### PR DESCRIPTION
Type inference cannot unify an explicitly empty object with a non empty object. Using a default didn't make sense anyway as the data is required.

Fixes #2456 