### PR TITLE
fix(stdlib): remove unused notification rule fields from slack api

### DIFF
--- a/stdlib/slack/flux_gen.go
+++ b/stdlib/slack/flux_gen.go
@@ -22,10 +22,10 @@ var pkgAST = &ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 15,
-					Line:   63,
+					Line:   54,
 				},
 				File:   "",
-				Source: "package slack\n\nimport \"http\"\nimport \"json\"\n\nbuiltin validateColorString\n\noption defaultURL = \"https://slack.com/api/chat.postMessage\"\n\n// `message` sends a single message to a Slack channel. It will work either with the chat.postMessage API or with a slack webhook.\n// `url` - string - URL of the slack endpoint. Defaults to: \"https://slack.com/api/chat.postMessage\", if one uses the webhook api this must be acquired as part of the slack API setup. This URL will be secret. Don't worry about secrets for the initial implementation.\n// `token` - string - the api token string.  Defaults to: \"\", and can be ignored if one uses the webhook api URL.\n// `username` - string - Username posting the message.\n// `channel` - string - Name of channel in which to post the message. No default.\n// `workspace` - string - Name of the slack workspace to use if there are multiple. Defaults to empty string.\n// `text` - string - The text to display.\n// `iconEmoji` - string - Name of : enclose emoji to use as image of user when posting message, will not show as the avatar icon with a slack webhook.\n// `color` - string - Color to give message: one of good, warning, and danger, or any hex rgb color value ex. #439FE0.\nmessage = (url=defaultURL, token=\"\", username, channel, workspace, text, iconEmoji, color) => {\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        username: username,\n        channel: channel,\n        workspace: workspace,\n        attachments: attachments,\n        as_user: false,\n        icon_emoji: iconEmoji,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}\n\n// `endpoint` creates the endpoint for the Slack external service.\n// `url` - string - URL of the slack endpoint. Defaults to: \"https://slack.com/api/chat.postMessage\", if one uses the webhook api this must be acquired as part of the slack API setup, and this URL will be secret.\n// `token` - string - token for the slack endpoint.  This can be ignored if one uses the webhook url acquired as part of the slack API setup, but must be supplied if the chat.postMessage API is used.\n// The returned factory function accepts a `mapFn` parameter.\n// The `mapFn` must return an object with `username`, `channel`, `workspace`, `text`, `iconEmoji`, and `color` fields as defined in the `message` function arguments.\nendpoint = (url=defaultURL, token=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+				Source: "package slack\n\nimport \"http\"\nimport \"json\"\n\nbuiltin validateColorString\n\noption defaultURL = \"https://slack.com/api/chat.postMessage\"\n\n// `message` sends a single message to a Slack channel. It will work either with the chat.postMessage API or with a slack webhook.\n// `url` - string - URL of the slack endpoint. Defaults to: \"https://slack.com/api/chat.postMessage\", if one uses the webhook api this must be acquired as part of the slack API setup. This URL will be secret. Don't worry about secrets for the initial implementation.\n// `token` - string - the api token string.  Defaults to: \"\", and can be ignored if one uses the webhook api URL.\n// `channel` - string - Name of channel in which to post the message. No default.\n// `text` - string - The text to display.\n// `color` - string - Color to give message: one of good, warning, and danger, or any hex rgb color value ex. #439FE0.\nmessage = (url=defaultURL, token=\"\", channel, text, color) => {\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        channel: channel,\n        attachments: attachments,\n        as_user: false,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}\n\n// `endpoint` creates the endpoint for the Slack external service.\n// `url` - string - URL of the slack endpoint. Defaults to: \"https://slack.com/api/chat.postMessage\", if one uses the webhook api this must be acquired as part of the slack API setup, and this URL will be secret.\n// `token` - string - token for the slack endpoint.  This can be ignored if one uses the webhook url acquired as part of the slack API setup, but must be supplied if the chat.postMessage API is used.\n// The returned factory function accepts a `mapFn` parameter.\n// The `mapFn` must return an object with `channel`, `text`, and `color` fields as defined in the `message` function arguments.\nendpoint = (url=defaultURL, token=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -141,13 +141,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 2,
-						Line:   41,
+						Line:   35,
 					},
 					File:   "",
-					Source: "message = (url=defaultURL, token=\"\", username, channel, workspace, text, iconEmoji, color) => {\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        username: username,\n        channel: channel,\n        workspace: workspace,\n        attachments: attachments,\n        as_user: false,\n        icon_emoji: iconEmoji,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}",
+					Source: "message = (url=defaultURL, token=\"\", channel, text, color) => {\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        channel: channel,\n        attachments: attachments,\n        as_user: false,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}",
 					Start: ast.Position{
 						Column: 1,
-						Line:   19,
+						Line:   16,
 					},
 				},
 			},
@@ -157,13 +157,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 8,
-							Line:   19,
+							Line:   16,
 						},
 						File:   "",
 						Source: "message",
 						Start: ast.Position{
 							Column: 1,
-							Line:   19,
+							Line:   16,
 						},
 					},
 				},
@@ -175,13 +175,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 2,
-							Line:   41,
+							Line:   35,
 						},
 						File:   "",
-						Source: "(url=defaultURL, token=\"\", username, channel, workspace, text, iconEmoji, color) => {\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        username: username,\n        channel: channel,\n        workspace: workspace,\n        attachments: attachments,\n        as_user: false,\n        icon_emoji: iconEmoji,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}",
+						Source: "(url=defaultURL, token=\"\", channel, text, color) => {\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        channel: channel,\n        attachments: attachments,\n        as_user: false,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}",
 						Start: ast.Position{
 							Column: 11,
-							Line:   19,
+							Line:   16,
 						},
 					},
 				},
@@ -191,13 +191,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 2,
-								Line:   41,
+								Line:   35,
 							},
 							File:   "",
-							Source: "{\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        username: username,\n        channel: channel,\n        workspace: workspace,\n        attachments: attachments,\n        as_user: false,\n        icon_emoji: iconEmoji,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}",
+							Source: "{\n    attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]\n\n    data = {\n        channel: channel,\n        attachments: attachments,\n        as_user: false,\n    }\n\n    headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }\n    enc = json.encode(v:data)\n    return http.post(headers: headers, url: url, data: enc)\n}",
 							Start: ast.Position{
-								Column: 95,
-								Line:   19,
+								Column: 63,
+								Line:   16,
 							},
 						},
 					},
@@ -207,13 +207,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 7,
-									Line:   24,
+									Line:   21,
 								},
 								File:   "",
 								Source: "attachments = [{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]",
 								Start: ast.Position{
 									Column: 5,
-									Line:   20,
+									Line:   17,
 								},
 							},
 						},
@@ -223,13 +223,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 16,
-										Line:   20,
+										Line:   17,
 									},
 									File:   "",
 									Source: "attachments",
 									Start: ast.Position{
 										Column: 5,
-										Line:   20,
+										Line:   17,
 									},
 								},
 							},
@@ -241,13 +241,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 7,
-										Line:   24,
+										Line:   21,
 									},
 									File:   "",
 									Source: "[{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }]",
 									Start: ast.Position{
 										Column: 19,
-										Line:   20,
+										Line:   17,
 									},
 								},
 							},
@@ -257,13 +257,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 6,
-											Line:   24,
+											Line:   21,
 										},
 										File:   "",
 										Source: "{\n        color: validateColorString(color),\n        text: string(v: text),\n        mrkdwn_in: [\"text\"],\n    }",
 										Start: ast.Position{
 											Column: 20,
-											Line:   20,
+											Line:   17,
 										},
 									},
 								},
@@ -273,13 +273,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   21,
+												Line:   18,
 											},
 											File:   "",
 											Source: "color: validateColorString(color)",
 											Start: ast.Position{
 												Column: 9,
-												Line:   21,
+												Line:   18,
 											},
 										},
 									},
@@ -289,13 +289,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 14,
-													Line:   21,
+													Line:   18,
 												},
 												File:   "",
 												Source: "color",
 												Start: ast.Position{
 													Column: 9,
-													Line:   21,
+													Line:   18,
 												},
 											},
 										},
@@ -308,13 +308,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 41,
-														Line:   21,
+														Line:   18,
 													},
 													File:   "",
 													Source: "color",
 													Start: ast.Position{
 														Column: 36,
-														Line:   21,
+														Line:   18,
 													},
 												},
 											},
@@ -324,13 +324,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 41,
-															Line:   21,
+															Line:   18,
 														},
 														File:   "",
 														Source: "color",
 														Start: ast.Position{
 															Column: 36,
-															Line:   21,
+															Line:   18,
 														},
 													},
 												},
@@ -340,13 +340,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 41,
-																Line:   21,
+																Line:   18,
 															},
 															File:   "",
 															Source: "color",
 															Start: ast.Position{
 																Column: 36,
-																Line:   21,
+																Line:   18,
 															},
 														},
 													},
@@ -361,13 +361,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 42,
-													Line:   21,
+													Line:   18,
 												},
 												File:   "",
 												Source: "validateColorString(color)",
 												Start: ast.Position{
 													Column: 16,
-													Line:   21,
+													Line:   18,
 												},
 											},
 										},
