### PR TITLE
feat: add select function to experimental/query package

### DIFF
--- a/stdlib/experimental/query/from.flux
+++ b/stdlib/experimental/query/from.flux
@@ -1,5 +1,7 @@
 package query
 
+import "strings"
+
 fromRange = (bucket, start, stop=now()) =>
     from(bucket: bucket)
         |> range(start: start, stop: stop)
@@ -24,3 +26,30 @@ inBucket = (
         |> filterMeasurement(measurement)
         |> filter(fn: predicate)
         |> filterFields(fields)
+
+splitData = (v, t=",") => strings.split(v:v, t:t)
+sanitizeList = (v) => strings.replaceAll(v:v, t: ", ", u: ",")
+
+select = (
+    src,
+    fields,
+    start,
+    stop=now(),
+    where=(r) => true
+) => {
+    srcData = splitData(v: src, t: ":")
+    bucket = srcData[0]
+    measurements = sanitizeList(v: string(v: srcData[1]))
+    measurementsArr = splitData(v: measurements)
+    fieldsList = sanitizeList(v: fields)
+    fieldsArr = splitData(v: fieldsList)
+
+    data = from(bucket: bucket)
+        |> range(start: start, stop: stop)
+        |> filter(fn: (r) =>
+          (if measurements == "*" then true else contains(value: r._measurement, set: measurementsArr)) and
+          (if fields == "*" then true else contains(value: r._field, set: fieldsArr)))
+        |> filter(fn: where)
+
+    return data
+}


### PR DESCRIPTION
This adds a new `select` function to the `experimental/query` package. This function does a lot of string manipulation, which adds an observable cost to using it, but I'm curious to see if we can learn anything about usability.

I'm experimenting with different patterns for selecting data. The `src` parameter expects a string using the following pattern:

```
bucketName:measurement

OR

bucketName:measurement1,measurement2
```

The `fields` parameter expects a comma delimited list of of field keys

It is designed to support one or more measurements, one or more fields, and even measurement and field wildcards (`*`). The following calls all work.

```js
import "experimental/query"

query.select(src: "bucket:measurement", fields: "field1", start: -1h)
query.select(src: "bucket:m1,m2", fields: "field1,field2", start: -1h)
query.select(src: "bucket:*", fields: "*", start: -1h, where: (r) => r.host != "host1")
```

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
