### PR TITLE
refactor(repl): remove the querier interface

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -28,7 +28,7 @@ func execute(cmd *cobra.Command, args []string) error {
 	deps := flux.NewDefaultDependencies()
 	deps.Deps.FilesystemService = filesystem.SystemFS
 	ctx := deps.Inject(context.Background())
-	r := repl.New(ctx, deps, querier{})
+	r := repl.New(ctx, deps)
 	if err := r.Input(args[0]); err != nil {
 		return fmt.Errorf("failed to execute query: %v", err)
 	}

--- a/cmd/flux/cmd/repl.go
+++ b/cmd/flux/cmd/repl.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"context"
+
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/dependencies/filesystem"
-	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/repl"
 	"github.com/spf13/cobra"
 )
@@ -22,27 +22,11 @@ var replCmd = &cobra.Command{
 		// one useful example is socket.from, kafka.to, and sql.from/sql.to where we need
 		// to access the url validator in deps to validate the user-specified url.
 		ctx := deps.Inject(context.Background())
-		r := repl.New(ctx, deps, querier{})
+		r := repl.New(ctx, deps)
 		r.Run()
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(replCmd)
-}
-
-type querier struct{}
-
-func (querier) Query(ctx context.Context, deps flux.Dependencies, c flux.Compiler) (flux.ResultIterator, error) {
-	program, err := c.Compile(ctx)
-	if err != nil {
-		return nil, err
-	}
-	ctx = deps.Inject(ctx)
-	alloc := &memory.Allocator{}
-	qry, err := program.Start(ctx, alloc)
-	if err != nil {
-		return nil, err
-	}
-	return flux.NewResultIteratorFromQuery(qry), nil
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -428,7 +428,7 @@ func TestInterpreter_MultiPhaseInterpretation(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := dependenciestest.Default().Inject(context.Background())
-			r := repl.New(ctx, dependenciestest.Default(), nil)
+			r := repl.New(ctx, dependenciestest.Default())
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)
 			}
@@ -540,7 +540,7 @@ func TestInterpreter_MultipleEval(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := dependenciestest.Default().Inject(context.Background())
-			r := repl.New(ctx, dependenciestest.Default(), nil)
+			r := repl.New(ctx, dependenciestest.Default())
 
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)


### PR DESCRIPTION
The querier interface will no longer work properly for algorithm w and
so it has been removed in favor of implementing the needed functionality
within the repl itself.

This removes the querier interface which is now dead code.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written