### PR TITLE
fix(ast): properly categorize parse errors as "invalid"

### DIFF
--- a/ast/errors.go
+++ b/ast/errors.go
@@ -94,7 +94,8 @@ func GetErrors(n Node) (errs []error) {
 	Walk(CreateVisitor(func(node Node) {
 		if nerrs := node.Errs(); len(nerrs) > 0 {
 			for _, err := range nerrs {
-				errs = append(errs, errors.Wrapf(err, codes.Inherit, "loc %v", node.Location()))
+				// Errors in the AST are a result of invalid Flux, so the error code should be codes.Invalid.
+				errs = append(errs, errors.Wrapf(err, codes.Invalid, "loc %v", node.Location()))
 			}
 		}
 	}), n)

--- a/ast/errors_test.go
+++ b/ast/errors_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 func TestPrintErrors(t *testing.T) {
@@ -46,5 +48,10 @@ func TestPrintErrors(t *testing.T) {
 error:2:7: invalid statement: &
 `; want != got {
 		t.Errorf("unexpected output -want/+got\n\t- %q\n\t+ %q", want, got)
+	}
+
+	theErr := ast.GetError(file)
+	if got, want := errors.Code(theErr), codes.Invalid; got != want {
+		t.Errorf("wanted error code: %q, got %q", want.String(), got.String())
 	}
 }


### PR DESCRIPTION
Errors in the AST are represented as a simple wrapper around a `string` and have no code.  When we return errors to callers, we wrap them in our `errors.Error` struct with `code.Inherit`.  But since the underlying error has no code, we defaulted to `codes.Internal` for errors in the AST.  This change just forces the code to be `codes.Invalid`, since errors in the AST result from parse errors in invalid Flux source code.