### PR TITLE
fix: fail gracefully when tableFind does not have an execution context

### DIFF
--- a/lang/dependencies.go
+++ b/lang/dependencies.go
@@ -23,6 +23,10 @@ func (d ExecutionDependencies) Inject(ctx context.Context) context.Context {
 	return context.WithValue(ctx, executionDependenciesKey, d)
 }
 
+func HaveExecutionDependencies(ctx context.Context) bool {
+	return ctx.Value(executionDependenciesKey) != nil
+}
+
 func GetExecutionDependencies(ctx context.Context) ExecutionDependencies {
 	return ctx.Value(executionDependenciesKey).(ExecutionDependencies)
 }

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -88,6 +88,11 @@ func tableFindCall(ctx context.Context, args values.Object) (values.Value, error
 	if err != nil {
 		return nil, errors.Wrap(err, codes.Inherit, "error in table object compilation")
 	}
+
+	if !lang.HaveExecutionDependencies(ctx) {
+		return nil, errors.New(codes.Invalid, "do not have an execution context for tableFind, if using the repl, try executing this code on the server using the InfluxDB API")
+	}
+
 	deps := lang.GetExecutionDependencies(ctx)
 	if p, ok := p.(lang.LoggingProgram); ok {
 		p.SetLogger(deps.Logger)


### PR DESCRIPTION
In the repl, a tablefind result that is captured to a variable, then used in a
map or a filter, causes the repl to attempt to execute a query. It fails with a
panic when it attempts to get the execution context.

A proper solution is part of a bigger design discussion. This patch simply
fails the query gracefully so we can identify the problem more easily and cause
less confusion. The user can be directed to execute on the server process when
encountering this issue.

Design discussion: https://github.com/influxdata/influxdb/issues/13976
Users experiencing this problem: #2442 #2387
Docs: https://github.com/influxdata/docs-v2/issues/735