@@ -377,13 +377,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 35,
-														Line:   21,
+														Line:   18,
 													},
 													File:   "",
 													Source: "validateColorString",
 													Start: ast.Position{
 														Column: 16,
-														Line:   21,
+														Line:   18,
 													},
 												},
 											},
@@ -396,13 +396,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   22,
+												Line:   19,
 											},
 											File:   "",
 											Source: "text: string(v: text)",
 											Start: ast.Position{
 												Column: 9,
-												Line:   22,
+												Line:   19,
 											},
 										},
 									},
@@ -412,13 +412,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 13,
-													Line:   22,
+													Line:   19,
 												},
 												File:   "",
 												Source: "text",
 												Start: ast.Position{
 													Column: 9,
-													Line:   22,
+													Line:   19,
 												},
 											},
 										},
@@ -431,13 +431,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 29,
-														Line:   22,
+														Line:   19,
 													},
 													File:   "",
 													Source: "v: text",
 													Start: ast.Position{
 														Column: 22,
-														Line:   22,
+														Line:   19,
 													},
 												},
 											},
@@ -447,13 +447,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 29,
-															Line:   22,
+															Line:   19,
 														},
 														File:   "",
 														Source: "v: text",
 														Start: ast.Position{
 															Column: 22,
-															Line:   22,
+															Line:   19,
 														},
 													},
 												},
@@ -463,13 +463,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 23,
-																Line:   22,
+																Line:   19,
 															},
 															File:   "",
 															Source: "v",
 															Start: ast.Position{
 																Column: 22,
-																Line:   22,
+																Line:   19,
 															},
 														},
 													},
@@ -481,13 +481,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 29,
-																Line:   22,
+																Line:   19,
 															},
 															File:   "",
 															Source: "text",
 															Start: ast.Position{
 																Column: 25,
-																Line:   22,
+																Line:   19,
 															},
 														},
 													},
@@ -501,13 +501,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 30,
-													Line:   22,
+													Line:   19,
 												},
 												File:   "",
 												Source: "string(v: text)",
 												Start: ast.Position{
 													Column: 15,
-													Line:   22,
+													Line:   19,
 												},
 											},
 										},
@@ -517,13 +517,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 21,
-														Line:   22,
+														Line:   19,
 													},
 													File:   "",
 													Source: "string",
 													Start: ast.Position{
 														Column: 15,
-														Line:   22,
+														Line:   19,
 													},
 												},
 											},
@@ -536,13 +536,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 28,
-												Line:   23,
+												Line:   20,
 											},
 											File:   "",
 											Source: "mrkdwn_in: [\"text\"]",
 											Start: ast.Position{
 												Column: 9,
-												Line:   23,
+												Line:   20,
 											},
 										},
 									},
@@ -552,13 +552,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 18,
-													Line:   23,
+													Line:   20,
 												},
 												File:   "",
 												Source: "mrkdwn_in",
 												Start: ast.Position{
 													Column: 9,
-													Line:   23,
+													Line:   20,
 												},
 											},
 										},
@@ -570,13 +570,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 28,
-													Line:   23,
+													Line:   20,
 												},
 												File:   "",
 												Source: "[\"text\"]",
 												Start: ast.Position{
 													Column: 20,
-													Line:   23,
+													Line:   20,
 												},
 											},
 										},
@@ -586,13 +586,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 27,
-														Line:   23,
+														Line:   20,
 													},
 													File:   "",
 													Source: "\"text\"",
 													Start: ast.Position{
 														Column: 21,
-														Line:   23,
+														Line:   20,
 													},
 												},
 											},
@@ -609,13 +609,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   33,
+									Line:   27,
 								},
 								File:   "",
-								Source: "data = {\n        username: username,\n        channel: channel,\n        workspace: workspace,\n        attachments: attachments,\n        as_user: false,\n        icon_emoji: iconEmoji,\n    }",
+								Source: "data = {\n        channel: channel,\n        attachments: attachments,\n        as_user: false,\n    }",
 								Start: ast.Position{
 									Column: 5,
-									Line:   26,
+									Line:   23,
 								},
 							},
 						},
@@ -625,13 +625,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 9,
-										Line:   26,
+										Line:   23,
 									},
 									File:   "",
 									Source: "data",
 									Start: ast.Position{
 										Column: 5,
-										Line:   26,
+										Line:   23,
 									},
 								},
 							},
@@ -643,13 +643,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 6,
-										Line:   33,
+										Line:   27,
 									},
 									File:   "",
-									Source: "{\n        username: username,\n        channel: channel,\n        workspace: workspace,\n        attachments: attachments,\n        as_user: false,\n        icon_emoji: iconEmoji,\n    }",
+									Source: "{\n        channel: channel,\n        attachments: attachments,\n        as_user: false,\n    }",
 									Start: ast.Position{
 										Column: 12,
-										Line:   26,
+										Line:   23,
 									},
 								},
 							},
@@ -658,66 +658,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 27,
-											Line:   27,
-										},
-										File:   "",
-										Source: "username: username",
-										Start: ast.Position{
-											Column: 9,
-											Line:   27,
-										},
-									},
-								},
-								Key: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 17,
-												Line:   27,
-											},
-											File:   "",
-											Source: "username",
-											Start: ast.Position{
-												Column: 9,
-												Line:   27,
-											},
-										},
-									},
-									Name: "username",
-								},
-								Value: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 27,
-												Line:   27,
-											},
-											File:   "",
-											Source: "username",
-											Start: ast.Position{
-												Column: 19,
-												Line:   27,
-											},
-										},
-									},
-									Name: "username",
-								},
-							}, &ast.Property{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
 											Column: 25,
-											Line:   28,
+											Line:   24,
 										},
 										File:   "",
 										Source: "channel: channel",
 										Start: ast.Position{
 											Column: 9,
-											Line:   28,
+											Line:   24,
 										},
 									},
 								},
@@ -727,13 +675,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 16,
-												Line:   28,
+												Line:   24,
 											},
 											File:   "",
 											Source: "channel",
 											Start: ast.Position{
 												Column: 9,
-												Line:   28,
+												Line:   24,
 											},
 										},
 									},
@@ -745,13 +693,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 25,
-												Line:   28,
+												Line:   24,
 											},
 											File:   "",
 											Source: "channel",
 											Start: ast.Position{
 												Column: 18,
-												Line:   28,
+												Line:   24,
 											},
 										},
 									},
@@ -762,66 +710,14 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 29,
-											Line:   29,
-										},
-										File:   "",
-										Source: "workspace: workspace",
-										Start: ast.Position{
-											Column: 9,
-											Line:   29,
-										},
-									},
-								},
-								Key: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 18,
-												Line:   29,
-											},
-											File:   "",
-											Source: "workspace",
-											Start: ast.Position{
-												Column: 9,
-												Line:   29,
-											},
-										},
-									},
-									Name: "workspace",
-								},
-								Value: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 29,
-												Line:   29,
-											},
-											File:   "",
-											Source: "workspace",
-											Start: ast.Position{
-												Column: 20,
-												Line:   29,
-											},
-										},
-									},
-									Name: "workspace",
-								},
-							}, &ast.Property{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
 											Column: 33,
-											Line:   30,
+											Line:   25,
 										},
 										File:   "",
 										Source: "attachments: attachments",
 										Start: ast.Position{
 											Column: 9,
-											Line:   30,
+											Line:   25,
 										},
 									},
 								},
@@ -831,13 +727,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   30,
+												Line:   25,
 											},
 											File:   "",
 											Source: "attachments",
 											Start: ast.Position{
 												Column: 9,
-												Line:   30,
+												Line:   25,
 											},
 										},
 									},
@@ -849,13 +745,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 33,
-												Line:   30,
+												Line:   25,
 											},
 											File:   "",
 											Source: "attachments",
 											Start: ast.Position{
 												Column: 22,
-												Line:   30,
+												Line:   25,
 											},
 										},
 									},
@@ -867,13 +763,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 23,
-											Line:   31,
+											Line:   26,
 										},
 										File:   "",
 										Source: "as_user: false",
 										Start: ast.Position{
 											Column: 9,
-											Line:   31,
+											Line:   26,
 										},
 									},
 								},
@@ -883,13 +779,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 16,
-												Line:   31,
+												Line:   26,
 											},
 											File:   "",
 											Source: "as_user",
 											Start: ast.Position{
 												Column: 9,
-												Line:   31,
+												Line:   26,
 											},
 										},
 									},
@@ -901,69 +797,17 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   31,
+												Line:   26,
 											},
 											File:   "",
 											Source: "false",
 											Start: ast.Position{
 												Column: 18,
-												Line:   31,
+												Line:   26,
 											},
 										},
 									},
 									Name: "false",
