### PR TITLE
chore: use non-symlink stdlib path in Rust build

### DIFF
--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -1,8 +1,6 @@
 package libflux
 
-// #cgo CFLAGS: -I.
-// #cgo LDFLAGS: -L. -llibstd
-// #include "flux.h"
+// #include "influxdata/flux.h"
 // #include <stdlib.h>
 import "C"
 

--- a/libflux/go/libflux/parser.go
+++ b/libflux/go/libflux/parser.go
@@ -1,8 +1,7 @@
 package libflux
 
-// #cgo CFLAGS: -I.
-// #cgo LDFLAGS: -L. -lflux
-// #include "flux.h"
+// #cgo pkg-config: flux
+// #include "influxdata/flux.h"
 // #include <stdlib.h>
 import "C"
 

--- a/libflux/src/flux/semantic/bootstrap.rs
+++ b/libflux/src/flux/semantic/bootstrap.rs
@@ -79,7 +79,7 @@ pub fn infer_stdlib() -> Result<
 > {
     let (builtins, mut f) = builtin_types()?;
 
-    let files = file_map(parse_flux_files("../../stdlib")?);
+    let files = file_map(parse_flux_files("../../../stdlib")?);
 
     let (prelude, importer) = infer_pre(&mut f, &files, &builtins)?;
     let importer = infer_std(&mut f, &files, &builtins, prelude.clone(), importer)?;


### PR DESCRIPTION
These are just some minor tweaks that let `pkg-config` builds succeed.