### PR TITLE
feat(stdlib): add influxdb source

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -2,10 +2,18 @@ package main
 
 import (
 	"github.com/influxdata/flux/cmd/flux/cmd"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
+
 	// Register the sqlite3 database driver.
 	_ "github.com/mattn/go-sqlite3"
 )
 
+const DefaultInfluxDBHost = "http://localhost:9999"
+
 func main() {
+	plan.RegisterLogicalRules(influxdb.DefaultFromAttributes{
+		Host: func(v string) *string { return &v }(DefaultInfluxDBHost),
+	})
 	cmd.Execute()
 }

--- a/execute/executetest/compile.go
+++ b/execute/executetest/compile.go
@@ -22,11 +22,18 @@ var (
 func FunctionExpression(t testing.TB, source string) *semantic.FunctionExpression {
 	t.Helper()
 
-	if prelude == nil {
-		prelude = runtime.Prelude()
-	}
 	if stdlib == nil {
 		stdlib = runtime.StdLib()
+	}
+	if prelude == nil {
+		prelude = values.NewScope()
+		for _, path := range []string{"universe", "influxdata/influxdb"} {
+			p, err := stdlib.ImportPackageObject(path)
+			if err != nil {
+				t.Fatalf("error importing prelude package %q: %s", path, err)
+			}
+			p.Range(prelude.Set)
+		}
 	}
 
 	pkg, err := semantic.AnalyzeSource(source)

--- a/interpreter/package.go
+++ b/interpreter/package.go
@@ -18,6 +18,9 @@ type Package struct {
 	// name is the name of the package.
 	name string
 
+	// path is the canonical import path that is used to import this package.
+	path string
+
 	// object contains the object properties of this package.
 	object values.Object
 
@@ -26,16 +29,17 @@ type Package struct {
 	sideEffects []SideEffect
 }
 
-func NewPackageWithValues(name string, obj values.Object) *Package {
+func NewPackageWithValues(name, path string, obj values.Object) *Package {
 	return &Package{
 		name:   name,
+		path:   path,
 		object: obj,
 	}
 }
 
 func NewPackage(name string) *Package {
 	obj := values.NewObject(semantic.NewObjectType(nil))
-	return NewPackageWithValues(name, obj)
+	return NewPackageWithValues(name, "", obj)
 }
 
 func (p *Package) Copy() *Package {
@@ -50,9 +54,17 @@ func (p *Package) Copy() *Package {
 		sideEffects: sideEffects,
 	}
 }
+
+// Name returns the package name.
 func (p *Package) Name() string {
 	return p.name
 }
+
+// Path returns the canonical import path for this package.
+func (p *Package) Path() string {
+	return p.path
+}
+
 func (p *Package) SideEffects() []SideEffect {
 	return p.sideEffects
 }

--- a/interpreter/package_test.go
+++ b/interpreter/package_test.go
@@ -42,13 +42,13 @@ func TestAccessNestedImport(t *testing.T) {
 	t.Skip("Handle imports for user-defined packages https://github.com/influxdata/flux/issues/2343")
 	// package a
 	// x = 0
-	packageA := interpreter.NewPackageWithValues("a", values.NewObjectWithValues(map[string]values.Value{
+	packageA := interpreter.NewPackageWithValues("a", "", values.NewObjectWithValues(map[string]values.Value{
 		"x": values.NewInt(0),
 	}))
 
 	// package b
 	// import "a"
-	packageB := interpreter.NewPackageWithValues("b", values.NewObjectWithValues(map[string]values.Value{
+	packageB := interpreter.NewPackageWithValues("b", "", values.NewObjectWithValues(map[string]values.Value{
 		"a": packageA,
 	}))
 

--- a/libflux/src/flux/semantic/builtins.rs
+++ b/libflux/src/flux/semantic/builtins.rs
@@ -124,7 +124,14 @@ pub fn builtins() -> Builtins<'static> {
             "influxdata/influxdb" => maplit::hashmap! {
                 // This is a one-or-the-other parameters function
                 // https://github.com/influxdata/flux/issues/1659
-                "from" => "forall [t0, t1] (?bucket: string, ?bucketID: string) -> [{_measurement: string | _field: string | _time: time | _value: t0 | t1}]",
+                "from" => r#"forall [t0, t1] (
+                    ?bucket: string,
+                    ?bucketID: string,
+                    ?org: string,
+                    ?orgID: string,
+                    ?host: string,
+                    ?token: string
+                ) -> [{_measurement: string | _field: string | _time: time | _value: t0 | t1}]"#,
                 // exactly one of (bucket, bucketID) must be specified
                 // exactly one of (org, orgID) must be specified
                 // https://github.com/influxdata/flux/issues/1660

--- a/plan/format_test.go
+++ b/plan/format_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestFormatted(t *testing.T) {
 	fromSpec := &influxdb.FromProcedureSpec{
-		Bucket: "my-bucket",
+		Bucket: influxdb.NameOrID{Name: "my-bucket"},
 	}
 
 	// (r) => r._value > 5.0

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -54,7 +54,7 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 
 	var (
 		fromSpec = &influxdb.FromProcedureSpec{
-			Bucket: "my-bucket",
+			Bucket: influxdb.NameOrID{Name: "my-bucket"},
 		}
 		rangeSpec = &universe.RangeProcedureSpec{
 			Bounds: flux.Bounds{
@@ -449,7 +449,9 @@ func TestLogicalPlanner(t *testing.T) {
 				yield(name: "result")`,
 		wantPlan: plantest.PlanSpec{
 			Nodes: []plan.Node{
-				plan.CreateLogicalNode("from0", &influxdb.FromProcedureSpec{Bucket: "telegraf"}),
+				plan.CreateLogicalNode("from0", &influxdb.FromProcedureSpec{
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+				}),
 				plan.CreateLogicalNode("merged_filter1_filter2_filter3", &universe.FilterProcedureSpec{
 					Fn: interpreter.ResolvedFunction{
 						Scope: valuestest.Scope(),
@@ -497,7 +499,9 @@ func TestLogicalPlanner(t *testing.T) {
 				from(bucket: "telegraf") |> map(fn: (r) => ({r with _value: r._value * 2.0})) |> filter(fn: (r) => r._value < 10.0) |> yield(name: "result")`,
 			wantPlan: plantest.PlanSpec{
 				Nodes: []plan.Node{
-					plan.CreateLogicalNode("from0", &influxdb.FromProcedureSpec{Bucket: "telegraf"}),
+					plan.CreateLogicalNode("from0", &influxdb.FromProcedureSpec{
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+					}),
 					plan.CreateLogicalNode("filter2_copy", &universe.FilterProcedureSpec{
 						Fn: interpreter.ResolvedFunction{
 							Scope: valuestest.Scope(),
@@ -555,7 +559,9 @@ func TestLogicalPlanner(t *testing.T) {
 					yield(name: "result")`,
 			wantPlan: plantest.PlanSpec{
 				Nodes: []plan.Node{
-					plan.CreateLogicalNode("from0", &influxdb.FromProcedureSpec{Bucket: "telegraf"}),
+					plan.CreateLogicalNode("from0", &influxdb.FromProcedureSpec{
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+					}),
 					plan.CreateLogicalNode("merged_filter1_filter3_copy", &universe.FilterProcedureSpec{
 						Fn: interpreter.ResolvedFunction{
 							Scope: valuestest.Scope(),

--- a/runtime/builtins_test.go
+++ b/runtime/builtins_test.go
@@ -19,7 +19,7 @@ func TestValidatePackageBuiltins(t *testing.T) {
 	}{
 		{
 			name: "no errors",
-			pkg: interpreter.NewPackageWithValues("test", values.NewObjectWithValues(map[string]values.Value{
+			pkg: interpreter.NewPackageWithValues("test", "", values.NewObjectWithValues(map[string]values.Value{
 				"foo": values.NewInt(0),
 			})),
 			astPkg: &ast.Package{
@@ -34,7 +34,7 @@ func TestValidatePackageBuiltins(t *testing.T) {
 		},
 		{
 			name: "extra values",
-			pkg: interpreter.NewPackageWithValues("test", values.NewObjectWithValues(map[string]values.Value{
+			pkg: interpreter.NewPackageWithValues("test", "", values.NewObjectWithValues(map[string]values.Value{
 				"foo": values.NewInt(0),
 			})),
 			astPkg: &ast.Package{},
@@ -42,7 +42,7 @@ func TestValidatePackageBuiltins(t *testing.T) {
 		},
 		{
 			name: "missing values",
-			pkg:  interpreter.NewPackageWithValues("test", values.NewObjectWithValues(map[string]values.Value{})),
+			pkg:  interpreter.NewPackageWithValues("test", "", values.NewObjectWithValues(map[string]values.Value{})),
 			astPkg: &ast.Package{
 				Files: []*ast.File{{
 					Body: []ast.Statement{
@@ -56,7 +56,7 @@ func TestValidatePackageBuiltins(t *testing.T) {
 		},
 		{
 			name: "missing and values",
-			pkg: interpreter.NewPackageWithValues("test", values.NewObjectWithValues(map[string]values.Value{
+			pkg: interpreter.NewPackageWithValues("test", "", values.NewObjectWithValues(map[string]values.Value{
 				"foo": values.NewInt(0),
 				"bar": values.NewInt(0),
 			})),

--- a/runtime/importer.go
+++ b/runtime/importer.go
@@ -82,7 +82,7 @@ func (imp *importer) ImportPackageObject(path string) (*interpreter.Package, err
 		return nil, err
 	}
 	obj := newObjectFromScope(scope)
-	imp.pkgs[path] = interpreter.NewPackageWithValues(itrp.PackageName(), obj)
+	imp.pkgs[path] = interpreter.NewPackageWithValues(itrp.PackageName(), path, obj)
 	return imp.pkgs[path], nil
 }
 

--- a/stdlib/experimental/group_test.go
+++ b/stdlib/experimental/group_test.go
@@ -36,8 +36,10 @@ from(bucket: "telegraf") |> range(start: -1m) |> experimental.group(mode: "exten
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
-						ID:   "from0",
-						Spec: &influxdb.FromOpSpec{Bucket: "telegraf"},
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+						},
 					},
 					{
 						ID: "range1",

--- a/stdlib/experimental/mqtt/to_test.go
+++ b/stdlib/experimental/mqtt/to_test.go
@@ -27,7 +27,7 @@ from(bucket:"mybucket") |> mqtt.to(broker: "tcp://iot.eclipse.org:1883", timeout
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/influxdata/influxdb/errors.go
+++ b/stdlib/influxdata/influxdb/errors.go
@@ -1,0 +1,46 @@
+package influxdb
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+func handleError(target interface{}) error {
+	if errStr, ok := target.(string); ok {
+		return errors.New(codes.Unknown, errStr)
+	}
+	if internalErrMap, ok := target.(map[string]interface{}); ok {
+		internalErr := new(flux.Error)
+		if code, ok := internalErrMap["code"].(string); ok {
+			internalErr.Code = handleErrorCode(code)
+		}
+		if msg, ok := internalErrMap["message"].(string); ok {
+			internalErr.Msg = msg
+		}
+		if err, ok := internalErrMap["error"]; ok {
+			internalErr.Err = handleError(err)
+		}
+		return internalErr
+	}
+	return nil
+}
+
+func handleErrorCode(code string) codes.Code {
+	switch code {
+	case "internal error":
+		return codes.Internal
+	case "not found":
+		return codes.NotFound
+	case "invalid":
+		return codes.Invalid
+	case "unavailable":
+		return codes.Unavailable
+	case "forbidden":
+		return codes.PermissionDenied
+	case "unauthorized":
+		return codes.Unauthenticated
+	default:
+		return codes.Unknown
+	}
+}

--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -4,18 +4,46 @@
 package influxdb
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values"
 )
 
-const FromKind = "from"
+const (
+	FromKind       = "from"
+	FromRemoteKind = "influxdata/influxdb.fromRemote"
+)
+
+// NameOrID signifies the name of an organization/bucket
+// or an ID for an organization/bucket.
+type NameOrID struct {
+	ID   string
+	Name string
+}
 
 type FromOpSpec struct {
-	Bucket string
+	Org    *NameOrID
+	Bucket NameOrID
+	Host   *string
+	Token  *string
 }
 
 func init() {
@@ -24,16 +52,60 @@ func init() {
 	runtime.RegisterPackageValue("influxdata/influxdb", FromKind, flux.MustValue(flux.FunctionValue(FromKind, createFromOpSpec, fromSignature)))
 	flux.RegisterOpSpec(FromKind, newFromOp)
 	plan.RegisterProcedureSpec(FromKind, newFromProcedure, FromKind)
+	execute.RegisterSource(FromRemoteKind, createFromSource)
+	plan.RegisterPhysicalRules(
+		FromRemoteRule{},
+		MergeRemoteRangeRule{},
+		MergeRemoteFilterRule{},
+	)
 }
 
 func createFromOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
 	spec := new(FromOpSpec)
-	if b, _, e := args.GetString("bucket"); e != nil {
-		return nil, e
+
+	if b, ok, err := getNameOrID(args, "bucket", "bucketID"); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, errors.New(codes.Invalid, "must specify only one of bucket or bucketID")
 	} else {
 		spec.Bucket = b
 	}
+
+	if o, ok, err := getNameOrID(args, "org", "orgID"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Org = &o
+	}
+
+	if h, ok, err := args.GetString("host"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Host = &h
+	}
+
+	if token, ok, err := args.GetString("token"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Token = &token
+	}
 	return spec, nil
+}
+
+func getNameOrID(args flux.Arguments, nameParam, idParam string) (NameOrID, bool, error) {
+	name, nameOk, err := args.GetString(nameParam)
+	if err != nil {
+		return NameOrID{}, false, err
+	}
+
+	id, idOk, err := args.GetString(idParam)
+	if err != nil {
+		return NameOrID{}, false, err
+	}
+
+	if nameOk && idOk {
+		return NameOrID{}, false, errors.Newf(codes.Invalid, "must specify one of %s or %s", nameParam, idParam)
+	}
+	return NameOrID{Name: name, ID: id}, nameOk || idOk, nil
 }
 
 func newFromOp() flux.OperationSpec {
@@ -46,7 +118,11 @@ func (s *FromOpSpec) Kind() flux.OperationKind {
 
 type FromProcedureSpec struct {
 	plan.DefaultCost
-	Bucket string
+
+	Org    *NameOrID
+	Bucket NameOrID
+	Host   *string
+	Token  *string
 }
 
 func newFromProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
@@ -56,7 +132,10 @@ func newFromProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.Proce
 	}
 
 	return &FromProcedureSpec{
+		Org:    spec.Org,
 		Bucket: spec.Bucket,
+		Host:   spec.Host,
+		Token:  spec.Token,
 	}, nil
 }
 
@@ -68,4 +147,349 @@ func (s *FromProcedureSpec) Copy() plan.ProcedureSpec {
 	ns := new(FromProcedureSpec)
 	*ns = *s
 	return ns
+}
+
+type FromRemoteProcedureSpec struct {
+	plan.DefaultCost
+
+	*FromProcedureSpec
+	Range           *universe.RangeProcedureSpec
+	Transformations []plan.ProcedureSpec
+}
+
+func (s *FromRemoteProcedureSpec) Kind() plan.ProcedureKind {
+	return FromRemoteKind
+}
+
+func (s *FromRemoteProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(FromRemoteProcedureSpec)
+	*ns = *s
+	ns.FromProcedureSpec = s.FromProcedureSpec.Copy().(*FromProcedureSpec)
+	if s.Range != nil {
+		ns.Range = s.Range.Copy().(*universe.RangeProcedureSpec)
+	}
+	if len(s.Transformations) > 0 {
+		// Add an extra slot for a transformation in anticipation
+		// of one being appended.
+		ns.Transformations = make([]plan.ProcedureSpec, len(s.Transformations), len(s.Transformations)+1)
+		copy(ns.Transformations, s.Transformations)
+	}
+	return ns
+}
+
+type source struct {
+	id      execute.DatasetID
+	spec    *FromRemoteProcedureSpec
+	deps    flux.Dependencies
+	mem     *memory.Allocator
+	ts      execute.TransformationSet
+	imports map[string]*ast.ImportDeclaration
+}
+
+func createFromSource(ps plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	spec := ps.(*FromRemoteProcedureSpec)
+	if spec.Range == nil {
+		return nil, errors.Newf(codes.Invalid, "bounds must be set")
+	}
+
+	// These parameters are only required for the remote influxdb
+	// source. If running flux within influxdb, these aren't
+	// required.
+	if spec.Org == nil {
+		return nil, errors.Newf(codes.Invalid, "org must be set")
+	}
+
+	deps := flux.GetDependencies(a.Context())
+	s := &source{
+		id:   id,
+		spec: spec,
+		deps: deps,
+		mem:  a.Allocator(),
+	}
+
+	if err := s.validateHost(*spec.Host); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *source) AddTransformation(t execute.Transformation) {
+	s.ts = append(s.ts, t)
+}
+
+func (s *source) Run(ctx context.Context) {
+	err := s.run(ctx)
+	s.ts.Finish(s.id, err)
+}
+
+func (s *source) run(ctx context.Context) error {
+	req, err := s.newRequest(ctx)
+	if err != nil {
+		return err
+	}
+
+	client, err := s.deps.HTTPClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	} else if resp.StatusCode != 200 {
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Newf(codes.Invalid, "error when reading response body: %s", err)
+		}
+		return s.parseError(data)
+	}
+	return s.processResults(resp.Body)
+}
+
+func (s *source) validateHost(host string) error {
+	validator, err := s.deps.URLValidator()
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(host)
+	if err != nil {
+		return err
+	}
+	return validator.Validate(u)
+}
+
+func (s *source) newRequest(ctx context.Context) (*http.Request, error) {
+	u, err := url.Parse(*s.spec.Host)
+	if err != nil {
+		return nil, err
+	}
+	u.Path += "/api/v2/query"
+	u.RawQuery = func() string {
+		params := make(url.Values)
+		if s.spec.Org.ID != "" {
+			params.Set("orgID", s.spec.Org.ID)
+		} else {
+			params.Set("org", s.spec.Org.Name)
+		}
+		return params.Encode()
+	}()
+
+	// Validate that the produced url is allowed.
+	urlv, err := s.deps.URLValidator()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := urlv.Validate(u); err != nil {
+		return nil, err
+	}
+
+	body, err := s.newRequestBody()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if s.spec.Token != nil {
+		req.Header.Set("Authorization", "Token "+*s.spec.Token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(ctx), nil
+}
+
+func (s *source) newRequestBody() ([]byte, error) {
+	var req struct {
+		AST     *ast.Package `json:"ast"`
+		Dialect struct {
+			Header         bool     `json:"header"`
+			DateTimeFormat string   `json:"dateTimeFormat"`
+			Annotations    []string `json:"annotations"`
+		} `json:"dialect"`
+	}
+	// Build the query. This needs to be done first to build
+	// up the list of imports.
+	query := s.buildQuery()
+	req.AST = &ast.Package{
+		Package: "main",
+		Files: []*ast.File{{
+			Package: &ast.PackageClause{
+				Name: &ast.Identifier{Name: "main"},
+			},
+			Imports: s.getImports(),
+			Name:    "query.flux",
+			Body: []ast.Statement{
+				&ast.ExpressionStatement{Expression: query},
+			},
+		}},
+	}
+	req.Dialect.Header = true
+	req.Dialect.DateTimeFormat = "RFC3339Nano"
+	req.Dialect.Annotations = []string{"group", "datatype", "default"}
+	return json.Marshal(req)
+}
+
+func (s *source) buildQuery() ast.Expression {
+	expr := &ast.PipeExpression{
+		Argument: &ast.CallExpression{
+			Callee:    &ast.Identifier{Name: "from"},
+			Arguments: []ast.Expression{s.fromArgs()},
+		},
+		Call: &ast.CallExpression{
+			Callee:    &ast.Identifier{Name: "range"},
+			Arguments: []ast.Expression{s.rangeArgs()},
+		},
+	}
+	for _, ps := range s.spec.Transformations {
+		expr = &ast.PipeExpression{
+			Argument: expr,
+			Call:     s.toAST(ps),
+		}
+	}
+	return expr
+}
+
+func (s *source) fromArgs() *ast.ObjectExpression {
+	var arg ast.Property
+	if s.spec.Bucket.ID != "" {
+		arg.Key = &ast.Identifier{Name: "bucketID"}
+		arg.Value = &ast.StringLiteral{Value: s.spec.Bucket.ID}
+	} else {
+		arg.Key = &ast.Identifier{Name: "bucket"}
+		arg.Value = &ast.StringLiteral{Value: s.spec.Bucket.Name}
+	}
+	return &ast.ObjectExpression{
+		Properties: []*ast.Property{&arg},
+	}
+}
+
+func (s *source) rangeArgs() *ast.ObjectExpression {
+	toLiteral := func(t flux.Time) ast.Literal {
+		if t.IsRelative {
+			// TODO(jsternberg): This seems wrong. Relative should be a values.Duration
+			// and not a time.Duration.
+			d := flux.ConvertDuration(t.Relative)
+			return &ast.DurationLiteral{Values: d.AsValues()}
+		}
+		return &ast.DateTimeLiteral{Value: t.Absolute}
+	}
+
+	args := make([]*ast.Property, 0, 2)
+	args = append(args, &ast.Property{
+		Key:   &ast.Identifier{Name: "start"},
+		Value: toLiteral(s.spec.Range.Bounds.Start),
+	})
+	if stop := s.spec.Range.Bounds.Stop; !stop.IsZero() && !(stop.IsRelative && stop.Relative == 0) {
+		args = append(args, &ast.Property{
+			Key:   &ast.Identifier{Name: "stop"},
+			Value: toLiteral(s.spec.Range.Bounds.Stop),
+		})
+	}
+	return &ast.ObjectExpression{Properties: args}
+}
+
+func (s *source) processResults(r io.ReadCloser) error {
+	defer func() { _ = r.Close() }()
+
+	config := csv.ResultDecoderConfig{Allocator: s.mem}
+	dec := csv.NewMultiResultDecoder(config)
+	results, err := dec.Decode(r)
+	if err != nil {
+		return err
+	}
+	defer results.Release()
+
+	for results.More() {
+		res := results.Next()
+		if err := res.Tables().Do(func(table flux.Table) error {
+			return s.ts.Process(s.id, table)
+		}); err != nil {
+			return err
+		}
+	}
+	results.Release()
+	return results.Err()
+}
+
+func (s *source) parseError(p []byte) error {
+	var e interface{}
+	if err := json.Unmarshal(p, &e); err != nil {
+		return err
+	}
+	return handleError(e)
+}
+
+func (s *source) toAST(spec plan.ProcedureSpec) *ast.CallExpression {
+	switch spec := spec.(type) {
+	case *universe.FilterProcedureSpec:
+		return s.filterToAST(spec)
+	default:
+		panic(fmt.Sprintf("unable to convert procedure spec of type %T to ast", spec))
+	}
+}
+
+func (s *source) filterToAST(spec *universe.FilterProcedureSpec) *ast.CallExpression {
+	// Iterate through the scope and include any imports.
+	spec.Fn.Scope.Range(func(k string, v values.Value) {
+		pkg, ok := v.(values.Package)
+		if !ok {
+			return
+		}
+
+		pkgpath := pkg.Path()
+		if pkgpath == "" {
+			return
+		}
+		s.includeImport(k, pkgpath)
+	})
+
+	fn := semantic.ToAST(spec.Fn.Fn).(ast.Expression)
+	properties := []*ast.Property{{
+		Key:   &ast.Identifier{Name: "fn"},
+		Value: fn,
+	}}
+	if spec.KeepEmptyTables {
+		properties = append(properties, &ast.Property{
+			Key:   &ast.Identifier{Name: "onEmpty"},
+			Value: &ast.StringLiteral{Value: "keep"},
+		})
+	}
+	return &ast.CallExpression{
+		Callee: &ast.Identifier{Name: "filter"},
+		Arguments: []ast.Expression{
+			&ast.ObjectExpression{Properties: properties},
+		},
+	}
+}
+
+func (s *source) includeImport(name, path string) {
+	// Look to see if we have already included an import
+	// with this name.
+	if _, ok := s.imports[name]; ok {
+		return
+	}
+
+	if s.imports == nil {
+		s.imports = make(map[string]*ast.ImportDeclaration)
+	}
+	decl := &ast.ImportDeclaration{
+		Path: &ast.StringLiteral{Value: path},
+		As:   &ast.Identifier{Name: name},
+	}
+	s.imports[name] = decl
+}
+
+func (s *source) getImports() []*ast.ImportDeclaration {
+	if len(s.imports) == 0 {
+		return nil
+	}
+
+	decls := make([]*ast.ImportDeclaration, 0, len(s.imports))
+	for _, decl := range s.imports {
+		decls = append(decls, decl)
+	}
+	return decls
 }

--- a/stdlib/influxdata/influxdb/from_internal_test.go
+++ b/stdlib/influxdata/influxdb/from_internal_test.go
@@ -1,0 +1,14 @@
+package influxdb
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/mock"
+)
+
+func CreateSource(ctx context.Context, ps *FromRemoteProcedureSpec) (execute.Source, error) {
+	id := executetest.RandomDatasetID()
+	return createFromSource(ps, id, mock.AdministrationWithContext(ctx))
+}

--- a/stdlib/influxdata/influxdb/from_test.go
+++ b/stdlib/influxdata/influxdb/from_test.go
@@ -1,31 +1,40 @@
 package influxdb_test
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/csv"
+	urldeps "github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/querytest"
+	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values"
+	"github.com/influxdata/flux/values/valuestest"
 )
 
 func TestFrom_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
 		{
-			Name: "from no args",
-			Raw:  `from()`,
-			Want: &flux.Spec{
-				Operations: []*flux.Operation{
-					{
-						ID: "from0",
-						Spec: &influxdb.FromOpSpec{
-							Bucket: "",
-						},
-					},
-				},
-			},
+			Name:    "from no args",
+			Raw:     `from()`,
+			WantErr: true,
 		},
 		{
 			Name:    "from unexpected arg",
@@ -40,7 +49,7 @@ func TestFrom_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -72,6 +81,52 @@ func TestFrom_NewQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "from with host and token",
+			Raw:  `from(bucket:"mybucket", host: "http://localhost:9999", token: "mytoken")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
+							Host:   stringPtr("http://localhost:9999"),
+							Token:  stringPtr("mytoken"),
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "from with org",
+			Raw:  `from(org: "influxdata", bucket:"mybucket")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Org:    &influxdb.NameOrID{Name: "influxdata"},
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "from with org id and bucket id",
+			Raw:  `from(orgID: "97aa81cc0e247dc4", bucketID: "1e01ac57da723035")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Org:    &influxdb.NameOrID{ID: "97aa81cc0e247dc4"},
+							Bucket: influxdb.NameOrID{ID: "1e01ac57da723035"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -81,4 +136,934 @@ func TestFrom_NewQuery(t *testing.T) {
 			querytest.NewQueryTestHelper(t, tc)
 		})
 	}
+}
+
+func TestFrom_Run(t *testing.T) {
+	type want struct {
+		params url.Values
+		ast    *ast.Package
+		tables func() []*executetest.Table
+	}
+
+	defaultTablesFn := func() []*executetest.Table {
+		return []*executetest.Table{{
+			KeyCols: []string{"_measurement", "_field"},
+			ColMeta: []flux.ColMeta{
+				{Label: "_time", Type: flux.TTime},
+				{Label: "_measurement", Type: flux.TString},
+				{Label: "_field", Type: flux.TString},
+				{Label: "_value", Type: flux.TFloat},
+			},
+			Data: [][]interface{}{
+				{execute.Time(0), "cpu", "usage_user", 2.0},
+				{execute.Time(10), "cpu", "usage_user", 8.0},
+				{execute.Time(20), "cpu", "usage_user", 5.0},
+				{execute.Time(30), "cpu", "usage_user", 9.0},
+				{execute.Time(40), "cpu", "usage_user", 3.0},
+				{execute.Time(50), "cpu", "usage_user", 1.0},
+			},
+		}}
+	}
+
+	for _, tt := range []struct {
+		name string
+		spec *influxdb.FromRemoteProcedureSpec
+		want want
+	}{
+		{
+			name: "basic query",
+			spec: &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{Name: "influxdata"},
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							IsRelative: true,
+							Relative:   -time.Minute,
+						},
+						Stop: flux.Time{
+							IsRelative: true,
+						},
+					},
+				},
+			},
+			want: want{
+				params: url.Values{
+					"org": []string{"influxdata"},
+				},
+				ast: &ast.Package{
+					Package: "main",
+					Files: []*ast.File{{
+						Name: "query.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "main"},
+						},
+						Body: []ast.Statement{
+							&ast.ExpressionStatement{
+								Expression: &ast.PipeExpression{
+									Argument: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "from"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key:   &ast.Identifier{Name: "bucket"},
+														Value: &ast.StringLiteral{Value: "telegraf"},
+													},
+												},
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "range"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key: &ast.Identifier{Name: "start"},
+														Value: &ast.DurationLiteral{Values: []ast.Duration{
+															{Magnitude: -1, Unit: "m"},
+														}},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+				tables: defaultTablesFn,
+			},
+		},
+		{
+			name: "basic query with org id and bucket id",
+			spec: &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{ID: "97aa81cc0e247dc4"},
+					Bucket: influxdb.NameOrID{ID: "1e01ac57da723035"},
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							IsRelative: true,
+							Relative:   -time.Minute,
+						},
+						Stop: flux.Time{
+							IsRelative: true,
+						},
+					},
+				},
+			},
+			want: want{
+				params: url.Values{
+					"orgID": []string{"97aa81cc0e247dc4"},
+				},
+				ast: &ast.Package{
+					Package: "main",
+					Files: []*ast.File{{
+						Name: "query.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "main"},
+						},
+						Body: []ast.Statement{
+							&ast.ExpressionStatement{
+								Expression: &ast.PipeExpression{
+									Argument: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "from"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key:   &ast.Identifier{Name: "bucketID"},
+														Value: &ast.StringLiteral{Value: "1e01ac57da723035"},
+													},
+												},
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "range"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key: &ast.Identifier{Name: "start"},
+														Value: &ast.DurationLiteral{Values: []ast.Duration{
+															{Magnitude: -1, Unit: "m"},
+														}},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+				tables: defaultTablesFn,
+			},
+		},
+		{
+			name: "basic query with absolute time range",
+			spec: &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{Name: "influxdata"},
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							Absolute: mustParseTime("2018-05-30T09:00:00Z"),
+						},
+						Stop: flux.Time{
+							Absolute: mustParseTime("2018-05-30T10:00:00Z"),
+						},
+					},
+				},
+			},
+			want: want{
+				params: url.Values{
+					"org": []string{"influxdata"},
+				},
+				ast: &ast.Package{
+					Package: "main",
+					Files: []*ast.File{{
+						Name: "query.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "main"},
+						},
+						Body: []ast.Statement{
+							&ast.ExpressionStatement{
+								Expression: &ast.PipeExpression{
+									Argument: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "from"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key:   &ast.Identifier{Name: "bucket"},
+														Value: &ast.StringLiteral{Value: "telegraf"},
+													},
+												},
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "range"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key: &ast.Identifier{Name: "start"},
+														Value: &ast.DateTimeLiteral{
+															Value: mustParseTime("2018-05-30T09:00:00Z"),
+														},
+													},
+													{
+														Key: &ast.Identifier{Name: "stop"},
+														Value: &ast.DateTimeLiteral{
+															Value: mustParseTime("2018-05-30T10:00:00Z"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+				tables: defaultTablesFn,
+			},
+		},
+		{
+			name: "filter query",
+			spec: &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{Name: "influxdata"},
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							IsRelative: true,
+							Relative:   -time.Minute,
+						},
+						Stop: flux.Time{
+							IsRelative: true,
+						},
+					},
+				},
+				Transformations: []plan.ProcedureSpec{
+					&universe.FilterProcedureSpec{
+						Fn: interpreter.ResolvedFunction{
+							Fn:    executetest.FunctionExpression(t, `(r) => r._value >= 0.0`),
+							Scope: valuestest.Scope(),
+						},
+					},
+				},
+			},
+			want: want{
+				params: url.Values{
+					"org": []string{"influxdata"},
+				},
+				ast: &ast.Package{
+					Package: "main",
+					Files: []*ast.File{{
+						Name: "query.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "main"},
+						},
+						Body: []ast.Statement{
+							&ast.ExpressionStatement{
+								Expression: &ast.PipeExpression{
+									Argument: &ast.PipeExpression{
+										Argument: &ast.CallExpression{
+											Callee: &ast.Identifier{Name: "from"},
+											Arguments: []ast.Expression{
+												&ast.ObjectExpression{
+													Properties: []*ast.Property{
+														{
+															Key:   &ast.Identifier{Name: "bucket"},
+															Value: &ast.StringLiteral{Value: "telegraf"},
+														},
+													},
+												},
+											},
+										},
+										Call: &ast.CallExpression{
+											Callee: &ast.Identifier{Name: "range"},
+											Arguments: []ast.Expression{
+												&ast.ObjectExpression{
+													Properties: []*ast.Property{
+														{
+															Key: &ast.Identifier{Name: "start"},
+															Value: &ast.DurationLiteral{Values: []ast.Duration{
+																{Magnitude: -1, Unit: "m"},
+															}},
+														},
+													},
+												},
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "filter"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key: &ast.Identifier{Name: "fn"},
+														Value: &ast.FunctionExpression{
+															Params: []*ast.Property{{
+																Key: &ast.Identifier{Name: "r"},
+															}},
+															Body: &ast.Block{
+																Body: []ast.Statement{
+																	&ast.ReturnStatement{
+																		Argument: &ast.BinaryExpression{
+																			Operator: ast.GreaterThanEqualOperator,
+																			Left: &ast.MemberExpression{
+																				Object:   &ast.Identifier{Name: "r"},
+																				Property: &ast.StringLiteral{Value: "_value"},
+																			},
+																			Right: &ast.FloatLiteral{Value: 0.0},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+				tables: defaultTablesFn,
+			},
+		},
+		{
+			name: "filter query with keep empty",
+			spec: &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{Name: "influxdata"},
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							IsRelative: true,
+							Relative:   -time.Minute,
+						},
+						Stop: flux.Time{
+							IsRelative: true,
+						},
+					},
+				},
+				Transformations: []plan.ProcedureSpec{
+					&universe.FilterProcedureSpec{
+						Fn: interpreter.ResolvedFunction{
+							Fn:    executetest.FunctionExpression(t, `(r) => r._value >= 0.0`),
+							Scope: valuestest.Scope(),
+						},
+						KeepEmptyTables: true,
+					},
+				},
+			},
+			want: want{
+				params: url.Values{
+					"org": []string{"influxdata"},
+				},
+				ast: &ast.Package{
+					Package: "main",
+					Files: []*ast.File{{
+						Name: "query.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "main"},
+						},
+						Body: []ast.Statement{
+							&ast.ExpressionStatement{
+								Expression: &ast.PipeExpression{
+									Argument: &ast.PipeExpression{
+										Argument: &ast.CallExpression{
+											Callee: &ast.Identifier{Name: "from"},
+											Arguments: []ast.Expression{
+												&ast.ObjectExpression{
+													Properties: []*ast.Property{
+														{
+															Key:   &ast.Identifier{Name: "bucket"},
+															Value: &ast.StringLiteral{Value: "telegraf"},
+														},
+													},
+												},
+											},
+										},
+										Call: &ast.CallExpression{
+											Callee: &ast.Identifier{Name: "range"},
+											Arguments: []ast.Expression{
+												&ast.ObjectExpression{
+													Properties: []*ast.Property{
+														{
+															Key: &ast.Identifier{Name: "start"},
+															Value: &ast.DurationLiteral{Values: []ast.Duration{
+																{Magnitude: -1, Unit: "m"},
+															}},
+														},
+													},
+												},
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "filter"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key: &ast.Identifier{Name: "fn"},
+														Value: &ast.FunctionExpression{
+															Params: []*ast.Property{{
+																Key: &ast.Identifier{Name: "r"},
+															}},
+															Body: &ast.Block{
+																Body: []ast.Statement{
+																	&ast.ReturnStatement{
+																		Argument: &ast.BinaryExpression{
+																			Operator: ast.GreaterThanEqualOperator,
+																			Left: &ast.MemberExpression{
+																				Object:   &ast.Identifier{Name: "r"},
+																				Property: &ast.StringLiteral{Value: "_value"},
+																			},
+																			Right: &ast.FloatLiteral{Value: 0.0},
+																		},
+																	},
+																},
+															},
+														},
+													},
+													{
+														Key:   &ast.Identifier{Name: "onEmpty"},
+														Value: &ast.StringLiteral{Value: "keep"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+				tables: defaultTablesFn,
+			},
+		},
+		{
+			name: "filter query with import",
+			spec: &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{Name: "influxdata"},
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							IsRelative: true,
+							Relative:   -time.Minute,
+						},
+						Stop: flux.Time{
+							IsRelative: true,
+						},
+					},
+				},
+				Transformations: []plan.ProcedureSpec{
+					&universe.FilterProcedureSpec{
+						Fn: interpreter.ResolvedFunction{
+							Fn: executetest.FunctionExpression(t, `
+import "math"
+(r) => r._value >= math.pi`,
+							),
+							Scope: func() values.Scope {
+								imp := runtime.StdLib()
+								// This is needed to prime the importer since universe
+								// depends on math and the anti-cyclical import detection
+								// doesn't work if you import math first.
+								_, _ = imp.ImportPackageObject("universe")
+								pkg, err := imp.ImportPackageObject("math")
+								if err != nil {
+									t.Fatal(err)
+								}
+
+								scope := values.NewScope()
+								scope.Set("math", pkg)
+								return scope
+							}(),
+						},
+						KeepEmptyTables: true,
+					},
+				},
+			},
+			want: want{
+				params: url.Values{
+					"org": []string{"influxdata"},
+				},
+				ast: &ast.Package{
+					Package: "main",
+					Files: []*ast.File{{
+						Name: "query.flux",
+						Package: &ast.PackageClause{
+							Name: &ast.Identifier{Name: "main"},
+						},
+						Imports: []*ast.ImportDeclaration{
+							{
+								Path: &ast.StringLiteral{Value: "math"},
+								As:   &ast.Identifier{Name: "math"},
+							},
+						},
+						Body: []ast.Statement{
+							&ast.ExpressionStatement{
+								Expression: &ast.PipeExpression{
+									Argument: &ast.PipeExpression{
+										Argument: &ast.CallExpression{
+											Callee: &ast.Identifier{Name: "from"},
+											Arguments: []ast.Expression{
+												&ast.ObjectExpression{
+													Properties: []*ast.Property{
+														{
+															Key:   &ast.Identifier{Name: "bucket"},
+															Value: &ast.StringLiteral{Value: "telegraf"},
+														},
+													},
+												},
+											},
+										},
+										Call: &ast.CallExpression{
+											Callee: &ast.Identifier{Name: "range"},
+											Arguments: []ast.Expression{
+												&ast.ObjectExpression{
+													Properties: []*ast.Property{
+														{
+															Key: &ast.Identifier{Name: "start"},
+															Value: &ast.DurationLiteral{Values: []ast.Duration{
+																{Magnitude: -1, Unit: "m"},
+															}},
+														},
+													},
+												},
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Callee: &ast.Identifier{Name: "filter"},
+										Arguments: []ast.Expression{
+											&ast.ObjectExpression{
+												Properties: []*ast.Property{
+													{
+														Key: &ast.Identifier{Name: "fn"},
+														Value: &ast.FunctionExpression{
+															Params: []*ast.Property{{
+																Key: &ast.Identifier{Name: "r"},
+															}},
+															Body: &ast.Block{
+																Body: []ast.Statement{
+																	&ast.ReturnStatement{
+																		Argument: &ast.BinaryExpression{
+																			Operator: ast.GreaterThanEqualOperator,
+																			Left: &ast.MemberExpression{
+																				Object:   &ast.Identifier{Name: "r"},
+																				Property: &ast.StringLiteral{Value: "_value"},
+																			},
+																			Right: &ast.MemberExpression{
+																				Object:   &ast.Identifier{Name: "math"},
+																				Property: &ast.StringLiteral{Value: "pi"},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+													{
+														Key:   &ast.Identifier{Name: "onEmpty"},
+														Value: &ast.StringLiteral{Value: "keep"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+				tables: defaultTablesFn,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if want, got := "/api/v2/query", r.URL.Path; want != got {
+					t.Errorf("unexpected query path -want/+got:\n- %q\n+ %q", want, got)
+				}
+				if want, got := tt.want.params, r.URL.Query(); !cmp.Equal(want, got) {
+					t.Errorf("unexpected query params -want/+got:\n%s", cmp.Diff(want, got))
+				}
+				if want, got := "application/json", r.Header.Get("Content-Type"); want != got {
+					t.Errorf("unexpected query content type -want/+got:\n- %q\n+ %q", want, got)
+					return
+				}
+
+				var req struct {
+					AST     *ast.Package `json:"ast"`
+					Dialect struct {
+						Header         bool     `json:"header"`
+						DateTimeFormat string   `json:"dateTimeFormat"`
+						Annotations    []string `json:"annotations"`
+					} `json:"dialect"`
+				}
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					t.Errorf("client did not send json: %s", err)
+					return
+				}
+
+				if want, got := tt.want.ast, req.AST; !cmp.Equal(want, got) {
+					t.Errorf("unexpected ast in request body -want/+got:\n%s", cmp.Diff(want, got))
+				}
+
+				w.Header().Add("Content-Type", "text/csv")
+				results := flux.NewSliceResultIterator([]flux.Result{
+					&executetest.Result{
+						Nm:   "_result",
+						Tbls: tt.want.tables(),
+					},
+				})
+				enc := csv.NewMultiResultEncoder(csv.ResultEncoderConfig{
+					Annotations: req.Dialect.Annotations,
+					NoHeader:    !req.Dialect.Header,
+					Delimiter:   ',',
+				})
+				if _, err := enc.Encode(w, results); err != nil {
+					t.Errorf("error encoding results: %s", err)
+				}
+			}))
+			defer server.Close()
+
+			spec := tt.spec.Copy().(*influxdb.FromRemoteProcedureSpec)
+			spec.Host = stringPtr(server.URL)
+
+			deps := flux.NewDefaultDependencies()
+			ctx := deps.Inject(context.Background())
+			store := executetest.NewDataStore()
+			s, err := influxdb.CreateSource(ctx, spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.AddTransformation(store)
+			s.Run(context.Background())
+
+			if err := store.Err(); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := executetest.TablesFromCache(store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			executetest.NormalizeTables(got)
+
+			want := tt.want.tables()
+			executetest.NormalizeTables(want)
+
+			if !cmp.Equal(want, got) {
+				t.Errorf("unexpected tables returned from server -want/+got:\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestFrom_Run_Errors(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		fn   func(w http.ResponseWriter)
+		want error
+	}{
+		{
+			name: "internal error",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = io.WriteString(w, `{"code":"internal error","message":"An internal error has occurred"}`)
+			},
+			want: errors.New(codes.Internal, "An internal error has occurred"),
+		},
+		{
+			name: "not found",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = io.WriteString(w, `{"code":"not found","message":"bucket not found"}`)
+			},
+			want: errors.New(codes.NotFound, "bucket not found"),
+		},
+		{
+			name: "invalid",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"code":"invalid","message":"query was invalid"}`)
+			},
+			want: errors.New(codes.Invalid, "query was invalid"),
+		},
+		{
+			name: "unavailable",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = io.WriteString(w, `{"code":"unavailable","message":"service unavailable"}`)
+			},
+			want: errors.New(codes.Unavailable, "service unavailable"),
+		},
+		{
+			name: "forbidden",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = io.WriteString(w, `{"code":"forbidden","message":"user does not have access to bucket"}`)
+			},
+			want: errors.New(codes.PermissionDenied, "user does not have access to bucket"),
+		},
+		{
+			name: "unauthorized",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = io.WriteString(w, `{"code":"unauthorized","message":"credentials required"}`)
+			},
+			want: errors.New(codes.Unauthenticated, "credentials required"),
+		},
+		{
+			name: "nested influxdb error",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"code":"invalid","message":"query was invalid","error":{"code":"not found","message":"resource not found"}}`)
+			},
+			want: errors.Wrap(
+				errors.New(codes.NotFound, "resource not found"),
+				codes.Invalid,
+				"query was invalid",
+			),
+		},
+		{
+			name: "nested internal error",
+			fn: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{"code":"invalid","message":"query was invalid","error":"internal error"}`)
+			},
+			want: errors.Wrap(
+				errors.New(codes.Unknown, "internal error"),
+				codes.Invalid,
+				"query was invalid",
+			),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tt.fn(w)
+			}))
+			defer server.Close()
+
+			spec := &influxdb.FromRemoteProcedureSpec{
+				FromProcedureSpec: &influxdb.FromProcedureSpec{
+					Org:    &influxdb.NameOrID{Name: "influxdata"},
+					Bucket: influxdb.NameOrID{Name: "telegraf"},
+					Host:   stringPtr(server.URL),
+					Token:  stringPtr("mytoken"),
+				},
+				Range: &universe.RangeProcedureSpec{
+					Bounds: flux.Bounds{
+						Start: flux.Time{
+							IsRelative: true,
+							Relative:   -time.Minute,
+						},
+						Stop: flux.Time{
+							IsRelative: true,
+						},
+					},
+				},
+			}
+
+			deps := flux.NewDefaultDependencies()
+			ctx := deps.Inject(context.Background())
+			store := executetest.NewDataStore()
+			s, err := influxdb.CreateSource(ctx, spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.AddTransformation(store)
+			s.Run(context.Background())
+
+			got := store.Err()
+			if got == nil {
+				t.Fatal("expected error")
+			}
+			want := tt.want
+
+			if !cmp.Equal(want, got) {
+				t.Errorf("unexpected error:\n%s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func TestFrom_URLValidator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("received unexpected request")
+	}))
+	defer server.Close()
+
+	spec := &influxdb.FromRemoteProcedureSpec{
+		FromProcedureSpec: &influxdb.FromProcedureSpec{
+			Org:    &influxdb.NameOrID{Name: "influxdata"},
+			Bucket: influxdb.NameOrID{Name: "telegraf"},
+			Host:   stringPtr(server.URL),
+			Token:  stringPtr("mytoken"),
+		},
+		Range: &universe.RangeProcedureSpec{
+			Bounds: flux.Bounds{
+				Start: flux.Time{
+					IsRelative: true,
+					Relative:   -time.Minute,
+				},
+				Stop: flux.Time{
+					IsRelative: true,
+				},
+			},
+		},
+	}
+
+	deps := flux.NewDefaultDependencies()
+	deps.Deps.URLValidator = urldeps.PrivateIPValidator{}
+	ctx := deps.Inject(context.Background())
+	if _, err := influxdb.CreateSource(ctx, spec); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFrom_HTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(""))
+	}))
+	defer server.Close()
+
+	spec := &influxdb.FromRemoteProcedureSpec{
+		FromProcedureSpec: &influxdb.FromProcedureSpec{
+			Org:    &influxdb.NameOrID{Name: "influxdata"},
+			Bucket: influxdb.NameOrID{Name: "telegraf"},
+			Host:   stringPtr(server.URL),
+			Token:  stringPtr("mytoken"),
+		},
+		Range: &universe.RangeProcedureSpec{
+			Bounds: flux.Bounds{
+				Start: flux.Time{
+					IsRelative: true,
+					Relative:   -time.Minute,
+				},
+				Stop: flux.Time{
+					IsRelative: true,
+				},
+			},
+		},
+	}
+
+	counter := &RequestCounter{}
+	deps := flux.NewDefaultDependencies()
+	deps.Deps.HTTPClient = &http.Client{
+		Transport: counter,
+	}
+	ctx := deps.Inject(context.Background())
+	store := executetest.NewDataStore()
+	s, err := influxdb.CreateSource(ctx, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.AddTransformation(store)
+	s.Run(context.Background())
+
+	if err := store.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if counter.Count == 0 {
+		t.Error("custom http client was not used")
+	}
+}
+
+func stringPtr(v string) *string {
+	return &v
+}
+
+func mustParseTime(v string) time.Time {
+	t, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+type RequestCounter struct {
+	Count int
+}
+
+func (r *RequestCounter) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.Count++
+	return http.DefaultTransport.RoundTrip(req)
 }

--- a/stdlib/influxdata/influxdb/rules.go
+++ b/stdlib/influxdata/influxdb/rules.go
@@ -1,0 +1,118 @@
+package influxdb
+
+import (
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/stdlib/universe"
+)
+
+type FromRemoteRule struct{}
+
+func (p FromRemoteRule) Name() string {
+	return "influxdata/influxdb.FromRemoteRule"
+}
+
+func (p FromRemoteRule) Pattern() plan.Pattern {
+	return plan.Pat(FromKind)
+}
+
+func (p FromRemoteRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+	spec := node.ProcedureSpec().(*FromProcedureSpec)
+	if spec.Host == nil {
+		return node, false, nil
+	}
+
+	return plan.CreatePhysicalNode("fromRemote", &FromRemoteProcedureSpec{
+		FromProcedureSpec: spec,
+	}), true, nil
+}
+
+type MergeRemoteRangeRule struct{}
+
+func (p MergeRemoteRangeRule) Name() string {
+	return "influxdata/influxdb.MergeRemoteRangeRule"
+}
+
+func (p MergeRemoteRangeRule) Pattern() plan.Pattern {
+	return plan.Pat(universe.RangeKind, plan.Pat(FromRemoteKind))
+}
+
+func (p MergeRemoteRangeRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+	fromNode := node.Predecessors()[0]
+	fromSpec := fromNode.ProcedureSpec().(*FromRemoteProcedureSpec)
+	if fromSpec.Range != nil {
+		return node, false, nil
+	}
+
+	rangeSpec := node.ProcedureSpec().(*universe.RangeProcedureSpec)
+	newFromSpec := fromSpec.Copy().(*FromRemoteProcedureSpec)
+	newFromSpec.Range = rangeSpec
+	n, err := plan.MergeToPhysicalNode(node, fromNode, newFromSpec)
+	if err != nil {
+		return nil, false, err
+	}
+	return n, true, nil
+}
+
+type MergeRemoteFilterRule struct{}
+
+func (p MergeRemoteFilterRule) Name() string {
+	return "influxdata/influxdb.MergeRemoteFilterRule"
+}
+
+func (p MergeRemoteFilterRule) Pattern() plan.Pattern {
+	return plan.Pat(universe.FilterKind, plan.Pat(FromRemoteKind))
+}
+
+func (p MergeRemoteFilterRule) Rewrite(node plan.Node) (plan.Node, bool, error) {
+	fromNode := node.Predecessors()[0]
+	fromSpec := fromNode.ProcedureSpec().(*FromRemoteProcedureSpec)
+	if fromSpec.Range == nil {
+		return node, false, nil
+	}
+
+	fromSpec = fromSpec.Copy().(*FromRemoteProcedureSpec)
+	fromSpec.Transformations = append(fromSpec.Transformations, node.ProcedureSpec())
+
+	n, err := plan.MergeToPhysicalNode(node, fromNode, fromSpec)
+	if err != nil {
+		return nil, false, err
+	}
+	return n, true, nil
+}
+
+// DefaultFromAttributes is used to inject default attributes
+// for the various from attributes.
+//
+// This rule is not added by default. Each process must fill
+// out the suitable defaults and add the rule on startup.
+type DefaultFromAttributes struct {
+	Org   *NameOrID
+	Host  *string
+	Token *string
+}
+
+func (d DefaultFromAttributes) Name() string {
+	return "influxdata/influxdb.DefaultFromAttributes"
+}
+
+func (d DefaultFromAttributes) Pattern() plan.Pattern {
+	return plan.Pat(FromKind)
+}
+
+func (d DefaultFromAttributes) Rewrite(n plan.Node) (plan.Node, bool, error) {
+	spec := n.ProcedureSpec().(*FromProcedureSpec)
+	changed := false
+	if spec.Org == nil && d.Org != nil {
+		spec.Org = d.Org
+		changed = true
+	}
+	if spec.Token == nil && d.Token != nil {
+		spec.Token = d.Token
+		changed = true
+	}
+	if spec.Host == nil && d.Host != nil {
+		spec.Host = d.Host
+		changed = true
+	}
+	return n, changed, nil
+}

--- a/stdlib/influxdata/influxdb/rules_test.go
+++ b/stdlib/influxdata/influxdb/rules_test.go
@@ -1,0 +1,288 @@
+package influxdb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
+	"github.com/influxdata/flux/stdlib/universe"
+	"github.com/influxdata/flux/values/valuestest"
+)
+
+func TestFromRemoteRule_WithHost(t *testing.T) {
+	fromSpec := influxdb.FromProcedureSpec{
+		Bucket: influxdb.NameOrID{Name: "telegraf"},
+		Host:   stringPtr("http://localhost:9999"),
+	}
+	rangeSpec := universe.RangeProcedureSpec{
+		Bounds: flux.Bounds{
+			Start: flux.Time{
+				IsRelative: true,
+				Relative:   -time.Minute,
+			},
+			Stop: flux.Time{
+				IsRelative: true,
+			},
+		},
+	}
+
+	tc := plantest.RuleTestCase{
+		Name: "with host",
+		Rules: []plan.Rule{
+			influxdb.FromRemoteRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("from", &fromSpec),
+				plan.CreateLogicalNode("range", &rangeSpec),
+			},
+			Edges: [][2]int{{0, 1}},
+		},
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("fromRemote", &influxdb.FromRemoteProcedureSpec{
+					FromProcedureSpec: &fromSpec,
+				}),
+				plan.CreateLogicalNode("range", &rangeSpec),
+			},
+			Edges: [][2]int{{0, 1}},
+		},
+	}
+	plantest.PhysicalRuleTestHelper(t, &tc)
+}
+
+func TestFromRemoteRule_WithoutHost(t *testing.T) {
+	fromSpec := influxdb.FromProcedureSpec{
+		Bucket: influxdb.NameOrID{Name: "telegraf"},
+	}
+	rangeSpec := universe.RangeProcedureSpec{
+		Bounds: flux.Bounds{
+			Start: flux.Time{
+				IsRelative: true,
+				Relative:   -time.Minute,
+			},
+			Stop: flux.Time{
+				IsRelative: true,
+			},
+		},
+	}
+
+	tc := plantest.RuleTestCase{
+		Name: "without host",
+		Rules: []plan.Rule{
+			influxdb.FromRemoteRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("from", &fromSpec),
+				plan.CreateLogicalNode("range", &rangeSpec),
+			},
+			Edges: [][2]int{{0, 1}},
+		},
+		After: &plantest.PlanSpec{
+			// No host means no change.
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("from", &fromSpec),
+				plan.CreateLogicalNode("range", &rangeSpec),
+			},
+			Edges: [][2]int{{0, 1}},
+		},
+	}
+	plantest.PhysicalRuleTestHelper(t, &tc)
+}
+
+func TestMergeRemoteRangeRule(t *testing.T) {
+	fromSpec := influxdb.FromProcedureSpec{
+		Bucket: influxdb.NameOrID{Name: "telegraf"},
+		Host:   stringPtr("http://localhost:9999"),
+	}
+	rangeSpec := universe.RangeProcedureSpec{
+		Bounds: flux.Bounds{
+			Start: flux.Time{
+				IsRelative: true,
+				Relative:   -time.Minute,
+			},
+			Stop: flux.Time{
+				IsRelative: true,
+			},
+		},
+	}
+
+	tc := plantest.RuleTestCase{
+		Name: "MergeRemoteRange",
+		Rules: []plan.Rule{
+			influxdb.FromRemoteRule{},
+			influxdb.MergeRemoteRangeRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("from", &fromSpec),
+				plan.CreateLogicalNode("range", &rangeSpec),
+			},
+			Edges: [][2]int{{0, 1}},
+		},
+		After: &plantest.PlanSpec{
+			// No host means no change.
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("merged_fromRemote_range", &influxdb.FromRemoteProcedureSpec{
+					FromProcedureSpec: &fromSpec,
+					Range:             &rangeSpec,
+				}),
+			},
+		},
+	}
+	plantest.PhysicalRuleTestHelper(t, &tc)
+}
+
+func TestMergeRemoteFilterRule(t *testing.T) {
+	fromSpec := influxdb.FromProcedureSpec{
+		Bucket: influxdb.NameOrID{Name: "telegraf"},
+		Host:   stringPtr("http://localhost:9999"),
+	}
+	rangeSpec := universe.RangeProcedureSpec{
+		Bounds: flux.Bounds{
+			Start: flux.Time{
+				IsRelative: true,
+				Relative:   -time.Minute,
+			},
+			Stop: flux.Time{
+				IsRelative: true,
+			},
+		},
+	}
+	filterSpec := universe.FilterProcedureSpec{
+		Fn: interpreter.ResolvedFunction{
+			Fn:    executetest.FunctionExpression(t, `(r) => r._value > 0.0`),
+			Scope: valuestest.Scope(),
+		},
+	}
+
+	tc := plantest.RuleTestCase{
+		Name: "MergeRemoteRange",
+		Rules: []plan.Rule{
+			influxdb.FromRemoteRule{},
+			influxdb.MergeRemoteRangeRule{},
+			influxdb.MergeRemoteFilterRule{},
+		},
+		Before: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreateLogicalNode("from", &fromSpec),
+				plan.CreateLogicalNode("range", &rangeSpec),
+				plan.CreateLogicalNode("filter", &filterSpec),
+			},
+			Edges: [][2]int{
+				{0, 1},
+				{1, 2},
+			},
+		},
+		After: &plantest.PlanSpec{
+			Nodes: []plan.Node{
+				plan.CreatePhysicalNode("merged_fromRemote_range_filter", &influxdb.FromRemoteProcedureSpec{
+					FromProcedureSpec: &fromSpec,
+					Range:             &rangeSpec,
+					Transformations: []plan.ProcedureSpec{
+						&filterSpec,
+					},
+				}),
+			},
+		},
+	}
+	plantest.PhysicalRuleTestHelper(t, &tc)
+}
+
+func TestDefaultFromAttributes(t *testing.T) {
+	for _, tc := range []plantest.RuleTestCase{
+		{
+			Name: "all defaults",
+			Rules: []plan.Rule{
+				influxdb.DefaultFromAttributes{
+					Org:   &influxdb.NameOrID{Name: "influxdata"},
+					Host:  stringPtr("http://localhost:9999"),
+					Token: stringPtr("mytoken"),
+				},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &influxdb.FromProcedureSpec{
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+					}),
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &influxdb.FromProcedureSpec{
+						Org:    &influxdb.NameOrID{Name: "influxdata"},
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+						Host:   stringPtr("http://localhost:9999"),
+						Token:  stringPtr("mytoken"),
+					}),
+				},
+			},
+		},
+		{
+			Name: "no defaults",
+			Rules: []plan.Rule{
+				influxdb.DefaultFromAttributes{
+					Org:   &influxdb.NameOrID{Name: "influxdata"},
+					Host:  stringPtr("http://localhost:9999"),
+					Token: stringPtr("mytoken"),
+				},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &influxdb.FromProcedureSpec{
+						Org:    &influxdb.NameOrID{Name: "alternate_org"},
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+						Host:   stringPtr("http://mysupersecretserver:9999"),
+						Token:  stringPtr("differenttoken"),
+					}),
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &influxdb.FromProcedureSpec{
+						Org:    &influxdb.NameOrID{Name: "alternate_org"},
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+						Host:   stringPtr("http://mysupersecretserver:9999"),
+						Token:  stringPtr("differenttoken"),
+					}),
+				},
+			},
+		},
+		{
+			Name: "with remote from",
+			Rules: []plan.Rule{
+				influxdb.FromRemoteRule{},
+				influxdb.DefaultFromAttributes{
+					Host: stringPtr("http://localhost:9999"),
+				},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreateLogicalNode("from", &influxdb.FromProcedureSpec{
+						Bucket: influxdb.NameOrID{Name: "telegraf"},
+					}),
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("fromRemote", &influxdb.FromRemoteProcedureSpec{
+						FromProcedureSpec: &influxdb.FromProcedureSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+							Host:   stringPtr("http://localhost:9999"),
+						},
+					}),
+				},
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}

--- a/stdlib/kafka/to_test.go
+++ b/stdlib/kafka/to_test.go
@@ -32,14 +32,14 @@ func TestToKafka_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
 						ID: "toKafka1",
 						Spec: &fkafka.ToKafkaOpSpec{
 							Brokers:      []string{"brokerurl:8989"},
-							Topic:        "totallynotfaketopic", //Balancer: &kafka.Hash{},
+							Topic:        "totallynotfaketopic", // Balancer: &kafka.Hash{},
 							Name:         "series1",
 							TimeColumn:   execute.DefaultTimeColLabel,
 							ValueColumns: []string{execute.DefaultValueColLabel},
@@ -428,23 +428,21 @@ func TestToKafka_Process(t *testing.T) {
 				},
 			},
 			want: wanted{
-				Table: []*executetest.Table{
-					&executetest.Table{
-						ColMeta: []flux.ColMeta{
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: "fred", Type: flux.TString},
-						},
-						Data: [][]interface{}{
-							{execute.Time(11), 2.0, "one"},
-							{execute.Time(21), 1.0, "seven"},
-							{execute.Time(31), 3.0, "nine"},
-							{execute.Time(51), 2.0, "one"},
-							{execute.Time(61), 1.0, "seven"},
-							{execute.Time(71), 3.0, "nine"},
-						},
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "fred", Type: flux.TString},
 					},
-				},
+					Data: [][]interface{}{
+						{execute.Time(11), 2.0, "one"},
+						{execute.Time(21), 1.0, "seven"},
+						{execute.Time(31), 3.0, "nine"},
+						{execute.Time(51), 2.0, "one"},
+						{execute.Time(61), 1.0, "seven"},
+						{execute.Time(71), 3.0, "nine"},
+					},
+				}},
 				Result: [][]kafka.Message{{
 					{Value: []byte("multi_block,fred=one _value=2 11"), Key: []byte{0x41, 0x9d, 0x7f, 0x17, 0xc8, 0x21, 0xfb, 0x69}},
 					{Value: []byte("multi_block,fred=seven _value=1 21"), Key: []byte{0x8f, 0x83, 0x72, 0x66, 0x7b, 0x78, 0x77, 0x18}},
@@ -496,23 +494,21 @@ func TestToKafka_Process(t *testing.T) {
 				},
 			},
 			want: wanted{
-				Table: []*executetest.Table{
-					&executetest.Table{
-						ColMeta: []flux.ColMeta{
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: "fred", Type: flux.TString},
-						},
-						Data: [][]interface{}{
-							{execute.Time(11), 2.0, "one"},
-							{execute.Time(21), 1.0, "seven"},
-							{execute.Time(31), 3.0, "nine"},
-							{execute.Time(51), 2.0, "one"},
-							{execute.Time(61), 1.0, "seven"},
-							{execute.Time(71), 3.0, "nine"},
-						},
+				Table: []*executetest.Table{{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "fred", Type: flux.TString},
 					},
-				},
+					Data: [][]interface{}{
+						{execute.Time(11), 2.0, "one"},
+						{execute.Time(21), 1.0, "seven"},
+						{execute.Time(31), 3.0, "nine"},
+						{execute.Time(51), 2.0, "one"},
+						{execute.Time(61), 1.0, "seven"},
+						{execute.Time(71), 3.0, "nine"},
+					},
+				}},
 				Result: [][]kafka.Message{{
 					{Value: []byte("multi_collist_blocks,fred=one _value=2 11"), Key: []byte{0xfc, 0xab, 0xa3, 0x68, 0x81, 0x48, 0x7d, 0x8a}},
 					{Value: []byte("multi_collist_blocks,fred=seven _value=1 21"), Key: []byte{0x9f, 0xe1, 0x82, 0x97, 0x49, 0x92, 0x56, 0x1a}},

--- a/stdlib/sql/to_test.go
+++ b/stdlib/sql/to_test.go
@@ -30,7 +30,7 @@ func TestSqlTo(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -377,7 +377,7 @@ func TestSqlite3To(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/columns_test.go
+++ b/stdlib/universe/columns_test.go
@@ -22,7 +22,7 @@ func TestColumns_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{
@@ -59,7 +59,7 @@ func TestColumns_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{

--- a/stdlib/universe/count_test.go
+++ b/stdlib/universe/count_test.go
@@ -25,7 +25,7 @@ func TestCount_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{

--- a/stdlib/universe/covariance_test.go
+++ b/stdlib/universe/covariance_test.go
@@ -27,7 +27,7 @@ func TestCovariance_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -51,7 +51,7 @@ func TestCovariance_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -76,13 +76,13 @@ func TestCovariance_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
 						ID: "from1",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/fill_test.go
+++ b/stdlib/universe/fill_test.go
@@ -77,7 +77,7 @@ func TestFill_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -32,7 +32,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -93,7 +93,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -150,7 +150,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -207,7 +207,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -264,7 +264,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -317,7 +317,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -348,7 +348,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -374,7 +374,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -401,7 +401,7 @@ func TestFilter_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/group_test.go
+++ b/stdlib/universe/group_test.go
@@ -40,8 +40,10 @@ func TestGroup_NewQuery(t *testing.T) {
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
-						ID:   "from0",
-						Spec: &influxdb.FromOpSpec{Bucket: "telegraf"},
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+						},
 					},
 					{
 						ID: "range1",
@@ -73,8 +75,10 @@ func TestGroup_NewQuery(t *testing.T) {
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
-						ID:   "from0",
-						Spec: &influxdb.FromOpSpec{Bucket: "telegraf"},
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+						},
 					},
 					{
 						ID: "range1",
@@ -106,8 +110,10 @@ func TestGroup_NewQuery(t *testing.T) {
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
-						ID:   "from0",
-						Spec: &influxdb.FromOpSpec{Bucket: "telegraf"},
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+						},
 					},
 					{
 						ID: "range1",
@@ -139,8 +145,10 @@ func TestGroup_NewQuery(t *testing.T) {
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
-						ID:   "from0",
-						Spec: &influxdb.FromOpSpec{Bucket: "telegraf"},
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+						},
 					},
 					{
 						ID: "range1",
@@ -175,8 +183,10 @@ func TestGroup_NewQuery(t *testing.T) {
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
-						ID:   "from0",
-						Spec: &influxdb.FromOpSpec{Bucket: "telegraf"},
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "telegraf"},
+						},
 					},
 					{
 						ID: "range1",

--- a/stdlib/universe/holt_winters_test.go
+++ b/stdlib/universe/holt_winters_test.go
@@ -23,7 +23,7 @@ func TestHoltWinters_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{
@@ -65,7 +65,7 @@ func TestHoltWinters_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{

--- a/stdlib/universe/join_test.go
+++ b/stdlib/universe/join_test.go
@@ -29,7 +29,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "dbA",
+							Bucket: influxdb.NameOrID{Name: "dbA"},
 						},
 					},
 					{
@@ -50,7 +50,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from2",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "dbB",
+							Bucket: influxdb.NameOrID{Name: "dbB"},
 						},
 					},
 					{
@@ -97,7 +97,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "flux",
+							Bucket: influxdb.NameOrID{Name: "flux"},
 						},
 					},
 					{
@@ -118,7 +118,7 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "from2",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "flux",
+							Bucket: influxdb.NameOrID{Name: "flux"},
 						},
 					},
 					{

--- a/stdlib/universe/keys_test.go
+++ b/stdlib/universe/keys_test.go
@@ -22,7 +22,7 @@ func TestKeys_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{
@@ -59,7 +59,7 @@ func TestKeys_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -28,7 +28,7 @@ func TestMap_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -54,7 +54,7 @@ func TestMap_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -81,7 +81,7 @@ func TestMap_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/pivot_test.go
+++ b/stdlib/universe/pivot_test.go
@@ -25,7 +25,7 @@ func TestPivot_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
+							Bucket: influxdb.NameOrID{Name: "testdb"},
 						},
 					},
 					{

--- a/stdlib/universe/quantile_test.go
+++ b/stdlib/universe/quantile_test.go
@@ -25,7 +25,7 @@ func TestQuantile_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
+							Bucket: influxdb.NameOrID{Name: "testdb"},
 						},
 					},
 					{
@@ -67,7 +67,7 @@ func TestQuantile_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
+							Bucket: influxdb.NameOrID{Name: "testdb"},
 						},
 					},
 					{
@@ -108,7 +108,7 @@ func TestQuantile_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
+							Bucket: influxdb.NameOrID{Name: "testdb"},
 						},
 					},
 					{
@@ -149,7 +149,7 @@ func TestQuantile_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
+							Bucket: influxdb.NameOrID{Name: "testdb"},
 						},
 					},
 					{
@@ -192,7 +192,7 @@ func TestQuantile_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "testdb",
+							Bucket: influxdb.NameOrID{Name: "testdb"},
 						},
 					},
 					{

--- a/stdlib/universe/range_test.go
+++ b/stdlib/universe/range_test.go
@@ -25,7 +25,7 @@ func TestRange_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/schema_functions_test.go
+++ b/stdlib/universe/schema_functions_test.go
@@ -27,7 +27,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -59,7 +59,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -89,7 +89,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -119,7 +119,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -150,7 +150,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -183,7 +183,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{
@@ -216,7 +216,7 @@ func TestSchemaMutions_NewQueries(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -28,7 +28,7 @@ func TestStateTracking_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{
@@ -77,7 +77,7 @@ func TestStateTracking_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mydb",
+							Bucket: influxdb.NameOrID{Name: "mydb"},
 						},
 					},
 					{

--- a/stdlib/universe/union_test.go
+++ b/stdlib/universe/union_test.go
@@ -25,8 +25,10 @@ func TestUnion_NewQuery(t *testing.T) {
 				union(tables: [a, b])`,
 			Want: &flux.Spec{Operations: []*flux.Operation{
 				{
-					ID:   "from0",
-					Spec: &influxdb.FromOpSpec{Bucket: "dbA"},
+					ID: "from0",
+					Spec: &influxdb.FromOpSpec{
+						Bucket: influxdb.NameOrID{Name: "dbA"},
+					},
 				},
 				{
 					ID: "range1",
@@ -44,8 +46,10 @@ func TestUnion_NewQuery(t *testing.T) {
 					},
 				},
 				{
-					ID:   "from2",
-					Spec: &influxdb.FromOpSpec{Bucket: "dbB"},
+					ID: "from2",
+					Spec: &influxdb.FromOpSpec{
+						Bucket: influxdb.NameOrID{Name: "dbB"},
+					},
 				},
 				{
 					ID: "range3",
@@ -84,8 +88,10 @@ func TestUnion_NewQuery(t *testing.T) {
 				union(tables: [a, b, c])`,
 			Want: &flux.Spec{Operations: []*flux.Operation{
 				{
-					ID:   "from0",
-					Spec: &influxdb.FromOpSpec{Bucket: "dbA"},
+					ID: "from0",
+					Spec: &influxdb.FromOpSpec{
+						Bucket: influxdb.NameOrID{Name: "dbA"},
+					},
 				},
 				{
 					ID: "range1",
@@ -103,8 +109,10 @@ func TestUnion_NewQuery(t *testing.T) {
 					},
 				},
 				{
-					ID:   "from2",
-					Spec: &influxdb.FromOpSpec{Bucket: "dbB"},
+					ID: "from2",
+					Spec: &influxdb.FromOpSpec{
+						Bucket: influxdb.NameOrID{Name: "dbB"},
+					},
 				},
 				{
 					ID: "range3",
@@ -122,8 +130,10 @@ func TestUnion_NewQuery(t *testing.T) {
 					},
 				},
 				{
-					ID:   "from4",
-					Spec: &influxdb.FromOpSpec{Bucket: "dbC"},
+					ID: "from4",
+					Spec: &influxdb.FromOpSpec{
+						Bucket: influxdb.NameOrID{Name: "dbC"},
+					},
 				},
 				{
 					ID: "range5",

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -28,7 +28,7 @@ func TestWindow_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "mybucket",
+							Bucket: influxdb.NameOrID{Name: "mybucket"},
 						},
 					},
 					{

--- a/stdlib/universe/yield_test.go
+++ b/stdlib/universe/yield_test.go
@@ -24,7 +24,7 @@ func TestYield_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "foo",
+							Bucket: influxdb.NameOrID{Name: "foo"},
 						},
 					},
 					{
@@ -51,7 +51,7 @@ func TestYield_NewQuery(t *testing.T) {
 					{
 						ID: "from3",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "foo",
+							Bucket: influxdb.NameOrID{Name: "foo"},
 						},
 					},
 					{
@@ -110,7 +110,7 @@ func TestYield_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "foo",
+							Bucket: influxdb.NameOrID{Name: "foo"},
 						},
 					},
 					{
@@ -157,7 +157,7 @@ func TestYield_NewQuery(t *testing.T) {
 					{
 						ID: "from0",
 						Spec: &influxdb.FromOpSpec{
-							Bucket: "foo",
+							Bucket: influxdb.NameOrID{Name: "foo"},
 						},
 					},
 					{

--- a/values/package.go
+++ b/values/package.go
@@ -2,7 +2,12 @@ package values
 
 type Package interface {
 	Object
+
+	// Name returns the package name.
 	Name() string
+
+	// Path returns the canonical import path for this package.
+	Path() string
 }
 
 // SetOption will set an option on the package and return


### PR DESCRIPTION
The influxdb source will recognize the `from |> range` pattern and it
will convert it to an AST and serialize that to a remote influxdb v2
server.

If a `filter` is included afterwards, it will be converted back to AST
and be included in the influxdb from call.

Fixes #2470.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written