### PR TITLE
fix: remove algow todos

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -14,8 +14,6 @@ func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) 
 	if in.Nature() != semantic.Object {
 		return nil, errors.Newf(codes.Invalid, "function input must be an object @ %v", f.Location())
 	}
-	// TODO (algow): how do externs work now?
-	//extern := values.BuildExternAssignments(f, scope)
 
 	// Retrieve the function argument types and create an object type from them.
 	fnType := f.TypeOf()
@@ -181,7 +179,7 @@ func substituteTypes(subst map[uint64]semantic.MonoType, inType, in semantic.Mon
 		}
 		return nil
 	case semantic.Fun:
-		// TODO(algow): Support passing functions to compiled functions.
+		// TODO: https://github.com/influxdata/flux/issues/2587
 		return errors.New(codes.Unimplemented)
 	default:
 		return errors.Newf(codes.Internal, "unknown semantic kind: %s", inType)

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -30,34 +30,20 @@ type compiledFn struct {
 	inputScope Scope
 }
 
-func (c compiledFn) validate(input values.Object) error {
-	// TODO (algow): update to use new types
-	//sig := c.fnType.FunctionSignature()
-	//properties := input.Type().Properties()
-	//if len(properties) != len(sig.Parameters) {
-	//	return errors.New(codes.Invalid, "mismatched parameters and properties")
-	//}
-	//for k, v := range sig.Parameters {
-	//	if !values.AssignableTo(properties[k], v) {
-	//		return errors.Newf(codes.Invalid, "parameter %q has the wrong type, expected %v got %v", k, v, properties[k])
-	//	}
-	//}
-	return nil
-}
-
 func (c compiledFn) buildScope(input values.Object) error {
-	if err := c.validate(input); err != nil {
-		return err
-	}
 	input.Range(func(k string, v values.Value) {
 		c.inputScope.Set(k, v)
 	})
 	return nil
 }
 
+// Type returns the return type of the compiled function.
+// Will panic if assigned type is not a function type.
 func (c compiledFn) Type() semantic.MonoType {
-	// TODO (algow): validate we have a function type
-	rt, _ := c.fnType.ReturnType()
+	rt, err := c.fnType.ReturnType()
+	if err != nil {
+		panic(err)
+	}
 	return rt
 }
 

