### PR TITLE
perf(semantic): do not scan top level type environment for free varia…

### DIFF
--- a/libflux/src/flux/semantic/env.rs
+++ b/libflux/src/flux/semantic/env.rs
@@ -17,18 +17,18 @@ pub struct Environment {
 
 impl Substitutable for Environment {
     fn apply(self, sub: &Substitution) -> Self {
-        Environment {
-            parent: match self.parent {
-                Some(env) => Some(Box::new(env.apply(sub))),
-                None => None,
+        match self.parent {
+            Some(env) => Environment {
+                parent: Some(Box::new(env.apply(sub))),
+                values: self.values.apply(sub),
             },
-            values: self.values.apply(sub),
+            None => self,
         }
     }
     fn free_vars(&self) -> Vec<Tvar> {
         match &self.parent {
             Some(env) => union(env.free_vars(), self.values.free_vars()),
-            None => self.values.free_vars(),
+            None => Vec::new(),
         }
     }
 }


### PR DESCRIPTION
…bles

The top level type environment is guaranteed never to have any free variables.
Therefore when `free_vars()` is called on a top level type environment, just
return an empty list. Similarly when applying a substitution, immediately
return the original environment.

In theory this should reduce the time complexity of type inference from
quadritic to linear for most programs. Unfortunately linear time complexity
will not be achieved until redundant memory allocations and data structure
copies are reduced.

Closes https://github.com/influxdata/flux/issues/2517.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
