### PR TITLE
fix: allow array and row types to be equatable

### DIFF
--- a/libflux/src/flux/semantic/tests.rs
+++ b/libflux/src/flux/semantic/tests.rs
@@ -1446,17 +1446,37 @@ fn binary_expr_comparison() {
             ],
             src: &src,
         }
-        test_infer_err! {
+        test_infer! {
             env: map![
                 "a" => "forall [] {a: int | b: float}",
                 "b" => "forall [] {a: int | b: float}",
             ],
             src: &src,
+            exp: map![
+                "c" => "forall [] bool",
+            ],
         }
         test_infer_err! {
             env: map![
+                "a" => "forall [] {a: int | b: float | c: regexp}",
+                "b" => "forall [] {a: int | b: float | c: regexp}",
+            ],
+            src: &src,
+        }
+        test_infer! {
+            env: map![
                 "a" => "forall [] [int]",
                 "b" => "forall [] [int]",
+            ],
+            src: &src,
+            exp: map![
+                "c" => "forall [] bool",
+            ],
+        }
+        test_infer_err! {
+            env: map![
+                "a" => "forall [] [regexp]",
+                "b" => "forall [] [regexp]",
             ],
             src: &src,
         }


### PR DESCRIPTION
### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written