--- a/execute/row_fn_test.go
+++ b/execute/row_fn_test.go
@@ -157,13 +157,10 @@ func TestRowMapFn_Eval(t *testing.T) {
 				for i := 0; i < cr.Len(); i++ {
 					obj, err := f.Eval(ctx, i, cr)
 					if err != nil {
-						// TODO(algow): determine correct type
-						got = append(got, nil)
-					} else {
-						got = append(got, obj)
+						return err
 					}
+					got = append(got, obj)
 				}
-
 				return nil
 			}); err != nil {
 				t.Fatal(err)

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -42,10 +42,6 @@ type SideEffect struct {
 
 // Eval evaluates the expressions composing a Flux package and returns any side effects that occurred during this evaluation.
 func (itrp *Interpreter) Eval(ctx context.Context, node semantic.Node, scope values.Scope, importer Importer) ([]SideEffect, error) {
-	// TODO (algow): how does this change?
-	//n := values.BuildExternAssignments(node, scope)
-
-	// reset side effect list
 	itrp.sideEffects = itrp.sideEffects[:0]
 	if err := itrp.doRoot(ctx, node, scope, importer); err != nil {
 		return nil, err
@@ -332,17 +328,6 @@ func (itrp *Interpreter) doExpression(ctx context.Context, expr semantic.Express
 			return nil, err
 		}
 
-		// TODO (algow): validate that indeed type inference fixes this
-		// TODO(jsternberg): This next section needs to be removed
-		// since type inference should give the correct type.
-		//if ltyp == semantic.Nil && l.Type().Nature() != semantic.Nil {
-		//	// There's a weird bug in type inference where it
-		//	// determines the type is null even when it's not.
-		//	ltyp = l.Type()
-		//}
-		//if rtyp == semantic.Nil && r.Type().Nature() != semantic.Nil {
-		//	rtyp = r.Type()
-		//}
 		bf, err := values.LookupBinaryFunction(values.BinaryFuncSignature{
 			Operator: e.Operator,
 			Left:     l.Type().Nature(),

--- a/interpreter/package_test.go
+++ b/interpreter/package_test.go
@@ -38,7 +38,6 @@ func (imp *importer) ImportPackageObject(path string) (*interpreter.Package, err
 }
 
 func TestAccessNestedImport(t *testing.T) {
-	// TODO(algow): unskip when issue is complete
 	t.Skip("Handle imports for user-defined packages https://github.com/influxdata/flux/issues/2343")
 	// package a
 	// x = 0
@@ -386,7 +385,6 @@ func TestInterpreter_MutateOption(t *testing.T) {
 }
 
 func TestInterpreter_SetQualifiedOption(t *testing.T) {
-	// TODO(algow): unskip when issue is complete
 	t.Skip("Handle imports for user-defined packages https://github.com/influxdata/flux/issues/2343")
 	externalPackage := interpreter.NewPackage("alert")
 	values.SetOption(externalPackage, "state", values.NewString("Warning"))

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -438,7 +438,6 @@ func getRules(plannerPkg values.Object, optionName string) ([]string, error) {
 	rules := value.Array()
 	et, err := rules.Type().ElemType()
 	if err != nil {
-		//TODO (algow): correctly wrap error
 		return nil, err
 	}
 	if et.Nature() != semantic.String {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -88,23 +88,6 @@ func Example_option() {
 	// Output:
 }
 
-// TODO(algow): This method doesn't work since you cannot set new options from outside of the package.
-// Example_setOption demonstrates setting an option value on a scope object
-// func Example_setOption() {
-//
-// 	// Import the universe package.
-// 	importer := flux.StdLib()
-// 	universe, _ := importer.ImportPackageObject("universe")
-//
-// 	// Create a new option binding
-// 	universe.Set("dummy_option", values.NewInt(3))
-//
-// 	v, _ := universe.Lookup("dummy_option")
-//
-// 	fmt.Printf("dummy_option = %d", v.Int())
-// 	// Output: dummy_option = 3
-// }
-
 // Example_overrideDefaultOptionExternally demonstrates how declaring an option
 // in a Flux script will change that option's binding globally.
 func Example_overrideDefaultOptionExternally() {
@@ -125,42 +108,3 @@ func Example_overrideDefaultOptionExternally() {
 	fmt.Printf("The new current time (UTC) is: %v", now)
 	// Output: The new current time (UTC) is: 2018-07-13T00:00:00.000000000Z
 }
-
-// Example_overrideDefaultOptionInternally demonstrates how one can override a default
-// option that is used in a query before that query is evaluated by the interpreter.
-// func Example_overrideDefaultOptionInternally() {
-// 	queryString := `what_time_is_it = now()`
-//
-// 	ctx := dependenciestest.Default().Inject(context.Background())
-//
-// 	importer := flux.StdLib()
-// 	universe, _ := importer.ImportPackageObject("universe")
-//
-// 	// Define a new now function which returns a static time value of 2018-07-13T00:00:00.000000000Z
-// 	timeValue := time.Date(2018, 7, 13, 0, 0, 0, 0, time.UTC)
-// 	functionName := "newTime"
-// 	// TODO (algow): determine correct type
-// 	functionType := semantic.NewFunctionType(semantic.MonoType{}, nil)
-// 	functionCall := func(ctx context.Context, args values.Object) (values.Value, error) {
-// 		return values.NewTime(values.ConvertTime(timeValue)), nil
-// 	}
-// 	sideEffect := false
-//
-// 	newNowFunc := values.NewFunction(functionName, functionType, functionCall, sideEffect)
-//
-// 	// Override the default now function with the new one
-//  values.SetOption(universe, "now", newNowFunc)
-//
-// 	// Evaluate package
-// 	_, err := itrp.Eval(ctx, semPkg, universe, nil)
-// 	if err != nil {
-// 		fmt.Println(err)
-// 	}
-//
-// 	// After evaluating the package, lookup the value of what_time_is_it
-// 	now, _ := universe.Lookup("what_time_is_it")
-//
-// 	// what_time_is_it? Why it's ....
-// 	fmt.Printf("The new current time (UTC) is: %v", now)
-// 	// Output: The new current time (UTC) is: 2018-07-13T00:00:00.000000000Z
-// }

--- a/values/function.go
+++ b/values/function.go
@@ -15,9 +15,12 @@ type Function interface {
 	Call(ctx context.Context, args Object) (Value, error)
 }
 
-// NewFunction returns a new function value
+// NewFunction returns a new function value.
+// This function will panic if it is passed anything other than a function type.
 func NewFunction(name string, typ semantic.MonoType, call func(ctx context.Context, args Object) (Value, error), sideEffect bool) *function {
-	// TODO (algow): error if type is not a function type
+	if typ.Kind() != semantic.Fun {
+		panic("expected function type, but instead got " + typ.String())
+	}
 	return &function{
 		name:          name,
 		t:             typ,

--- a/values/values.go
+++ b/values/values.go
@@ -142,7 +142,6 @@ func (v value) String() string {
 
 var (
 	// InvalidValue is a non nil value who's type is semantic.Invalid
-	// TODO (algow): create a invalid monotype
 	InvalidValue = value{}
 
 	// Null is an untyped nil value.


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

This PR fixes the remaining algow TODOs and removes the ones that are no longer relevant. Non-blocking TODOs (such as user-defined packages and binary operator constraints) still remain with their issues linked.

Closes https://github.com/influxdata/flux/issues/2586.