### PR TITLE
fix: create unique C files to force CGO to consider code changed

### DIFF
--- a/libflux/go/libflux/.gitignore
+++ b/libflux/go/libflux/.gitignore
@@ -1,0 +1,2 @@
+/libflux.c
+/liblibstd.c


### PR DESCRIPTION
Updating .a files in a CGO package does not trigger rebuilding of packages that
depend on it. Unique C files do work though. Generate them using shasum, which
comes from the perl package. refs #2511