### PR TITLE
fix(stdlib): influxdb source would serialize the wrong sign duration literal

### DIFF
--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -395,12 +395,21 @@ func (s *source) fromArgs() *ast.ObjectExpression {
 }
 
 func (s *source) rangeArgs() *ast.ObjectExpression {
-	toLiteral := func(t flux.Time) ast.Literal {
+	toLiteral := func(t flux.Time) ast.Expression {
 		if t.IsRelative {
 			// TODO(jsternberg): This seems wrong. Relative should be a values.Duration
 			// and not a time.Duration.
 			d := flux.ConvertDuration(t.Relative)
-			return &ast.DurationLiteral{Values: d.AsValues()}
+			var expr ast.Expression = &ast.DurationLiteral{
+				Values: d.AsValues(),
+			}
+			if d.IsNegative() {
+				expr = &ast.UnaryExpression{
+					Operator: ast.SubtractionOperator,
+					Argument: expr,
+				}
+			}
+			return expr
 		}
 		return &ast.DateTimeLiteral{Value: t.Absolute}
 	}

--- a/stdlib/influxdata/influxdb/from_test.go
+++ b/stdlib/influxdata/influxdb/from_test.go
@@ -224,9 +224,12 @@ func TestFrom_Run(t *testing.T) {
 												Properties: []*ast.Property{
 													{
 														Key: &ast.Identifier{Name: "start"},
-														Value: &ast.DurationLiteral{Values: []ast.Duration{
-															{Magnitude: -1, Unit: "m"},
-														}},
+														Value: &ast.UnaryExpression{
+															Operator: ast.SubtractionOperator,
+															Argument: &ast.DurationLiteral{Values: []ast.Duration{
+																{Magnitude: 1, Unit: "m"},
+															}},
+														},
 													},
 												},
 											},
@@ -294,9 +297,12 @@ func TestFrom_Run(t *testing.T) {
 												Properties: []*ast.Property{
 													{
 														Key: &ast.Identifier{Name: "start"},
-														Value: &ast.DurationLiteral{Values: []ast.Duration{
-															{Magnitude: -1, Unit: "m"},
-														}},
+														Value: &ast.UnaryExpression{
+															Operator: ast.SubtractionOperator,
+															Argument: &ast.DurationLiteral{Values: []ast.Duration{
+																{Magnitude: 1, Unit: "m"},
+															}},
+														},
 													},
 												},
 											},
@@ -448,9 +454,12 @@ func TestFrom_Run(t *testing.T) {
 													Properties: []*ast.Property{
 														{
 															Key: &ast.Identifier{Name: "start"},
-															Value: &ast.DurationLiteral{Values: []ast.Duration{
-																{Magnitude: -1, Unit: "m"},
-															}},
+															Value: &ast.UnaryExpression{
+																Operator: ast.SubtractionOperator,
+																Argument: &ast.DurationLiteral{Values: []ast.Duration{
+																	{Magnitude: 1, Unit: "m"},
+																}},
+															},
 														},
 													},
 												},
@@ -560,9 +569,12 @@ func TestFrom_Run(t *testing.T) {
 													Properties: []*ast.Property{
 														{
 															Key: &ast.Identifier{Name: "start"},
-															Value: &ast.DurationLiteral{Values: []ast.Duration{
-																{Magnitude: -1, Unit: "m"},
-															}},
+															Value: &ast.UnaryExpression{
+																Operator: ast.SubtractionOperator,
+																Argument: &ast.DurationLiteral{Values: []ast.Duration{
+																	{Magnitude: 1, Unit: "m"},
+																}},
+															},
 														},
 													},
 												},
@@ -699,9 +711,12 @@ import "math"
 													Properties: []*ast.Property{
 														{
 															Key: &ast.Identifier{Name: "start"},
-															Value: &ast.DurationLiteral{Values: []ast.Duration{
-																{Magnitude: -1, Unit: "m"},
-															}},
+															Value: &ast.UnaryExpression{
+																Operator: ast.SubtractionOperator,
+																Argument: &ast.DurationLiteral{Values: []ast.Duration{
+																	{Magnitude: 1, Unit: "m"},
+																}},
+															},
 														},
 													},
 												},

--- a/values/time.go
+++ b/values/time.go
@@ -229,27 +229,23 @@ func (d Duration) Duration() time.Duration {
 }
 
 // AsValues will reconstruct the duration as a set of values.
+// All of the components will be positive numbers.
 func (d Duration) AsValues() []ast.Duration {
 	if d.IsZero() {
 		return nil
-	}
-
-	scale := int64(1)
-	if d.negative {
-		scale = -1
 	}
 
 	var values []ast.Duration
 	if d.months > 0 {
 		if years := d.months / 12; years > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: years * scale,
+				Magnitude: years,
 				Unit:      ast.YearUnit,
 			})
 		}
 		if months := d.months % 12; months > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: months * scale,
+				Magnitude: months,
 				Unit:      ast.MonthUnit,
 			})
 		}
@@ -274,49 +270,49 @@ func (d Duration) AsValues() []ast.Duration {
 
 		if weeks > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: weeks * scale,
+				Magnitude: weeks,
 				Unit:      ast.WeekUnit,
 			})
 		}
 		if days > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: days * scale,
+				Magnitude: days,
 				Unit:      ast.DayUnit,
 			})
 		}
 		if hours > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: hours * scale,
+				Magnitude: hours,
 				Unit:      ast.HourUnit,
 			})
 		}
 		if mins > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: mins * scale,
+				Magnitude: mins,
 				Unit:      ast.MinuteUnit,
 			})
 		}
 		if secs > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: secs * scale,
+				Magnitude: secs,
 				Unit:      ast.SecondUnit,
 			})
 		}
 		if msecs > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: msecs * scale,
+				Magnitude: msecs,
 				Unit:      ast.MillisecondUnit,
 			})
 		}
 		if usecs > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: usecs * scale,
+				Magnitude: usecs,
 				Unit:      ast.MicrosecondUnit,
 			})
 		}
 		if nsecs > 0 {
 			values = append(values, ast.Duration{
-				Magnitude: nsecs * scale,
+				Magnitude: nsecs,
 				Unit:      ast.NanosecondUnit,
 			})
 		}
@@ -339,15 +335,11 @@ func (d Duration) String() string {
 		buf = buf[:0]
 	}
 	var sb strings.Builder
-	if values[0].Magnitude < 0 {
+	if d.IsNegative() {
 		sb.WriteByte('-')
 	}
 	for _, v := range values {
-		mag := v.Magnitude
-		if mag < 0 {
-			mag = -mag
-		}
-		writeInt(&sb, mag, v.Unit)
+		writeInt(&sb, v.Magnitude, v.Unit)
 	}
 	return sb.String()
 }


### PR DESCRIPTION
The duration literal `AsValues()` function was confusing. It would
write the values as negative magnitudes, but there was another portion
of code that would then use the unary negative operator on those values
when resolving times.

Instead of confusingly serializing negative magnitudes, which isn't done
by the parser, the `AsValues()` method has been changed to only use
positive magnitudes and the sections of code that turn that into a
literal have been changed to use the unary negative operator.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written