### PR TITLE
feat: create a docker environment for flux release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
-*
+.git
+libflux/target/

--- a/Dockerfile_release
+++ b/Dockerfile_release
@@ -1,0 +1,28 @@
+FROM golang:1.13
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV GO111MODULE=on
+ENV CGO_ENABLED=1
+
+COPY . /go/src/github.com/influxdata/flux
+WORKDIR /go/src/github.com/influxdata/flux
+
+# Install common packages
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        clang \
+        gcc-arm-linux-gnueabihf \
+        gcc-arm-linux-gnueabi \
+        gcc-aarch64-linux-gnu \
+        gcc-i686-linux-gnu && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+
+RUN cd libflux && cargo build
+RUN go build \
+        -ldflags '-extldflags "-fno-PIC -static"' \
+        -buildmode pie \
+        -tags 'libflux static_build' \
+        -o flux \
+        .


### PR DESCRIPTION
This patch adds the start of a Dockerfile to be used for releasing flux,
complete with cross compilers for all triples except
`x86_64-apple-darwin` and `x86_64-pc-windows-gnu`, which require a bit
more setup.

The intent here is to start with the Dockerfile, add support for using
`pkg-config` (and ditching `flux-config`), and being able to build flux,
including `libflux`, for any architecture by invoking `go build`. This
docker image will be used similar to `Dockerfile_build` is converted
into `quay.io/influxdb/flux-build`.