-								},
-							}, &ast.Property{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 30,
-											Line:   32,
-										},
-										File:   "",
-										Source: "icon_emoji: iconEmoji",
-										Start: ast.Position{
-											Column: 9,
-											Line:   32,
-										},
-									},
-								},
-								Key: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 19,
-												Line:   32,
-											},
-											File:   "",
-											Source: "icon_emoji",
-											Start: ast.Position{
-												Column: 9,
-												Line:   32,
-											},
-										},
-									},
-									Name: "icon_emoji",
-								},
-								Value: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 30,
-												Line:   32,
-											},
-											File:   "",
-											Source: "iconEmoji",
-											Start: ast.Position{
-												Column: 21,
-												Line:   32,
-											},
-										},
-									},
-									Name: "iconEmoji",
 								},
 							}},
 							With: nil,
@@ -974,13 +818,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   38,
+									Line:   32,
 								},
 								File:   "",
 								Source: "headers = {\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }",
 								Start: ast.Position{
 									Column: 5,
-									Line:   35,
+									Line:   29,
 								},
 							},
 						},
@@ -990,13 +834,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 12,
-										Line:   35,
+										Line:   29,
 									},
 									File:   "",
 									Source: "headers",
 									Start: ast.Position{
 										Column: 5,
-										Line:   35,
+										Line:   29,
 									},
 								},
 							},
@@ -1008,13 +852,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 6,
-										Line:   38,
+										Line:   32,
 									},
 									File:   "",
 									Source: "{\n        \"Authorization\": \"Bearer \" + token,\n        \"Content-Type\": \"application/json\",\n    }",
 									Start: ast.Position{
 										Column: 15,
-										Line:   35,
+										Line:   29,
 									},
 								},
 							},
@@ -1024,13 +868,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 43,
-											Line:   36,
+											Line:   30,
 										},
 										File:   "",
 										Source: "\"Authorization\": \"Bearer \" + token",
 										Start: ast.Position{
 											Column: 9,
-											Line:   36,
+											Line:   30,
 										},
 									},
 								},
@@ -1040,13 +884,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 24,
-												Line:   36,
+												Line:   30,
 											},
 											File:   "",
 											Source: "\"Authorization\"",
 											Start: ast.Position{
 												Column: 9,
-												Line:   36,
+												Line:   30,
 											},
 										},
 									},
@@ -1058,13 +902,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 43,
-												Line:   36,
+												Line:   30,
 											},
 											File:   "",
 											Source: "\"Bearer \" + token",
 											Start: ast.Position{
 												Column: 26,
-												Line:   36,
+												Line:   30,
 											},
 										},
 									},
@@ -1074,13 +918,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 35,
-													Line:   36,
+													Line:   30,
 												},
 												File:   "",
 												Source: "\"Bearer \"",
 												Start: ast.Position{
 													Column: 26,
-													Line:   36,
+													Line:   30,
 												},
 											},
 										},
@@ -1093,13 +937,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 43,
-													Line:   36,
+													Line:   30,
 												},
 												File:   "",
 												Source: "token",
 												Start: ast.Position{
 													Column: 38,
-													Line:   36,
+													Line:   30,
 												},
 											},
 										},
@@ -1112,13 +956,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 43,
-											Line:   37,
+											Line:   31,
 										},
 										File:   "",
 										Source: "\"Content-Type\": \"application/json\"",
 										Start: ast.Position{
 											Column: 9,
-											Line:   37,
+											Line:   31,
 										},
 									},
 								},
@@ -1128,13 +972,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   37,
+												Line:   31,
 											},
 											File:   "",
 											Source: "\"Content-Type\"",
 											Start: ast.Position{
 												Column: 9,
-												Line:   37,
+												Line:   31,
 											},
 										},
 									},
@@ -1146,13 +990,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 43,
-												Line:   37,
+												Line:   31,
 											},
 											File:   "",
 											Source: "\"application/json\"",
 											Start: ast.Position{
 												Column: 25,
-												Line:   37,
+												Line:   31,
 											},
 										},
 									},
@@ -1167,13 +1011,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 30,
-									Line:   39,
+									Line:   33,
 								},
 								File:   "",
 								Source: "enc = json.encode(v:data)",
 								Start: ast.Position{
 									Column: 5,
-									Line:   39,
+									Line:   33,
 								},
 							},
 						},
@@ -1183,13 +1027,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 8,
-										Line:   39,
+										Line:   33,
 									},
 									File:   "",
 									Source: "enc",
 									Start: ast.Position{
 										Column: 5,
-										Line:   39,
+										Line:   33,
 									},
 								},
 							},
@@ -1202,13 +1046,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   39,
+											Line:   33,
 										},
 										File:   "",
 										Source: "v:data",
 										Start: ast.Position{
 											Column: 23,
-											Line:   39,
+											Line:   33,
 										},
 									},
 								},
@@ -1218,13 +1062,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   39,
+												Line:   33,
 											},
 											File:   "",
 											Source: "v:data",
 											Start: ast.Position{
 												Column: 23,
-												Line:   39,
+												Line:   33,
 											},
 										},
 									},
@@ -1234,13 +1078,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 24,
-													Line:   39,
+													Line:   33,
 												},
 												File:   "",
 												Source: "v",
 												Start: ast.Position{
 													Column: 23,
-													Line:   39,
+													Line:   33,
 												},
 											},
 										},
@@ -1252,13 +1096,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 29,
-													Line:   39,
+													Line:   33,
 												},
 												File:   "",
 												Source: "data",
 												Start: ast.Position{
 													Column: 25,
-													Line:   39,
+													Line:   33,
 												},
 											},
 										},
@@ -1272,13 +1116,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 30,
-										Line:   39,
+										Line:   33,
 									},
 									File:   "",
 									Source: "json.encode(v:data)",
 									Start: ast.Position{
 										Column: 11,
-										Line:   39,
+										Line:   33,
 									},
 								},
 							},
@@ -1288,13 +1132,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 22,
-											Line:   39,
+											Line:   33,
 										},
 										File:   "",
 										Source: "json.encode",
 										Start: ast.Position{
 											Column: 11,
-											Line:   39,
+											Line:   33,
 										},
 									},
 								},
@@ -1304,13 +1148,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 15,
-												Line:   39,
+												Line:   33,
 											},
 											File:   "",
 											Source: "json",
 											Start: ast.Position{
 												Column: 11,
-												Line:   39,
+												Line:   33,
 											},
 										},
 									},
@@ -1322,13 +1166,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 22,
-												Line:   39,
+												Line:   33,
 											},
 											File:   "",
 											Source: "encode",
 											Start: ast.Position{
 												Column: 16,
-												Line:   39,
+												Line:   33,
 											},
 										},
 									},
@@ -1344,13 +1188,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 59,
-											Line:   40,
+											Line:   34,
 										},
 										File:   "",
 										Source: "headers: headers, url: url, data: enc",
 										Start: ast.Position{
 											Column: 22,
-											Line:   40,
+											Line:   34,
 										},
 									},
 								},
@@ -1360,13 +1204,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 38,
-												Line:   40,
+												Line:   34,
 											},
 											File:   "",
 											Source: "headers: headers",
 											Start: ast.Position{
 												Column: 22,
-												Line:   40,
+												Line:   34,
 											},
 										},
 									},
@@ -1376,13 +1220,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 29,
-													Line:   40,
+													Line:   34,
 												},
 												File:   "",
 												Source: "headers",
 												Start: ast.Position{
 													Column: 22,
-													Line:   40,
+													Line:   34,
 												},
 											},
 										},
@@ -1394,13 +1238,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 38,
-													Line:   40,
+													Line:   34,
 												},
 												File:   "",
 												Source: "headers",
 												Start: ast.Position{
 													Column: 31,
-													Line:   40,
+													Line:   34,
 												},
 											},
 										},
@@ -1412,13 +1256,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 48,
-												Line:   40,
+												Line:   34,
 											},
 											File:   "",
 											Source: "url: url",
 											Start: ast.Position{
 												Column: 40,
-												Line:   40,
+												Line:   34,
 											},
 										},
 									},
@@ -1428,13 +1272,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 43,
-													Line:   40,
+													Line:   34,
 												},
 												File:   "",
 												Source: "url",
 												Start: ast.Position{
 													Column: 40,
-													Line:   40,
+													Line:   34,
 												},
 											},
 										},
@@ -1446,13 +1290,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 48,
-													Line:   40,
+													Line:   34,
 												},
 												File:   "",
 												Source: "url",
 												Start: ast.Position{
 													Column: 45,
-													Line:   40,
+													Line:   34,
 												},
 											},
 										},
@@ -1464,13 +1308,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 59,
-												Line:   40,
+												Line:   34,
 											},
 											File:   "",
 											Source: "data: enc",
 											Start: ast.Position{
 												Column: 50,
-												Line:   40,
+												Line:   34,
 											},
 										},
 									},
@@ -1480,13 +1324,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 54,
-													Line:   40,
+													Line:   34,
 												},
 												File:   "",
 												Source: "data",
 												Start: ast.Position{
 													Column: 50,
-													Line:   40,
+													Line:   34,
 												},
 											},
 										},
@@ -1498,13 +1342,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 59,
-													Line:   40,
+													Line:   34,
 												},
 												File:   "",
 												Source: "enc",
 												Start: ast.Position{
 													Column: 56,
-													Line:   40,
+													Line:   34,
 												},
 											},
 										},
