### PR TITLE
fix: deserialize the default vector if array elements are null

### DIFF
--- a/libflux/src/flux/ast/mod.rs
+++ b/libflux/src/flux/ast/mod.rs
@@ -848,6 +848,7 @@ pub struct ArrayExpr {
     #[serde(default)]
     #[serde(flatten)]
     pub base: BaseNode,
+    #[serde(deserialize_with = "deserialize_default_from_null")]
     pub elements: Vec<Expression>,
 }
 


### PR DESCRIPTION
The go code will serialize an empty array as null sometimes and the rust
code needs to accept that.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written