### PR TITLE
fix: don't construct a compiler.compilerScope with a nil value.Scope

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -1161,3 +1161,9 @@ func TestCompileAndEval(t *testing.T) {
 		})
 	}
 }
+
+func TestToScopeNil(t *testing.T) {
+	if compiler.ToScope(nil) != nil {
+		t.Fatal("ToScope made non-nil scope from a nil base")
+	}
+}

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -93,6 +93,9 @@ func NewScope() Scope {
 	return ToScope(values.NewScope())
 }
 func ToScope(s values.Scope) Scope {
+	if s == nil {
+		return nil
+	}
 	return compilerScope{s}
 }
 

--- a/execute/row_fn_test.go
+++ b/execute/row_fn_test.go
@@ -263,7 +263,7 @@ func TestRowMapFn_Eval(t *testing.T) {
 	}
 }
 
-func TestRowPredicateFn_EvalRow(t *testing.T) {
+func testRowPredicateFn_EvalRow(t *testing.T, scope compiler.Scope) {
 	gt2F := func() (*execute.RowPredicateFn, error) {
 		return execute.NewRowPredicateFn(&semantic.FunctionExpression{
 			Block: &semantic.FunctionBlock{
@@ -279,7 +279,7 @@ func TestRowPredicateFn_EvalRow(t *testing.T) {
 					Right: &semantic.FloatLiteral{Value: 2.0},
 				},
 			},
-		}, prelude())
+		}, scope)
 	}
 
 	testCases := []struct {
@@ -370,4 +370,9 @@ func TestRowPredicateFn_EvalRow(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRowPredicateFn_EvalRow(t *testing.T) {
+	testRowPredicateFn_EvalRow(t, prelude())
+	testRowPredicateFn_EvalRow(t, compiler.ToScope(nil))
 }

--- a/stdlib/universe/table_fns_test.go
+++ b/stdlib/universe/table_fns_test.go
@@ -139,7 +139,7 @@ func TestTableFind_Call(t *testing.T) {
 		want flux.Table
 		fn   string
 		// fn      func(key values.Object) (values.Value, error)
-		wantErr error
+		wantErr      error
 		omitExecDeps bool
 	}{
 		{
@@ -168,9 +168,9 @@ func TestTableFind_Call(t *testing.T) {
 			fn:      `f = (key) => key.user == "no-user"`,
 		},
 		{
-			name: "no execution context", // notifying the user of no-execution context
-			wantErr: fmt.Errorf("do not have an execution context for tableFind, if using the repl, try executing this code on the server using the InfluxDB API"),
-			fn:   `f = (key) => key.user == "user1" and key._measurement == "CPU"`,
+			name:         "no execution context", // notifying the user of no-execution context
+			wantErr:      fmt.Errorf("do not have an execution context for tableFind, if using the repl, try executing this code on the server using the InfluxDB API"),
+			fn:           `f = (key) => key.user == "user1" and key._measurement == "CPU"`,
 			omitExecDeps: true,
 		},
 	}


### PR DESCRIPTION
In the case of the influx query command, it is possible for a nil scope to be
present in the Spec. In this case the system attempts to build a
compiler.compilerScope using a nil value.Scope as the embedded anonymous field,
resulting in an eventual panic when passed to interface methods that use it as
the receiver object.

Instead return nil when attempting to use nil as the base scope,
indicating there is no scope. The function evaluation copes with with this and
creates an empty scope if none is present.

refs influxdata/influxdb#17062