@@ -1518,13 +1362,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 60,
-										Line:   40,
+										Line:   34,
 									},
 									File:   "",
 									Source: "http.post(headers: headers, url: url, data: enc)",
 									Start: ast.Position{
 										Column: 12,
-										Line:   40,
+										Line:   34,
 									},
 								},
 							},
@@ -1534,13 +1378,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   40,
+											Line:   34,
 										},
 										File:   "",
 										Source: "http.post",
 										Start: ast.Position{
 											Column: 12,
-											Line:   40,
+											Line:   34,
 										},
 									},
 								},
@@ -1550,13 +1394,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 16,
-												Line:   40,
+												Line:   34,
 											},
 											File:   "",
 											Source: "http",
 											Start: ast.Position{
 												Column: 12,
-												Line:   40,
+												Line:   34,
 											},
 										},
 									},
@@ -1568,13 +1412,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 21,
-												Line:   40,
+												Line:   34,
 											},
 											File:   "",
 											Source: "post",
 											Start: ast.Position{
 												Column: 17,
-												Line:   40,
+												Line:   34,
 											},
 										},
 									},
@@ -1587,13 +1431,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 60,
-									Line:   40,
+									Line:   34,
 								},
 								File:   "",
 								Source: "return http.post(headers: headers, url: url, data: enc)",
 								Start: ast.Position{
 									Column: 5,
-									Line:   40,
+									Line:   34,
 								},
 							},
 						},
@@ -1605,13 +1449,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 26,
-								Line:   19,
+								Line:   16,
 							},
 							File:   "",
 							Source: "url=defaultURL",
 							Start: ast.Position{
 								Column: 12,
-								Line:   19,
+								Line:   16,
 							},
 						},
 					},
@@ -1621,13 +1465,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 15,
-									Line:   19,
+									Line:   16,
 								},
 								File:   "",
 								Source: "url",
 								Start: ast.Position{
 									Column: 12,
-									Line:   19,
+									Line:   16,
 								},
 							},
 						},
@@ -1639,13 +1483,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 26,
-									Line:   19,
+									Line:   16,
 								},
 								File:   "",
 								Source: "defaultURL",
 								Start: ast.Position{
 									Column: 16,
-									Line:   19,
+									Line:   16,
 								},
 							},
 						},
@@ -1657,13 +1501,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 36,
-								Line:   19,
+								Line:   16,
 							},
 							File:   "",
 							Source: "token=\"\"",
 							Start: ast.Position{
 								Column: 28,
-								Line:   19,
+								Line:   16,
 							},
 						},
 					},
@@ -1673,13 +1517,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 33,
-									Line:   19,
+									Line:   16,
 								},
 								File:   "",
 								Source: "token",
 								Start: ast.Position{
 									Column: 28,
-									Line:   19,
+									Line:   16,
 								},
 							},
 						},
@@ -1691,13 +1535,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 36,
-									Line:   19,
+									Line:   16,
 								},
 								File:   "",
 								Source: "\"\"",
 								Start: ast.Position{
 									Column: 34,
-									Line:   19,
+									Line:   16,
 								},
 							},
 						},
@@ -1708,49 +1552,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 46,
-								Line:   19,
-							},
-							File:   "",
-							Source: "username",
-							Start: ast.Position{
-								Column: 38,
-								Line:   19,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 46,
-									Line:   19,
-								},
-								File:   "",
-								Source: "username",
-								Start: ast.Position{
-									Column: 38,
-									Line:   19,
-								},
-							},
-						},
-						Name: "username",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 55,
-								Line:   19,
+								Column: 45,
+								Line:   16,
 							},
 							File:   "",
 							Source: "channel",
 							Start: ast.Position{
-								Column: 48,
-								Line:   19,
+								Column: 38,
+								Line:   16,
 							},
 						},
 					},
@@ -1759,14 +1568,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 55,
-									Line:   19,
+									Column: 45,
+									Line:   16,
 								},
 								File:   "",
 								Source: "channel",
 								Start: ast.Position{
-									Column: 48,
-									Line:   19,
+									Column: 38,
+									Line:   16,
 								},
 							},
 						},
@@ -1778,49 +1587,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 66,
-								Line:   19,
-							},
-							File:   "",
-							Source: "workspace",
-							Start: ast.Position{
-								Column: 57,
-								Line:   19,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 66,
-									Line:   19,
-								},
-								File:   "",
-								Source: "workspace",
-								Start: ast.Position{
-									Column: 57,
-									Line:   19,
-								},
-							},
-						},
-						Name: "workspace",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 72,
-								Line:   19,
+								Column: 51,
+								Line:   16,
 							},
 							File:   "",
 							Source: "text",
 							Start: ast.Position{
-								Column: 68,
-								Line:   19,
+								Column: 47,
+								Line:   16,
 							},
 						},
 					},
@@ -1829,14 +1603,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 72,
-									Line:   19,
+									Column: 51,
+									Line:   16,
 								},
 								File:   "",
 								Source: "text",
 								Start: ast.Position{
-									Column: 68,
-									Line:   19,
+									Column: 47,
+									Line:   16,
 								},
 							},
 						},
@@ -1848,49 +1622,14 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 83,
-								Line:   19,
-							},
-							File:   "",
-							Source: "iconEmoji",
-							Start: ast.Position{
-								Column: 74,
-								Line:   19,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 83,
-									Line:   19,
-								},
-								File:   "",
-								Source: "iconEmoji",
-								Start: ast.Position{
-									Column: 74,
-									Line:   19,
-								},
-							},
-						},
-						Name: "iconEmoji",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 90,
-								Line:   19,
+								Column: 58,
+								Line:   16,
 							},
 							File:   "",
 							Source: "color",
 							Start: ast.Position{
-								Column: 85,
-								Line:   19,
+								Column: 53,
+								Line:   16,
 							},
 						},
 					},
@@ -1899,14 +1638,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 90,
-									Line:   19,
+									Column: 58,
+									Line:   16,
 								},
 								File:   "",
 								Source: "color",
 								Start: ast.Position{
-									Column: 85,
-									Line:   19,
+									Column: 53,
+									Line:   16,
 								},
 							},
 						},
@@ -1921,13 +1660,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 15,
-						Line:   63,
+						Line:   54,
 					},
 					File:   "",
-					Source: "endpoint = (url=defaultURL, token=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+					Source: "endpoint = (url=defaultURL, token=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 					Start: ast.Position{
 						Column: 1,
-						Line:   48,
+						Line:   42,
 					},
 				},
 			},
@@ -1937,13 +1676,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 9,
-							Line:   48,
+							Line:   42,
 						},
 						File:   "",
 						Source: "endpoint",
 						Start: ast.Position{
 							Column: 1,
-							Line:   48,
+							Line:   42,
 						},
 					},
 				},
@@ -1955,13 +1694,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 15,
-							Line:   63,
+							Line:   54,
 						},
 						File:   "",
-						Source: "(url=defaultURL, token=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+						Source: "(url=defaultURL, token=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 						Start: ast.Position{
 							Column: 12,
-							Line:   48,
+							Line:   42,
 						},
 					},
 				},
@@ -1971,13 +1710,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 15,
-								Line:   63,
+								Line:   54,
 							},
 							File:   "",
-							Source: "(mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+							Source: "(mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 							Start: ast.Position{
 								Column: 5,
-								Line:   49,
+								Line:   43,
 							},
 						},
 					},
@@ -1987,13 +1726,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 15,
-									Line:   63,
+									Line:   54,
 								},
 								File:   "",
-								Source: "(tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+								Source: "(tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 								Start: ast.Position{
 									Column: 9,
-									Line:   50,
+									Line:   44,
 								},
 							},
 						},
@@ -2004,13 +1743,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   50,
+											Line:   44,
 										},
 										File:   "",
 										Source: "tables",
 										Start: ast.Position{
 											Column: 24,
-											Line:   50,
+											Line:   44,
 										},
 									},
 								},
@@ -2021,13 +1760,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 15,
-										Line:   63,
+										Line:   54,
 									},
 									File:   "",
-									Source: "tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+									Source: "tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 									Start: ast.Position{
 										Column: 24,
-										Line:   50,
+										Line:   44,
 									},
 								},
 							},
@@ -2038,13 +1777,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 14,
-												Line:   63,
+												Line:   54,
 											},
 											File:   "",
-											Source: "fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            }",
+											Source: "fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            }",
 											Start: ast.Position{
 												Column: 20,
-												Line:   51,
+												Line:   45,
 											},
 										},
 									},
@@ -2054,13 +1793,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 14,
-													Line:   63,
+													Line:   54,
 												},
 												File:   "",
-												Source: "fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            }",
+												Source: "fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            }",
 												Start: ast.Position{
 													Column: 20,
-													Line:   51,
+													Line:   45,
 												},
 											},
 										},
