### PR TITLE
feat: initial grammar for flux and a partial grammar for influxql

### DIFF
--- a/colm/flux.lm
+++ b/colm/flux.lm
@@ -1,0 +1,392 @@
+lex
+	literal
+		`+ `- `* `/ `% `^
+		`== `< `> `<= `>=
+		`!= `=~ `!~ `=
+		`=> `<-
+		`( `) `[ `] `{ `}
+		`: `|> `, `.
+
+	literal
+		`and `or `not
+		`empty `in
+		`import `package
+		`return `option `builtin
+		`test `if `then `else `exists
+
+	ignore / '//' [^\n]* '\n' /
+	ignore / [ \t\n\r]+ /
+
+	# Documented, but not in the scanner.
+	literal `with `type `any `... `->
+	literal `; `'
+
+	rl decimal_lit
+		/ ( digit - "0" ) digit* /
+
+	# missing: "µs"
+	rl duration_unit
+		/ "y" | "mo" | "w" | "d" | "h" | "m" | "s" | "ms" | "us" | "ns" /
+
+	rl date          / digit{4} "-" digit{2} "-" digit{2} /
+	rl time_offset   / "Z" | ( ("+" | "-" ) digit{2} ":" digit{2} ) /
+	rl time          / digit{2} ":" digit{2} ":" digit{2} ( "." digit* )? time_offset? /
+
+	rl escaped_char
+		/ "\\" ( "n" | "r" | "t" | "\\" | '"' | "${" ) /
+	rl unicode_value
+		/ ( any - [\\$] ) | escaped_char /
+	rl byte_value
+		/ "\\x" xdigit{2} /
+	rl dollar_value
+		/ "$" ( any - "{" ) /
+	rl string_lit_char
+		/ ( unicode_value | byte_value | dollar_value ) /
+
+	token identifier
+		/ ( alpha | "_" ) ( alnum | "_" )* /
+
+	token int_lit
+		/ "0" | decimal_lit /
+
+	token float_lit
+		/ ( digit+ "." digit* ) | ("." digit+) /
+
+	token duration_lit
+		/ ( int_lit duration_unit )+ /
+
+	token date_time_lit
+		/ date ( "T" time )? /
+
+	token string_lit
+		/ '"' string_lit_char* "$"? :> '"' /
+end
+
+lex
+	rl regex_escaped_char / "\\" ( "/" | "\\") /
+	rl regex_unicode_value / ( any - "/" ) | regex_escaped_char /
+
+	token regex_lit
+		/ ( regex_unicode_value | byte_value )+ "/" /
+end
+
+#
+# Assignment and scope
+#
+
+def variable_assignment
+	[identifier `= expression]
+|	[`test identifier `= expression]
+
+def opt_qual
+	[identifier `.]
+|	[]
+
+def option_assignment
+	[`option opt_qual identifier `= expression]
+
+#
+# Blocks
+#
+
+def block
+	[`{ statement_list  `,`? `}]
+
+def statement_list
+	[statement*]
+
+#
+# Expressions
+#
+
+#
+# Object Literals
+#
+def object_literal
+	[`{ object_body `,`? `} ]
+
+def object_body
+	[with_properties]
+|	[property_list]
+
+def with_properties
+	[identifier `with property_list]
+
+def comma_property
+	[`, property]
+
+def property_list
+	[ property comma_property*]
+|	[]
+
+def colon_expr
+	[`: expression]
+
+def property
+	[identifier colon_expr?]
+|	[string_lit `: expression]
+
+#
+# Array Literals
+#
+
+def array_literal
+	[`[ expression_list `]]
+
+def comma_expression
+	[`, expression]
+
+def expression_list
+	[expression comma_expression*]
+|	[]
+
+#
+# Function Literals
+#
+
+def function_literal
+	[function_parameters `=> function_body]
+
+def opt_paramter_list
+	[parameter_list `,`?]
+|	[]
+
+def function_parameters
+	[`( opt_paramter_list `)]
+
+def comma_parameter
+	[`, parameter]
+
+def parameter_list
+	[parameter comma_parameter*]
+
+def equals_expression
+	[`= expression]
+
+def parameter
+	[identifier equals_expression?]
+
+def function_body
+	[expression]
+|	[block]
+
+
+#
+# Call Expressions
+#
+def call_expression
+	[`( property_list `,`? `)]
+
+
+#
+# Pipe Expressions
+#
+def pipe_receive_lit
+	[`<-]
+
+#
+# Index Expressions
+#
+
+def index_expression
+	[`[ expression `]]
+
+#
+# Member Expressions
+#
+
+def member_expression
+	[dot_expression]
+|	[member_bracket_expression]
+
+def dot_expression
+	[`. identifier]
+
+def member_bracket_expression
+	[`[ string_lit `]]
+
+#
+# Operations
+#
+
+def expression
+	[conditional_expression]
+
+def conditional_expression
+	[`if expression `then expression `else expression]
+|	[logical_expression]
+
+def logical_expression
+	[logical_expression logical_operator unary_logical_expression]
+|	[unary_logical_expression]
+
+def logical_operator
+	[`and] | [`or]
+
+def unary_logical_expression
+	[unary_logical_operator unary_logical_expression]
+|	[comparison_expression]
+
+def unary_logical_operator
+	[`not] | [`exists]
+
+def comparison_expression
+	[comparison_expression comparison_operator additive_expression]
+|	[additive_expression]
+
+def comparison_operator
+	[`==] | [`!=] | [`<] | [`<=] | [`>] | [`>=] | [`=~] | [`!~]
+
+def additive_expression
+	[additive_expression additive_operator multiplicative_expression]
+|	[multiplicative_expression]
+
+def additive_operator
+	[`+] | [`-]
+
+def multiplicative_expression
+	[multiplicative_expression multiplicative_operator pipe_expression]
+|	[pipe_expression]
+
+def multiplicative_operator
+	[`*] | [`/] | [`%] | [`^]
+
+def pipe_expression
+	[pipe_expression pipe_operator unary_expression]
+|	[unary_expression]
+
+def pipe_operator
+	[`|>]
+
+def unary_expression
+	[prefix_operator unary_expression]
+|	[postfix_expression]
+
+def prefix_operator
+	[`+] | [`-]
+
+def postfix_expression
+	[postfix_expression postfix_operator]
+|	[primary_expression]
+
+def postfix_operator
+	[member_expression]
+|	[call_expression]
+|	[index_expression]
+
+def primary_expression
+	[identifier]
+|	[_literal]
+|	[`( expression `)]
+
+def _literal
+	[int_lit]
+|	[float_lit]
+|	[string_lit]
+|	[`/ regex_lit]
+|	[date_time_lit]
+|	[duration_lit]
+|	[pipe_receive_lit]
+|	[object_literal]
+|	[array_literal]
+|	[function_literal]
+
+#
+# System built-ins
+#
+def builtin_statement
+	[`builtin identifier `: type_expression]
+|	[`builtin identifier]
+
+#
+# Packages
+#
+def file
+	[package_clause? import_list? statement_list]
+
+def import_list
+	[import_declaration*]
+
+def	package_clause
+	[`package identifier]
+
+#
+# Statements
+#
+
+def statement
+	[option_assignment] commit
+|	[builtin_statement] commit
+|	[variable_assignment] commit
+|	[return_statement] commit
+|	[expression_statement] commit
+
+def import_declaration
+	[`import identifier? string_lit]
+
+def return_statement
+	[`return expression]
+
+def expression_statement
+	[expression]
+
+def semi_object_upper_bound
+	[`; object_upper_bound]
+
+#
+# Named Types
+#
+def type_assignment
+	[`type identifier `= type_expression]
+
+def type_expression
+	[identifier]
+|	[type_parameter]
+|	[object_type]
+|	[array_type]
+|	[generator_type]
+|	[function_type]
+
+def type_parameter
+	[ `' identifier ]
+
+def object_type
+	[ `{ property_type_list semi_object_upper_bound? `,`? `}]
+
+def object_upper_bound
+	[`any] | [property_type_list]
+
+def comma_property_type
+	[`, property_type]
+
+def property_type_list
+	[property_type comma_property_type?]
+
+def property_type
+	[identifier `: type_expression]
+|	[string_lit `: type_expression]
+
+def array_type
+	[`[ `] type_expression]
+
+def generator_type
+	[`[ `... `] type_expression]
+
+def function_type
+	[parameter_type_list `-> type_expression]
+
+def comma_parameter_type
+	[`, parameter_type]
+
+def opt_paramter_type_list
+	[parameter_type comma_parameter_type*]
+|	[]
+
+def parameter_type_list
+	[`( opt_paramter_type_list `) ]
+
+def parameter_type
+	[identifier `: pipe_receive_lit? type_expression]
+
+def flux
+	[file]

--- a/colm/influxql.lm
+++ b/colm/influxql.lm
@@ -1,0 +1,313 @@
+lex 
+	ignore / '#' [^\n]* '\n' /
+	ignore /[ \t\n]+/
+
+	literal
+		`ALL           `ALTER         `ANY           `AS            `ASC           `BEGIN
+		`BY            `CREATE        `CONTINUOUS    `DATABASE      `DATABASES     `DEFAULT
+		`DELETE        `DESC          `DESTINATIONS  `DIAGNOSTICS   `DISTINCT      `DROP
+		`DURATION      `END           `EVERY         `EXPLAIN       `FIELD         `FOR
+		`FROM          `GRANT         `GRANTS        `GROUP         `GROUPS        `IN
+		`INF           `INSERT        `INTO          `KEY           `KEYS          `KILL
+		`LIMIT         `SHOW          `MEASUREMENT   `MEASUREMENTS  `NAME          `OFFSET
+		`ON            `ORDER         `PASSWORD      `POLICY        `POLICIES      `PRIVILEGES
+		`QUERIES       `QUERY         `READ          `REPLICATION   `RESAMPLE      `RETENTION
+		`REVOKE        `SELECT        `SERIES        `SET           `SHARD         `SHARDS
+		`SLIMIT        `SOFFSET       `STATS         `SUBSCRIPTION  `SUBSCRIPTIONS `TAG
+		`TO            `USER          `USERS         `VALUES        `WHERE         `WITH
+		`WRITE
+
+	literal
+		`AND `OR
+		`+ `- `* `/ `% `& `| `^
+		`= `!= `<> `< `<= `> `>= 
+		`=~ `!~
+		`. `: `( `) `, `;
+	
+	# Not sure if these are keywords, or just identifiers with a restriction.
+	literal `TRUE `FALSE
+
+	rl newline             / 0x0a /
+	rl unicode_char        / any - 0x0a /
+
+	rl ascii_letter        / "A" .. "Z" | "a" .. "z" /
+	rl letter              / ascii_letter | "_" /
+
+	token quoted_identifier   / '"' ( unicode_char unicode_char* ) :> '"' /
+	token unquoted_identifier / letter ( letter | digit )* /
+
+	# FIXME: int_lit does not allow "0" (both docs.influxdata.com and README.md).
+	# FIXME: docs.influxdata.com does not include +/-
+	token int_lit          / ( "0" | ( "1" .. "9" ) digit* ) /
+
+	token float_lit        / int_lit "." int_lit /
+
+	token string_lit       / "'" ( unicode_char )* :> "'" /
+
+	# missing: "µs"
+	rl duration_unit       / "ns" | "u" | "ms" | "s" | "m" | "h" | "d" | "w" /
+	token duration_lit     / int_lit duration_unit /
+end
+
+def identifier
+	[unquoted_identifier]
+|	[quoted_identifier]
+
+lex
+	rl regex_escaped_char / "\\" ( "/" | "\\") /
+	rl regex_unicode_value / ( any - "/" ) | regex_escaped_char /
+
+	token regex_tail
+		/ regex_unicode_value+ "/" /
+end
+
+# There are requirements on the contents of the time lit, based on Go's
+# date/time format. For now using the string lit, which is a superset of the
+# time literal.
+def time_lit
+	[string_lit]
+
+def bool_lit
+	[`TRUE] | [`FALSE]
+
+def regex_lit
+	[`/ regex_tail]
+
+def fields
+	[fields `, field]
+|	[field]
+
+def into_clause
+	[`INTO measurement]
+|	[`INTO back_ref]
+
+def from_clause
+	[`FROM measurements]
+
+def opt_where_clause
+	[where_clause]
+|	[]
+
+def where_clause
+	[`WHERE expr]
+
+# Missing fill(fill_option) -- not sure how to parse this. "fill" is not in the
+# keywords list. 
+def group_by_clause
+	[`GROUP `BY dimensions opt_fill]
+
+def order_by_clause
+	[`ORDER `BY sort_fields]
+
+def limit_clause
+	[`LIMIT int_lit]
+
+def offset_clause
+	[`OFFSET int_lit]
+
+def slimit_clause
+	[`SLIMIT int_lit]
+
+def soffset_clause
+	[`SOFFSET int_lit]
+
+# identifier = "tz"
+# DOC FIXME: 1. syntax not EBNF. Actually a function call.
+def timezone_clause
+	[identifier `( string_lit `)]
+
+def select_stmt
+	[`SELECT fields
+		into_clause? from_clause opt_where_clause
+		group_by_clause? order_by_clause? limit_clause?
+		offset_clause? slimit_clause? soffset_clause? timezone_clause?]
+
+#on_clause       = "ON" db_name .
+#
+#to_clause       = "TO" user_name .
+#
+#
+#with_measurement_clause = "WITH MEASUREMENT" ( "=" measurement | "=~" regex_lit ) .
+#
+#with_tag_clause = "WITH KEY" ( "=" tag_key | "!=" tag_key | "=~" regex_lit | "IN (" tag_keys ")"
+
+#
+# Expressions
+# FIXME: missing =~ and !~
+#
+def expr
+	[disjunction_expression]
+
+def OR [`OR]
+def AND [`AND]
+
+def disjunction_expression
+	[disjunction_expression OR conjunction_expression]
+|	[conjunction_expression]
+
+def conjunction_expression
+	[conjunction_expression AND comparison_expression]
+|	[comparison_expression]
+
+def comparison_expression
+	[comparison_expression comparison_operator additive_expression]
+|	[additive_expression]
+
+def comparison_operator
+	[`=] | [`!=] | [`<>] | [`<] | [`<=] | [`>] | [`>=] | [`=~] | [`!~]
+
+def additive_expression
+	[additive_expression additive_operator multiplicative_expression]
+|	[multiplicative_expression]
+
+def additive_operator
+	[`+] | [`-] | [`|] | [`^]
+
+def multiplicative_expression
+	[multiplicative_expression multiplicative_operator prefix_expression]
+|	[prefix_expression]
+
+def multiplicative_operator
+	[`*] | [`/] | [`%] | [`&] 
+
+def call_args
+	[call_args `, expr]
+|	[expr]
+
+def unary_op
+	[`-] | [`+] | []
+
+def prefix_expression
+	[unary_op unary_expr]
+|	[unary_expr]
+
+# seems to be missing function call.
+# DOC FIXME: spec seems to be missing function call.
+# FIXME: does not allow +/-
+def unary_expr
+	[`( expr `)]
+|	[identifier `( call_args? `)]
+|	[var_ref]
+|	[time_lit]
+|	[string_lit]
+|	[int_lit]
+|	[float_lit]
+|	[bool_lit]
+|	[duration_lit]
+|	[regex_lit]
+
+#
+# Other
+#
+
+def opt_alias
+	[`AS identifier]
+|	[]
+
+def back_ref
+	[policy_name `. `: `MEASUREMENT]
+|	[db_name `. policy_name? `. `: `MEASUREMENT ]
+
+def db_name
+	[identifier]
+
+# FIXME: does not allow *
+def dimension
+	[expr]
+|	[`*]
+
+def dimensions
+	[dimensions `, dimension]
+|	[dimension]
+
+def field_key
+	[identifier]
+
+def field
+	[expr opt_alias]
+
+# identfier = "fill"
+# DOC FIXME: 1. syntax not EBNF, needs to be optional. Actually a function call.
+def opt_fill
+	[identifier `( fill_option `)]
+|	[]
+
+# identifier = "null" | "none" | "previous" | "linear"
+def fill_option
+	[identifier] | [int_lit] | [float_lit]
+
+def host
+	[string_lit]
+
+def measurement
+	[measurement_name]
+|	[policy_name `. measurement_name]
+|	[db_name `. policy_name?  `. measurement_name]
+
+def measurements
+	[measurements `, measurement]
+|	[measurement]
+
+def measurement_name
+	[identifier]
+|	[regex_lit]
+
+#
+#password         = string_lit .
+#
+def policy_name
+	[identifier]
+#
+#privilege        = "ALL" [ "PRIVILEGES" ] | "READ" | "WRITE" .
+#
+#query_id         = int_lit .
+#
+#query_name       = identifier .
+#
+#retention_policy = identifier .
+#
+#retention_policy_option      = retention_policy_duration |
+#                               retention_policy_replication |
+#                               retention_policy_shard_group_duration |
+#                               "DEFAULT" .
+#
+#retention_policy_duration    = "DURATION" duration_lit .
+#
+#retention_policy_replication = "REPLICATION" int_lit .
+#
+#retention_policy_shard_group_duration = "SHARD DURATION" duration_lit .
+#
+#retention_policy_name = "NAME" identifier .
+#
+#series_id        = int_lit .
+#
+#shard_id         = int_lit .
+
+def opt_sort_dir
+	[`ASC]
+|	[`DESC]
+|	[]
+
+def sort_field
+	[field_key opt_sort_dir]
+
+def sort_fields
+	[sort_fields `, sort_field]
+|	[sort_field]
+
+#subscription_name = identifier .
+#
+#tag_key          = identifier .
+#
+#tag_keys         = tag_key { "," tag_key } .
+#
+#user_name        = identifier .
+
+def var_ref
+	[measurement]
+
+def item
+	[select_stmt `;]
+
+def influxql
+	[item*]

--- a/colm/parseflux/.gitignore
+++ b/colm/parseflux/.gitignore
@@ -1,0 +1,2 @@
+/parseflux.c
+/parseflux

--- a/colm/parseflux/Makefile
+++ b/colm/parseflux/Makefile
@@ -1,0 +1,6 @@
+COLM=$(HOME)/pkgs/colm-suite/bin/colm
+
+all: parseflux
+
+parseflux: parseflux.lm ../flux.lm
+	$(COLM) -o $@ $<

--- a/colm/parseflux/input.flux
+++ b/colm/parseflux/input.flux
@@ -1,0 +1,72 @@
+0.
+72.40
+072.40  // == 72.40
+2.71828
+.26
+
+1s
+10d
+1h15m  // 1 hour and 15 minutes
+5w
+1mo5d  // 1 month and 5 days
+-1mo5d // negative 1 month and 5 days
+5w * 2 // 10 weeks
+
+2018-01-01
+2018-01-01T00:00:00.1Z
+2018-01-01T00:00:00.00000001Z
+2018-01-01T00:00:00.00000002
+2018-01-01T00:00:00.00000001+00:00
+
+n = 1
+m = 2
+x = 5.4
+f = () => {
+    n = "a"
+    m = "b"
+    return n + m
+}
+
+option severity = ["low", "moderate", "high"]
+option alert.severity = ["low", "critical"]
+
+{a: 1, b: 2, c: 3}
+{a, b, c}
+{o with x: 5, y: 5}
+{o with a, b}
+
+() => 1
+(a, b) => a + b
+(x=1, y=1) => x * y
+(a, b, c) => {
+    d = a + b
+    return d / c
+}
+
+add = (a,b) => a + b
+mul = (a,b) => a * b
+
+f(a:1, b:9.6)
+float(v:1)
+
+add(a: a, b: b) 
+add(a, b)
+
+add = (a,b) => a + b
+a = 1
+b = 2
+
+add(a: a, b)
+add(a, b: b)
+
+foo |> bar |> baz
+
+obj.k //asdlkfj
+obj["k"]
+
+color = if code == 0 then "green" else if code == 1 then "yellow" else "red"
+
+from( bucket: "the-bucket")
+        |> range( start: -2m  , stop: -1m  )
+        |> filter( fn: (r) => ( r._measurement == "cpu" ) )
+        |> filter( fn: (r) => ( r.cpu == "cpu-total" ) )

--- a/colm/parseflux/parseflux.lm
+++ b/colm/parseflux/parseflux.lm
@@ -1,0 +1,9 @@
+include '../flux.lm'
+
+parse Flux: file [stdin]
+if !Flux {
+	print "[error]
+	exit(1)
+}
+
+print [Flux]

--- a/colm/transpile/.gitignore
+++ b/colm/transpile/.gitignore
@@ -1,0 +1,3 @@
+/transpile.c
+/transpile
+/config.sh

--- a/colm/transpile/Makefile
+++ b/colm/transpile/Makefile
@@ -1,0 +1,6 @@
+COLM=$(HOME)/pkgs/colm-suite/bin/colm
+
+all: transpile
+
+transpile: transpile.lm ../flux.lm ../influxql.lm
+	$(COLM) -o $@ $<

--- a/colm/transpile/q01.ql
+++ b/colm/transpile/q01.ql
@@ -1,0 +1,4 @@
+# Covering select, measurement, time and a where clause
+
+SELECT usage_user FROM cpu
+	WHERE time > -2m AND time < -1m AND ( cpu = 'cpu0' OR cpu = 'cpu1' );

--- a/colm/transpile/q02.ql
+++ b/colm/transpile/q02.ql
@@ -1,0 +1,4 @@
+# Alternate expression tree from which we extract time.
+
+SELECT usage_user FROM cpu
+	WHERE ( time > -2m AND time < -1m ) AND ( cpu = 'cpu0' OR cpu = 'cpu1' );

--- a/colm/transpile/q03.ql
+++ b/colm/transpile/q03.ql
@@ -1,0 +1,4 @@
+# Alternate expression tree from which we extract time.
+
+SELECT usage_user FROM cpu
+	WHERE ( cpu = 'cpu0' OR cpu = 'cpu1' ) AND ( ( ( ( time > -2m ) AND ( time < -1m ) ) ) );

--- a/colm/transpile/q04.ql
+++ b/colm/transpile/q04.ql
@@ -1,0 +1,5 @@
+# Disjunction of time issue.
+# https://github.com/influxdata/influxdb/issues/7530
+
+SELECT usage_user FROM cpu
+	WHERE cpu = 'cpu0' OR cpu = 'cpu1' AND time > -2m AND time < -1m;

--- a/colm/transpile/q05.ql
+++ b/colm/transpile/q05.ql
@@ -1,0 +1,5 @@
+# Disjunction of time issue.
+# https://github.com/influxdata/influxdb/issues/7530
+
+SELECT usage_user FROM cpu
+	WHERE cpu = 'cpu0' AND time > -2m OR cpu = 'cpu1' AND time < -1m;

--- a/colm/transpile/q06.ql
+++ b/colm/transpile/q06.ql
@@ -1,0 +1,5 @@
+# Disjunction of time issue.
+# https://github.com/influxdata/influxdb/issues/7530
+
+SELECT usage_user FROM cpu
+	WHERE cpu = 'cpu0' OR cpu = 'cpu1' AND ( time > -2m ) OR ( time < -1m );

--- a/colm/transpile/q07.ql
+++ b/colm/transpile/q07.ql
@@ -1,0 +1,5 @@
+# Disjunction of time issue.
+# https://github.com/influxdata/influxdb/issues/7530
+
+SELECT usage_user FROM cpu
+	WHERE ( cpu = 'cpu1' OR time > -2m ) OR ( cpu = 'cpu0' OR time < -1m );

--- a/colm/transpile/q08.ql
+++ b/colm/transpile/q08.ql
@@ -1,0 +1,5 @@
+# Disjunction of time issue.
+# https://github.com/influxdata/influxdb/issues/7530
+
+SELECT usage_user FROM cpu
+	WHERE cpu = 'cpu1' OR time > -2m OR cpu = 'cpu0' OR time < -1m;

--- a/colm/transpile/q09.ql
+++ b/colm/transpile/q09.ql
@@ -1,0 +1,5 @@
+# Fail on bad time constraint.
+
+SELECT usage_user FROM cpu
+	WHERE x > ( time - 1 ) AND ( cpu = 'cpu0' OR cpu = 'cpu1' );
+

--- a/colm/transpile/q10.ql
+++ b/colm/transpile/q10.ql
@@ -1,0 +1,4 @@
+# Absolute time. WARNING: could gernerate a lot of data.
+
+SELECT usage_user FROM cpu
+	WHERE time > "2020-02-07T14:36:21Z" AND ( cpu = 'cpu0' OR cpu = 'cpu1' );

--- a/colm/transpile/q11.ql
+++ b/colm/transpile/q11.ql
@@ -1,0 +1,5 @@
+# Absolute time. WARNING: could gernerate a lot of data.
+
+SELECT usage_user FROM cpu
+	WHERE ( time > "2020-02-07T14:36:21Z" ) AND cpu = 'cpu0' OR cpu = 'cpu1';
+

--- a/colm/transpile/q12.ql
+++ b/colm/transpile/q12.ql
@@ -1,0 +1,5 @@
+# Quoted field.
+
+SELECT "usage_user" FROM cpu
+	WHERE time > -1m AND cpu = 'cpu0' OR cpu = 'cpu1';
+

--- a/colm/transpile/q13.ql
+++ b/colm/transpile/q13.ql
@@ -1,0 +1,5 @@
+# Quoted measurement.
+
+SELECT usage_user FROM "cpu"
+	WHERE time > -1m AND cpu = 'cpu0' OR cpu = 'cpu1';
+

--- a/colm/transpile/query.ql
+++ b/colm/transpile/query.ql
@@ -1,0 +1,90 @@
+# InfluxQL Queries.
+
+SELECT "foo" FROM bar WHERE baz = 'yes';
+
+SELECT mean("ENERGY_Power") FROM "consumer"
+	WHERE ( "topic" = 'power_meter/solar/SENSOR' AND time >= now() - 3m )
+	GROUP BY time(1m);
+
+SELECT ENERGY_Power FROM "mqtt_consumer"
+	WHERE ( "topic" = 'power_meter/solar/SENSOR' ) AND time >= now() - 3m;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/basic_random_group_by_interval_sum.influxql
+SELECT sum(f) FROM m WHERE time >= 0 AND time <= 20h GROUP BY time(5h);
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/series_agg_0.influxql
+SELECT difference(f) FROM m GROUP BY *;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/SelectorMath_29.influxql
+SELECT last(f3), f3 FROM m WHERE time >= 0 AND time < 100s GROUP BY time(20s);
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/ands.influxql
+SELECT n FROM ctr WHERE
+    n > -1 AND n > -2 AND n > -3 AND n > -4 AND n > -5 AND n > -6 AND n > -7 AND n > -8 AND
+    n > -9 AND n > -10 AND n > -11 AND n > -12 AND n > -13 AND n > -14 AND n > -15 AND n > -16 AND
+    n > -17 AND n > -18 AND n > -19 AND n > -20 AND n > -21 AND n > -22 AND n > -23 AND n > -24 AND
+    n > -25 AND n > -26 AND n > -27 AND n > -28 AND n > -29 AND n > -30 AND n > -31 AND n > -32 AND
+    n > -33 AND n > -34 AND n > -35 AND n > -36 AND n > -37 AND n > -38 AND n > -39 AND n > -40 AND
+    n > -41 AND n > -42 AND n > -43 AND n > -44 AND n > -45 AND n > -46 AND n > -47 AND n > -48 AND
+    n > -49 AND n > -50 AND n > -51 AND n > -52 AND n > -53 AND n > -54 AND n > -55 AND n > -56 AND
+    n > -57 AND n > -58 AND n > -59 AND n > -60 AND n > -61 AND n > -62 AND n > -63 AND n > -64 AND
+    n > -65 AND n > -66 AND n > -67 AND n > -68 AND n > -69 AND n > -70 AND n > -71 AND n > -72 AND
+    n > -73 AND n > -74 AND n > -75 AND n > -76 AND n > -77 AND n > -78 AND n > -79 AND n > -80 AND
+    n > -81 AND n > -82 AND n > -83 AND n > -84 AND n > -85 AND n > -86 AND n > -87 AND n > -88 AND
+    n > -89 AND n > -90 AND n > -91 AND n > -92 AND n > -93 AND n > -94 AND n > -95 AND n > -96 AND
+    n > -97 AND n > -98 AND n > -99 AND n > -100 AND n > -101 AND n > -102 AND n > -103 AND n > -104 AND
+    n > -105 AND n > -106 AND n > -107 AND n > -108 AND n > -109 AND n > -110 AND n > -111 AND n > -112 AND
+    n > -113 AND n > -114 AND n > -115 AND n > -116 AND n > -117 AND n > -118 AND n > -119 AND n > -120 AND
+    n > -121 AND n > -122 AND n > -123 AND n > -124 AND n > -125 AND n > -126 AND n > -127 AND n > -128 AND
+    n > -129 AND n > -130 AND n > -131 AND n > -132 AND n > -133 AND n > -134 AND n > -135 AND n > -136 AND
+    n > -137 AND n > -138 AND n > -139 AND n > -140 AND n > -141 AND n > -142 AND n > -143 AND n > -144 AND
+    n > -145 AND n > -146 AND n > -147 AND n > -148 AND n > -149 AND n > -150 AND n > -151 AND n > -152 AND
+    n > -153 AND n > -154 AND n > -155 AND n > -156 AND n > -157 AND n > -158 AND n > -159 AND n > -160 AND
+    n > -161 AND n > -162 AND n > -163 AND n > -164 AND n > -165 AND n > -166 AND n > -167 AND n > -168 AND
+    n > -169 AND n > -170 AND n > -171 AND n > -172 AND n > -173 AND n > -174 AND n > -175 AND n > -176 AND
+    n > -177 AND n > -178 AND n > -179 AND n > -180 AND n > -181 AND n > -182 AND n > -183 AND n > -184 AND
+    n > -185 AND n > -186 AND n > -187 AND n > -188 AND n > -189 AND n > -190 AND n > -191 AND n > -192 AND
+    n > -193 AND n > -194 AND n > -195 AND n > -196 AND n > -197 AND n > -198 AND n > -199 AND n > -200;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/selector_4.influxql
+SELECT max(f) FROM m;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/hardcoded_literal_0.influxql
+SELECT count("n") FROM "ctr" WHERE time >= 0m AND time <= 840m;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/ors.influxql
+SELECT n FROM ctr WHERE n > 2000 OR
+    n > 2001 OR n > 2002 OR n > 2003 OR n > 2004 OR n > 2005 OR n > 2006 OR n > 2007 OR n > 2008 OR 
+    n > 2009 OR n > 2010 OR n > 2011 OR n > 2012 OR n > 2013 OR n > 2014 OR n > 2015 OR n > 2016 OR 
+    n > 2017 OR n > 2018 OR n > 2019 OR n > 2020 OR n > 2021 OR n > 2022 OR n > 2023 OR n > 2024 OR 
+    n > 2025 OR n > 2026 OR n > 2027 OR n > 2028 OR n > 2029 OR n > 2030 OR n > 2031 OR n > 2032 OR
+    n > 2033 OR n > 2034 OR n > 2035 OR n > 2036 OR n > 2037 OR n > 2038 OR n > 2039 OR n > 2040 OR 
+    n > 2041 OR n > 2042 OR n > 2043 OR n > 2044 OR n > 2045 OR n > 2046 OR n > 2047 OR n > 2048 OR 
+    n > 2049 OR n > 2050 OR n > 2051 OR n > 2052 OR n > 2053 OR n > 2054 OR n > 2055 OR n > 2056 OR 
+    n > 2057 OR n > 2058 OR n > 2059 OR n > 2060 OR n > 2061 OR n > 2062 OR n > 2063 OR n > 2064 OR 
+    n > 2065 OR n > 2066 OR n > 2067 OR n > 2068 OR n > 2069 OR n > 2070 OR n > 2071 OR n > 2072 OR 
+    n > 2073 OR n > 2074 OR n > 2075 OR n > 2076 OR n > 2077 OR n > 2078 OR n > 2079 OR n > 2080 OR 
+    n > 2081 OR n > 2082 OR n > 2083 OR n > 2084 OR n > 2085 OR n > 2086 OR n > 2087 OR n > 2088 OR 
+    n > 2089 OR n > 2090 OR n > 2091 OR n > 2092 OR n > 2093 OR n > 2094 OR n > 2095 OR n > 2096 OR 
+    n > 2097 OR n > 2098 OR n > 2099 OR n > 2100 OR n > 2101 OR n > 2102 OR n > 2103 OR n > 2104 OR 
+    n > 2105 OR n > 2106 OR n > 2107 OR n > 2108 OR n > 2109 OR n > 2110 OR n > 2111 OR n > 2112 OR 
+    n > 2113 OR n > 2114 OR n > 2115 OR n > 2116 OR n > 2117 OR n > 2118 OR n > 2119 OR n > 2120 OR 
+    n > 2121 OR n > 2122 OR n > 2123 OR n > 2124 OR n > 2125 OR n > 2126 OR n > 2127 OR n > 2128 OR 
+    n > 2129 OR n > 2130 OR n > 2131 OR n > 2132 OR n > 2133 OR n > 2134 OR n > 2135 OR n > 2136 OR 
+    n > 2137 OR n > 2138 OR n > 2139 OR n > 2140 OR n > 2141 OR n > 2142 OR n > 2143 OR n > 2144 OR 
+    n > 2145 OR n > 2146 OR n > 2147 OR n > 2148 OR n > 2149 OR n > 2150 OR n > 2151 OR n > 2152 OR 
+    n > 2153 OR n > 2154 OR n > 2155 OR n > 2156 OR n > 2157 OR n > 2158 OR n > 2159 OR n > 2160 OR 
+    n > 2161 OR n > 2162 OR n > 2163 OR n > 2164 OR n > 2165 OR n > 2166 OR n > 2167 OR n > 2168 OR 
+    n > 2169 OR n > 2170 OR n > 2171 OR n > 2172 OR n > 2173 OR n > 2174 OR n > 2175 OR n > 2176 OR 
+    n > 2177 OR n > 2178 OR n > 2179 OR n > 2180 OR n > 2181 OR n > 2182 OR n > 2183 OR n > 2184 OR 
+    n > 2185 OR n > 2186 OR n > 2187 OR n > 2188 OR n > 2189 OR n > 2190 OR n > 2191 OR n > 2192 OR 
+    n > 2193 OR n > 2194 OR n > 2195 OR n > 2196 OR n > 2197 OR n > 2198 OR n > 2199 OR n >= 0;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/regex_measurement_0.influxql
+SELECT n FROM /^m/;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/regex_tag_0.influxql
+SELECT n FROM hex WHERE t =~ /^(0x7b|0x70|0x55|0x19|0x65|0xa3|0x89|0xc1|0x3|0x14|0x29|0x81|0xb7|0xb9|0x82|0x56|0xa0|0xc7|0x5a|0x7d)$/;
+
+# https://github.com/influxdata/influxdb/blob/master/query/influxql/testdata/derivative_count.influxql
+SELECT derivative(count(f), 10s) FROM d WHERE time >= 0 AND time <= 100s GROUP BY time(20s);

--- a/colm/transpile/run
+++ b/colm/transpile/run
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# usage: ./run.sh influxql query
+#        ./run.sh flux query
+
+if ! [ -f config.sh ]; then
+	echo "please create a config.sh that sets ORG, BUCKET and TOKEN"
+	exit 1;
+fi
+
+unset ORG BUCKET TOKEN
+. config.sh
+
+IFQL=`mktemp /tmp/tmp.XXXXX`
+FLUX=`mktemp /tmp/tmp.XXXXX`
+trap "rm -f $IFQL $FLUX" EXIT
+
+# outputs the input text which can either be literal code outputted as is, or
+# catted from @filename.
+input()
+{
+	if [ "${1:0:1}" = '@' ]; then
+		cat ${1:1}
+	else
+		echo ${1}
+	fi
+}
+
+if [ "$1" = influxql ]; then
+	input "$2" > $IFQL
+
+	if ! ./transpile $BUCKET < $IFQL >> $FLUX; then
+		rm $IFQL $FLUX
+		exit 1;
+	fi
+elif [ "$1" = flux ]; then
+	input "$2" > $FLUX
+fi
+
+echo sending query:
+cat $FLUX
+
+curl -s \
+	-H "Authorization: Token $TOKEN" \
+	-H "Content-Type: application/vnd.flux" \
+	"http://localhost:9999/api/v2/query?org=$ORG" \
+	--data-binary "@$FLUX"
+echo
+
+

--- a/colm/transpile/transpile.lm
+++ b/colm/transpile/transpile.lm
@@ -1,0 +1,265 @@
+namespace flux
+	include '../flux.lm'
+end
+
+include '../influxql.lm'
+
+if argv->length < 1 {
+	send stderr "usage: ./transpile bucket-name
+	exit(1)
+}
+
+parse P: influxql [stdin] 
+if ( !P ) {
+	send stderr "error parsing influxql query: [error]
+	exit( 1 )
+}
+
+bool time_constraint( Any: any )
+{
+	for UE: unary_expr in Any {
+		if match UE "time"
+			return true
+	}
+	return false
+}
+
+def time_range
+	Start: flux::expression
+	Stop: flux::expression
+[]
+
+void unquote_times( AE: ref<additive_expression> )
+{
+	for QI: quoted_identifier in AE {
+		Time: str = $QI
+		Time = prefix( suffix( Time, 1 ), Time.length - 2 )
+		QI.data = Time
+	}
+}
+
+bool check_time( Range: ref<time_range>, CE: comparison_expression )
+{
+	if match CE "time [Op: comparison_operator Rhs: additive_expression ]"
+			&& ( match Op "<" || match Op "<=" )
+	{
+		unquote_times( Rhs )
+		Range.Stop = parse flux::expression [Rhs]
+		return true
+	}
+
+	if match CE "time [Op: comparison_operator Rhs: additive_expression ]"
+			&& ( match Op ">" || match Op ">=" )
+	{
+		unquote_times( Rhs )
+		Range.Start = parse flux::expression [Rhs]
+		return true
+	}
+
+	return false
+}
+
+# Find time constraints and verify we can handle them.
+void yank_time( Range: ref<time_range>, Expr: ref<expr> )
+{
+	Error: bool = false
+	for CE: comparison_expression in Expr {
+		if ( time_constraint( CE ) ) {
+			if !match CE "( [expr] )" {
+				if !check_time( Range, CE ) {
+					send stderr "ERROR: wonky time constraint: [CE]
+					Error = true
+				}
+
+				CE = cons comparison_expression " __ERASE_ME__ "
+			}
+		}
+	}
+
+	if ( Error )
+		exit(1)
+}
+
+# Remove the expression components left behind by the time yanking.
+void clean_expr( Expr: ref<expr> )
+{
+	Modified: bool = true
+	while ( Modified ) {
+		Modified = false
+		for DE: disjunction_expression in Expr {
+			if match DE
+				"[ Left: disjunction_expression ] OR __ERASE_ME__"
+			{
+				DE = Left
+				Modified = true
+			}
+			else if match DE
+				"__ERASE_ME__ OR [ Right: conjunction_expression ]"
+			{
+				DE = cons disjunction_expression [Right]
+				Modified = true
+			}
+		}
+
+		for CE: conjunction_expression in Expr {
+			if match CE
+				"[ Left: conjunction_expression ] AND __ERASE_ME__"
+			{
+				CE = Left
+				Modified = true
+			}
+			else if match CE
+				"__ERASE_ME__ AND [ Right: comparison_expression ]"
+			{
+				CE = cons conjunction_expression [Right]
+				Modified = true
+			}
+		}
+
+		for CmpE: comparison_expression in Expr {
+			if match CmpE "( __ERASE_ME__ )" {
+				CmpE = cons comparison_expression "__ERASE_ME__"
+				Modified = true
+			}
+		}
+	}
+}
+
+void add_time_range( Output: output, Range: time_range )
+{
+	# Range stop.
+	cons Stop: flux::comma_property* []
+	if Range.Stop
+		Stop = parse flux::comma_property* ", stop: [$Range.Stop] "
+
+	send Output
+		"	|> range( start: [Range.Start] [Stop] )
+}
+
+void add_measurement_filter( Output: output, SS: select_stmt )
+{
+	# Add measurement as a filter.
+	for Measurement: measurement in SS.from_clause {
+		M: str = $Measurement
+		if match Measurement [unquoted_identifier]
+			M = "\"[M]\""
+		send Output
+			"	|> filter( fn: (r) => ( r._measurement == [M] ) )
+	}
+}
+
+void add_where_filter( Output: output, WC: where_clause )
+{
+	# We are hacking the influxql query so that it will parse as a flux query.
+	for Op: AND in WC.expr {
+		match Op [And: `AND]
+		And.data = 'and'
+		Op = cons AND [And]
+	}
+
+	for Op: OR in WC.expr {
+		match Op [Or: `OR]
+		Or.data = 'or'
+		Op = cons OR [Or]
+	}
+
+	for CE: comparison_operator in WC.expr {
+		if match CE [Eq: `=] {
+			Eq.data = "=="
+			CE = cons comparison_operator [ Eq ]
+		}
+	}
+
+	for SL: string_lit in WC.expr {
+		Str: str = $SL
+		Str = prefix( suffix( Str, 1 ), Str.length - 2 )
+		SL.data = "\"[Str]\""
+	}
+
+	# Reparsing the expression as a flux query. This sends the InfluxQL tree,
+	# as text, to a flux expession parser.
+	parse Expr: flux::expression [WC.expr]
+	if !Expr {
+		send stderr
+			"ERROR: failed to reparse remaining parts of where clause as flux expression: [error]
+			"ERROR: [WC.expr]
+		exit(1)
+	}
+	
+	# After reparsing as flux we do some rewriting to add r. qualifications.
+	for UE: flux::unary_expression in Expr {
+		if match UE [ID: flux::identifier] {
+			UE = cons flux::unary_expression " r.[ID] "
+		}
+	}
+
+	# Generate.
+	send Output
+		"	|> filter( fn: (r) => ( [Expr ] ) )
+}
+
+void add_select_filter( Output: output, SS: select_stmt )
+{
+	# Add select expression as a filter. Note that this just works on simple
+	# select expression that name a value. It does not evaluate expressions.
+	for Field: field in SS.fields {
+		if match Field [Id: identifier] {
+			FieldName: str = $Id
+			if match Id [unquoted_identifier]
+				FieldName = "\"[FieldName]\""
+
+			send Output
+				"	|> filter( fn: (r) => ( r._field == [FieldName] ) )
+		}
+	}
+}
+
+# (not an exhaustive list)
+# 1. Extract time constraints from the where clause.
+# 2. Build range from extracted time constraints.
+# 3. Add measurement filter.
+# 4. Build filter from remaining where clause.
+# 5. Apply group by (not implemented)
+# 6. Apply simple select expressions.
+
+alias output parser<flux::flux>
+
+for SS: select_stmt in P {
+	# send stderr "select statement: [^SS]
+	cons Range: time_range []
+
+	# Extracting time range from the whre clause. Leaves WC.expr altered.
+	WC: where_clause = SS.opt_where_clause.where_clause
+	if WC {
+		yank_time( Range, WC.expr )
+		clean_expr( WC.expr )
+	}
+
+	# If there is no start range, add one. 
+	if !Range.Start
+		Range.Start = parse flux::expression "-1m"
+
+	# Writing output. Note that this output stream is a parser, so it is
+	# parsing what is sent to it, as we go along. At the end we will extract
+	# the tree and there is opportunity for further rewriting on that. Although
+	# we are not doing that in this version.
+	new Output: output()
+	send Output
+		"from( bucket: \"[argv->head_el->value]\")
+
+	add_time_range( Output, Range )
+	add_measurement_filter( Output, SS )
+	add_where_filter( Output, WC )
+	add_select_filter( Output, SS )
+
+	send Output [] eos
+
+	Flux: flux::flux = Output->tree
+	if !Flux {
+		send stderr "ERROR: failed to parse output text: [Output->error]
+		exit(1)
+	}
+	else {
+		print [Flux]
+	}
+}


### PR DESCRIPTION
This patch adds a colm-based grammar for Flux, derived from the SPEC. It also
adds a partial grammar for InfluxQL, with a focus on the SELECT statement.

Also added is a colm-based transpiler experiment, with limited functionality.
It is useful for experimenting with transpiler techniques. The transpiler:
  1. Extracts time constraints from the where clause.
  2. Adds filters using measurement, where clause and select clauses.