### PR TITLE
feat(execute): query profiling

### DIFF
--- a/lang/dependencies.go
+++ b/lang/dependencies.go
@@ -4,16 +4,18 @@ import (
 	"context"
 
 	"github.com/influxdata/flux/memory"
-
 	"go.uber.org/zap"
 )
 
-type key int
+type dependencyKey int
 
-const executionDependenciesKey key = iota
+const (
+	executionDependenciesKey dependencyKey = iota
+	compileOptionsKey
+)
 
 // ExecutionDependencies represents the dependencies that a function call
-// executed by the Interpreter needs in order to trigger the execution of a flux.Program
+// executed by the Interpreter needs in order to trigger the execution of a flux.Program.
 type ExecutionDependencies struct {
 	Allocator *memory.Allocator
 	Logger    *zap.Logger
@@ -25,4 +27,16 @@ func (d ExecutionDependencies) Inject(ctx context.Context) context.Context {
 
 func GetExecutionDependencies(ctx context.Context) ExecutionDependencies {
 	return ctx.Value(executionDependenciesKey).(ExecutionDependencies)
+}
+
+// CompileOptions represents multiple `lang.CompileOption` objects.
+// It can be injected in the context and is used by the `flux.Compiler`s in package lang when compiling.
+type CompileOptions []CompileOption
+
+func (c CompileOptions) Inject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, compileOptionsKey, c)
+}
+
+func getCompileOptions(ctx context.Context) CompileOptions {
+	return ctx.Value(compileOptionsKey).(CompileOptions)
 }


### PR DESCRIPTION
This is a first implementation of query profiling in the Flux engine.

The implementation adds a wrapper around a `Transport` to that, if profiling is enabled, it adds metadata to tables.

The metadata is added to the `Statistics`.

The metadata contains the detail for every table and transformation in the pipeline, plus aggregated profiling info for table (avg across every table).

`ExecuteOptions` have been created to let a `Program` create an executor with profiling enabled.

`CompileOptions` contain also `ExecuteOptions` and are `Dependency`s, so that they can be passed using the context and specified by the controller in InfluxDB. 