@@ -2070,13 +1809,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 22,
-														Line:   51,
+														Line:   45,
 													},
 													File:   "",
 													Source: "fn",
 													Start: ast.Position{
 														Column: 20,
-														Line:   51,
+														Line:   45,
 													},
 												},
 											},
@@ -2088,13 +1827,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 14,
-														Line:   63,
+														Line:   54,
 													},
 													File:   "",
-													Source: "(r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            }",
+													Source: "(r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            }",
 													Start: ast.Position{
 														Column: 24,
-														Line:   51,
+														Line:   45,
 													},
 												},
 											},
@@ -2104,13 +1843,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 14,
-															Line:   63,
+															Line:   54,
 														},
 														File:   "",
-														Source: "{\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            }",
+														Source: "{\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            }",
 														Start: ast.Position{
 															Column: 31,
-															Line:   51,
+															Line:   45,
 														},
 													},
 												},
@@ -2120,13 +1859,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 34,
-																Line:   52,
+																Line:   46,
 															},
 															File:   "",
 															Source: "obj = mapFn(r: r)",
 															Start: ast.Position{
 																Column: 17,
-																Line:   52,
+																Line:   46,
 															},
 														},
 													},
@@ -2136,13 +1875,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 20,
-																	Line:   52,
+																	Line:   46,
 																},
 																File:   "",
 																Source: "obj",
 																Start: ast.Position{
 																	Column: 17,
-																	Line:   52,
+																	Line:   46,
 																},
 															},
 														},
@@ -2155,13 +1894,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 33,
-																		Line:   52,
+																		Line:   46,
 																	},
 																	File:   "",
 																	Source: "r: r",
 																	Start: ast.Position{
 																		Column: 29,
-																		Line:   52,
+																		Line:   46,
 																	},
 																},
 															},
@@ -2171,13 +1910,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 33,
-																			Line:   52,
+																			Line:   46,
 																		},
 																		File:   "",
 																		Source: "r: r",
 																		Start: ast.Position{
 																			Column: 29,
-																			Line:   52,
+																			Line:   46,
 																		},
 																	},
 																},
@@ -2187,13 +1926,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 30,
-																				Line:   52,
+																				Line:   46,
 																			},
 																			File:   "",
 																			Source: "r",
 																			Start: ast.Position{
 																				Column: 29,
-																				Line:   52,
+																				Line:   46,
 																			},
 																		},
 																	},
@@ -2205,13 +1944,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 33,
-																				Line:   52,
+																				Line:   46,
 																			},
 																			File:   "",
 																			Source: "r",
 																			Start: ast.Position{
 																				Column: 32,
-																				Line:   52,
+																				Line:   46,
 																			},
 																		},
 																	},
@@ -2225,13 +1964,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 34,
-																	Line:   52,
+																	Line:   46,
 																},
 																File:   "",
 																Source: "mapFn(r: r)",
 																Start: ast.Position{
 																	Column: 23,
-																	Line:   52,
+																	Line:   46,
 																},
 															},
 														},
@@ -2241,13 +1980,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 28,
-																		Line:   52,
+																		Line:   46,
 																	},
 																	File:   "",
 																	Source: "mapFn",
 																	Start: ast.Position{
 																		Column: 23,
-																		Line:   52,
+																		Line:   46,
 																	},
 																},
 															},
@@ -2261,13 +2000,13 @@ var pkgAST = &ast.Package{
 															Loc: &ast.SourceLocation{
 																End: ast.Position{
 																	Column: 26,
-																	Line:   62,
+																	Line:   53,
 																},
 																File:   "",
-																Source: "{r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}",
+																Source: "{r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}",
 																Start: ast.Position{
 																	Column: 24,
-																	Line:   53,
+																	Line:   47,
 																},
 															},
 														},
@@ -2277,13 +2016,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 25,
-																		Line:   62,
+																		Line:   53,
 																	},
 																	File:   "",
-																	Source: "_sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)",
+																	Source: "_sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)",
 																	Start: ast.Position{
 																		Column: 32,
-																		Line:   53,
+																		Line:   47,
 																	},
 																},
 															},
@@ -2293,13 +2032,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 37,
-																			Line:   53,
+																			Line:   47,
 																		},
 																		File:   "",
 																		Source: "_sent",
 																		Start: ast.Position{
 																			Column: 32,
-																			Line:   53,
+																			Line:   47,
 																		},
 																	},
 																},
@@ -2312,13 +2051,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 24,
-																				Line:   62,
+																				Line:   53,
 																			},
 																			File:   "",
-																			Source: "v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100",
+																			Source: "v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100",
 																			Start: ast.Position{
 																				Column: 46,
-																				Line:   53,
+																				Line:   47,
 																			},
 																		},
 																	},
@@ -2328,13 +2067,13 @@ var pkgAST = &ast.Package{
 																			Loc: &ast.SourceLocation{
 																				End: ast.Position{
 																					Column: 24,
-																					Line:   62,
+																					Line:   53,
 																				},
 																				File:   "",
-																				Source: "v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100",
+																				Source: "v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100",
 																				Start: ast.Position{
 																					Column: 46,
-																					Line:   53,
+																					Line:   47,
 																				},
 																			},
 																		},
@@ -2344,13 +2083,13 @@ var pkgAST = &ast.Package{
 																				Loc: &ast.SourceLocation{
 																					End: ast.Position{
 																						Column: 47,
-																						Line:   53,
+																						Line:   47,
 																					},
 																					File:   "",
 																					Source: "v",
 																					Start: ast.Position{
 																						Column: 46,
-																						Line:   53,
+																						Line:   47,
 																					},
 																				},
 																			},
@@ -2362,13 +2101,13 @@ var pkgAST = &ast.Package{
 																				Loc: &ast.SourceLocation{
 																					End: ast.Position{
 																						Column: 24,
-																						Line:   62,
+																						Line:   53,
 																					},
 																					File:   "",
-																					Source: "2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100",
+																					Source: "2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100",
 																					Start: ast.Position{
 																						Column: 49,
-																						Line:   53,
+																						Line:   47,
 																					},
 																				},
 																			},
@@ -2378,13 +2117,13 @@ var pkgAST = &ast.Package{
 																					Loc: &ast.SourceLocation{
 																						End: ast.Position{
 																							Column: 50,
-																							Line:   53,
+																							Line:   47,
 																						},
 																						File:   "",
 																						Source: "2",
 																						Start: ast.Position{
 																							Column: 49,
-																							Line:   53,
+																							Line:   47,
 																						},
 																					},
 																				},
@@ -2397,13 +2136,13 @@ var pkgAST = &ast.Package{
 																					Loc: &ast.SourceLocation{
 																						End: ast.Position{
 																							Column: 24,
-																							Line:   62,
+																							Line:   53,
 																						},
 																						File:   "",
-																						Source: "message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100",
+																						Source: "message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100",
 																						Start: ast.Position{
 																							Column: 54,
-																							Line:   53,
+																							Line:   47,
 																						},
 																					},
 																				},
@@ -2414,13 +2153,13 @@ var pkgAST = &ast.Package{
 																							Loc: &ast.SourceLocation{
 																								End: ast.Position{
 																									Column: 37,
-																									Line:   61,
+																									Line:   52,
 																								},
 																								File:   "",
-																								Source: "url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color",
+																								Source: "url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color",
 																								Start: ast.Position{
 																									Column: 21,
-																									Line:   54,
+																									Line:   48,
 																								},
 																							},
 																						},
@@ -2430,13 +2169,13 @@ var pkgAST = &ast.Package{
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
 																										Column: 29,
-																										Line:   54,
+																										Line:   48,
 																									},
 																									File:   "",
 																									Source: "url: url",
 																									Start: ast.Position{
 																										Column: 21,
-																										Line:   54,
+																										Line:   48,
 																									},
 																								},
 																							},
@@ -2446,13 +2185,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 24,
-																											Line:   54,
+																											Line:   48,
 																										},
 																										File:   "",
 																										Source: "url",
 																										Start: ast.Position{
 																											Column: 21,
-																											Line:   54,
+																											Line:   48,
 																										},
 																									},
 																								},
@@ -2464,13 +2203,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 29,
-																											Line:   54,
+																											Line:   48,
 																										},
 																										File:   "",
 																										Source: "url",
 																										Start: ast.Position{
 																											Column: 26,
-																											Line:   54,
+																											Line:   48,
 																										},
 																									},
 																								},
@@ -2482,13 +2221,13 @@ var pkgAST = &ast.Package{
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
 																										Column: 33,
-																										Line:   55,
+																										Line:   49,
 																									},
 																									File:   "",
 																									Source: "token: token",
 																									Start: ast.Position{
 																										Column: 21,
-																										Line:   55,
+																										Line:   49,
 																									},
 																								},
 																							},
@@ -2498,13 +2237,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 26,
-																											Line:   55,
+																											Line:   49,
 																										},
 																										File:   "",
 																										Source: "token",
 																										Start: ast.Position{
 																											Column: 21,
-																											Line:   55,
+																											Line:   49,
 																										},
 																									},
 																								},
