### PR TITLE
test(stdlib): unskip usage tests

### DIFF
--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -50,9 +50,7 @@ var skip = map[string]map[string]string{
 		"partition_strings_splitN":       "pandas. map does not correctly handled returned arrays (https://github.com/influxdata/flux/issues/1387)",
 	},
 	"testing/usage": {
-		"api":     "todo(algow): stalls",
-		"storage": "todo(algow): stalls",
-		"writes":  "todo(algow): stalls",
+		"storage": "overwriting field in map with different type (https://github.com/influxdata/flux/issues/2570)",
 	},
 }
 


### PR DESCRIPTION
These tests used to hang but are no longer. One test (storage) was
kept skipped as it is failing now with another error (map type error).


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
