### PR TITLE
refactor(stdlib): improve the post physical validation error messages for the influxdb source

### DIFF
--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -31,6 +31,12 @@ import (
 
 func init() {
 	execute.RegisterSource(influxdb.FromKind, mock.CreateMockFromSource)
+	plan.RegisterLogicalRules(
+		influxdb.DefaultFromAttributes{
+			Org:  &influxdb.NameOrID{Name: "influxdata"},
+			Host: func(v string) *string { return &v }("http://localhost:9999"),
+		},
+	)
 }
 
 func TestFluxCompiler(t *testing.T) {
@@ -45,7 +51,7 @@ func TestFluxCompiler(t *testing.T) {
 	}{
 		{
 			name: "simple",
-			q:    `from(bucket: "foo")`,
+			q:    `from(bucket: "foo") |> range(start: -5m)`,
 		},
 		{
 			name: "syntax error",
@@ -59,12 +65,12 @@ func TestFluxCompiler(t *testing.T) {
 		},
 		{
 			name: "from with no streaming data",
-			q:    `x = from(bucket: "foo")`,
+			q:    `x = from(bucket: "foo") |> range(start: -5m)`,
 			err:  "no streaming data",
 		},
 		{
 			name: "from with yield",
-			q:    `x = from(bucket: "foo") |> yield()`,
+			q:    `x = from(bucket: "foo") |> range(start: -5m) |> yield()`,
 		},
 		{
 			name: "extern",
@@ -80,7 +86,7 @@ func TestFluxCompiler(t *testing.T) {
 			},
 			q: `twentySeven = twentySix + 1
 				twentySeven
-				from(bucket: "foo")`,
+				from(bucket: "foo") |> range(start: -5m)`,
 		},
 		{
 			name: "extern with error",
@@ -96,13 +102,13 @@ func TestFluxCompiler(t *testing.T) {
 			},
 			q: `twentySeven = twentyFive + 2
 				twentySeven
-				from(bucket: "foo")`,
+				from(bucket: "foo") |> range(start: -5m)`,
 			err: "undeclared variable twentyFive",
 		},
 		{
 			name: "with now",
 			now:  time.Unix(1000, 0),
-			q:    `from(bucket: "foo")`,
+			q:    `from(bucket: "foo") |> range(start: -5m)`,
 		},
 	} {
 		tc := tc
@@ -362,8 +368,6 @@ func TestCompileOptions_FromFluxOptions(t *testing.T) {
 	nowFn := func() time.Time {
 		return parser.MustParseTime("2018-10-10T00:00:00Z").Value
 	}
-
-	plan.RegisterPhysicalRules(&plantest.MergeFromRangePhysicalRule{})
 	plan.RegisterLogicalRules(&removeCount{})
 
 	tcs := []struct {
@@ -380,55 +384,50 @@ import "planner"
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
 		},
 		{
-			name: "remove push down range",
+			name: "remove push down filter",
 			files: []string{`
 import "planner"
 
-option planner.disablePhysicalRules = ["fromRangeRule"]
+option planner.disablePhysicalRules = ["influxdata/influxdb.MergeRemoteFilterRule"]
 
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
 					{1, 2},
-					{2, 3},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
 		},
 		{
-			name: "remove push down range and count",
+			name: "remove push down filter and count",
 			files: []string{`
 import "planner"
 
-option planner.disablePhysicalRules = ["fromRangeRule"]
+option planner.disablePhysicalRules = ["influxdata/influxdb.MergeRemoteFilterRule"]
 option planner.disableLogicalRules = ["removeCountRule"]
 
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
@@ -437,25 +436,23 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 					{0, 1},
 					{1, 2},
 					{2, 3},
-					{3, 4},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
 		},
 		{
-			name: "remove push down range and count - with non existent rule",
+			name: "remove push down filter and count - with non existent rule",
 			files: []string{`
 import "planner"
 
-option planner.disablePhysicalRules = ["fromRangeRule", "non_existent"]
+option planner.disablePhysicalRules = ["influxdata/influxdb.MergeRemoteFilterRule", "non_existent"]
 option planner.disableLogicalRules = ["removeCountRule", "non_existent"]
 
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
@@ -464,7 +461,6 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 					{0, 1},
 					{1, 2},
 					{2, 3},
-					{3, 4},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -481,13 +477,11 @@ option planner.disableLogicalRules = ["foo", "bar", "mew", "buz", "foxtrot"]
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -504,13 +498,11 @@ option planner.disableLogicalRules = [""]
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -572,13 +564,11 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 			// This shouldn't change the plan.
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -589,14 +579,13 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 			files: []string{`
 import pl "planner"
 
-option pl.disablePhysicalRules = ["fromRangeRule"]
+option pl.disablePhysicalRules = ["influxdata/influxdb.MergeRemoteFilterRule"]
 option pl.disableLogicalRules = ["removeCountRule"]
 
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
@@ -605,7 +594,6 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 					{0, 1},
 					{1, 2},
 					{2, 3},
-					{3, 4},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -617,7 +605,7 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 				`package main
 import pl "planner"
 
-option pl.disablePhysicalRules = ["fromRangeRule"]
+option pl.disablePhysicalRules = ["influxdata/influxdb.MergeRemoteFilterRule"]
 
 from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> count()`,
 				`package foo
@@ -626,8 +614,7 @@ import "planner"
 option planner.disableLogicalRules = ["removeCountRule"]`},
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
-					&plan.PhysicalPlanNode{Spec: &influxdb.FromProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
+					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
@@ -636,7 +623,6 @@ option planner.disableLogicalRules = ["removeCountRule"]`},
 					{0, 1},
 					{1, 2},
 					{2, 3},
-					{3, 4},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -54,7 +54,9 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 
 	var (
 		fromSpec = &influxdb.FromProcedureSpec{
+			Org:    &influxdb.NameOrID{Name: "influxdata"},
 			Bucket: influxdb.NameOrID{Name: "my-bucket"},
+			Host:   func(v string) *string { return &v }("http://localhost:9999"),
 		}
 		rangeSpec = &universe.RangeProcedureSpec{
 			Bounds: flux.Bounds{

--- a/plan/rules_test.go
+++ b/plan/rules_test.go
@@ -10,7 +10,17 @@ import (
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 )
+
+func init() {
+	plan.RegisterLogicalRules(
+		influxdb.DefaultFromAttributes{
+			Org:  &influxdb.NameOrID{Name: "influxdata"},
+			Host: func(v string) *string { return &v }("http://localhost:9999"),
+		},
+	)
+}
 
 func TestRuleRegistration(t *testing.T) {
 	simpleRule := plantest.SimpleRule{}
@@ -43,8 +53,6 @@ func TestRuleRegistration(t *testing.T) {
 	// Test rule registration for the physical plan too.
 	simpleRule.SeenNodes = simpleRule.SeenNodes[0:0]
 	plan.RegisterPhysicalRules(&simpleRule)
-	// register a rule that merges from and range
-	plan.RegisterPhysicalRules(&plantest.MergeFromRangePhysicalRule{})
 
 	physicalPlanner := plan.NewPhysicalPlanner()
 	_, err = physicalPlanner.Plan(logicalPlanSpec)


### PR DESCRIPTION
The error messages for the influxdb source have been improved to give
better hints about what to do when rules cannot be rewritten to the
proper physical forms for whatever reason.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written