@@ -2516,13 +2255,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 33,
-																											Line:   55,
+																											Line:   49,
 																										},
 																										File:   "",
 																										Source: "token",
 																										Start: ast.Position{
 																											Column: 28,
-																											Line:   55,
+																											Line:   49,
 																										},
 																									},
 																								},
@@ -2533,101 +2272,14 @@ var pkgAST = &ast.Package{
 																								Errors: nil,
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
-																										Column: 43,
-																										Line:   56,
-																									},
-																									File:   "",
-																									Source: "username: obj.username",
-																									Start: ast.Position{
-																										Column: 21,
-																										Line:   56,
-																									},
-																								},
-																							},
-																							Key: &ast.Identifier{
-																								BaseNode: ast.BaseNode{
-																									Errors: nil,
-																									Loc: &ast.SourceLocation{
-																										End: ast.Position{
-																											Column: 29,
-																											Line:   56,
-																										},
-																										File:   "",
-																										Source: "username",
-																										Start: ast.Position{
-																											Column: 21,
-																											Line:   56,
-																										},
-																									},
-																								},
-																								Name: "username",
-																							},
-																							Value: &ast.MemberExpression{
-																								BaseNode: ast.BaseNode{
-																									Errors: nil,
-																									Loc: &ast.SourceLocation{
-																										End: ast.Position{
-																											Column: 43,
-																											Line:   56,
-																										},
-																										File:   "",
-																										Source: "obj.username",
-																										Start: ast.Position{
-																											Column: 31,
-																											Line:   56,
-																										},
-																									},
-																								},
-																								Object: &ast.Identifier{
-																									BaseNode: ast.BaseNode{
-																										Errors: nil,
-																										Loc: &ast.SourceLocation{
-																											End: ast.Position{
-																												Column: 34,
-																												Line:   56,
-																											},
-																											File:   "",
-																											Source: "obj",
-																											Start: ast.Position{
-																												Column: 31,
-																												Line:   56,
-																											},
-																										},
-																									},
-																									Name: "obj",
-																								},
-																								Property: &ast.Identifier{
-																									BaseNode: ast.BaseNode{
-																										Errors: nil,
-																										Loc: &ast.SourceLocation{
-																											End: ast.Position{
-																												Column: 43,
-																												Line:   56,
-																											},
-																											File:   "",
-																											Source: "username",
-																											Start: ast.Position{
-																												Column: 35,
-																												Line:   56,
-																											},
-																										},
-																									},
-																									Name: "username",
-																								},
-																							},
-																						}, &ast.Property{
-																							BaseNode: ast.BaseNode{
-																								Errors: nil,
-																								Loc: &ast.SourceLocation{
-																									End: ast.Position{
 																										Column: 41,
-																										Line:   57,
+																										Line:   50,
 																									},
 																									File:   "",
 																									Source: "channel: obj.channel",
 																									Start: ast.Position{
 																										Column: 21,
-																										Line:   57,
+																										Line:   50,
 																									},
 																								},
 																							},
@@ -2637,13 +2289,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 28,
-																											Line:   57,
+																											Line:   50,
 																										},
 																										File:   "",
 																										Source: "channel",
 																										Start: ast.Position{
 																											Column: 21,
-																											Line:   57,
+																											Line:   50,
 																										},
 																									},
 																								},
@@ -2655,13 +2307,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 41,
-																											Line:   57,
+																											Line:   50,
 																										},
 																										File:   "",
 																										Source: "obj.channel",
 																										Start: ast.Position{
 																											Column: 30,
-																											Line:   57,
+																											Line:   50,
 																										},
 																									},
 																								},
@@ -2671,13 +2323,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 33,
-																												Line:   57,
+																												Line:   50,
 																											},
 																											File:   "",
 																											Source: "obj",
 																											Start: ast.Position{
 																												Column: 30,
-																												Line:   57,
+																												Line:   50,
 																											},
 																										},
 																									},
@@ -2689,13 +2341,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 41,
-																												Line:   57,
+																												Line:   50,
 																											},
 																											File:   "",
 																											Source: "channel",
 																											Start: ast.Position{
 																												Column: 34,
-																												Line:   57,
+																												Line:   50,
 																											},
 																										},
 																									},
@@ -2707,101 +2359,14 @@ var pkgAST = &ast.Package{
 																								Errors: nil,
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
-																										Column: 45,
-																										Line:   58,
-																									},
-																									File:   "",
-																									Source: "workspace: obj.workspace",
-																									Start: ast.Position{
-																										Column: 21,
-																										Line:   58,
-																									},
-																								},
-																							},
-																							Key: &ast.Identifier{
-																								BaseNode: ast.BaseNode{
-																									Errors: nil,
-																									Loc: &ast.SourceLocation{
-																										End: ast.Position{
-																											Column: 30,
-																											Line:   58,
-																										},
-																										File:   "",
-																										Source: "workspace",
-																										Start: ast.Position{
-																											Column: 21,
-																											Line:   58,
-																										},
-																									},
-																								},
-																								Name: "workspace",
-																							},
-																							Value: &ast.MemberExpression{
-																								BaseNode: ast.BaseNode{
-																									Errors: nil,
-																									Loc: &ast.SourceLocation{
-																										End: ast.Position{
-																											Column: 45,
-																											Line:   58,
-																										},
-																										File:   "",
-																										Source: "obj.workspace",
-																										Start: ast.Position{
-																											Column: 32,
-																											Line:   58,
-																										},
-																									},
-																								},
-																								Object: &ast.Identifier{
-																									BaseNode: ast.BaseNode{
-																										Errors: nil,
-																										Loc: &ast.SourceLocation{
-																											End: ast.Position{
-																												Column: 35,
-																												Line:   58,
-																											},
-																											File:   "",
-																											Source: "obj",
-																											Start: ast.Position{
-																												Column: 32,
-																												Line:   58,
-																											},
-																										},
-																									},
-																									Name: "obj",
-																								},
-																								Property: &ast.Identifier{
-																									BaseNode: ast.BaseNode{
-																										Errors: nil,
-																										Loc: &ast.SourceLocation{
-																											End: ast.Position{
-																												Column: 45,
-																												Line:   58,
-																											},
-																											File:   "",
-																											Source: "workspace",
-																											Start: ast.Position{
-																												Column: 36,
-																												Line:   58,
-																											},
-																										},
-																									},
-																									Name: "workspace",
-																								},
-																							},
-																						}, &ast.Property{
-																							BaseNode: ast.BaseNode{
-																								Errors: nil,
-																								Loc: &ast.SourceLocation{
-																									End: ast.Position{
 																										Column: 35,
-																										Line:   59,
+																										Line:   51,
 																									},
 																									File:   "",
 																									Source: "text: obj.text",
 																									Start: ast.Position{
 																										Column: 21,
-																										Line:   59,
+																										Line:   51,
 																									},
 																								},
 																							},
@@ -2811,13 +2376,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 25,
-																											Line:   59,
+																											Line:   51,
 																										},
 																										File:   "",
 																										Source: "text",
 																										Start: ast.Position{
 																											Column: 21,
-																											Line:   59,
+																											Line:   51,
 																										},
 																									},
 																								},
@@ -2829,13 +2394,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 35,
-																											Line:   59,
+																											Line:   51,
 																										},
 																										File:   "",
 																										Source: "obj.text",
 																										Start: ast.Position{
 																											Column: 27,
-																											Line:   59,
+																											Line:   51,
 																										},
 																									},
 																								},
@@ -2845,13 +2410,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 30,
-																												Line:   59,
+																												Line:   51,
 																											},
 																											File:   "",
 																											Source: "obj",
 																											Start: ast.Position{
 																												Column: 27,
-																												Line:   59,
+																												Line:   51,
 																											},
 																										},
 																									},
@@ -2863,13 +2428,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 35,
-																												Line:   59,
+																												Line:   51,
 																											},
 																											File:   "",
 																											Source: "text",
 																											Start: ast.Position{
 																												Column: 31,
-																												Line:   59,
+																												Line:   51,
 																											},
 																										},
 																									},
@@ -2881,101 +2446,14 @@ var pkgAST = &ast.Package{
 																								Errors: nil,
 																								Loc: &ast.SourceLocation{
 																									End: ast.Position{
-																										Column: 45,
-																										Line:   60,
-																									},
-																									File:   "",
-																									Source: "iconEmoji: obj.iconEmoji",
-																									Start: ast.Position{
-																										Column: 21,
-																										Line:   60,
-																									},
-																								},
-																							},
-																							Key: &ast.Identifier{
-																								BaseNode: ast.BaseNode{
-																									Errors: nil,
-																									Loc: &ast.SourceLocation{
-																										End: ast.Position{
-																											Column: 30,
-																											Line:   60,
-																										},
-																										File:   "",
-																										Source: "iconEmoji",
-																										Start: ast.Position{
-																											Column: 21,
-																											Line:   60,
-																										},
-																									},
-																								},
-																								Name: "iconEmoji",
-																							},
-																							Value: &ast.MemberExpression{
-																								BaseNode: ast.BaseNode{
-																									Errors: nil,
-																									Loc: &ast.SourceLocation{
-																										End: ast.Position{
-																											Column: 45,
-																											Line:   60,
-																										},
-																										File:   "",
-																										Source: "obj.iconEmoji",
-																										Start: ast.Position{
-																											Column: 32,
-																											Line:   60,
-																										},
-																									},
-																								},
-																								Object: &ast.Identifier{
-																									BaseNode: ast.BaseNode{
-																										Errors: nil,
-																										Loc: &ast.SourceLocation{
-																											End: ast.Position{
-																												Column: 35,
-																												Line:   60,
-																											},
-																											File:   "",
-																											Source: "obj",
-																											Start: ast.Position{
-																												Column: 32,
-																												Line:   60,
-																											},
-																										},
-																									},
-																									Name: "obj",
-																								},
-																								Property: &ast.Identifier{
-																									BaseNode: ast.BaseNode{
-																										Errors: nil,
-																										Loc: &ast.SourceLocation{
-																											End: ast.Position{
-																												Column: 45,
-																												Line:   60,
-																											},
-																											File:   "",
-																											Source: "iconEmoji",
-																											Start: ast.Position{
-																												Column: 36,
-																												Line:   60,
-																											},
-																										},
-																									},
-																									Name: "iconEmoji",
-																								},
-																							},
-																						}, &ast.Property{
-																							BaseNode: ast.BaseNode{
-																								Errors: nil,
-																								Loc: &ast.SourceLocation{
-																									End: ast.Position{
 																										Column: 37,
-																										Line:   61,
+																										Line:   52,
 																									},
 																									File:   "",
 																									Source: "color: obj.color",
 																									Start: ast.Position{
 																										Column: 21,
-																										Line:   61,
+																										Line:   52,
 																									},
 																								},
 																							},
@@ -2985,13 +2463,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 26,
-																											Line:   61,
+																											Line:   52,
 																										},
 																										File:   "",
 																										Source: "color",
 																										Start: ast.Position{
 																											Column: 21,
-																											Line:   61,
+																											Line:   52,
 																										},
 																									},
 																								},
@@ -3003,13 +2481,13 @@ var pkgAST = &ast.Package{
 																									Loc: &ast.SourceLocation{
 																										End: ast.Position{
 																											Column: 37,
-																											Line:   61,
+																											Line:   52,
 																										},
 																										File:   "",
 																										Source: "obj.color",
 																										Start: ast.Position{
 																											Column: 28,
-																											Line:   61,
+																											Line:   52,
 																										},
 																									},
 																								},
@@ -3019,13 +2497,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 31,
-																												Line:   61,
+																												Line:   52,
 																											},
 																											File:   "",
 																											Source: "obj",
 																											Start: ast.Position{
 																												Column: 28,
-																												Line:   61,
+																												Line:   52,
 																											},
 																										},
 																									},
@@ -3037,13 +2515,13 @@ var pkgAST = &ast.Package{
 																										Loc: &ast.SourceLocation{
 																											End: ast.Position{
 																												Column: 37,
-																												Line:   61,
+																												Line:   52,
 																											},
 																											File:   "",
 																											Source: "color",
 																											Start: ast.Position{
 																												Column: 32,
-																												Line:   61,
+																												Line:   52,
 																											},
 																										},
 																									},
@@ -3058,13 +2536,13 @@ var pkgAST = &ast.Package{
 																						Loc: &ast.SourceLocation{
 																							End: ast.Position{
 																								Column: 18,
-																								Line:   62,
+																								Line:   53,
 																							},
 																							File:   "",
-																							Source: "message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                )",
+																							Source: "message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                )",
 																							Start: ast.Position{
 																								Column: 54,
-																								Line:   53,
+																								Line:   47,
 																							},
 																						},
 																					},
@@ -3074,13 +2552,13 @@ var pkgAST = &ast.Package{
 																							Loc: &ast.SourceLocation{
 																								End: ast.Position{
 																									Column: 61,
-																									Line:   53,
+																									Line:   47,
 																								},
 																								File:   "",
 																								Source: "message",
 																								Start: ast.Position{
 																									Column: 54,
-																									Line:   53,
+																									Line:   47,
 																								},
 																							},
 																						},
@@ -3094,13 +2572,13 @@ var pkgAST = &ast.Package{
 																						Loc: &ast.SourceLocation{
 																							End: ast.Position{
 																								Column: 24,
-																								Line:   62,
+																								Line:   53,
 																							},
 																							File:   "",
 																							Source: "100",
 																							Start: ast.Position{
 																								Column: 21,
-																								Line:   62,
+																								Line:   53,
 																							},
 																						},
 																					},
@@ -3116,13 +2594,13 @@ var pkgAST = &ast.Package{
 																	Loc: &ast.SourceLocation{
 																		End: ast.Position{
 																			Column: 25,
-																			Line:   62,
+																			Line:   53,
 																		},
 																		File:   "",
-																		Source: "string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)",
+																		Source: "string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)",
 																		Start: ast.Position{
 																			Column: 39,
-																			Line:   53,
+																			Line:   47,
 																		},
 																	},
 																},
@@ -3132,13 +2610,13 @@ var pkgAST = &ast.Package{
 																		Loc: &ast.SourceLocation{
 																			End: ast.Position{
 																				Column: 45,
-																				Line:   53,
+																				Line:   47,
 																			},
 																			File:   "",
 																			Source: "string",
 																			Start: ast.Position{
 																				Column: 39,
-																				Line:   53,
+																				Line:   47,
 																			},
 																		},
 																	},
@@ -3152,13 +2630,13 @@ var pkgAST = &ast.Package{
 																Loc: &ast.SourceLocation{
 																	End: ast.Position{
 																		Column: 26,
-																		Line:   53,
+																		Line:   47,
 																	},
 																	File:   "",
 																	Source: "r",
 																	Start: ast.Position{
 																		Column: 25,
-																		Line:   53,
+																		Line:   47,
 																	},
 																},
 															},
@@ -3170,13 +2648,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 26,
-																Line:   62,
+																Line:   53,
 															},
 															File:   "",
-															Source: "return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}",
+															Source: "return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}",
 															Start: ast.Position{
 																Column: 17,
-																Line:   53,
+																Line:   47,
 															},
 														},
 													},
@@ -3188,13 +2666,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 26,
-															Line:   51,
+															Line:   45,
 														},
 														File:   "",
 														Source: "r",
 														Start: ast.Position{
 															Column: 25,
-															Line:   51,
+															Line:   45,
 														},
 													},
 												},
@@ -3204,13 +2682,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 26,
-																Line:   51,
+																Line:   45,
 															},
 															File:   "",
 															Source: "r",
 															Start: ast.Position{
 																Column: 25,
-																Line:   51,
+																Line:   45,
 															},
 														},
 													},
@@ -3227,13 +2705,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 15,
-											Line:   63,
+											Line:   54,
 										},
 										File:   "",
-										Source: "map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    username: obj.username,\n                    channel: obj.channel,\n                    workspace: obj.workspace,\n                    text: obj.text,\n                    iconEmoji: obj.iconEmoji,\n                    color: obj.color,\n                ) / 100)}\n            })",
+										Source: "map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == message(\n                    url: url,\n                    token: token,\n                    channel: obj.channel,\n                    text: obj.text,\n                    color: obj.color,\n                ) / 100)}\n            })",
 										Start: ast.Position{
 											Column: 16,
-											Line:   51,
+											Line:   45,
 										},
 									},
 								},
@@ -3243,13 +2721,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 19,
-												Line:   51,
+												Line:   45,
 											},
 											File:   "",
 											Source: "map",
 											Start: ast.Position{
 												Column: 16,
-												Line:   51,
+												Line:   45,
 											},
 										},
 									},
@@ -3263,13 +2741,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 19,
-										Line:   50,
+										Line:   44,
 									},
 									File:   "",
 									Source: "tables=<-",
 									Start: ast.Position{
 										Column: 10,
-										Line:   50,
+										Line:   44,
 									},
 								},
 							},
@@ -3279,13 +2757,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 16,
-											Line:   50,
+											Line:   44,
 										},
 										File:   "",
 										Source: "tables",
 										Start: ast.Position{
 											Column: 10,
-											Line:   50,
+											Line:   44,
 										},
 									},
 								},
@@ -3296,13 +2774,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 19,
-										Line:   50,
+										Line:   44,
 									},
 									File:   "",
 									Source: "<-",
 									Start: ast.Position{
 										Column: 17,
-										Line:   50,
+										Line:   44,
 									},
 								},
 							}},
@@ -3314,13 +2792,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 11,
-									Line:   49,
+									Line:   43,
 								},
 								File:   "",
 								Source: "mapFn",
 								Start: ast.Position{
 									Column: 6,
-									Line:   49,
+									Line:   43,
 								},
 							},
 						},
@@ -3330,13 +2808,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 11,
-										Line:   49,
+										Line:   43,
 									},
 									File:   "",
 									Source: "mapFn",
 									Start: ast.Position{
 										Column: 6,
-										Line:   49,
+										Line:   43,
 									},
 								},
 							},
@@ -3351,13 +2829,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 27,
-								Line:   48,
+								Line:   42,
 							},
 							File:   "",
 							Source: "url=defaultURL",
 							Start: ast.Position{
 								Column: 13,
-								Line:   48,
+								Line:   42,
 							},
 						},
 					},
@@ -3367,13 +2845,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 16,
-									Line:   48,
+									Line:   42,
 								},
 								File:   "",
 								Source: "url",
 								Start: ast.Position{
 									Column: 13,
-									Line:   48,
+									Line:   42,
 								},
 							},
 						},
@@ -3385,13 +2863,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 27,
-									Line:   48,
+									Line:   42,
 								},
 								File:   "",
 								Source: "defaultURL",
 								Start: ast.Position{
 									Column: 17,
-									Line:   48,
+									Line:   42,
 								},
 							},
 						},
@@ -3403,13 +2881,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 37,
-								Line:   48,
+								Line:   42,
 							},
 							File:   "",
 							Source: "token=\"\"",
 							Start: ast.Position{
 								Column: 29,
-								Line:   48,
+								Line:   42,
 							},
 						},
 					},
@@ -3419,13 +2897,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 34,
-									Line:   48,
+									Line:   42,
 								},
 								File:   "",
 								Source: "token",
 								Start: ast.Position{
 									Column: 29,
-									Line:   48,
+									Line:   42,
 								},
 							},
 						},
@@ -3437,13 +2915,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 37,
-									Line:   48,
+									Line:   42,
 								},
 								File:   "",
 								Source: "\"\"",
 								Start: ast.Position{
 									Column: 35,
-									Line:   48,
+									Line:   42,
 								},
 							},
 						},

--- a/stdlib/slack/slack.flux
+++ b/stdlib/slack/slack.flux
@@ -10,13 +10,10 @@ option defaultURL = "https://slack.com/api/chat.postMessage"
 // `message` sends a single message to a Slack channel. It will work either with the chat.postMessage API or with a slack webhook.
 // `url` - string - URL of the slack endpoint. Defaults to: "https://slack.com/api/chat.postMessage", if one uses the webhook api this must be acquired as part of the slack API setup. This URL will be secret. Don't worry about secrets for the initial implementation.
 // `token` - string - the api token string.  Defaults to: "", and can be ignored if one uses the webhook api URL.
-// `username` - string - Username posting the message.
 // `channel` - string - Name of channel in which to post the message. No default.
-// `workspace` - string - Name of the slack workspace to use if there are multiple. Defaults to empty string.
 // `text` - string - The text to display.
-// `iconEmoji` - string - Name of : enclose emoji to use as image of user when posting message, will not show as the avatar icon with a slack webhook.
 // `color` - string - Color to give message: one of good, warning, and danger, or any hex rgb color value ex. #439FE0.
-message = (url=defaultURL, token="", username, channel, workspace, text, iconEmoji, color) => {
+message = (url=defaultURL, token="", channel, text, color) => {
     attachments = [{
         color: validateColorString(color),
         text: string(v: text),
@@ -24,12 +21,9 @@ message = (url=defaultURL, token="", username, channel, workspace, text, iconEmo
     }]
 
     data = {
-        username: username,
         channel: channel,
-        workspace: workspace,
         attachments: attachments,
         as_user: false,
-        icon_emoji: iconEmoji,
     }
 
     headers = {
@@ -44,7 +38,7 @@ message = (url=defaultURL, token="", username, channel, workspace, text, iconEmo
 // `url` - string - URL of the slack endpoint. Defaults to: "https://slack.com/api/chat.postMessage", if one uses the webhook api this must be acquired as part of the slack API setup, and this URL will be secret.
 // `token` - string - token for the slack endpoint.  This can be ignored if one uses the webhook url acquired as part of the slack API setup, but must be supplied if the chat.postMessage API is used.
 // The returned factory function accepts a `mapFn` parameter.
-// The `mapFn` must return an object with `username`, `channel`, `workspace`, `text`, `iconEmoji`, and `color` fields as defined in the `message` function arguments.
+// The `mapFn` must return an object with `channel`, `text`, and `color` fields as defined in the `message` function arguments.
 endpoint = (url=defaultURL, token="") =>
     (mapFn) =>
         (tables=<-) => tables
@@ -53,11 +47,8 @@ endpoint = (url=defaultURL, token="") =>
                 return {r with _sent: string(v: 2 == message(
                     url: url,
                     token: token,
-                    username: obj.username,
                     channel: obj.channel,
-                    workspace: obj.workspace,
                     text: obj.text,
-                    iconEmoji: obj.iconEmoji,
                     color: obj.color,
                 ) / 100)}
             })

--- a/stdlib/slack/slack_test.go
+++ b/stdlib/slack/slack_test.go
@@ -28,16 +28,16 @@ import "csv"
 import "slack"
 
 data = "
-#datatype,string,string,string,string,string,string,string
-#group,false,false,false,false,false,false,false
-#default,_result,,,
-,result,qusername,qchannel,qworkspace,qtext,qiconEmoji,qiconEmoji,qcolor
-,,fakeUser0,fakeChannel,workspace,this is a lot of text yay,\"#FF0000\"
+#datatype,string,string,string
+#group,false,false,false
+#default,_result,,
+,result,qchannel,qtext,qcolor
+,,fakeChannel,this is a lot of text yay,\"#FF0000\"
 "
 
 process = slack.endpoint(url:url, token:token)( mapFn: 
 	(r) => {
-		return {username:r.qusername,channel:r.qchannel,workspace:r.qorkspace,text:r.qtext,iconEmoji:r.qiconEmoji,color:r.color}
+		return {channel:r.qchannel,text:r.qtext,color:r.color}
 	}
 )
 
@@ -104,9 +104,6 @@ type Request struct {
 
 type PostData struct {
 	Channel     string       `json:"channel"`
-	Workspace   string       `json:"workspace"`
-	Icon        string       `json:"icon_emoji"`
-	Username    string       `json:"username"`
 	Text        string       `json:"text"`
 	Attachments []Attachment `json:"attachments"`
 }
@@ -129,9 +126,6 @@ func TestSlackPost(t *testing.T) {
 		channel   string
 		URL       string
 		token     string
-		username  string
-		workspace string
-		icon      string
 	}{
 		{
 			name:     "....",
@@ -140,8 +134,6 @@ func TestSlackPost(t *testing.T) {
 			channel:  "general",
 			URL:      s.URL,
 			token:    "faketoken",
-			username: "username",
-			icon:     ":thumbsup:",
 		},
 		{
 			name:     "....",
@@ -150,8 +142,6 @@ func TestSlackPost(t *testing.T) {
 			channel:  "general",
 			URL:      s.URL,
 			token:    "faketoken",
-			username: "username",
-			icon:     ":thumbsup:",
 		},
 	}
 
@@ -163,7 +153,7 @@ func TestSlackPost(t *testing.T) {
 import "slack"
 
 endpoint = slack.endpoint(url:url, token:token)(mapFn: (r) => {
-	return {username:r.fusername,channel:r.qchannel,workspace:r.qworkspace,text:r.qtext,iconEmoji:r.qiconEmoji,color:r.wcolor}
+	return {channel:r.qchannel,text:r.qtext,color:r.wcolor}
 })
 
 csv.from(csv:data) |> endpoint()`
@@ -189,11 +179,11 @@ csv.from(csv:data) |> endpoint()`
 						Name: "data",
 					},
 					Init: &ast.StringLiteral{
-						Value: `#datatype,string,string,string,string,string,string,string,string
-#group,false,false,false,false,false,false,false,false
-#default,_result,,,,,,,
-,result,,fusername,qchannel,qworkspace,qtext,qiconEmoji,wcolor
-,,,` + strings.Join([]string{tc.username, tc.channel, tc.workspace, tc.text, tc.icon, tc.color}, ","),
+						Value: `#datatype,string,string,string,string,string
+#group,false,false,false,false,false
+#default,_result,,,,
+,result,,qchannel,qtext,wcolor
+,,,` + strings.Join([]string{tc.channel, tc.text, tc.color}, ","),
 					},
 				},
 			}}))
@@ -260,15 +250,6 @@ csv.from(csv:data) |> endpoint()`
 			}
 			if req.PostData.Attachments[0].Color != tc.color {
 				t.Errorf("got color %s, expected %s", req.PostData.Attachments[0].Color, tc.color)
-			}
-			if req.PostData.Username != tc.username {
-				t.Errorf("got username %s, expected %s", req.PostData.Username, tc.username)
-			}
-			if req.PostData.Workspace != tc.workspace {
-				t.Errorf("got workspace %s, expected %s", req.PostData.Workspace, tc.workspace)
-			}
-			if req.PostData.Icon != tc.icon {
-				t.Errorf("got icon-emoji %s, expected %s", req.PostData.Icon, tc.icon)
 			}
 		})
 	}


### PR DESCRIPTION
The Slack notification rule apis have some fields that no longer used by InfluxDB. There are unification errors caused by the presence of these fields in the Flux api. We are removing these fields to see if that fixes type checking. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
