### PR TITLE
feat: storing comments in the AST and preserving on format

### DIFF
--- a/libflux/src/flux/ast/check/tests.rs
+++ b/libflux/src/flux/ast/check/tests.rs
@@ -57,6 +57,7 @@ fn test_check_collect_existing_error() {
                 source: Some(String::from("a = 1\nb=2\nc=a+b")),
             },
             errors: vec![String::from("error 1")],
+            ..BaseNode::default()
         },
         name: String::from("test_check_collect_existing_error"),
         metadata: String::new(),
@@ -70,7 +71,7 @@ fn test_check_collect_existing_error() {
                     end: Position { line: 1, column: 6 },
                     source: Some(String::from("a = 1")),
                 },
-                errors: vec![],
+                ..BaseNode::default()
             },
             id: Identifier {
                 base: BaseNode {
@@ -80,7 +81,7 @@ fn test_check_collect_existing_error() {
                         end: Position { line: 1, column: 2 },
                         source: Some(String::from("a")),
                     },
-                    errors: vec![],
+                    ..BaseNode::default()
                 },
                 name: String::from("a"),
             },
@@ -93,10 +94,12 @@ fn test_check_collect_existing_error() {
                         source: Some(String::from("1")),
                     },
                     errors: vec![String::from("error 2"), String::from("error 3")],
+                    ..BaseNode::default()
                 },
                 value: 1,
             }),
         }))],
+        eof: None,
     };
     let got = check(walk::Node::File(&file));
     assert_eq!(3, got.len());

--- a/libflux/src/flux/ast/flatbuffers/tests.rs
+++ b/libflux/src/flux/ast/flatbuffers/tests.rs
@@ -492,7 +492,7 @@ fn compare_exprs(
                 }
                 let fb_we = &fb_elems.get(i);
                 let fb_e = &fb_we.expr();
-                compare_exprs(&ast_ae.elements[i], fb_we.expr_type(), fb_e)?;
+                compare_exprs(&ast_ae.elements[i].expression, fb_we.expr_type(), fb_e)?;
                 i = i + 1
             }
         }
@@ -532,7 +532,7 @@ fn compare_exprs(
             let fb_oe = fbast::ObjectExpression::init_from_table(*fb_tbl);
             compare_base(&ast_oe.base, &fb_oe.base_node())?;
             compare_property_list(&ast_oe.properties, &fb_oe.properties())?;
-            compare_opt_ids(&ast_oe.with, &fb_oe.with())
+            compare_with_ids(&ast_oe.with, &fb_oe.with())
         }
         (ast::Expression::Member(ast_me), fbast::Expression::MemberExpression) => {
             let fb_me = fbast::MemberExpression::init_from_table(*fb_tbl);
@@ -818,6 +818,18 @@ fn compare_ids(ast_id: &ast::Identifier, fb_id: &Option<fbast::Identifier>) -> R
     compare_base(&ast_id.base, &fb_id.base_node())?;
     compare_strings("id", &ast_id.name, &fb_id.name())?;
     Ok(())
+}
+
+fn compare_with_ids(
+    ast_id: &Option<ast::WithSource>,
+    fb_id: &Option<fbast::Identifier>,
+) -> Result<(), String> {
+    match (ast_id, fb_id) {
+        (None, None) => Ok(()),
+        (Some(_), None) => Err(String::from("compare opt ids, ast had one, fb did not")),
+        (None, Some(_)) => Err(String::from("compare opt ids, ast had none, fb did")),
+        (Some(ast_id), fb_id) => compare_ids(&ast_id.source, fb_id),
+    }
 }
 
 fn compare_opt_ids(

--- a/libflux/src/flux/ast/tests.rs
+++ b/libflux/src/flux/ast/tests.rs
@@ -71,6 +71,7 @@ fn test_string_interpolation() {
 fn test_paren_expression() {
     let n = Expression::Paren(Box::new(ParenExpr {
         base: BaseNode::default(),
+        lparen: None,
         expression: Expression::StringExpr(Box::new(StringExpr {
             base: BaseNode::default(),
             parts: vec![
@@ -87,6 +88,7 @@ fn test_paren_expression() {
                 }),
             ],
         })),
+        rparen: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -168,13 +170,14 @@ fn test_json_simple_file() {
         imports: Vec::new(),
         name: String::new(),
         metadata: String::new(),
-        body: vec![Statement::Expr(ExprStmt {
+        body: vec![Statement::Expr(Box::new(ExprStmt {
             base: BaseNode::default(),
             expression: Expression::StringLit(StringLit {
                 base: Default::default(),
                 value: "hello".to_string(),
             }),
-        })],
+        }))],
+        eof: None,
     };
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -228,13 +231,14 @@ fn test_json_file() {
         }],
         name: String::new(),
         metadata: String::from("parser-type=none"),
-        body: vec![Statement::Expr(ExprStmt {
+        body: vec![Statement::Expr(Box::new(ExprStmt {
             base: BaseNode::default(),
             expression: Expression::StringLit(StringLit {
                 base: Default::default(),
                 value: "hello".to_string(),
             }),
-        })],
+        }))],
+        eof: None,
     };
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -261,13 +265,15 @@ fn test_json_file() {
 fn test_json_block() {
     let n = Block {
         base: BaseNode::default(),
-        body: vec![Statement::Expr(ExprStmt {
+        lbrace: None,
+        body: vec![Statement::Expr(Box::new(ExprStmt {
             base: BaseNode::default(),
             expression: Expression::StringLit(StringLit {
                 base: Default::default(),
                 value: "hello".to_string(),
             }),
-        })],
+        }))],
+        rbrace: None,
     };
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -288,13 +294,13 @@ fn test_json_block() {
 */
 #[test]
 fn test_json_expression_statement() {
-    let n = Statement::Expr(ExprStmt {
+    let n = Statement::Expr(Box::new(ExprStmt {
         base: BaseNode::default(),
         expression: Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         }),
-    });
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
@@ -314,13 +320,13 @@ fn test_json_expression_statement() {
 */
 #[test]
 fn test_json_return_statement() {
-    let n = Statement::Return(ReturnStmt {
+    let n = Statement::Return(Box::new(ReturnStmt {
         base: BaseNode::default(),
         argument: Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         }),
-    });
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
@@ -371,6 +377,7 @@ fn test_json_option_statement() {
             },
             init: Expression::Object(Box::new(ObjectExpr {
                 base: BaseNode::default(),
+                lbrace: None,
                 with: None,
                 properties: vec![
                     Property {
@@ -379,10 +386,12 @@ fn test_json_option_statement() {
                             base: BaseNode::default(),
                             name: "name".to_string(),
                         }),
+                        separator: None,
                         value: Some(Expression::StringLit(StringLit {
                             base: Default::default(),
                             value: "foo".to_string(),
                         })),
+                        comma: None,
                     },
                     Property {
                         base: BaseNode::default(),
@@ -390,6 +399,7 @@ fn test_json_option_statement() {
                             base: BaseNode::default(),
                             name: "every".to_string(),
                         }),
+                        separator: None,
                         value: Some(Expression::Duration(DurationLit {
                             base: Default::default(),
                             values: vec![Duration {
@@ -397,8 +407,10 @@ fn test_json_option_statement() {
                                 unit: "h".to_string(),
                             }],
                         })),
+                        comma: None,
                     },
                 ],
+                rbrace: None,
             })),
         })),
     }));
@@ -421,13 +433,13 @@ fn test_json_option_statement() {
 */
 #[test]
 fn test_json_builtin_statement() {
-    let n = Statement::Builtin(BuiltinStmt {
+    let n = Statement::Builtin(Box::new(BuiltinStmt {
         base: BaseNode::default(),
         id: Identifier {
             base: BaseNode::default(),
             name: "task".to_string(),
         },
-    });
+    }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
         serialized,
@@ -479,6 +491,7 @@ fn test_json_test_statement() {
             },
             init: Expression::Object(Box::new(ObjectExpr {
                 base: BaseNode::default(),
+                lbrace: None,
                 with: None,
                 properties: vec![
                     Property {
@@ -487,10 +500,12 @@ fn test_json_test_statement() {
                             base: BaseNode::default(),
                             name: "want".to_string(),
                         }),
+                        separator: None,
                         value: Some(Expression::Integer(IntegerLit {
                             base: Default::default(),
                             value: 0,
                         })),
+                        comma: None,
                     },
                     Property {
                         base: BaseNode::default(),
@@ -498,12 +513,15 @@ fn test_json_test_statement() {
                             base: BaseNode::default(),
                             name: "got".to_string(),
                         }),
+                        separator: None,
                         value: Some(Expression::Integer(IntegerLit {
                             base: Default::default(),
                             value: 0,
                         })),
+                        comma: None,
                     },
                 ],
+                rbrace: None,
             })),
         },
     }));
@@ -548,10 +566,12 @@ fn test_json_qualified_option_statement() {
                     base: BaseNode::default(),
                     name: "alert".to_string(),
                 }),
+                lbrack: None,
                 property: PropertyKey::Identifier(Identifier {
                     base: BaseNode::default(),
                     name: "state".to_string(),
                 }),
+                rbrack: None,
             },
             init: Expression::StringLit(StringLit {
                 base: Default::default(),
@@ -616,10 +636,12 @@ fn test_json_call_expression() {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
+        lparen: None,
         arguments: vec![Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         })],
+        rparen: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -647,7 +669,9 @@ fn test_json_call_expression_empty_arguments() {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
+        lparen: None,
         arguments: vec![],
+        rparen: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -684,10 +708,12 @@ fn test_json_pipe_expression() {
                 base: BaseNode::default(),
                 name: "a".to_string(),
             }),
+            lparen: None,
             arguments: vec![Expression::StringLit(StringLit {
                 base: BaseNode::default(),
                 value: "hello".to_string(),
             })],
+            rparen: None,
         },
     }));
     let serialized = serde_json::to_string(&n).unwrap();
@@ -716,10 +742,12 @@ fn test_json_member_expression_with_identifier() {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
+        lbrack: None,
         property: PropertyKey::Identifier(Identifier {
             base: BaseNode::default(),
             name: "b".to_string(),
         }),
+        rbrack: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -747,10 +775,12 @@ fn test_json_member_expression_with_string_literal() {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
+        lbrack: None,
         property: PropertyKey::StringLit(StringLit {
             base: BaseNode::default(),
             value: "b".to_string(),
         }),
+        rbrack: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -778,10 +808,12 @@ fn test_json_index_expression() {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
+        lbrack: None,
         index: Expression::Integer(IntegerLit {
             base: BaseNode::default(),
             value: 3,
         }),
+        rbrack: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -805,14 +837,19 @@ fn test_json_index_expression() {
 fn test_json_arrow_function_expression() {
     let n = Expression::Function(Box::new(FunctionExpr {
         base: BaseNode::default(),
+        lparen: None,
         params: vec![Property {
             base: BaseNode::default(),
             key: PropertyKey::Identifier(Identifier {
                 base: BaseNode::default(),
                 name: "a".to_string(),
             }),
+            separator: None,
             value: None,
+            comma: None,
         }],
+        rparen: None,
+        arrow: None,
         body: FunctionBody::Expr(Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
@@ -933,10 +970,15 @@ fn test_json_logical_expression() {
 fn test_json_array_expression() {
     let n = Expression::Array(Box::new(ArrayExpr {
         base: BaseNode::default(),
-        elements: vec![Expression::StringLit(StringLit {
-            base: BaseNode::default(),
-            value: "hello".to_string(),
-        })],
+        lbrack: None,
+        elements: vec![ArrayItem {
+            expression: Expression::StringLit(StringLit {
+                base: BaseNode::default(),
+                value: "hello".to_string(),
+            }),
+            comma: None,
+        }],
+        rbrack: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -962,6 +1004,7 @@ fn test_json_array_expression() {
 fn test_json_object_expression() {
     let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
+        lbrace: None,
         with: None,
         properties: vec![Property {
             base: BaseNode::default(),
@@ -969,11 +1012,14 @@ fn test_json_object_expression() {
                 base: BaseNode::default(),
                 name: "a".to_string(),
             }),
+            separator: None,
             value: Some(Expression::StringLit(StringLit {
                 base: BaseNode::default(),
                 value: "hello".to_string(),
             })),
+            comma: None,
         }],
+        rbrace: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -999,6 +1045,7 @@ fn test_json_object_expression() {
 fn test_json_object_expression_with_string_literal_key() {
     let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
+        lbrace: None,
         with: None,
         properties: vec![Property {
             base: BaseNode::default(),
@@ -1006,11 +1053,14 @@ fn test_json_object_expression_with_string_literal_key() {
                 base: BaseNode::default(),
                 value: "a".to_string(),
             }),
+            separator: None,
             value: Some(Expression::StringLit(StringLit {
                 base: BaseNode::default(),
                 value: "hello".to_string(),
             })),
+            comma: None,
         }],
+        rbrace: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -1035,6 +1085,7 @@ fn test_json_object_expression_with_string_literal_key() {
 fn test_json_object_expression_implicit_keys() {
     let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
+        lbrace: None,
         with: None,
         properties: vec![Property {
             base: BaseNode::default(),
@@ -1042,8 +1093,11 @@ fn test_json_object_expression_implicit_keys() {
                 base: BaseNode::default(),
                 name: "a".to_string(),
             }),
+            separator: None,
             value: None,
+            comma: None,
         }],
+        rbrace: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -1058,9 +1112,13 @@ fn test_json_object_expression_implicit_keys() {
 fn test_json_object_expression_implicit_keys_and_with() {
     let n = Expression::Object(Box::new(ObjectExpr {
         base: BaseNode::default(),
-        with: Some(Identifier {
-            base: BaseNode::default(),
-            name: "a".to_string(),
+        lbrace: None,
+        with: Some(WithSource {
+            source: Identifier {
+                base: BaseNode::default(),
+                name: "a".to_string(),
+            },
+            with: None,
         }),
         properties: vec![Property {
             base: BaseNode::default(),
@@ -1068,8 +1126,11 @@ fn test_json_object_expression_implicit_keys_and_with() {
                 base: BaseNode::default(),
                 name: "a".to_string(),
             }),
+            separator: None,
             value: None,
+            comma: None,
         }],
+        rbrace: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -1094,14 +1155,17 @@ fn test_json_object_expression_implicit_keys_and_with() {
 fn test_json_conditional_expression() {
     let n = Expression::Conditional(Box::new(ConditionalExpr {
         base: BaseNode::default(),
+        tk_if: None,
         test: Expression::Boolean(BooleanLit {
             base: BaseNode::default(),
             value: true,
         }),
+        tk_then: None,
         alternate: Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "false".to_string(),
         }),
+        tk_else: None,
         consequent: Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "true".to_string(),
@@ -1133,10 +1197,12 @@ fn test_json_property() {
             base: BaseNode::default(),
             name: "a".to_string(),
         }),
+        separator: None,
         value: Some(Expression::StringLit(StringLit {
             base: BaseNode::default(),
             value: "hello".to_string(),
         })),
+        comma: None,
     };
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(
@@ -1375,8 +1441,9 @@ fn test_object_expression_with_source_locations_and_errors() {
                 },
                 source: Some("{a: \"hello\"}".to_string()),
             },
-            errors: vec![],
+            ..BaseNode::default()
         },
+        lbrace: None,
         with: None,
         properties: vec![Property {
             base: BaseNode {
@@ -1390,6 +1457,7 @@ fn test_object_expression_with_source_locations_and_errors() {
                     source: Some("a: \"hello\"".to_string()),
                 },
                 errors: vec!["an error".to_string()],
+                ..BaseNode::default()
             },
             key: PropertyKey::Identifier(Identifier {
                 base: BaseNode {
@@ -1399,10 +1467,11 @@ fn test_object_expression_with_source_locations_and_errors() {
                         end: Position { line: 1, column: 3 },
                         source: Some("a".to_string()),
                     },
-                    errors: vec![],
+                    ..BaseNode::default()
                 },
                 name: "a".to_string(),
             }),
+            separator: None,
             value: Some(Expression::StringLit(StringLit {
                 base: BaseNode {
                     location: SourceLocation {
@@ -1415,10 +1484,13 @@ fn test_object_expression_with_source_locations_and_errors() {
                         source: Some("\"hello\"".to_string()),
                     },
                     errors: vec!["an error".to_string(), "another error".to_string()],
+                    ..BaseNode::default()
                 },
                 value: "hello".to_string(),
             })),
+            comma: None,
         }],
+        rbrace: None,
     }));
     let serialized = serde_json::to_string(&n).unwrap();
     assert_eq!(

--- a/libflux/src/flux/ast/walk/mod.rs
+++ b/libflux/src/flux/ast/walk/mod.rs
@@ -295,7 +295,7 @@ where
             Node::Identifier(_) => {}
             Node::ArrayExpr(n) => {
                 for element in n.elements.iter() {
-                    walk(&w, Node::from_expr(&element));
+                    walk(&w, Node::from_expr(&element.expression));
                 }
             }
             Node::FunctionExpr(n) => {
@@ -309,8 +309,8 @@ where
                 walk(&w, Node::from_expr(&n.right));
             }
             Node::ObjectExpr(n) => {
-                if let Some(i) = &n.with {
-                    walk(&w, Node::Identifier(i));
+                if let Some(ws) = &n.with {
+                    walk(&w, Node::Identifier(&ws.source));
                 }
                 for prop in n.properties.iter() {
                     walk(&w, Node::Property(&prop));

--- a/libflux/src/flux/formatter/mod.rs
+++ b/libflux/src/flux/formatter/mod.rs
@@ -31,6 +31,8 @@ pub fn format(contents: String) -> Result<String, String> {
 pub struct Formatter {
     builder: String,
     indentation: u32,
+    clear: bool,
+    temp_indent: bool,
     err: Option<Error>,
 }
 
@@ -39,6 +41,8 @@ impl Default for Formatter {
         Formatter {
             builder: String::new(),
             indentation: 0,
+            clear: true,
+            temp_indent: false,
             err: None,
         }
     }
@@ -54,12 +58,26 @@ impl Formatter {
         Ok(self.builder.clone())
     }
 
+    // Do not use to send newline. This is not (yet) setting clear
+    // appropriately.
     fn write_string(&mut self, s: &str) {
+        self.clear = false;
         (&mut self.builder).push_str(s);
     }
+
     fn write_rune(&mut self, c: char) {
+        if c == '\n' {
+            self.clear = true;
+            if self.temp_indent {
+                self.temp_indent = false;
+                self.unindent();
+            }
+        } else if c != '\t' && c != ' ' {
+            self.clear = false;
+        }
         (&mut self.builder).push(c);
     }
+
     fn write_indent(&mut self) {
         for _ in 0..self.indentation {
             self.write_rune('\t')
@@ -75,6 +93,22 @@ impl Formatter {
 
     fn set_indent(&mut self, i: u32) {
         self.indentation = i;
+        self.temp_indent = false;
+    }
+
+    fn format_comments(&mut self, mut comment: &ast::CommentList) {
+        while let Some(boxed) = comment {
+            if !self.clear {
+                self.write_rune('\n');
+                self.temp_indent = true;
+                self.indent();
+                self.write_indent();
+            }
+            self.write_string((*boxed).lit.as_str());
+            self.clear = true;
+            self.write_indent();
+            comment = &(*boxed).next;
+        }
     }
 
     fn write_comment(&mut self, comment: &str) {
@@ -121,6 +155,13 @@ impl Formatter {
             self.write_indent();
             self.format_node(&Node::from_stmt(n.body.get(i).unwrap()));
             prev = cur;
+        }
+
+        if n.eof.is_some() {
+            self.write_rune(sep);
+            self.set_indent(0);
+            self.clear = true;
+            self.format_comments(&n.eof);
         }
     }
 
@@ -197,12 +238,14 @@ impl Formatter {
     fn format_property(&mut self, n: &ast::Property) {
         self.format_property_key(&n.key);
         if let Some(v) = &n.value {
+            self.format_comments(&n.separator);
             self.write_string(": ");
             self.format_node(&Node::from_expr(&v));
         }
     }
 
     fn format_function_expression(&mut self, n: &ast::FunctionExpr) {
+        self.format_comments(&n.lparen);
         self.write_rune('(');
         let sep = ", ";
         for i in 0..n.params.len() {
@@ -210,9 +253,14 @@ impl Formatter {
                 self.write_string(sep)
             }
             // treat properties differently than in general case
-            self.format_function_argument(n.params.get(i).unwrap())
+            let property = n.params.get(i).unwrap();
+            self.format_function_argument(property);
+            self.format_comments(&property.comma);
         }
-        self.write_string(") =>");
+        self.format_comments(&n.rparen);
+        self.write_string(") ");
+        self.format_comments(&n.arrow);
+        self.write_string("=>");
         // must wrap body with parenthesis in order to discriminate between:
         //  - returning an object: (x) => ({foo: x})
         //  - and block statements:
@@ -238,6 +286,7 @@ impl Formatter {
     fn format_function_argument(&mut self, n: &ast::Property) {
         if let Some(v) = &n.value {
             self.format_property_key(&n.key);
+            self.format_comments(&n.separator);
             self.write_rune('=');
             self.format_node(&Node::from_expr(&v));
         } else {
@@ -253,10 +302,16 @@ impl Formatter {
     }
 
     fn format_paren_expression(&mut self, n: &ast::ParenExpr) {
-        self.format_node(&Node::from_expr(&n.expression))
+        // This could mix up ordering, but since the parens are programatically
+        // added back, we would need to pass any closing comments down,
+        // seriously complicating the function interface. For now, permit reordering.
+        self.format_comments(&n.lparen);
+        self.format_node(&Node::from_expr(&n.expression));
+        self.format_comments(&n.rparen);
     }
 
     fn format_string_expression(&mut self, n: &ast::StringExpr) {
+        self.format_comments(&n.base.comments);
         self.write_rune('"');
         for p in &n.parts {
             self.format_string_expression_part(p)
@@ -282,25 +337,32 @@ impl Formatter {
     }
 
     fn format_array_expression(&mut self, n: &ast::ArrayExpr) {
+        self.format_comments(&n.lbrack);
         self.write_rune('[');
         let sep = ", ";
         for i in 0..n.elements.len() {
             if i != 0 {
                 self.write_string(sep)
             }
-            self.format_node(&Node::from_expr(n.elements.get(i).unwrap()));
+            let item = n.elements.get(i).unwrap();
+            self.format_node(&Node::from_expr(&item.expression));
+            self.format_comments(&item.comma);
         }
+        self.format_comments(&n.rbrack);
         self.write_rune(']')
     }
 
     fn format_index_expression(&mut self, n: &ast::IndexExpr) {
         self.format_child_with_parens(Node::IndexExpr(n), Node::from_expr(&n.array));
+        self.format_comments(&n.lbrack);
         self.write_rune('[');
         self.format_node(&Node::from_expr(&n.index));
+        self.format_comments(&n.rbrack);
         self.write_rune(']');
     }
 
     fn format_block(&mut self, n: &ast::Block) {
+        self.format_comments(&n.lbrace);
         self.write_rune('{');
         let sep = '\n';
         if !n.body.is_empty() {
@@ -328,20 +390,24 @@ impl Formatter {
             self.unindent();
             self.write_indent()
         }
+        self.format_comments(&n.rbrace);
         self.write_rune('}')
     }
 
     fn format_return_statement(&mut self, n: &ast::ReturnStmt) {
+        self.format_comments(&n.base.comments);
         self.write_string("return ");
         self.format_node(&Node::from_expr(&n.argument));
     }
 
     fn format_option_statement(&mut self, n: &ast::OptionStmt) {
+        self.format_comments(&n.base.comments);
         self.write_string("option ");
         self.format_assignment(&n.assignment);
     }
 
     fn format_test_statement(&mut self, n: &ast::TestStmt) {
+        self.format_comments(&n.base.comments);
         self.write_string("test ");
         self.format_node(&Node::VariableAssgn(&n.assignment));
     }
@@ -393,12 +459,15 @@ impl Formatter {
 
         match &n.property {
             ast::PropertyKey::Identifier(m) => {
+                self.format_comments(&n.lbrack);
                 self.write_rune('.');
                 self.format_node(&Node::Identifier(&m));
             }
             ast::PropertyKey::StringLit(m) => {
+                self.format_comments(&n.lbrack);
                 self.write_rune('[');
                 self.format_node(&Node::StringLit(&m));
+                self.format_comments(&n.rbrack);
                 self.write_rune(']');
             }
         }
@@ -409,12 +478,14 @@ impl Formatter {
         self.write_rune('\n');
         self.indent();
         self.write_indent();
+        self.format_comments(&n.base.comments);
         self.write_string("|> ");
         self.format_node(&Node::CallExpr(&n.call));
     }
 
     fn format_call_expression(&mut self, n: &ast::CallExpr) {
         self.format_child_with_parens(Node::CallExpr(n), Node::from_expr(&n.callee));
+        self.format_comments(&n.lparen);
         self.write_rune('(');
         let sep = ", ";
         for i in 0..n.arguments.len() {
@@ -427,6 +498,7 @@ impl Formatter {
                 _ => self.format_node(&Node::from_expr(c)),
             }
         }
+        self.format_comments(&n.rparen);
         self.write_rune(')');
     }
 
@@ -439,11 +511,13 @@ impl Formatter {
 
     fn format_object_expression_braces(&mut self, n: &ast::ObjectExpr, braces: bool) {
         let multiline = n.properties.len() > 3;
+        self.format_comments(&n.lbrace);
         if braces {
             self.write_rune('{');
         }
         if let Some(with) = &n.with {
-            self.format_identifier(&with);
+            self.format_identifier(&with.source);
+            self.format_comments(&with.with);
             self.write_string(" with ");
         }
         if multiline {
@@ -464,44 +538,54 @@ impl Formatter {
                     self.write_indent()
                 }
             }
-            self.format_node(&Node::Property(n.properties.get(i).unwrap()));
+            let property = n.properties.get(i).unwrap();
+            self.format_node(&Node::Property(property));
+            self.format_comments(&property.comma);
         }
         if multiline {
             self.write_string(sep);
             self.unindent();
             self.write_indent();
         }
+        self.format_comments(&n.rbrace);
         if braces {
             self.write_rune('}');
         }
     }
 
     fn format_identifier(&mut self, n: &ast::Identifier) {
+        self.format_comments(&n.base.comments);
         self.write_string(&n.name);
     }
 
     fn format_variable_assignment(&mut self, n: &ast::VariableAssgn) {
         self.format_node(&Node::Identifier(&n.id));
+        self.format_comments(&n.base.comments);
         self.write_string(" = ");
         self.format_node(&Node::from_expr(&n.init));
     }
 
     fn format_conditional_expression(&mut self, n: &ast::ConditionalExpr) {
+        self.format_comments(&n.tk_if);
         self.write_string("if ");
         self.format_node(&Node::from_expr(&n.test));
+        self.format_comments(&n.tk_then);
         self.write_string(" then ");
         self.format_node(&Node::from_expr(&n.consequent));
+        self.format_comments(&n.tk_else);
         self.write_string(" else ");
         self.format_node(&Node::from_expr(&n.alternate));
     }
 
     fn format_member_assignment(&mut self, n: &ast::MemberAssgn) {
         self.format_node(&Node::MemberExpr(&n.member));
+        self.format_comments(&n.base.comments);
         self.write_string(" = ");
         self.format_node(&Node::from_expr(&n.init));
     }
 
     fn format_unary_expression(&mut self, n: &ast::UnaryExpr) {
+        self.format_comments(&n.base.comments);
         self.write_string(&n.operator.to_string());
         match n.operator {
             ast::Operator::SubtractionOperator => {}
@@ -515,6 +599,7 @@ impl Formatter {
 
     fn format_binary_expression(&mut self, n: &ast::BinaryExpr) {
         self.format_binary(
+            &n.base.comments,
             &n.operator.to_string(),
             Node::BinaryExpr(&n),
             Node::from_expr(&n.left),
@@ -524,6 +609,7 @@ impl Formatter {
 
     fn format_logical_expression(&mut self, n: &ast::LogicalExpr) {
         self.format_binary(
+            &n.base.comments,
             &n.operator.to_string(),
             Node::LogicalExpr(&n),
             Node::from_expr(&n.left),
@@ -531,15 +617,24 @@ impl Formatter {
         );
     }
 
-    fn format_binary(&mut self, op: &str, parent: Node, left: Node, right: Node) {
+    fn format_binary(
+        &mut self,
+        comments: &ast::CommentList,
+        op: &str,
+        parent: Node,
+        left: Node,
+        right: Node,
+    ) {
         self.format_left_child_with_parens(&parent, &left);
         self.write_rune(' ');
+        self.format_comments(comments);
         self.write_string(op);
         self.write_rune(' ');
         self.format_right_child_with_parens(&parent, &right);
     }
 
     fn format_import_declaration(&mut self, n: &ast::ImportDeclaration) {
+        self.format_comments(&n.base.comments);
         self.write_string("import ");
         if let Some(alias) = &n.alias {
             if !alias.name.is_empty() {
@@ -555,12 +650,14 @@ impl Formatter {
     }
 
     fn format_package_clause(&mut self, n: &ast::PackageClause) {
+        self.format_comments(&n.base.comments);
         self.write_string("package ");
         self.format_node(&Node::Identifier(&n.name));
         self.write_rune('\n');
     }
 
     fn format_string_literal(&mut self, n: &ast::StringLit) {
+        self.format_comments(&n.base.comments);
         if let Some(src) = &n.base.location.source {
             if !src.is_empty() {
                 // Preserve the exact literal if we have it
@@ -588,6 +685,7 @@ impl Formatter {
         self.write_rune('"');
     }
 
+    // TODO(adriandt): this code appears dead. Boolean literal is no longer a node type?
     fn format_boolean_literal(&mut self, n: &ast::BooleanLit) {
         let s: &str;
         if n.value {
@@ -625,10 +723,12 @@ impl Formatter {
         } else {
             f = v.to_rfc3339_opts(SecondsFormat::Secs, true)
         }
+        self.format_comments(&n.base.comments);
         self.write_string(&f);
     }
 
     fn format_duration_literal(&mut self, n: &ast::DurationLit) {
+        self.format_comments(&n.base.comments);
         for d in &n.values {
             self.write_string(&format!("{}", d.magnitude));
             self.write_string(&d.unit)
@@ -636,6 +736,7 @@ impl Formatter {
     }
 
     fn format_float_literal(&mut self, n: &ast::FloatLit) {
+        self.format_comments(&n.base.comments);
         let mut s = format!("{}", n.value);
         if !s.contains('.') {
             s.push_str(".0");
@@ -644,18 +745,22 @@ impl Formatter {
     }
 
     fn format_integer_literal(&mut self, n: &ast::IntegerLit) {
+        self.format_comments(&n.base.comments);
         self.write_string(&format!("{}", n.value));
     }
 
     fn format_unsigned_integer_literal(&mut self, n: &ast::UintLit) {
+        self.format_comments(&n.base.comments);
         self.write_string(&format!("{0:10}", n.value))
     }
 
-    fn format_pipe_literal(&mut self, _: &ast::PipeLit) {
+    fn format_pipe_literal(&mut self, n: &ast::PipeLit) {
+        self.format_comments(&n.base.comments);
         self.write_string("<-")
     }
 
     fn format_regexp_literal(&mut self, n: &ast::RegexpLit) {
+        self.format_comments(&n.base.comments);
         self.write_rune('/');
         self.write_string(&n.value.replace("/", "\\/"));
         self.write_rune('/')

--- a/libflux/src/flux/formatter/tests.rs
+++ b/libflux/src/flux/formatter/tests.rs
@@ -1,17 +1,13 @@
 use super::*;
-use crate::parser::Parser;
 use std::str;
 
 // This gives us a colorful diff.
 #[cfg(test)]
 use pretty_assertions::assert_eq;
 
-fn format_helper(expected: &str) {
-    let file = Parser::new(expected).parse_file("".to_string());
-    let mut fmt = Formatter::default();
-    fmt.format_file(&file, true);
-    let output = fmt.output().unwrap();
-    assert_eq!(expected, output);
+fn assert_unchanged(script: &str) {
+    let output = format(script.to_string()).unwrap();
+    assert_eq!(script, output);
 }
 
 fn assert_format(script: &str, expected: &str) {
@@ -21,11 +17,11 @@ fn assert_format(script: &str, expected: &str) {
 
 #[test]
 fn binary_op() {
-    format_helper("1 + 1 - 2");
+    assert_unchanged("1 + 1 - 2");
     assert_format("1 +  1 - 2", "1 + 1 - 2");
-    format_helper("1 * 1 / 2");
-    format_helper("2 ^ 4");
-    format_helper("1 * (1 / 2)");
+    assert_unchanged("1 * 1 / 2");
+    assert_unchanged("2 ^ 4");
+    assert_unchanged("1 * (1 / 2)");
 }
 
 #[test]
@@ -35,20 +31,20 @@ fn funcs() {
     (r.user ==     "user1")"#,
         "(r) =>\n\t(r.user == \"user1\")",
     );
-    format_helper(
+    assert_unchanged(
         r#"(r) =>
 	(r.user == "user1")"#,
     );
-    format_helper(
+    assert_unchanged(
         r#"add = (a, b) =>
 	(a + b)"#,
     ); // decl
-    format_helper("add(a: 1, b: 2)"); // call
-    format_helper(
+    assert_unchanged("add(a: 1, b: 2)"); // call
+    assert_unchanged(
         r#"foo = (arg=[]) =>
 	(1)"#,
     ); // nil value as default
-    format_helper(
+    assert_unchanged(
         r#"foo = (arg=[1, 2]) =>
 	(1)"#,
     ); // none nil value as default
@@ -56,22 +52,22 @@ fn funcs() {
 
 #[test]
 fn object() {
-    format_helper("{a: 1, b: {c: 11, d: 12}}");
-    format_helper("{foo with a: 1, b: {c: 11, d: 12}}"); // with
-    format_helper("{a, b, c}"); // implicit key object literal
-    format_helper(r#"{"a": 1, "b": 2}"#); // object with string literal keys
-    format_helper(r#"{"a": 1, b: 2}"#); // object with mixed keys
+    assert_unchanged("{a: 1, b: {c: 11, d: 12}}");
+    assert_unchanged("{foo with a: 1, b: {c: 11, d: 12}}"); // with
+    assert_unchanged("{a, b, c}"); // implicit key object literal
+    assert_unchanged(r#"{"a": 1, "b": 2}"#); // object with string literal keys
+    assert_unchanged(r#"{"a": 1, b: 2}"#); // object with mixed keys
 }
 
 #[test]
 fn member() {
-    format_helper("object.property"); // member ident
-    format_helper(r#"object["property"]"#); // member string literal
+    assert_unchanged("object.property"); // member ident
+    assert_unchanged(r#"object["property"]"#); // member string literal
 }
 
 #[test]
 fn array() {
-    format_helper(
+    assert_unchanged(
         r#"a = [1, 2, 3]
 
 a[i]"#,
@@ -80,38 +76,38 @@ a[i]"#,
 
 #[test]
 fn conditional() {
-    format_helper("if a then b else c");
-    format_helper(r#"if not a or b and c then 2 / (3 * 2) else obj.a(par: "foo")"#);
+    assert_unchanged("if a then b else c");
+    assert_unchanged(r#"if not a or b and c then 2 / (3 * 2) else obj.a(par: "foo")"#);
 }
 
 #[test]
 fn return_expr() {
-    format_helper("return 42");
+    assert_unchanged("return 42");
 }
 
 #[test]
 fn option() {
-    format_helper("option foo = {a: 1}");
-    format_helper(r#"option alert.state = "Warning""#); // qualified
+    assert_unchanged("option foo = {a: 1}");
+    assert_unchanged(r#"option alert.state = "Warning""#); // qualified
 }
 
 #[test]
 fn vars() {
-    format_helper("0.1"); // float
-    format_helper("100000000.0"); // integer float
-    format_helper("365d"); // duration
-    format_helper("1d1m1s"); // duration_multiple
-    format_helper("2018-05-22T19:53:00Z"); // time
-    format_helper("2018-05-22T19:53:01+07:00"); // zone
-    format_helper("2018-05-22T19:53:23.09012Z"); // nano sec
-    format_helper("2018-05-22T19:53:01.09012-07:00"); // nano with zone
-    format_helper(r#"/^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/"#); // regexp
-    format_helper(r#"/^http:\/\/\w+\.com$/"#); // regexp_escape
+    assert_unchanged("0.1"); // float
+    assert_unchanged("100000000.0"); // integer float
+    assert_unchanged("365d"); // duration
+    assert_unchanged("1d1m1s"); // duration_multiple
+    assert_unchanged("2018-05-22T19:53:00Z"); // time
+    assert_unchanged("2018-05-22T19:53:01+07:00"); // zone
+    assert_unchanged("2018-05-22T19:53:23.09012Z"); // nano sec
+    assert_unchanged("2018-05-22T19:53:01.09012-07:00"); // nano with zone
+    assert_unchanged(r#"/^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/"#); // regexp
+    assert_unchanged(r#"/^http:\/\/\w+\.com$/"#); // regexp_escape
 }
 
 #[test]
 fn block() {
-    format_helper(
+    assert_unchanged(
         r#"foo = () => {
 	foo(f: 1)
 	1 + 1
@@ -121,40 +117,40 @@ fn block() {
 
 #[test]
 fn str_lit() {
-    format_helper(r#""foo""#);
-    format_helper(
+    assert_unchanged(r#""foo""#);
+    assert_unchanged(
         r#""this is
 a string
 with multiple lines""#,
     ); // multi lines
-    format_helper(r#""foo \\ \" \r\n""#); // with escape
-    format_helper(r#""\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e""#); // with byte
+    assert_unchanged(r#""foo \\ \" \r\n""#); // with escape
+    assert_unchanged(r#""\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e""#); // with byte
 }
 
 #[test]
 fn package_import() {
-    format_helper(
+    assert_unchanged(
         r#"package foo
 "#,
     ); // package
-    format_helper(
+    assert_unchanged(
         r#"import "path/foo"
 import bar "path/bar""#,
     ); // imports
-    format_helper(
+    assert_unchanged(
         r#"import foo "path/foo"
 
 foo.from(bucket: "testdb")
 	|> range(start: 2018-05-20T19:53:26Z)"#,
     ); // no_package
-    format_helper(
+    assert_unchanged(
         r#"package foo
 
 
 from(bucket: "testdb")
 	|> range(start: 2018-05-20T19:53:26Z)"#,
     ); // no_imports
-    format_helper(
+    assert_unchanged(
         r#"package foo
 
 
@@ -168,7 +164,7 @@ from(bucket: "testdb")
 
 #[test]
 fn simple() {
-    format_helper(
+    assert_unchanged(
         r#"from(bucket: "testdb")
 	|> range(start: 2018-05-20T19:53:26Z)
 	|> filter(fn: (r) =>
@@ -181,7 +177,7 @@ fn simple() {
 
 #[test]
 fn medium() {
-    format_helper(
+    assert_unchanged(
         r#"from(bucket: "testdb")
 	|> range(start: 2018-05-20T19:53:26Z)
 	|> filter(fn: (r) =>
@@ -194,7 +190,7 @@ fn medium() {
 
 #[test]
 fn complex() {
-    format_helper(
+    assert_unchanged(
         r#"left = from(bucket: "test")
 	|> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
 	|> drop(columns: ["_start", "_stop"])
@@ -214,7 +210,7 @@ join(tables: {left: left, right: right}, on: ["_time", "_measurement"])"#,
 
 #[test]
 fn option_complete() {
-    format_helper(
+    assert_unchanged(
         r#"option task = {
 	name: "foo",
 	every: 1h,
@@ -234,7 +230,7 @@ from(bucket: "test")
 
 #[test]
 fn functions_complete() {
-    format_helper(
+    assert_unchanged(
         r#"foo = () =>
 	(from(bucket: "testdb"))
 bar = (x=<-) =>
@@ -254,7 +250,7 @@ foo()
 
 #[test]
 fn multi_indent() {
-    format_helper(
+    assert_unchanged(
         r#"_sortLimit = (n, desc, columns=["_value"], tables=<-) =>
 	(tables
 		|> sort(columns: columns, desc: desc)
@@ -277,4 +273,297 @@ highestAverage = (n, columns=["_value"], by, tables=<-) =>
 			_sortLimit: top,
 		))"#,
     )
+}
+
+#[test]
+fn comments() {
+    assert_unchanged("// attach to id\nid");
+    assert_unchanged("// attach to int\n1");
+    assert_unchanged("// attach to float\n1.1");
+    assert_unchanged("// attach to string\n\"hello\"");
+    assert_unchanged("// attach to regex\n/hello/");
+    assert_unchanged("// attach to time\n2020-02-28T00:00:00Z");
+    assert_unchanged("// attach to duration\n2m");
+    assert_unchanged("// attach to bool\ntrue");
+    assert_format(
+        "// attach to open paren\n( 1 + 1 )",
+        "// attach to open paren\n1 + 1",
+    );
+    assert_format(
+        "( 1 + 1 // attach to close paren\n )",
+        "1 + 1\n\t// attach to close paren\n\t",
+    );
+    // A reordering we have to live with, unless we do some refactoring in the
+    // formatter.
+    assert_format(
+        "1 * // attach to open paren\n( 1 + 1 )",
+        "1 * (\n\t// attach to open paren\n\t1 + 1)",
+    );
+    assert_unchanged("1 * (1 + 1\n\t// attach to close paren\n\t)");
+    assert_unchanged("from\n\t//comment\n\t(bucket: bucket)");
+    assert_unchanged("from(\n\t//comment\n\tbucket: bucket)");
+    assert_unchanged("from(bucket\n\t//comment\n\t: bucket)");
+    assert_unchanged("from(bucket: \n\t//comment\n\tbucket)");
+    assert_unchanged("from(bucket: bucket\n\t//comment\n\t)");
+    assert_unchanged("from(\n\t//comment\n\tbucket)");
+    assert_unchanged("from(bucket\n\t//comment\n\t, _option)");
+    assert_unchanged("from(bucket, \n\t//comment\n\t_option)");
+    assert_unchanged("from(bucket, _option\n\t//comment\n\t)");
+    assert_format(
+        "from(bucket, _option//comment1\n,//comment2\n)",
+        "from(bucket, _option\n\t//comment1\n\t//comment2\n)",
+    );
+
+    /* Expressions. */
+    assert_unchanged("1 \n\t//comment\n\t<= 1");
+    assert_unchanged("1 \n\t//comment\n\t+ 1");
+    assert_unchanged("1 \n\t//comment\n\t* 1");
+    assert_unchanged("from()\n\t//comment\n\t|> to()");
+    assert_unchanged("//comment\n+1");
+    assert_format("1 * //comment\n-1", "1 * (\n\t//comment\n\t-1)");
+    assert_unchanged("i = \n\t//comment\n\tnot true");
+    assert_unchanged("//comment\nexists 1");
+    assert_unchanged("a \n\t//comment\n\t=~ /foo/");
+    assert_unchanged("a \n\t//comment\n\t!~ /foo/");
+    assert_unchanged("a \n\t//comment\n\tand b");
+    assert_unchanged("a \n\t//comment\n\tor b");
+
+    assert_unchanged("a\n\t//comment\n\t = 1");
+    assert_unchanged("//comment\noption a = 1");
+    assert_unchanged("option a\n\t//comment\n\t = 1");
+    assert_unchanged("option a\n\t//comment\n\t.b = 1");
+    assert_unchanged("option a.\n\t//comment\n\tb = 1");
+    assert_unchanged("option a.b\n\t//comment\n\t = 1");
+
+    // Some funny business here. Propbably need to scan write_string for \n
+    assert_unchanged("f = \n\t//comment\n\t(a) =>\n\t(a())");
+    assert_unchanged("f = (\n\t//comment\n\ta) =>\n\t(a())");
+    assert_unchanged("f = (\n\t//comment\n\ta, b) =>\n\t(a())");
+    assert_unchanged("f = (a\n\t//comment\n\t, b) =>\n\t(a())");
+    assert_unchanged("f = (a\n\t//comment\n\t=1, b=2) =>\n\t\t(a())");
+    assert_unchanged("f = (a=\n\t//comment\n\t1, b=2) =>\n\t(a())");
+    assert_unchanged("f = (a=1\n\t//comment\n\t, b=2) =>\n\t\t(a())");
+    assert_unchanged("f = (a=1, \n\t//comment\n\tb=2) =>\n\t\t(a())");
+    assert_unchanged("f = (a=1, b\n\t//comment\n\t=2) =>\n\t\t(a())");
+    assert_unchanged("f = (a=1, b=\n\t//comment\n\t2) =>\n\t(a())");
+    assert_format(
+        "f = (a=1, b=2//comment\n,) =>\n\t(a())",
+        "f = (a=1, b=2\n\t//comment\n\t) =>\n\t(a())",
+    );
+    assert_unchanged("f = (a=1, b=2\n\t//comment\n\t) =>\n\t(a())");
+    assert_format(
+        "f = (a=1, b=2,//comment\n) =>\n\t(a())",
+        "f = (a=1, b=2\n\t//comment\n\t) =>\n\t(a())",
+    );
+    assert_format(
+        "f = (a=1, b=2//comment1\n,//comment2\n) =>\n\t(a())",
+        "f = (a=1, b=2\n\t//comment1\n\t//comment2\n\t) =>\n\t(a())",
+    );
+    assert_unchanged("f = (a=1, b=2) \n\t//comment\n\t=>\n\t(a())");
+    assert_format(
+        "f = (a=1, b=2) =>\n\t//comment\n(a())",
+        "f = (a=1, b=2) =>\n\t(\n\t\t//comment\n\t\ta())",
+    );
+    assert_format(
+        "f = (a=1, b=2) =>\n\t//comment\na()",
+        "f = (a=1, b=2) =>\n\t(\n\t\t//comment\n\t\ta())",
+    );
+
+    assert_unchanged("//comment\ntest a = 1");
+    assert_unchanged("test \n\t//comment\n\ta = 1");
+    assert_unchanged("test a\n\t//comment\n\t = 1");
+    assert_unchanged("test a = \n\t//comment\n\t1");
+
+    assert_unchanged("//comment\nreturn x");
+    assert_unchanged("return \n\t//comment\n\tx");
+
+    assert_unchanged("//comment\nif 1 then 2 else 3");
+    assert_unchanged("if \n\t//comment\n\t1 then 2 else 3");
+    assert_unchanged("if 1\n\t//comment\n\t then 2 else 3");
+    assert_unchanged("if 1 then \n\t//comment\n\t2 else 3");
+    assert_unchanged("if 1 then 2\n\t//comment\n\t else 3");
+    assert_unchanged("if 1 then 2 else \n\t//comment\n\t3");
+
+    assert_unchanged("//comment\nfoo[\"bar\"]");
+    assert_unchanged("foo\n\t//comment\n\t[\"bar\"]");
+    assert_unchanged("foo[\n\t//comment\n\t\"bar\"]");
+    assert_unchanged("foo[\"bar\"\n\t//comment\n\t]");
+
+    assert_unchanged("a = \n\t//comment\n\t[1, 2, 3]");
+    assert_unchanged("a = [\n\t//comment\n\t1, 2, 3]");
+    assert_unchanged("a = [1\n\t//comment\n\t, 2, 3]");
+    assert_unchanged("a = [1, \n\t//comment\n\t2, 3]");
+    assert_unchanged("a = [1, \n\t//comment1\n\t2\n\t//comment2\n\t, 3]");
+    assert_unchanged("a = [1, 2, 3\n\t//comment\n\t]");
+
+    assert_unchanged("a = b\n\t//comment\n\t[1]");
+    assert_unchanged("a = b[\n\t//comment\n\t1]");
+    assert_unchanged("a = b[1\n\t//comment\n\t]");
+
+    assert_unchanged("//comment\n{_time: r._time, io_time: r._value}");
+    assert_unchanged("{\n\t//comment\n\t_time: r._time, io_time: r._value}");
+    assert_unchanged("{_time\n\t//comment\n\t: r._time, io_time: r._value}");
+    assert_unchanged("{_time: \n\t//comment\n\tr._time, io_time: r._value}");
+    assert_unchanged("{_time: r\n\t//comment\n\t._time, io_time: r._value}");
+    assert_unchanged("{_time: r.\n\t//comment\n\t_time, io_time: r._value}");
+    assert_unchanged("{_time: r\n\t//comment\n\t[\"_time\"], io_time: r._value}");
+    assert_unchanged("{_time: r._time\n\t//comment\n\t, io_time: r._value}");
+    assert_unchanged("{_time: r._time, \n\t//comment\n\tio_time: r._value}");
+    assert_unchanged("{_time: r._time, io_time\n\t//comment\n\t: r._value}");
+    assert_unchanged("{_time: r._time, io_time: \n\t//comment\n\ttr._value}");
+    assert_unchanged("{_time: r._time, io_time: r\n\t//comment\n\t._value}");
+    assert_unchanged("{_time: r._time, io_time: r.\n\t//comment\n\t_value}");
+    assert_unchanged("{_time: r._time, io_time: r._value\n\t//comment\n\t}");
+    assert_format(
+        "{_time: r._time, io_time: r._value\n\t//comment\n\t,}",
+        "{_time: r._time, io_time: r._value\n\t//comment\n\t}",
+    );
+    assert_format(
+        "{_time: r._time, io_time: r._value,\n\t//comment\n\t}",
+        "{_time: r._time, io_time: r._value\n\t//comment\n\t}",
+    );
+
+    assert_unchanged("//comment\nimport \"foo\"");
+    assert_unchanged("import \n\t//comment\n\t\"foo\"");
+    assert_unchanged("import \n\t//comment\n\tfoo \"foo\"");
+
+    assert_unchanged("//comment\npackage foo\n");
+    assert_unchanged("package \n\t//comment\n\tfoo\n");
+
+    assert_unchanged("{\n\t//comment\n\tfoo with a: 1, b: 2}");
+    assert_unchanged("{foo\n\t//comment\n\t with a: 1, b: 2}");
+    assert_unchanged("{foo with \n\t//comment\n\ta: 1, b: 2}");
+
+    assert_unchanged("fn = (tables=\n\t//comment\n\t<-) =>\n\t(tables)");
+
+    // Comments around braces needs some work.
+    assert_unchanged("fn = (a) => \n\t//comment\n\t{\n\treturn a\n}");
+    assert_unchanged("fn = (a) => {\n\treturn a\n// ending\n}");
+
+    assert_format(
+        r#"    // hi
+// there
+{_time: r._time, io_time: r._value, // this is the end
+}
+
+// minimal
+foo = (arg=[1, 2]) => (1)
+
+// left
+left = from(bucket: "test")
+	|> range(start: 2018-05-22T19:53:00Z
+	// i write too many comments
+	, stop: 2018-05-22T19:55:00Z)
+	// and put them in strange places
+	|>  drop
+
+		// this hurts my eyes
+(columns: ["_start", "_stop"])
+		// just terrible
+	|> filter(fn: (r) =>
+		(r.user 
+
+		// (don't fire me, this is intentional)
+		== "user1"))
+	|> group(by
+	// strange place for a comment
+: ["user"])
+
+right = from(bucket: "test")
+	|> range(start: 2018-05-22T19:53:00Z,
+			// please stop
+			stop: 2018-05-22T19:55:00Z)
+	|> drop( // spare me the pain
+// this hurts
+columns: ["_start", "_stop"// what
+])
+	|> filter(
+		// just why
+		fn: (r) =>
+		// user 2 is the best user
+		(r.user == "user2"))
+	|> group(by: //just stop
+["_measurement"])
+
+join(tables: {left: left, right: right}, on: ["_time", "_measurement"])
+
+from(bucket, _option // friends
+,// stick together
+)
+
+i = // definitely
+not true
+// a
+// list
+// of
+// comments
+
+j
+
+// not lost
+"#,
+        r#"// hi
+// there
+{_time: r._time, io_time: r._value
+	// this is the end
+	}
+
+// minimal
+foo = (arg=[1, 2]) =>
+	(1)
+// left
+left = from(bucket: "test")
+	|> range(start: 2018-05-22T19:53:00Z
+		// i write too many comments
+		, stop: 2018-05-22T19:55:00Z)
+	// and put them in strange places
+	|> drop
+		// this hurts my eyes
+		(columns: ["_start", "_stop"])
+	// just terrible
+	|> filter(fn: (r) =>
+		(r.user 
+			// (don't fire me, this is intentional)
+			== "user1"))
+	|> group(by
+		// strange place for a comment
+		: ["user"])
+right = from(bucket: "test")
+	|> range(start: 2018-05-22T19:53:00Z, 
+		// please stop
+		stop: 2018-05-22T19:55:00Z)
+	|> drop(
+		// spare me the pain
+		// this hurts
+		columns: ["_start", "_stop"
+			// what
+			])
+	|> filter(
+		// just why
+		fn: (r) =>
+		(
+			// user 2 is the best user
+			r.user == "user2"))
+	|> group(by: 
+		//just stop
+		["_measurement"])
+
+join(tables: {left: left, right: right}, on: ["_time", "_measurement"])
+from(bucket, _option
+	// friends
+	// stick together
+)
+
+i = 
+	// definitely
+	not true
+
+// a
+// list
+// of
+// comments
+j
+// not lost
+"#,
+    );
 }

--- a/libflux/src/flux/parser/tests.rs
+++ b/libflux/src/flux/parser/tests.rs
@@ -55,51 +55,51 @@ fn string_interpolation_simple() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 19),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 19),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringExpr(Box::new(StringExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 19),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     parts: vec![
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a + b = ".to_string(),
                         }),
                         StringExprPart::Interpolated(InterpolatedPart {
                             base: BaseNode {
                                 location: loc.get(1, 10, 1, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             expression: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 12, 1, 17),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 left: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 12, 1, 13),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "a".to_string(),
                                 }),
                                 right: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 16, 1, 17),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "b".to_string(),
                                 }),
@@ -108,7 +108,8 @@ fn string_interpolation_simple() {
                         }),
                     ],
                 })),
-            }),],
+            })),],
+            eof: None,
         },
     )
 }
@@ -123,39 +124,39 @@ fn string_interpolation_multiple() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 24),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 24),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringExpr(Box::new(StringExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 24),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     parts: vec![
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a = ".to_string(),
                         }),
                         StringExprPart::Interpolated(InterpolatedPart {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             expression: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 8, 1, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string(),
                             }),
@@ -163,26 +164,27 @@ fn string_interpolation_multiple() {
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 10, 1, 19),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: " and b = ".to_string(),
                         }),
                         StringExprPart::Interpolated(InterpolatedPart {
                             base: BaseNode {
                                 location: loc.get(1, 19, 1, 23),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             expression: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 21, 1, 22),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string(),
                             }),
                         }),
                     ],
                 })),
-            }),],
+            })),],
+            eof: None,
         },
     )
 }
@@ -197,69 +199,69 @@ fn string_interpolation_nested() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 44),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 44),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringExpr(Box::new(StringExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 44),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     parts: vec![
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "we ".to_string(),
                         }),
                         StringExprPart::Interpolated(InterpolatedPart {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 34),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             expression: Expression::StringExpr(Box::new(StringExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 7, 1, 33),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 parts: vec![
                                     StringExprPart::Text(TextPart {
                                         base: BaseNode {
                                             location: loc.get(1, 8, 1, 12),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "can ".to_string(),
                                     }),
                                     StringExprPart::Interpolated(InterpolatedPart {
                                         base: BaseNode {
                                             location: loc.get(1, 12, 1, 32),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         expression: Expression::Binary(Box::new(BinaryExpr {
                                             base: BaseNode {
                                                 location: loc.get(1, 14, 1, 31),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             left: Expression::StringLit(StringLit {
                                                 base: BaseNode {
                                                     location: loc.get(1, 14, 1, 19),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 value: "add".to_string(),
                                             }),
                                             right: Expression::StringLit(StringLit {
                                                 base: BaseNode {
                                                     location: loc.get(1, 22, 1, 31),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 value: "strings".to_string(),
                                             }),
@@ -272,13 +274,14 @@ fn string_interpolation_nested() {
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 34, 1, 43),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: " together".to_string(),
                         }),
                     ],
                 })),
-            }),],
+            })),],
+            eof: None,
         },
     )
 }
@@ -293,39 +296,39 @@ fn string_interp_with_escapes() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 45),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 45),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringExpr(Box::new(StringExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 45),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     parts: vec![
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 30),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "string \"interpolation with ".to_string(),
                         }),
                         StringExprPart::Interpolated(InterpolatedPart {
                             base: BaseNode {
                                 location: loc.get(1, 30, 1, 42),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             expression: Expression::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 32, 1, 41),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "escapes".to_string(),
                             }),
@@ -333,13 +336,14 @@ fn string_interp_with_escapes() {
                         StringExprPart::Text(TextPart {
                             base: BaseNode {
                                 location: loc.get(1, 42, 1, 44),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "\"".to_string(),
                         }),
                     ],
                 })),
-            }),],
+            })),],
+            eof: None,
         },
     )
 }
@@ -354,7 +358,7 @@ fn bad_string_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -363,46 +367,53 @@ fn bad_string_expression() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 18),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 3),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "fn".to_string(),
                 },
                 init: Expression::Function(Box::new(FunctionExpr {
                     base: BaseNode {
                         location: loc.get(1, 6, 1, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     params: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 7, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 7, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
-                        value: None
+                        separator: None,
+                        value: None,
+                        comma: None,
                     }],
+                    rparen: None,
+                    arrow: None,
                     body: FunctionBody::Expr(Expression::StringExpr(Box::new(StringExpr {
                         base: BaseNode {
                             location: loc.get(1, 13, 1, 18),
                             errors: vec![
                                 "got unexpected token in string expression @1:18-1:18: EOF"
                                     .to_string()
-                            ]
+                            ],
+                            ..BaseNode::default()
                         },
                         parts: vec![],
-                    })))
+                    }))),
                 })),
             }))],
+            eof: None,
         },
     )
 }
@@ -417,25 +428,26 @@ fn package_clause() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: Some(PackageClause {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 name: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "foo".to_string()
                 }
             }),
             imports: vec![],
-            body: vec![]
+            body: vec![],
+            eof: None,
         },
     )
 }
@@ -450,7 +462,7 @@ fn import() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -458,18 +470,19 @@ fn import() {
             imports: vec![ImportDeclaration {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 18),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 alias: None,
                 path: StringLit {
                     base: BaseNode {
                         location: loc.get(1, 8, 1, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "path/foo".to_string()
                 }
             }],
-            body: vec![]
+            body: vec![],
+            eof: None,
         },
     )
 }
@@ -484,7 +497,7 @@ fn import_as() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 22),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -492,24 +505,25 @@ fn import_as() {
             imports: vec![ImportDeclaration {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 22),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 alias: Some(Identifier {
                     base: BaseNode {
                         location: loc.get(1, 8, 1, 11),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "bar".to_string()
                 }),
                 path: StringLit {
                     base: BaseNode {
                         location: loc.get(1, 12, 1, 22),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "path/foo".to_string()
                 }
             }],
-            body: vec![]
+            body: vec![],
+            eof: None,
         }
     )
 }
@@ -527,7 +541,7 @@ import "path/bar""#,
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -536,13 +550,13 @@ import "path/bar""#,
                 ImportDeclaration {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     alias: None,
                     path: StringLit {
                         base: BaseNode {
                             location: loc.get(1, 8, 1, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "path/foo".to_string()
                     }
@@ -550,19 +564,20 @@ import "path/bar""#,
                 ImportDeclaration {
                     base: BaseNode {
                         location: loc.get(2, 1, 2, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     alias: None,
                     path: StringLit {
                         base: BaseNode {
                             location: loc.get(2, 8, 2, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "path/bar".to_string()
                     }
                 }
             ],
-            body: vec![]
+            body: vec![],
+            eof: None,
         }
     )
 }
@@ -583,19 +598,19 @@ import "path/bar""#,
         File {
             base: BaseNode {
                 location: loc.get(2, 1, 5, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: Some(PackageClause {
                 base: BaseNode {
                     location: loc.get(2, 1, 2, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 name: Identifier {
                     base: BaseNode {
                         location: loc.get(2, 9, 2, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "baz".to_string()
                 }
@@ -604,13 +619,13 @@ import "path/bar""#,
                 ImportDeclaration {
                     base: BaseNode {
                         location: loc.get(4, 1, 4, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     alias: None,
                     path: StringLit {
                         base: BaseNode {
                             location: loc.get(4, 8, 4, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "path/foo".to_string()
                     }
@@ -618,19 +633,20 @@ import "path/bar""#,
                 ImportDeclaration {
                     base: BaseNode {
                         location: loc.get(5, 1, 5, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     alias: None,
                     path: StringLit {
                         base: BaseNode {
                             location: loc.get(5, 8, 5, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "path/bar".to_string()
                     }
                 }
             ],
-            body: vec![]
+            body: vec![],
+            eof: None,
         },
     )
 }
@@ -653,19 +669,19 @@ import "path/bar"
         File {
             base: BaseNode {
                 location: loc.get(2, 1, 7, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: Some(PackageClause {
                 base: BaseNode {
                     location: loc.get(2, 1, 2, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 name: Identifier {
                     base: BaseNode {
                         location: loc.get(2, 9, 2, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "baz".to_string()
                 }
@@ -674,13 +690,13 @@ import "path/bar"
                 ImportDeclaration {
                     base: BaseNode {
                         location: loc.get(4, 1, 4, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     alias: None,
                     path: StringLit {
                         base: BaseNode {
                             location: loc.get(4, 8, 4, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "path/foo".to_string()
                     }
@@ -688,45 +704,46 @@ import "path/bar"
                 ImportDeclaration {
                     base: BaseNode {
                         location: loc.get(5, 1, 5, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     alias: None,
                     path: StringLit {
                         base: BaseNode {
                             location: loc.get(5, 8, 5, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "path/bar".to_string()
                     }
                 }
             ],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(7, 1, 7, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(7, 1, 7, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::AdditionOperator,
                     left: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(7, 1, 7, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
                     }),
                     right: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(7, 5, 7, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -749,7 +766,7 @@ fn optional_query_metadata() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 7, 7),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -758,137 +775,150 @@ fn optional_query_metadata() {
             body: vec![Statement::Option(Box::new(OptionStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 7, 7),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 assignment: Assignment::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 8, 7, 7),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 8, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "task".to_string()
                     },
                     init: Expression::Object(Box::new(ObjectExpr {
                         base: BaseNode {
                             location: loc.get(1, 15, 7, 7),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lbrace: None,
                         with: None,
                         properties: vec![
                             Property {
                                 base: BaseNode {
                                     location: loc.get(2, 5, 2, 16),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 5, 2, 9),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "name".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::StringLit(StringLit {
                                     base: BaseNode {
                                         location: loc.get(2, 11, 2, 16),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: "foo".to_string()
-                                }))
+                                })),
+                                comma: None,
                             },
                             Property {
                                 base: BaseNode {
                                     location: loc.get(3, 5, 3, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(3, 5, 3, 10),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "every".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Duration(DurationLit {
                                     base: BaseNode {
                                         location: loc.get(3, 12, 3, 14),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     values: vec![Duration {
                                         magnitude: 1,
                                         unit: "h".to_string()
                                     }]
-                                }))
+                                })),
+                                comma: None,
                             },
                             Property {
                                 base: BaseNode {
                                     location: loc.get(4, 5, 4, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(4, 5, 4, 10),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "delay".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Duration(DurationLit {
                                     base: BaseNode {
                                         location: loc.get(4, 12, 4, 15),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     values: vec![Duration {
                                         magnitude: 10,
                                         unit: "m".to_string()
                                     }]
-                                }))
+                                })),
+                                comma: None,
                             },
                             Property {
                                 base: BaseNode {
                                     location: loc.get(5, 5, 5, 22),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(5, 5, 5, 9),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "cron".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::StringLit(StringLit {
                                     base: BaseNode {
                                         location: loc.get(5, 11, 5, 22),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: "0 2 * * *".to_string()
-                                }))
+                                })),
+                                comma: None,
                             },
                             Property {
                                 base: BaseNode {
                                     location: loc.get(6, 5, 6, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(6, 5, 6, 10),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "retry".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Integer(IntegerLit {
                                     base: BaseNode {
                                         location: loc.get(6, 12, 6, 13),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 5
-                                }))
+                                })),
+                                comma: None,
                             }
-                        ]
+                        ],
+                        rbrace: None,
                     }))
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -911,7 +941,7 @@ fn optional_query_metadata_preceding_query_text() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 7, 22),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -921,115 +951,138 @@ fn optional_query_metadata_preceding_query_text() {
                 Statement::Option(Box::new(OptionStmt {
                     base: BaseNode {
                         location: loc.get(1, 1, 4, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     assignment: Assignment::Variable(Box::new(VariableAssgn {
                         base: BaseNode {
                             location: loc.get(1, 8, 4, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         id: Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 8, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "task".to_string()
                         },
                         init: Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 15, 4, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(2, 6, 2, 17),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 6, 2, 10),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "name".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(2, 12, 2, 17),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "foo".to_string()
-                                    }))
+                                    })),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(3, 6, 3, 15),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(3, 6, 3, 11),
-                                            errors: vec![]
+                                            comments: Some(Box::new(Comment {
+                                                lit: "// Name of task\n".to_string(),
+                                                next: None,
+                                            })),
+                                            ..BaseNode::default()
                                         },
                                         name: "every".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Duration(DurationLit {
                                         base: BaseNode {
                                             location: loc.get(3, 13, 3, 15),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         values: vec![Duration {
                                             magnitude: 1,
                                             unit: "h".to_string()
                                         }]
-                                    }))
+                                    })),
+                                    comma: None,
                                 }
-                            ]
+                            ],
+                            rbrace: Some(Box::new(Comment {
+                                lit: "// Execution frequency of task\n".to_string(),
+                                next: None,
+                            })),
                         }))
                     }))
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(7, 5, 7, 22),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(7, 5, 7, 22),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(7, 5, 7, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(7, 5, 7, 9),
-                                    errors: vec![]
+                                    comments: Some(Box::new(Comment {
+                                        lit: "// Task will execute the following query\n"
+                                            .to_string(),
+                                        next: None,
+                                    })),
+                                    ..BaseNode::default()
                                 },
                                 name: "from".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(7, 15, 7, 22),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(7, 15, 7, 20),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "count".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         }
                     })),
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -1044,7 +1097,7 @@ fn qualified_option() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 31),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1053,42 +1106,45 @@ fn qualified_option() {
             body: vec![Statement::Option(Box::new(OptionStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 31),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 assignment: Assignment::Member(Box::new(MemberAssgn {
                     base: BaseNode {
                         location: loc.get(1, 8, 1, 31),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     member: MemberExpr {
                         base: BaseNode {
                             location: loc.get(1, 8, 1, 19),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 8, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "alert".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 14, 1, 19),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "state".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     },
                     init: Expression::StringLit(StringLit {
                         base: BaseNode {
                             location: loc.get(1, 22, 1, 31),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "Warning".to_string()
                     })
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1103,25 +1159,26 @@ fn builtin() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Builtin(BuiltinStmt {
+            body: vec![Statement::Builtin(Box::new(BuiltinStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "from".to_string()
                 }
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1136,7 +1193,7 @@ fn test_statement() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 30),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1145,71 +1202,78 @@ fn test_statement() {
             body: vec![Statement::Test(Box::new(TestStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 30),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 assignment: VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 6, 1, 30),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "mean".to_string()
                     },
                     init: Expression::Object(Box::new(ObjectExpr {
                         base: BaseNode {
                             location: loc.get(1, 13, 1, 30),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lbrace: None,
                         with: None,
                         properties: vec![
                             Property {
                                 base: BaseNode {
                                     location: loc.get(1, 14, 1, 21),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 14, 1, 18),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "want".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Integer(IntegerLit {
                                     base: BaseNode {
                                         location: loc.get(1, 20, 1, 21),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 0
-                                }))
+                                })),
+                                comma: None,
                             },
                             Property {
                                 base: BaseNode {
                                     location: loc.get(1, 23, 1, 29),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 23, 1, 26),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "got".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Integer(IntegerLit {
                                     base: BaseNode {
                                         location: loc.get(1, 28, 1, 29),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 0
-                                }))
+                                })),
+                                comma: None,
                             }
-                        ]
+                        ],
+                        rbrace: None,
                     }))
                 }
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1224,32 +1288,35 @@ fn from() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 7),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 7),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Call(Box::new(CallExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 7),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
-                    arguments: vec![],
                     callee: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 5),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "from".to_string()
-                    })
+                    }),
+                    lparen: None,
+                    arguments: vec![],
+                    rparen: None,
                 })),
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1267,32 +1334,39 @@ fn comment() {
         File {
             base: BaseNode {
                 location: loc.get(2, 4, 2, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(2, 4, 2, 10),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Call(Box::new(CallExpr {
                     base: BaseNode {
                         location: loc.get(2, 4, 2, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
-                    arguments: vec![],
                     callee: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(2, 4, 2, 8),
-                            errors: vec![]
+                            comments: Some(Box::new(Comment {
+                                lit: "// Comment\n".to_string(),
+                                next: None,
+                            })),
+                            ..BaseNode::default()
                         },
                         name: "from".to_string()
-                    })
+                    }),
+                    lparen: None,
+                    arguments: vec![],
+                    rparen: None,
                 })),
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1307,32 +1381,35 @@ fn identifier_with_number() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 7),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 7),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Call(Box::new(CallExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 7),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
-                    arguments: vec![],
                     callee: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 5),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "tan2".to_string()
-                    })
+                    }),
+                    lparen: None,
+                    arguments: vec![],
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1347,25 +1424,26 @@ fn regex_literal() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 5),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 5),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Regexp(RegexpLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 5),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: ".*".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1380,25 +1458,26 @@ fn regex_literal_with_escape_sequence() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Regexp(RegexpLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "a/b\\\\c\\d".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1413,16 +1492,16 @@ fn bad_regex_literal() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 4),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 4),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Regexp(RegexpLit {
                     base: BaseNode {
@@ -1430,11 +1509,13 @@ fn bad_regex_literal() {
                         errors: vec![
                             "regex parse error: * error: repetition operator missing expression"
                                 .to_string()
-                        ]
+                        ],
+                        ..BaseNode::default()
                     },
                     value: "".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1449,40 +1530,40 @@ fn regex_match_operators() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 28),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 28),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 28),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::AndOperator,
                     left: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::RegexpMatchOperator,
                         left: Expression::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a".to_string()
                         }),
                         right: Expression::Regexp(RegexpLit {
                             base: BaseNode {
                                 location: loc.get(1, 8, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: ".*".to_string()
                         })
@@ -1490,26 +1571,27 @@ fn regex_match_operators() {
                     right: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 17, 1, 28),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotRegexpMatchOperator,
                         left: Expression::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 17, 1, 20),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "b".to_string()
                         }),
                         right: Expression::Regexp(RegexpLit {
                             base: BaseNode {
                                 location: loc.get(1, 24, 1, 28),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "c$".to_string()
                         })
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1524,7 +1606,7 @@ fn declare_variable_as_an_int() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1533,23 +1615,24 @@ fn declare_variable_as_an_int() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 10),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "howdy".to_string()
                 },
                 init: Expression::Integer(IntegerLit {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: 1
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1564,7 +1647,7 @@ fn declare_variable_as_a_float() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1573,23 +1656,24 @@ fn declare_variable_as_a_float() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "howdy".to_string()
                 },
                 init: Expression::Float(FloatLit {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: 1.1
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1604,7 +1688,7 @@ fn declare_variable_as_an_array() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 21),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1613,52 +1697,67 @@ fn declare_variable_as_an_array() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 21),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "howdy".to_string()
                 },
                 init: Expression::Array(Box::new(ArrayExpr {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 21),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrack: None,
                     elements: vec![
-                        Expression::Integer(IntegerLit {
-                            base: BaseNode {
-                                location: loc.get(1, 10, 1, 11),
-                                errors: vec![]
-                            },
-                            value: 1
-                        }),
-                        Expression::Integer(IntegerLit {
-                            base: BaseNode {
-                                location: loc.get(1, 13, 1, 14),
-                                errors: vec![]
-                            },
-                            value: 2
-                        }),
-                        Expression::Integer(IntegerLit {
-                            base: BaseNode {
-                                location: loc.get(1, 16, 1, 17),
-                                errors: vec![]
-                            },
-                            value: 3
-                        }),
-                        Expression::Integer(IntegerLit {
-                            base: BaseNode {
-                                location: loc.get(1, 19, 1, 20),
-                                errors: vec![]
-                            },
-                            value: 4
-                        })
-                    ]
+                        ArrayItem {
+                            expression: Expression::Integer(IntegerLit {
+                                base: BaseNode {
+                                    location: loc.get(1, 10, 1, 11),
+                                    ..BaseNode::default()
+                                },
+                                value: 1
+                            }),
+                            comma: None,
+                        },
+                        ArrayItem {
+                            expression: Expression::Integer(IntegerLit {
+                                base: BaseNode {
+                                    location: loc.get(1, 13, 1, 14),
+                                    ..BaseNode::default()
+                                },
+                                value: 2
+                            }),
+                            comma: None,
+                        },
+                        ArrayItem {
+                            expression: Expression::Integer(IntegerLit {
+                                base: BaseNode {
+                                    location: loc.get(1, 16, 1, 17),
+                                    ..BaseNode::default()
+                                },
+                                value: 3
+                            }),
+                            comma: None,
+                        },
+                        ArrayItem {
+                            expression: Expression::Integer(IntegerLit {
+                                base: BaseNode {
+                                    location: loc.get(1, 19, 1, 20),
+                                    ..BaseNode::default()
+                                },
+                                value: 4
+                            }),
+                            comma: None,
+                        }
+                    ],
+                    rbrack: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1673,7 +1772,7 @@ fn declare_variable_as_an_empty_array() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 11),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1682,23 +1781,26 @@ fn declare_variable_as_an_empty_array() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 11),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "howdy".to_string()
                 },
                 init: Expression::Array(Box::new(ArrayExpr {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 11),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrack: None,
                     elements: vec![],
+                    rbrack: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1716,7 +1818,7 @@ fn use_variable_to_declare_something() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1726,44 +1828,47 @@ fn use_variable_to_declare_something() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "howdy".to_string()
                     },
                     init: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 9, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
                     })
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(2, 4, 2, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(2, 4, 2, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 4, 2, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -1781,7 +1886,7 @@ fn variable_is_from_statement() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 17),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -1791,64 +1896,71 @@ fn variable_is_from_statement() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 15),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "howdy".to_string()
                     },
                     init: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 9, 1, 15),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(2, 4, 2, 17),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(2, 4, 2, 17),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Member(Box::new(MemberExpr {
                             base: BaseNode {
                                 location: loc.get(2, 4, 2, 15),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             object: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 4, 2, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "howdy".to_string()
                             }),
+                            lbrack: None,
                             property: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 10, 2, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "count".to_string()
-                            })
-                        }))
+                            }),
+                            rbrack: None,
+                        })),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -1863,52 +1975,57 @@ fn pipe_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 18),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 7),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 11, 1, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 11, 1, 16),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "count".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -1923,84 +2040,93 @@ fn pipe_expression_to_member_expression_function() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Member(Box::new(MemberExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 9),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             object: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
+                            lbrack: None,
                             property: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 8, 1, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "c".to_string()
-                            })
+                            }),
+                            rbrack: None,
                         })),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 10, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![Property {
                                 base: BaseNode {
                                     location: loc.get(1, 10, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 10, 1, 11),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "d".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 12, 1, 13),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "e".to_string()
-                                }))
-                            }]
-                        }))]
+                                })),
+                                comma: None,
+                            }],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2015,45 +2141,48 @@ fn literal_pipe_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 5,
                     }),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "pow2".to_string()
-                        })
-                    },
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
+                    }
                 })),
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2068,58 +2197,63 @@ fn member_expression_pipe_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 17),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 17),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 17),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "foo".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "bar".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 12, 1, 17),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 12, 1, 15),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "baz".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2134,92 +2268,101 @@ fn multiple_pipe_expressions() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 41),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 41),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 41),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 30),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::PipeExpr(Box::new(PipeExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             argument: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 1, 1, 5),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "from".to_string()
                                 }),
-                                arguments: vec![]
+                                lparen: None,
+                                arguments: vec![],
+                                rparen: None,
                             })),
                             call: CallExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 18),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 11, 1, 16),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "range".to_string()
                                 }),
-                                arguments: vec![]
+                                lparen: None,
+                                arguments: vec![],
+                                rparen: None,
                             }
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(1, 22, 1, 30),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 22, 1, 28),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "filter".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         }
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 34, 1, 41),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 34, 1, 39),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "count".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2234,52 +2377,58 @@ fn pipe_expression_into_non_call_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "foo".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 10, 1, 13),
-                            errors: vec!["pipe destination must be a function call".to_string()]
+                            errors: vec!["pipe destination must be a function call".to_string()],
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 10, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "bar".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }
                 })),
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2299,7 +2448,7 @@ fn two_variables_for_two_froms() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 4, 16),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2309,124 +2458,133 @@ fn two_variables_for_two_froms() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 15),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "howdy".to_string()
                     },
                     init: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 9, 1, 15),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
                 })),
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 4, 2, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 4, 2, 9),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "doody".to_string()
                     },
                     init: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(2, 12, 2, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 12, 2, 16),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(3, 4, 3, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(3, 4, 3, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(3, 4, 3, 9),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "howdy".to_string()
                         }),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(3, 11, 3, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(3, 11, 3, 16),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "count".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         }
                     }))
-                }),
-                Statement::Expr(ExprStmt {
+                })),
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(4, 4, 4, 16),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(4, 4, 4, 16),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(4, 4, 4, 9),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "doody".to_string()
                         }),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(4, 11, 4, 16),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(4, 11, 4, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "sum".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         }
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -2441,58 +2599,65 @@ fn from_with_database() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 32),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 32),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Call(Box::new(CallExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 32),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     callee: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 5),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "from".to_string()
                     }),
+                    lparen: None,
                     arguments: vec![Expression::Object(Box::new(ObjectExpr {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 31),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lbrace: None,
                         with: None,
                         properties: vec![Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 31),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "bucket".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 13, 1, 31),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "telegraf/autogen".to_string()
-                            }))
-                        }]
-                    }))]
+                            })),
+                            comma: None,
+                        }],
+                        rbrace: None,
+                    }))],
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2512,7 +2677,7 @@ fn map_member_expressions() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 3, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2522,118 +2687,129 @@ fn map_member_expressions() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 29),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "m".to_string()
                     },
                     init: Expression::Object(Box::new(ObjectExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 29),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lbrace: None,
                         with: None,
                         properties: vec![
                             Property {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 10),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "key1".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Integer(IntegerLit {
                                     base: BaseNode {
                                         location: loc.get(1, 12, 1, 13),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 1
-                                }))
+                                })),
+                                comma: None,
                             },
                             Property {
                                 base: BaseNode {
                                     location: loc.get(1, 15, 1, 28),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 15, 1, 19),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "key2".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::StringLit(StringLit {
                                     base: BaseNode {
                                         location: loc.get(1, 20, 1, 28),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: "value2".to_string()
-                                }))
+                                })),
+                                comma: None,
                             }
-                        ]
+                        ],
+                        rbrace: None,
                     }))
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(2, 4, 2, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(2, 4, 2, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 4, 2, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "m".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 6, 2, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "key1".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     }))
-                }),
-                Statement::Expr(ExprStmt {
+                })),
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(3, 4, 3, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(3, 4, 3, 13),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(3, 4, 3, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "m".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(3, 6, 3, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "key2".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -2648,7 +2824,7 @@ fn object_with_string_literal_key() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2657,43 +2833,48 @@ fn object_with_string_literal_key() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "x".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 13),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 9),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a".to_string()
                         }),
+                        separator: None,
                         value: Some(Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 11, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 10
-                        }))
-                    }]
+                        })),
+                        comma: None,
+                    }],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2708,7 +2889,7 @@ fn object_with_mixed_keys() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 21),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2717,65 +2898,72 @@ fn object_with_mixed_keys() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 21),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "x".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 21),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "a".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 10
-                            }))
+                            })),
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 15, 1, 20),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 15, 1, 16),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 18, 1, 20),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 11
-                            }))
+                            })),
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2790,7 +2978,7 @@ fn implicit_key_object_literal() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 11),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2799,53 +2987,60 @@ fn implicit_key_object_literal() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 11),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "x".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 11),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 10),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2861,7 +3056,7 @@ fn implicit_key_object_literal_error() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2870,54 +3065,61 @@ fn implicit_key_object_literal_error() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "x".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             // TODO(affo): this should error with ast.Check: "string literal key "a" must have a value".
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 9),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "a".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 11, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -2933,7 +3135,7 @@ fn implicit_and_explicit_keys_object_literal_error() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -2942,12 +3144,12 @@ fn implicit_and_explicit_keys_object_literal_error() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "x".to_string()
                 },
@@ -2955,47 +3157,54 @@ fn implicit_and_explicit_keys_object_literal_error() {
                     // TODO(affo): this should error in ast.Check(): "cannot mix implicit and explicit properties".
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 10),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "c".to_string()
-                            }))
+                            })),
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3010,73 +3219,83 @@ fn object_with() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 18),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
-                    with: Some(Identifier {
-                        base: BaseNode {
-                            location: loc.get(1, 2, 1, 3),
-                            errors: vec![]
+                    lbrace: None,
+                    with: Some(WithSource {
+                        source: Identifier {
+                            base: BaseNode {
+                                location: loc.get(1, 2, 1, 3),
+                                ..BaseNode::default()
+                            },
+                            name: "a".to_string()
                         },
-                        name: "a".to_string()
+                        with: None
                     }),
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 10),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "c".to_string()
-                            }))
+                            })),
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 14, 1, 17),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 14, 1, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "d".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 16, 1, 17),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "e".to_string()
-                            }))
+                            })),
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3091,61 +3310,71 @@ fn object_with_implicit_keys() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
-                    with: Some(Identifier {
-                        base: BaseNode {
-                            location: loc.get(1, 2, 1, 3),
-                            errors: vec![]
+                    lbrace: None,
+                    with: Some(WithSource {
+                        source: Identifier {
+                            base: BaseNode {
+                                location: loc.get(1, 2, 1, 3),
+                                ..BaseNode::default()
+                            },
+                            name: "a".to_string()
                         },
-                        name: "a".to_string()
+                        with: None,
                     }),
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 10),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 12, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 12, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "c".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3160,38 +3389,41 @@ fn index_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 5),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 5),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Index(Box::new(IndexExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 5),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     array: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
+                    lbrack: None,
                     index: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 3, 1, 4),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 3
-                    })
+                    }),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3206,51 +3438,56 @@ fn nested_index_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 8),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 8),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Index(Box::new(IndexExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 8),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     array: Expression::Index(Box::new(IndexExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 5),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         array: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
+                        lbrack: None,
                         index: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 3, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 3
-                        })
+                        }),
+                        rbrack: None,
                     })),
+                    lbrack: None,
                     index: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 7),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 5
-                    })
+                    }),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3265,45 +3502,50 @@ fn access_indexed_object_returned_from_function_call() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 7),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 7),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Index(Box::new(IndexExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 7),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     array: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 4),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "f".to_string()
                         }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
+                    lbrack: None,
                     index: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 3
-                    })
+                    }),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3318,51 +3560,56 @@ fn index_with_member_expressions() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 9),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 9),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Member(Box::new(MemberExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 9),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     object: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 4),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 3, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     })),
+                    lbrack: None,
                     property: PropertyKey::StringLit(StringLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "c".to_string()
-                    })
+                    }),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3377,58 +3624,65 @@ fn index_with_member_with_call_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 11),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 11),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Member(Box::new(MemberExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 11),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     object: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Member(Box::new(MemberExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             object: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 2),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
+                            lbrack: None,
                             property: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 3, 1, 4),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
-                            })
+                            }),
+                            rbrack: None,
                         })),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
+                    lbrack: None,
                     property: PropertyKey::StringLit(StringLit {
                         base: BaseNode {
                             location: loc.get(1, 7, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: "c".to_string()
-                    })
+                    }),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3443,45 +3697,51 @@ fn index_with_unclosed_bracket() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Index(Box::new(IndexExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec!["expected RBRACK, got EOF".to_string()]
+                        errors: vec!["expected RBRACK, got EOF".to_string()],
+                        ..BaseNode::default()
                     },
                     array: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
+                    lbrack: None,
                     index: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 3, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 3, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3496,45 +3756,51 @@ fn index_with_unbalanced_parenthesis() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Index(Box::new(IndexExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     array: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
+                    lbrack: None,
                     index: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 3, 1, 6),
-                            errors: vec!["expected RPAREN, got RBRACK".to_string()]
+                            errors: vec!["expected RPAREN, got RBRACK".to_string()],
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 3, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3549,38 +3815,42 @@ fn index_with_unexpected_rparen() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Index(Box::new(IndexExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec!["invalid expression @1:4-1:5: )".to_string()]
+                        errors: vec!["invalid expression @1:4-1:5: )".to_string()],
+                        ..BaseNode::default()
                     },
                     array: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
+                    lbrack: None,
                     index: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 3, 1, 4),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "b".to_string()
-                    })
+                    }),
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3595,39 +3865,40 @@ fn binary_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::LessThanOperator,
                     left: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 7),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "_value".to_string()
                     }),
                     right: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 10, 1, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 10.0
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3642,52 +3913,55 @@ fn member_expression_binary_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 16),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 16),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 16),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::LessThanOperator,
                     left: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 9),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "r".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 3, 1, 9),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "_value".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     })),
                     right: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 12, 1, 16),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 10.0
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -3707,7 +3981,7 @@ fn var_as_binary_expression_of_other_vars() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 4, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -3717,19 +3991,19 @@ fn var_as_binary_expression_of_other_vars() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
                     })
@@ -3737,19 +4011,19 @@ fn var_as_binary_expression_of_other_vars() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 13, 2, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "b".to_string()
                     },
                     init: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(2, 17, 2, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 2
                     })
@@ -3757,32 +4031,32 @@ fn var_as_binary_expression_of_other_vars() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(3, 13, 3, 22),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(3, 13, 3, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "c".to_string()
                     },
                     init: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(3, 17, 3, 22),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::AdditionOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(3, 17, 3, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(3, 21, 3, 22),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
@@ -3791,24 +4065,25 @@ fn var_as_binary_expression_of_other_vars() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(4, 13, 4, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(4, 13, 4, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "d".to_string()
                     },
                     init: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(4, 17, 4, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     })
                 }))
-            ]
+            ],
+            eof: None,
         },
     )
 }
@@ -3826,7 +4101,7 @@ fn var_as_unary_expression_of_other_vars() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 19),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -3836,19 +4111,19 @@ fn var_as_unary_expression_of_other_vars() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 5
                     })
@@ -3856,31 +4131,32 @@ fn var_as_unary_expression_of_other_vars() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 19),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 13, 2, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "c".to_string()
                     },
                     init: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(2, 17, 2, 19),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::SubtractionOperator,
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 18, 2, 19),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         })
                     }))
                 }))
-            ]
+            ],
+            eof: None,
         },
     )
 }
@@ -3898,7 +4174,7 @@ fn var_as_both_binary_and_unary_expressions() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 24),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -3908,19 +4184,19 @@ fn var_as_both_binary_and_unary_expressions() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 5
                     })
@@ -3928,45 +4204,46 @@ fn var_as_both_binary_and_unary_expressions() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 24),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 13, 2, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "c".to_string()
                     },
                     init: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(2, 17, 2, 24),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::MultiplicationOperator,
                         left: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(2, 17, 2, 19),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 10
                         }),
                         right: Expression::Unary(Box::new(UnaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 22, 2, 24),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::SubtractionOperator,
                             argument: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 23, 2, 24),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             })
                         }))
                     }))
                 }))
-            ]
+            ],
+            eof: None,
         },
     )
 }
@@ -3984,7 +4261,7 @@ fn unary_expressions_within_logical_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 42),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -3994,63 +4271,63 @@ fn unary_expressions_within_logical_expression() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 8),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 5.0
                     })
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 42),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(2, 13, 2, 42),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::OrOperator,
                         left: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 13, 2, 30),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::EqualOperator,
                             left: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 13, 2, 22),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::MultiplicationOperator,
                                 left: Expression::Float(FloatLit {
                                     base: BaseNode {
                                         location: loc.get(2, 13, 2, 17),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 10.0
                                 }),
                                 right: Expression::Unary(Box::new(UnaryExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 20, 2, 22),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::SubtractionOperator,
                                     argument: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 21, 2, 22),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "a".to_string()
                                     })
@@ -4059,13 +4336,13 @@ fn unary_expressions_within_logical_expression() {
                             right: Expression::Unary(Box::new(UnaryExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 26, 2, 30),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::SubtractionOperator,
                                 argument: Expression::Float(FloatLit {
                                     base: BaseNode {
                                         location: loc.get(2, 27, 2, 30),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 0.5
                                 })
@@ -4074,27 +4351,28 @@ fn unary_expressions_within_logical_expression() {
                         right: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 34, 2, 42),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::EqualOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 34, 2, 35),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
                             right: Expression::Float(FloatLit {
                                 base: BaseNode {
                                     location: loc.get(2, 39, 2, 42),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 6.0
                             })
                         }))
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -4109,45 +4387,48 @@ fn unary_expression_with_member_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 8),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 8),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Unary(Box::new(UnaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 8),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::NotOperator,
                     argument: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         object: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "m".to_string()
                         }),
+                        lbrack: None,
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 7, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
-                        })
+                        }),
+                        rbrack: None,
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4169,7 +4450,7 @@ a = 5.0
         File {
             base: BaseNode {
                 location: loc.get(2, 1, 6, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -4179,63 +4460,75 @@ a = 5.0
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 1, 2, 8),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 1, 2, 2),
-                            errors: vec![]
+                            comments: Some(Box::new(Comment {
+                                lit: "// define a\n".to_string(),
+                                next: None,
+                            })),
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(2, 5, 2, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 5.0
                     })
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(4, 1, 6, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(4, 1, 6, 13),
-                            errors: vec![]
+                            comments: Some(Box::new(Comment {
+                                lit: "// or this\n".to_string(),
+                                next: None,
+                            })),
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::OrOperator,
                         left: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(4, 1, 4, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::EqualOperator,
                             left: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(4, 1, 4, 10),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::MultiplicationOperator,
                                 left: Expression::Float(FloatLit {
                                     base: BaseNode {
                                         location: loc.get(4, 1, 4, 5),
-                                        errors: vec![]
+                                        comments: Some(Box::new(Comment {
+                                            lit: "// eval this\n".to_string(),
+                                            next: None,
+                                        })),
+                                        ..BaseNode::default()
                                     },
                                     value: 10.0
                                 }),
                                 right: Expression::Unary(Box::new(UnaryExpr {
                                     base: BaseNode {
                                         location: loc.get(4, 8, 4, 10),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::SubtractionOperator,
                                     argument: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(4, 9, 4, 10),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "a".to_string()
                                     })
@@ -4244,13 +4537,13 @@ a = 5.0
                             right: Expression::Unary(Box::new(UnaryExpr {
                                 base: BaseNode {
                                     location: loc.get(4, 14, 4, 18),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::SubtractionOperator,
                                 argument: Expression::Float(FloatLit {
                                     base: BaseNode {
                                         location: loc.get(4, 15, 4, 18),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 0.5
                                 })
@@ -4259,27 +4552,28 @@ a = 5.0
                         right: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(6, 5, 6, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::EqualOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(6, 5, 6, 6),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
                             right: Expression::Float(FloatLit {
                                 base: BaseNode {
                                     location: loc.get(6, 10, 6, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 6.0
                             })
                         }))
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -4294,7 +4588,7 @@ fn expressions_with_function_calls() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 16),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -4303,44 +4597,47 @@ fn expressions_with_function_calls() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 16),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "a".to_string()
                 },
                 init: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 16),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::EqualOperator,
                     left: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "foo".to_string()
-                        })
+                        }),
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     })),
                     right: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 14, 1, 16),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 10
                     })
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4358,94 +4655,101 @@ fn mix_unary_logical_and_binary_expressions() {
         File {
             base: BaseNode {
                 location: loc.get(2, 13, 2, 43),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(2, 13, 2, 43),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 43),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::OrOperator,
                     left: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(2, 13, 2, 33),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Paren(Box::new(ParenExpr {
                             base: BaseNode {
                                 location: loc.get(2, 17, 2, 33),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lparen: None,
                             expression: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 18, 2, 32),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::EqualOperator,
                                 left: Expression::Call(Box::new(CallExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 18, 2, 21),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
-                                    arguments: vec![],
+                                    lparen: None,
                                     callee: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 18, 2, 19),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "f".to_string()
-                                    })
+                                    }),
+                                    arguments: vec![],
+                                    rparen: None,
                                 })),
                                 right: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 25, 2, 32),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::MultiplicationOperator,
                                     left: Expression::Float(FloatLit {
                                         base: BaseNode {
                                             location: loc.get(2, 25, 2, 28),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: 6.0
                                     }),
                                     right: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 31, 2, 32),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "x".to_string()
                                     })
                                 }))
-                            }))
+                            })),
+                            rparen: None,
                         }))
                     })),
                     right: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(2, 37, 2, 43),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
-                        arguments: vec![],
+                        lparen: None,
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 37, 2, 41),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "fail".to_string()
-                        })
+                        }),
+                        arguments: vec![],
+                        rparen: None,
                     })),
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4463,100 +4767,109 @@ fn mix_unary_logical_and_binary_expressions_with_extra_parens() {
         File {
             base: BaseNode {
                 location: loc.get(2, 13, 2, 45),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(2, 13, 2, 45),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Paren(Box::new(ParenExpr {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 45),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     expression: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(2, 14, 2, 44),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::OrOperator,
                         left: Expression::Unary(Box::new(UnaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 14, 2, 34),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::NotOperator,
                             argument: Expression::Paren(Box::new(ParenExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 18, 2, 34),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lparen: None,
                                 expression: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 19, 2, 33),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::EqualOperator,
                                     left: Expression::Call(Box::new(CallExpr {
                                         base: BaseNode {
                                             location: loc.get(2, 19, 2, 22),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
-                                        arguments: vec![],
+                                        lparen: None,
                                         callee: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 19, 2, 20),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "f".to_string()
-                                        })
+                                        }),
+                                        arguments: vec![],
+                                        rparen: None,
                                     })),
                                     right: Expression::Binary(Box::new(BinaryExpr {
                                         base: BaseNode {
                                             location: loc.get(2, 26, 2, 33),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::MultiplicationOperator,
                                         left: Expression::Float(FloatLit {
                                             base: BaseNode {
                                                 location: loc.get(2, 26, 2, 29),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             value: 6.0
                                         }),
                                         right: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 32, 2, 33),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "x".to_string()
                                         })
                                     }))
-                                }))
+                                })),
+                                rparen: None,
                             }))
                         })),
                         right: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(2, 38, 2, 44),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
-                            arguments: vec![],
+                            lparen: None,
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 38, 2, 42),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "fail".to_string()
-                            })
+                            }),
+                            arguments: vec![],
+                            rparen: None,
                         })),
-                    }))
+                    })),
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4571,39 +4884,40 @@ fn modulo_op_ints() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::ModuloOperator,
                     left: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 3
                     }),
                     right: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 8
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4618,39 +4932,40 @@ fn modulo_op_floats() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 10),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::ModuloOperator,
                     left: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 4),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 8.3
                     }),
                     right: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 7, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 3.1
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4665,39 +4980,40 @@ fn power_op() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::PowerOperator,
                     left: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 2
                     }),
                     right: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 4
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4712,40 +5028,40 @@ fn binary_operator_precedence() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::SubtractionOperator,
                     left: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::DivisionOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
@@ -4753,12 +5069,13 @@ fn binary_operator_precedence() {
                     right: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 9, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1.0
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4773,40 +5090,40 @@ fn binary_operator_precedence_literals_only() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::SubtractionOperator,
                     left: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::DivisionOperator,
                         left: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 2
                         }),
                         right: Expression::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a".to_string()
                         })
@@ -4814,12 +5131,13 @@ fn binary_operator_precedence_literals_only() {
                     right: Expression::Float(FloatLit {
                         base: BaseNode {
                             location: loc.get(1, 11, 1, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1.0
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4834,40 +5152,40 @@ fn binary_operator_precedence_double_subtraction() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 10),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::SubtractionOperator,
                     left: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::SubtractionOperator,
                         left: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 1
                         }),
                         right: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 2
                         })
@@ -4875,12 +5193,13 @@ fn binary_operator_precedence_double_subtraction() {
                     right: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 9, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 3
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4895,59 +5214,62 @@ fn binary_operator_precedence_double_subtraction_with_parens() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::SubtractionOperator,
                     left: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
                     }),
                     right: Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::SubtractionOperator,
                             left: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 2
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 10, 1, 11),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 3
                             })
-                        }))
+                        })),
+                        rparen: None,
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -4962,40 +5284,40 @@ fn binary_operator_precedence_double_sum() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 10),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::AdditionOperator,
                     left: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::AdditionOperator,
                         left: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 1
                         }),
                         right: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 2
                         })
@@ -5003,12 +5325,13 @@ fn binary_operator_precedence_double_sum() {
                     right: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 9, 1, 10),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 3
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5023,59 +5346,62 @@ fn binary_operator_precedence_double_sum_with_parens() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Binary(Box::new(BinaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::AdditionOperator,
                     left: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
                     }),
                     right: Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::AdditionOperator,
                             left: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 2
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 10, 1, 11),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 3
                             })
-                        }))
+                        })),
+                        rparen: None,
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5090,39 +5416,39 @@ fn logical_unary_operator_precedence() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Unary(Box::new(UnaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::NotOperator,
                     argument: Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::EqualOperator,
                         left: Expression::Unary(Box::new(UnaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::SubtractionOperator,
                             argument: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 1
                             })
@@ -5130,13 +5456,14 @@ fn logical_unary_operator_precedence() {
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 11, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         })
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5154,137 +5481,143 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 72),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 2, 72),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 2, 72),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::OrOperator,
                     left: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 2, 32),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::OrOperator,
                         left: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 2, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::AndOperator,
                             left: Expression::Logical(Box::new(LogicalExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 55),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: LogicalOperator::AndOperator,
                                 left: Expression::Logical(Box::new(LogicalExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 1, 1, 41),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: LogicalOperator::AndOperator,
                                     left: Expression::Binary(Box::new(BinaryExpr {
                                         base: BaseNode {
                                             location: loc.get(1, 1, 1, 27),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::LessThanOperator,
                                         left: Expression::Binary(Box::new(BinaryExpr {
                                             base: BaseNode {
                                                 location: loc.get(1, 1, 1, 21),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             operator: Operator::EqualOperator,
                                             left: Expression::Call(Box::new(CallExpr {
                                                 base: BaseNode {
                                                     location: loc.get(1, 1, 1, 4),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
-                                                arguments: vec![],
                                                 callee: Expression::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(1, 1, 1, 2),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     name: "a".to_string()
-                                                })
+                                                }),
+                                                lparen: None,
+                                                arguments: vec![],
+                                                rparen: None,
                                             })),
                                             right: Expression::Binary(Box::new(BinaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(1, 8, 1, 21),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 operator: Operator::AdditionOperator,
                                                 left: Expression::Member(Box::new(MemberExpr {
                                                     base: BaseNode {
                                                         location: loc.get(1, 8, 1, 11),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     object: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(1, 8, 1, 9),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "b".to_string()
                                                     }),
+                                                    lbrack: None,
                                                     property: PropertyKey::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(1, 10, 1, 11),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "a".to_string()
-                                                    })
+                                                    }),
+                                                    rbrack: None,
                                                 })),
                                                 right: Expression::Binary(Box::new(BinaryExpr {
                                                     base: BaseNode {
                                                         location: loc.get(1, 14, 1, 21),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     operator: Operator::MultiplicationOperator,
                                                     left: Expression::Member(Box::new(
                                                         MemberExpr {
                                                             base: BaseNode {
                                                                 location: loc.get(1, 14, 1, 17),
-                                                                errors: vec![]
+                                                                ..BaseNode::default()
                                                             },
                                                             object: Expression::Identifier(
                                                                 Identifier {
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(1, 14, 1, 15),
-                                                                        errors: vec![]
+                                                                        ..BaseNode::default()
                                                                     },
                                                                     name: "b".to_string()
                                                                 }
                                                             ),
+                                                            lbrack: None,
                                                             property: PropertyKey::Identifier(
                                                                 Identifier {
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(1, 16, 1, 17),
-                                                                        errors: vec![]
+                                                                        ..BaseNode::default()
                                                                     },
                                                                     name: "c".to_string()
                                                                 }
-                                                            )
+                                                            ),
+                                                            rbrack: None,
                                                         }
                                                     )),
                                                     right: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(1, 20, 1, 21),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "d".to_string()
                                                     })
@@ -5294,7 +5627,7 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                                         right: Expression::Integer(IntegerLit {
                                             base: BaseNode {
                                                 location: loc.get(1, 24, 1, 27),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             value: 100
                                         })
@@ -5302,68 +5635,70 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                                     right: Expression::Binary(Box::new(BinaryExpr {
                                         base: BaseNode {
                                             location: loc.get(1, 32, 1, 41),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::NotEqualOperator,
                                         left: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(1, 32, 1, 33),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "e".to_string()
                                         }),
                                         right: Expression::Index(Box::new(IndexExpr {
                                             base: BaseNode {
                                                 location: loc.get(1, 37, 1, 41),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             array: Expression::Identifier(Identifier {
                                                 base: BaseNode {
                                                     location: loc.get(1, 37, 1, 38),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 name: "f".to_string()
                                             }),
+                                            lbrack: None,
                                             index: Expression::Identifier(Identifier {
                                                 base: BaseNode {
                                                     location: loc.get(1, 39, 1, 40),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 name: "g".to_string()
-                                            })
+                                            }),
+                                            rbrack: None,
                                         }))
                                     }))
                                 })),
                                 right: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 46, 1, 55),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::GreaterThanOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 46, 1, 47),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "h".to_string()
                                     }),
                                     right: Expression::Binary(Box::new(BinaryExpr {
                                         base: BaseNode {
                                             location: loc.get(1, 50, 1, 55),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::MultiplicationOperator,
                                         left: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(1, 50, 1, 51),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "i".to_string()
                                         }),
                                         right: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(1, 54, 1, 55),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "j".to_string()
                                         })
@@ -5373,26 +5708,26 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                             right: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 1, 2, 18),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::LessThanOperator,
                                 left: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 1, 2, 6),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::DivisionOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 1, 2, 2),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "k".to_string()
                                     }),
                                     right: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 5, 2, 6),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "l".to_string()
                                     })
@@ -5400,26 +5735,26 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                                 right: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 9, 2, 18),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::SubtractionOperator,
                                     left: Expression::Binary(Box::new(BinaryExpr {
                                         base: BaseNode {
                                             location: loc.get(2, 9, 2, 14),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::AdditionOperator,
                                         left: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 9, 2, 10),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "m".to_string()
                                         }),
                                         right: Expression::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 13, 2, 14),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "n".to_string()
                                         })
@@ -5427,7 +5762,7 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                                     right: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 17, 2, 18),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "o".to_string()
                                     })
@@ -5437,68 +5772,72 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                         right: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 22, 2, 32),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::LessThanEqualOperator,
                             left: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 22, 2, 25),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
-                                arguments: vec![],
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 22, 2, 23),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "p".to_string()
-                                })
+                                }),
+                                lparen: None,
+                                arguments: vec![],
+                                rparen: None,
                             })),
                             right: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 29, 2, 32),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
-                                arguments: vec![],
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 29, 2, 30),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "q".to_string()
-                                })
+                                }),
+                                lparen: None,
+                                arguments: vec![],
+                                rparen: None,
                             }))
                         }))
                     })),
                     right: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(2, 36, 2, 72),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::AndOperator,
                         left: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(2, 36, 2, 59),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::AndOperator,
                             left: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 36, 2, 42),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::GreaterThanEqualOperator,
                                 left: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 36, 2, 37),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "r".to_string()
                                 }),
                                 right: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 41, 2, 42),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "s".to_string()
                                 })
@@ -5506,26 +5845,26 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                             right: Expression::Unary(Box::new(UnaryExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 47, 2, 59),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::NotOperator,
                                 argument: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 51, 2, 59),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::RegexpMatchOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 51, 2, 52),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "t".to_string()
                                     }),
                                     right: Expression::Regexp(RegexpLit {
                                         base: BaseNode {
                                             location: loc.get(2, 56, 2, 59),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "a".to_string()
                                     })
@@ -5535,27 +5874,28 @@ k / l < m + n - o or p() <= q() or r >= s and not t =~ /a/ and u !~ /a/"#,
                         right: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 64, 2, 72),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::NotRegexpMatchOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 64, 2, 65),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "u".to_string()
                             }),
                             right: Expression::Regexp(RegexpLit {
                                 base: BaseNode {
                                     location: loc.get(2, 69, 2, 72),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "a".to_string()
                             })
                         }))
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5570,33 +5910,33 @@ fn logical_operators_precedence_1() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 11),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 11),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 11),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::OrOperator,
                     left: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         })
@@ -5604,12 +5944,13 @@ fn logical_operators_precedence_1() {
                     right: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 10, 1, 11),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "b".to_string()
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5624,46 +5965,47 @@ fn logical_operators_precedence_2() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 11),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 11),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 11),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::OrOperator,
                     left: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
                     right: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 11),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 10, 1, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5678,33 +6020,33 @@ fn logical_operators_precedence_3() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::AndOperator,
                     left: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 6),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         })
@@ -5712,12 +6054,13 @@ fn logical_operators_precedence_3() {
                     right: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 11, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "b".to_string()
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5732,46 +6075,47 @@ fn logical_operators_precedence_4() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::AndOperator,
                     left: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
                     right: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 7, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 11, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5786,40 +6130,40 @@ fn logical_operators_precedence_5() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::OrOperator,
                     left: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::AndOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 2),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 7, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
@@ -5827,12 +6171,13 @@ fn logical_operators_precedence_5() {
                     right: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 12, 1, 13),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "c".to_string()
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5847,53 +6192,54 @@ fn logical_operators_precedence_6() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::OrOperator,
                     left: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
                     right: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 13),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::AndOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         }),
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 12, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "c".to_string()
                         })
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5908,52 +6254,55 @@ fn logical_operators_precedence_7() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Unary(Box::new(UnaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 13),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::NotOperator,
                     argument: Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 13),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::OrOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
                             right: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             })
-                        }))
+                        })),
+                        rparen: None,
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -5968,52 +6317,55 @@ fn logical_operators_precedence_8() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Unary(Box::new(UnaryExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: Operator::NotOperator,
                     argument: Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 5, 1, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::AndOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
                             right: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 12, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             })
-                        }))
+                        })),
+                        rparen: None,
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6028,59 +6380,62 @@ fn logical_operators_precedence_9() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 15),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 15),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 15),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::AndOperator,
                     left: Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 9),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 8),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::OrOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 2, 1, 3),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
                             right: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 7, 1, 8),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             })
-                        }))
+                        })),
+                        rparen: None,
                     })),
                     right: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 14, 1, 15),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "c".to_string()
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6095,59 +6450,62 @@ fn logical_operators_precedence_10() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 15),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 15),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 15),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::AndOperator,
                     left: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     }),
                     right: Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 7, 1, 15),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(1, 8, 1, 14),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::OrOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 8, 1, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
                             right: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 13, 1, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "c".to_string()
                             })
-                        }))
+                        })),
+                        rparen: None,
                     }))
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6168,81 +6526,88 @@ fn two_logical_operations_with_parens() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 15),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 2, 15),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Logical(Box::new(LogicalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 2, 15),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     operator: LogicalOperator::AndOperator,
                     left: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 2, 9),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(1, 5, 2, 9),
-                                errors: vec!["expected comma in property list, got OR".to_string()]
+                                errors: vec!["expected comma in property list, got OR".to_string()],
+                                ..BaseNode::default()
                             },
                             callee: Expression::Paren(Box::new(ParenExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 5, 1, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lparen: None,
                                 expression: Expression::Logical(Box::new(LogicalExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 13),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: LogicalOperator::AndOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 6, 1, 7),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "a".to_string()
                                     }),
                                     right: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 12, 1, 13),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "b".to_string()
                                     })
-                                }))
+                                })),
+                                rparen: None,
                             })),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 2, 2, 8),
-                                    errors: vec![],
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![
                                     Property {
                                         base: BaseNode {
                                             location: loc.get(2, 2, 2, 3),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 2, 2, 3),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "a".to_string()
                                         }),
+                                        separator: None,
                                         value: None,
+                                        comma: None,
                                     },
                                     Property {
                                         base: BaseNode {
@@ -6250,30 +6615,36 @@ fn two_logical_operations_with_parens() {
                                             errors: vec![
                                                 "unexpected token for property key: OR (or)"
                                                     .to_string()
-                                            ]
+                                            ],
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::StringLit(StringLit {
                                             base: BaseNode {
                                                 location: loc.get(2, 4, 2, 4),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             value: "<invalid>".to_string()
                                         }),
+                                        separator: None,
                                         value: None,
+                                        comma: None,
                                     }
-                                ]
-                            }))]
+                                ],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }))
                     })),
                     right: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(2, 14, 2, 15),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "c".to_string()
                     })
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6291,7 +6662,7 @@ fn arrow_function_called() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 2, 16),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6301,104 +6672,116 @@ fn arrow_function_called() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 23),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "plusOne".to_string()
                     },
                     init: Expression::Function(Box::new(FunctionExpr {
                         base: BaseNode {
                             location: loc.get(1, 11, 1, 23),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         params: vec![Property {
                             base: BaseNode {
                                 location: loc.get(1, 12, 1, 13),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 12, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "r".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         }],
+                        rparen: None,
+                        arrow: None,
                         body: FunctionBody::Expr(Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 18, 1, 23),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::AdditionOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 18, 1, 19),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "r".to_string()
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 22, 1, 23),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 1
                             })
-                        })))
+                        }))),
                     }))
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(2, 4, 2, 16),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(2, 4, 2, 16),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(2, 4, 2, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "plusOne".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(2, 12, 2, 15),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![Property {
                                 base: BaseNode {
                                     location: loc.get(2, 12, 2, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 12, 2, 13),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "r".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Integer(IntegerLit {
                                     base: BaseNode {
                                         location: loc.get(2, 14, 2, 15),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: 5
-                                }))
-                            }]
-                        }))]
+                                })),
+                                comma: None,
+                            }],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -6413,7 +6796,7 @@ fn arrow_function_return_map() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 22),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6422,69 +6805,81 @@ fn arrow_function_return_map() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 22),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "toMap".to_string()
                 },
                 init: Expression::Function(Box::new(FunctionExpr {
                     base: BaseNode {
                         location: loc.get(1, 9, 1, 22),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     params: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 10, 1, 11),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 10, 1, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "r".to_string()
                         }),
-                        value: None
+                        separator: None,
+                        value: None,
+                        comma: None,
                     }],
+                    rparen: None,
+                    arrow: None,
                     body: FunctionBody::Expr(Expression::Paren(Box::new(ParenExpr {
                         base: BaseNode {
                             location: loc.get(1, 15, 1, 22),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         expression: Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 16, 1, 21),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![Property {
                                 base: BaseNode {
                                     location: loc.get(1, 17, 1, 20),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 17, 1, 18),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "r".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 19, 1, 20),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "r".to_string()
-                                }))
-                            }]
-                        }))
-                    })))
+                                })),
+                                comma: None,
+                            }],
+                            rbrace: None,
+                        })),
+                        rparen: None,
+                    }))),
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6499,7 +6894,7 @@ fn arrow_function_with_default_arg() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 25),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6508,79 +6903,87 @@ fn arrow_function_with_default_arg() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 25),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 5),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "addN".to_string()
                 },
                 init: Expression::Function(Box::new(FunctionExpr {
                     base: BaseNode {
                         location: loc.get(1, 8, 1, 25),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     params: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 10),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 10),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "r".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 12, 1, 15),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 12, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "n".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 14, 1, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 5
-                            }))
+                            })),
+                            comma: None,
                         }
                     ],
+                    rparen: None,
+                    arrow: None,
                     body: FunctionBody::Expr(Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 20, 1, 25),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::AdditionOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 20, 1, 21),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "r".to_string()
                         }),
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 24, 1, 25),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "n".to_string()
                         })
-                    })))
+                    }))),
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6599,7 +7002,7 @@ fn arrow_function_called_in_binary_expression() {
         File {
             base: BaseNode {
                 location: loc.get(2, 13, 3, 39),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6609,118 +7012,129 @@ fn arrow_function_called_in_binary_expression() {
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 13, 2, 35),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 13, 2, 20),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "plusOne".to_string()
                     },
                     init: Expression::Function(Box::new(FunctionExpr {
                         base: BaseNode {
                             location: loc.get(2, 23, 2, 35),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         params: vec![Property {
                             base: BaseNode {
                                 location: loc.get(2, 24, 2, 25),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 24, 2, 25),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "r".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         }],
+                        rparen: None,
+                        arrow: None,
                         body: FunctionBody::Expr(Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 30, 2, 35),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::AdditionOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 30, 2, 31),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "r".to_string()
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(2, 34, 2, 35),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 1
                             })
-                        })))
+                        }))),
                     }))
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(3, 13, 3, 39),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(3, 13, 3, 39),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::OrOperator,
                         left: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(3, 13, 3, 30),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::EqualOperator,
                             left: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(3, 13, 3, 25),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(3, 13, 3, 20),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "plusOne".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(3, 21, 3, 24),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(3, 21, 3, 24),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(3, 21, 3, 22),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "r".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::Integer(IntegerLit {
                                             base: BaseNode {
                                                 location: loc.get(3, 23, 3, 24),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             value: 5
-                                        }))
-                                    }]
-                                }))]
+                                        })),
+                                        comma: None,
+                                    }],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             })),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(3, 29, 3, 30),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 6
                             })
@@ -6728,20 +7142,23 @@ fn arrow_function_called_in_binary_expression() {
                         right: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(3, 34, 3, 39),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
-                            arguments: vec![],
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(3, 34, 3, 37),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "die".to_string()
-                            })
+                            }),
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         }))
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -6756,7 +7173,7 @@ fn arrow_function_as_single_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 38),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6765,70 +7182,78 @@ fn arrow_function_as_single_expression() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 38),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "f".to_string()
                 },
                 init: Expression::Function(Box::new(FunctionExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 38),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     params: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 7),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "r".to_string()
                         }),
-                        value: None
+                        separator: None,
+                        value: None,
+                        comma: None,
                     }],
+                    rparen: None,
+                    arrow: None,
                     body: FunctionBody::Expr(Expression::Binary(Box::new(BinaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 12, 1, 38),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::EqualOperator,
                         left: Expression::Member(Box::new(MemberExpr {
                             base: BaseNode {
                                 location: loc.get(1, 12, 1, 29),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             object: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 12, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "r".to_string()
                             }),
+                            lbrack: None,
                             property: PropertyKey::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 14, 1, 28),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "_measurement".to_string()
-                            })
+                            }),
+                            rbrack: None,
                         })),
                         right: Expression::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 33, 1, 38),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "cpu".to_string()
                         })
-                    })))
+                    }))),
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6848,7 +7273,7 @@ fn arrow_function_as_block() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 4, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6857,104 +7282,114 @@ fn arrow_function_as_block() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 4, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "f".to_string()
                 },
                 init: Expression::Function(Box::new(FunctionExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 4, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     params: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 7),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "r".to_string()
                         }),
-                        value: None
+                        separator: None,
+                        value: None,
+                        comma: None,
                     }],
+                    rparen: None,
+                    arrow: None,
                     body: FunctionBody::Block(Block {
                         base: BaseNode {
                             location: loc.get(1, 12, 4, 14),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lbrace: None,
                         body: vec![
                             Statement::Variable(Box::new(VariableAssgn {
                                 base: BaseNode {
                                     location: loc.get(2, 17, 2, 38),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 id: Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 17, 2, 18),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "m".to_string()
                                 },
                                 init: Expression::Member(Box::new(MemberExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 21, 2, 38),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     object: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 21, 2, 22),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "r".to_string()
                                     }),
+                                    lbrack: None,
                                     property: PropertyKey::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(2, 23, 2, 37),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "_measurement".to_string()
-                                    })
+                                    }),
+                                    rbrack: None,
                                 }))
                             })),
-                            Statement::Return(ReturnStmt {
+                            Statement::Return(Box::new(ReturnStmt {
                                 base: BaseNode {
                                     location: loc.get(3, 17, 3, 34),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 argument: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(3, 24, 3, 34),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::EqualOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(3, 24, 3, 25),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "m".to_string()
                                     }),
                                     right: Expression::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(3, 29, 3, 34),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "cpu".to_string()
                                     })
                                 }))
-                            })
-                        ]
-                    })
+                            }))
+                        ],
+                        rbrace: None,
+                    }),
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -6969,7 +7404,7 @@ fn conditional() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 26),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -6978,43 +7413,47 @@ fn conditional() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 26),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "a".to_string()
                 },
                 init: Expression::Conditional(Box::new(ConditionalExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 26),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     test: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 8, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "true".to_string()
                     }),
                     consequent: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 18, 1, 19),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 0
                     }),
                     alternate: Expression::Integer(IntegerLit {
                         base: BaseNode {
                             location: loc.get(1, 25, 1, 26),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         value: 1
-                    })
+                    }),
+                    tk_if: None,
+                    tk_then: None,
+                    tk_else: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -7031,7 +7470,7 @@ fn conditional_with_unary_logical_operators() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 85),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -7040,36 +7479,36 @@ fn conditional_with_unary_logical_operators() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 85),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "a".to_string()
                 },
                 init: Expression::Conditional(Box::new(ConditionalExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 85),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     test: Expression::Logical(Box::new(LogicalExpr {
                         base: BaseNode {
                             location: loc.get(1, 8, 1, 40),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: LogicalOperator::OrOperator,
                         left: Expression::Unary(Box::new(UnaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 8, 1, 16),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::ExistsOperator,
                             argument: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 15, 1, 16),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             })
@@ -7077,26 +7516,26 @@ fn conditional_with_unary_logical_operators() {
                         right: Expression::Logical(Box::new(LogicalExpr {
                             base: BaseNode {
                                 location: loc.get(1, 20, 1, 40),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: LogicalOperator::AndOperator,
                             left: Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 20, 1, 25),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::LessThanOperator,
                                 left: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 20, 1, 21),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "c".to_string()
                                 }),
                                 right: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 24, 1, 25),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "d".to_string()
                                 })
@@ -7104,26 +7543,26 @@ fn conditional_with_unary_logical_operators() {
                             right: Expression::Unary(Box::new(UnaryExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 30, 1, 40),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::NotOperator,
                                 argument: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 34, 1, 40),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::EqualOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 34, 1, 35),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "e".to_string()
                                     }),
                                     right: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 39, 1, 40),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "f".to_string()
                                     })
@@ -7134,67 +7573,73 @@ fn conditional_with_unary_logical_operators() {
                     consequent: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 46, 1, 64),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::NotOperator,
                         argument: Expression::Unary(Box::new(UnaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 50, 1, 64),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::ExistsOperator,
                             argument: Expression::Paren(Box::new(ParenExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 57, 1, 64),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lparen: None,
                                 expression: Expression::Binary(Box::new(BinaryExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 58, 1, 63),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     operator: Operator::SubtractionOperator,
                                     left: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 58, 1, 59),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "g".to_string()
                                     }),
                                     right: Expression::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 62, 1, 63),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "h".to_string()
                                     })
-                                }))
+                                })),
+                                rparen: None,
                             }))
                         }))
                     })),
                     alternate: Expression::Unary(Box::new(UnaryExpr {
                         base: BaseNode {
                             location: loc.get(1, 70, 1, 85),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::ExistsOperator,
                         argument: Expression::Unary(Box::new(UnaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 77, 1, 85),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::ExistsOperator,
                             argument: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 84, 1, 85),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "i".to_string()
                             })
                         }))
-                    }))
+                    })),
+                    tk_if: None,
+                    tk_then: None,
+                    tk_else: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -7213,44 +7658,44 @@ fn nested_conditionals() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 3, 50),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 3, 50),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Conditional(Box::new(ConditionalExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 3, 50),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     test: Expression::Conditional(Box::new(ConditionalExpr {
                         base: BaseNode {
                             location: loc.get(1, 4, 1, 33),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         test: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(1, 7, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::LessThanOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 7, 1, 8),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 0
                             })
@@ -7258,40 +7703,43 @@ fn nested_conditionals() {
                         consequent: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 18, 1, 22),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "true".to_string()
                         }),
                         alternate: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 28, 1, 33),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "false".to_string()
-                        })
+                        }),
+                        tk_if: None,
+                        tk_then: None,
+                        tk_else: None,
                     })),
                     consequent: Expression::Conditional(Box::new(ConditionalExpr {
                         base: BaseNode {
                             location: loc.get(2, 24, 2, 48),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         test: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(2, 27, 2, 32),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::GreaterThanOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 27, 2, 28),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "c".to_string()
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(2, 31, 2, 32),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 0
                             })
@@ -7299,40 +7747,43 @@ fn nested_conditionals() {
                         consequent: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(2, 38, 2, 40),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 30
                         }),
                         alternate: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(2, 46, 2, 48),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 60
-                        })
+                        }),
+                        tk_if: None,
+                        tk_then: None,
+                        tk_else: None,
                     })),
                     alternate: Expression::Conditional(Box::new(ConditionalExpr {
                         base: BaseNode {
                             location: loc.get(3, 24, 3, 50),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         test: Expression::Binary(Box::new(BinaryExpr {
                             base: BaseNode {
                                 location: loc.get(3, 27, 3, 33),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             operator: Operator::EqualOperator,
                             left: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(3, 27, 3, 28),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "d".to_string()
                             }),
                             right: Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(3, 32, 3, 33),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 0
                             })
@@ -7340,20 +7791,27 @@ fn nested_conditionals() {
                         consequent: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(3, 39, 3, 41),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 90
                         }),
                         alternate: Expression::Integer(IntegerLit {
                             base: BaseNode {
                                 location: loc.get(3, 47, 3, 50),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: 120
-                        })
-                    }))
+                        }),
+                        tk_if: None,
+                        tk_then: None,
+                        tk_else: None,
+                    })),
+                    tk_if: None,
+                    tk_then: None,
+                    tk_else: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -7370,155 +7828,173 @@ fn from_with_filter_with_no_parens() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 114),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 114),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Call(Box::new(CallExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 114),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     callee: Expression::Member(Box::new(MemberExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 39),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         property: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 33, 1, 39),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "filter".to_string()
                         }),
+                        lbrack: None,
                         object: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 32),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 5),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "from".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 31),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 31),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 6, 1, 12),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "bucket".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(1, 13, 1, 31),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "telegraf/autogen".to_string()
-                                    }))
-                                }]
-                            }))]
+                                    })),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         })),
+                        rbrack: None,
                     })),
+                    lparen: None,
                     arguments: vec![Expression::Object(Box::new(ObjectExpr {
                         base: BaseNode {
                             location: loc.get(1, 40, 1, 113),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lbrace: None,
                         with: None,
                         properties: vec![Property {
                             base: BaseNode {
                                 location: loc.get(1, 40, 1, 113),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 40, 1, 42),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "fn".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Function(Box::new(FunctionExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 44, 1, 113),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lparen: None,
                                 params: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(1, 45, 1, 46),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 45, 1, 46),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "r".to_string()
                                     }),
-                                    value: None
+                                    separator: None,
+                                    value: None,
+                                    comma: None,
                                 }],
+                                rparen: None,
+                                arrow: None,
                                 body: FunctionBody::Expr(Expression::Logical(Box::new(
                                     LogicalExpr {
                                         base: BaseNode {
                                             location: loc.get(1, 51, 1, 113),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: LogicalOperator::OrOperator,
                                         left: Expression::Logical(Box::new(LogicalExpr {
                                             base: BaseNode {
                                                 location: loc.get(1, 51, 1, 90),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             operator: LogicalOperator::AndOperator,
                                             left: Expression::Binary(Box::new(BinaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(1, 51, 1, 68),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 operator: Operator::EqualOperator,
                                                 left: Expression::Member(Box::new(MemberExpr {
                                                     base: BaseNode {
                                                         location: loc.get(1, 51, 1, 61),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     object: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(1, 51, 1, 52),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "r".to_string()
                                                     }),
+                                                    lbrack: None,
                                                     property: PropertyKey::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(1, 53, 1, 60),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         value: "other".to_string()
-                                                    })
+                                                    }),
+                                                    rbrack: None,
                                                 })),
                                                 right: Expression::StringLit(StringLit {
                                                     base: BaseNode {
                                                         location: loc.get(1, 63, 1, 68),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     value: "mem".to_string()
                                                 })
@@ -7526,33 +8002,35 @@ fn from_with_filter_with_no_parens() {
                                             right: Expression::Binary(Box::new(BinaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(1, 73, 1, 90),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 operator: Operator::EqualOperator,
                                                 left: Expression::Member(Box::new(MemberExpr {
                                                     base: BaseNode {
                                                         location: loc.get(1, 73, 1, 82),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     object: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(1, 73, 1, 74),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "r".to_string()
                                                     }),
+                                                    lbrack: None,
                                                     property: PropertyKey::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(1, 75, 1, 81),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         value: "this".to_string()
-                                                    })
+                                                    }),
+                                                    rbrack: None,
                                                 })),
                                                 right: Expression::StringLit(StringLit {
                                                     base: BaseNode {
                                                         location: loc.get(1, 84, 1, 90),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     value: "that".to_string()
                                                 })
@@ -7561,44 +8039,50 @@ fn from_with_filter_with_no_parens() {
                                         right: Expression::Binary(Box::new(BinaryExpr {
                                             base: BaseNode {
                                                 location: loc.get(1, 94, 1, 113),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             operator: Operator::NotEqualOperator,
                                             left: Expression::Member(Box::new(MemberExpr {
                                                 base: BaseNode {
                                                     location: loc.get(1, 94, 1, 104),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 object: Expression::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(1, 94, 1, 95),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     name: "r".to_string()
                                                 }),
+                                                lbrack: None,
                                                 property: PropertyKey::StringLit(StringLit {
                                                     base: BaseNode {
                                                         location: loc.get(1, 96, 1, 103),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     value: "these".to_string()
-                                                })
+                                                }),
+                                                rbrack: None,
                                             })),
                                             right: Expression::StringLit(StringLit {
                                                 base: BaseNode {
                                                     location: loc.get(1, 106, 1, 113),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 value: "those".to_string()
                                             })
                                         }))
                                     }
-                                )))
-                            })))
-                        }]
-                    }))]
+                                ))),
+                            }))),
+                            comma: None,
+                        }],
+                        rbrace: None,
+                    }))],
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -7613,139 +8097,154 @@ fn from_with_range() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 59),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 59),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 59),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 32),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 31),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![Property {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 31),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 12),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "bucket".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::StringLit(StringLit {
                                     base: BaseNode {
                                         location: loc.get(1, 13, 1, 31),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: "telegraf/autogen".to_string()
-                                }))
-                            }]
-                        }))]
+                                })),
+                                comma: None,
+                            }],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 34, 1, 59),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 34, 1, 39),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "range".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 40, 1, 58),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(1, 40, 1, 49),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 40, 1, 45),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "start".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Unary(Box::new(UnaryExpr {
                                         base: BaseNode {
                                             location: loc.get(1, 46, 1, 49),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::SubtractionOperator,
                                         argument: Expression::Duration(DurationLit {
                                             base: BaseNode {
                                                 location: loc.get(1, 47, 1, 49),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             values: vec![Duration {
                                                 magnitude: 1,
                                                 unit: "h".to_string()
                                             }]
                                         })
-                                    })))
+                                    }))),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(1, 51, 1, 58),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 51, 1, 54),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "end".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Duration(DurationLit {
                                         base: BaseNode {
                                             location: loc.get(1, 55, 1, 58),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         values: vec![Duration {
                                             magnitude: 10,
                                             unit: "m".to_string()
                                         }]
-                                    }))
+                                    })),
+                                    comma: None,
                                 }
-                            ]
-                        }))]
+                            ],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -7760,126 +8259,141 @@ fn from_with_limit() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 61),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 61),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 61),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 32),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
+                        lparen: None,
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "from".to_string()
                         }),
+                        rparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 31),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![Property {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 31),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 12),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "bucket".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::StringLit(StringLit {
                                     base: BaseNode {
                                         location: loc.get(1, 13, 1, 31),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: "telegraf/autogen".to_string()
-                                }))
-                            }]
+                                })),
+                                comma: None,
+                            }],
+                            rbrace: None,
                         }))]
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 34, 1, 61),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 34, 1, 39),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "limit".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 40, 1, 60),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(1, 40, 1, 49),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 40, 1, 45),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "limit".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Integer(IntegerLit {
                                         base: BaseNode {
                                             location: loc.get(1, 46, 1, 49),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: 100
-                                    }))
+                                    })),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(1, 51, 1, 60),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 51, 1, 57),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "offset".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Integer(IntegerLit {
                                         base: BaseNode {
                                             location: loc.get(1, 58, 1, 60),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: 10
-                                    }))
+                                    })),
+                                    comma: None,
                                 }
-                            ]
-                        }))]
+                            ],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -7898,166 +8412,183 @@ fn from_with_range_and_count() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 3, 17),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 3, 17),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 3, 17),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 2, 36),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 28),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 5),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "from".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 27),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 27),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(1, 6, 1, 12),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "bucket".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(1, 13, 1, 27),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "mydb/autogen".to_string()
-                                    }))
-                                }]
-                            }))]
+                                    })),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(2, 10, 2, 36),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 10, 2, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "range".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 16, 2, 35),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![
                                     Property {
                                         base: BaseNode {
                                             location: loc.get(2, 16, 2, 25),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 16, 2, 21),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "start".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::Unary(Box::new(UnaryExpr {
                                             base: BaseNode {
                                                 location: loc.get(2, 22, 2, 25),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             operator: Operator::SubtractionOperator,
                                             argument: Expression::Duration(DurationLit {
                                                 base: BaseNode {
                                                     location: loc.get(2, 23, 2, 25),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 values: vec![Duration {
                                                     magnitude: 4,
                                                     unit: "h".to_string()
                                                 }]
                                             })
-                                        })))
+                                        }))),
+                                        comma: None,
                                     },
                                     Property {
                                         base: BaseNode {
                                             location: loc.get(2, 27, 2, 35),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 27, 2, 31),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "stop".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::Unary(Box::new(UnaryExpr {
                                             base: BaseNode {
                                                 location: loc.get(2, 32, 2, 35),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             operator: Operator::SubtractionOperator,
                                             argument: Expression::Duration(DurationLit {
                                                 base: BaseNode {
                                                     location: loc.get(2, 33, 2, 35),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 values: vec![Duration {
                                                     magnitude: 2,
                                                     unit: "h".to_string()
                                                 }]
                                             })
-                                        })))
+                                        }))),
+                                        comma: None,
                                     }
-                                ]
-                            }))]
+                                ],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(3, 10, 3, 17),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(3, 10, 3, 15),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "count".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         }
     )
 }
@@ -8077,212 +8608,235 @@ fn from_with_range_limit_and_count() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 4, 17),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 4, 17),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 4, 17),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 3, 21),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::PipeExpr(Box::new(PipeExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 2, 36),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             argument: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 28),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 1, 1, 5),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "from".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 6, 1, 27),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(1, 6, 1, 27),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(1, 6, 1, 12),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "bucket".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::StringLit(StringLit {
                                             base: BaseNode {
                                                 location: loc.get(1, 13, 1, 27),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             value: "mydb/autogen".to_string()
-                                        }))
-                                    }]
-                                }))]
+                                        })),
+                                        comma: None,
+                                    }],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             })),
                             call: CallExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 10, 2, 36),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 10, 2, 15),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "range".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 16, 2, 35),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![
                                         Property {
                                             base: BaseNode {
                                                 location: loc.get(2, 16, 2, 25),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             key: PropertyKey::Identifier(Identifier {
                                                 base: BaseNode {
                                                     location: loc.get(2, 16, 2, 21),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 name: "start".to_string()
                                             }),
+                                            separator: None,
                                             value: Some(Expression::Unary(Box::new(UnaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(2, 22, 2, 25),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 operator: Operator::SubtractionOperator,
                                                 argument: Expression::Duration(DurationLit {
                                                     base: BaseNode {
                                                         location: loc.get(2, 23, 2, 25),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     values: vec![Duration {
                                                         magnitude: 4,
                                                         unit: "h".to_string()
                                                     }]
                                                 })
-                                            })))
+                                            }))),
+                                            comma: None,
                                         },
                                         Property {
                                             base: BaseNode {
                                                 location: loc.get(2, 27, 2, 35),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             key: PropertyKey::Identifier(Identifier {
                                                 base: BaseNode {
                                                     location: loc.get(2, 27, 2, 31),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 name: "stop".to_string()
                                             }),
+                                            separator: None,
                                             value: Some(Expression::Unary(Box::new(UnaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(2, 32, 2, 35),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 operator: Operator::SubtractionOperator,
                                                 argument: Expression::Duration(DurationLit {
                                                     base: BaseNode {
                                                         location: loc.get(2, 33, 2, 35),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     values: vec![Duration {
                                                         magnitude: 2,
                                                         unit: "h".to_string()
                                                     }]
                                                 })
-                                            })))
+                                            }))),
+                                            comma: None,
                                         }
-                                    ]
-                                }))]
+                                    ],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             }
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(3, 10, 3, 21),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(3, 10, 3, 15),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "limit".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(3, 16, 3, 20),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(3, 16, 3, 20),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(3, 16, 3, 17),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "n".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Integer(IntegerLit {
                                         base: BaseNode {
                                             location: loc.get(3, 18, 3, 20),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: 10
-                                    }))
-                                }]
-                            }))]
+                                    })),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(4, 10, 4, 17),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(4, 10, 4, 15),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "count".to_string()
                         }),
-                        arguments: vec![]
+                        lparen: None,
+                        arguments: vec![],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         }
     )
 }
@@ -8302,7 +8856,7 @@ join(tables:[a,b], on:["host"], fn: (a,b) => a["_field"] + b["_field"])"#,
         File {
             base: BaseNode {
                 location: loc.get(2, 1, 4, 72),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -8312,409 +8866,468 @@ join(tables:[a,b], on:["host"], fn: (a,b) => a["_field"] + b["_field"])"#,
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 1, 2, 51),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 1, 2, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(2, 5, 2, 51),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(2, 5, 2, 31),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 5, 2, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "from".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 10, 2, 30),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(2, 10, 2, 30),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 10, 2, 16),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "bucket".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(2, 17, 2, 30),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "dbA/autogen".to_string()
-                                    }))
-                                }]
-                            }))]
+                                    })),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(2, 35, 2, 51),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(2, 35, 2, 40),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "range".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 41, 2, 50),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(2, 41, 2, 50),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(2, 41, 2, 46),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "start".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Unary(Box::new(UnaryExpr {
                                         base: BaseNode {
                                             location: loc.get(2, 47, 2, 50),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::SubtractionOperator,
                                         argument: Expression::Duration(DurationLit {
                                             base: BaseNode {
                                                 location: loc.get(2, 48, 2, 50),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             values: vec![Duration {
                                                 magnitude: 1,
                                                 unit: "h".to_string()
                                             }]
                                         })
-                                    })))
-                                }]
-                            }))]
+                                    }))),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }
                     }))
                 })),
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(3, 1, 3, 51),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(3, 1, 3, 2),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "b".to_string()
                     },
                     init: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(3, 5, 3, 51),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(3, 5, 3, 31),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(3, 5, 3, 9),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "from".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(3, 10, 3, 30),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(3, 10, 3, 30),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(3, 10, 3, 16),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "bucket".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::StringLit(StringLit {
                                         base: BaseNode {
                                             location: loc.get(3, 17, 3, 30),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         value: "dbB/autogen".to_string()
-                                    }))
-                                }]
-                            }))]
+                                    })),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(3, 35, 3, 51),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(3, 35, 3, 40),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "range".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(3, 41, 3, 50),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(3, 41, 3, 50),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(3, 41, 3, 46),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "start".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Unary(Box::new(UnaryExpr {
                                         base: BaseNode {
                                             location: loc.get(3, 47, 3, 50),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         operator: Operator::SubtractionOperator,
                                         argument: Expression::Duration(DurationLit {
                                             base: BaseNode {
                                                 location: loc.get(3, 48, 3, 50),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             values: vec![Duration {
                                                 magnitude: 1,
                                                 unit: "h".to_string()
                                             }]
                                         })
-                                    })))
-                                }]
-                            }))]
+                                    }))),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }
                     }))
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(4, 1, 4, 72),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(4, 1, 4, 72),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(4, 1, 4, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "join".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(4, 6, 4, 71),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(4, 6, 4, 18),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(4, 6, 4, 12),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "tables".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Array(Box::new(ArrayExpr {
                                         base: BaseNode {
                                             location: loc.get(4, 13, 4, 18),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
+                                        lbrack: None,
                                         elements: vec![
-                                            Expression::Identifier(Identifier {
-                                                base: BaseNode {
-                                                    location: loc.get(4, 14, 4, 15),
-                                                    errors: vec![]
-                                                },
-                                                name: "a".to_string()
-                                            }),
-                                            Expression::Identifier(Identifier {
-                                                base: BaseNode {
-                                                    location: loc.get(4, 16, 4, 17),
-                                                    errors: vec![]
-                                                },
-                                                name: "b".to_string()
-                                            })
-                                        ]
-                                    })))
+                                            ArrayItem {
+                                                expression: Expression::Identifier(Identifier {
+                                                    base: BaseNode {
+                                                        location: loc.get(4, 14, 4, 15),
+                                                        ..BaseNode::default()
+                                                    },
+                                                    name: "a".to_string()
+                                                }),
+                                                comma: None,
+                                            },
+                                            ArrayItem {
+                                                expression: Expression::Identifier(Identifier {
+                                                    base: BaseNode {
+                                                        location: loc.get(4, 16, 4, 17),
+                                                        ..BaseNode::default()
+                                                    },
+                                                    name: "b".to_string()
+                                                }),
+                                                comma: None,
+                                            }
+                                        ],
+                                        rbrack: None,
+                                    }))),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(4, 20, 4, 31),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(4, 20, 4, 22),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "on".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Array(Box::new(ArrayExpr {
                                         base: BaseNode {
                                             location: loc.get(4, 23, 4, 31),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
-                                        elements: vec![Expression::StringLit(StringLit {
-                                            base: BaseNode {
-                                                location: loc.get(4, 24, 4, 30),
-                                                errors: vec![]
-                                            },
-                                            value: "host".to_string()
-                                        })]
-                                    })))
+                                        lbrack: None,
+                                        elements: vec![ArrayItem {
+                                            expression: Expression::StringLit(StringLit {
+                                                base: BaseNode {
+                                                    location: loc.get(4, 24, 4, 30),
+                                                    ..BaseNode::default()
+                                                },
+                                                value: "host".to_string()
+                                            }),
+                                            comma: None,
+                                        }],
+                                        rbrack: None,
+                                    }))),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(4, 33, 4, 71),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(4, 33, 4, 35),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         name: "fn".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Function(Box::new(FunctionExpr {
                                         base: BaseNode {
                                             location: loc.get(4, 37, 4, 71),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
+                                        lparen: None,
                                         params: vec![
                                             Property {
                                                 base: BaseNode {
                                                     location: loc.get(4, 38, 4, 39),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 key: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(4, 38, 4, 39),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     name: "a".to_string()
                                                 }),
-                                                value: None
+                                                separator: None,
+                                                value: None,
+                                                comma: None,
                                             },
                                             Property {
                                                 base: BaseNode {
                                                     location: loc.get(4, 40, 4, 41),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 key: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(4, 40, 4, 41),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     name: "b".to_string()
                                                 }),
-                                                value: None
+                                                separator: None,
+                                                value: None,
+                                                comma: None,
                                             }
                                         ],
+                                        rparen: None,
+                                        arrow: None,
                                         body: FunctionBody::Expr(Expression::Binary(Box::new(
                                             BinaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(4, 46, 4, 71),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 operator: Operator::AdditionOperator,
                                                 left: Expression::Member(Box::new(MemberExpr {
                                                     base: BaseNode {
                                                         location: loc.get(4, 46, 4, 57),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     object: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(4, 46, 4, 47),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "a".to_string()
                                                     }),
+                                                    lbrack: None,
                                                     property: PropertyKey::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(4, 48, 4, 56),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         value: "_field".to_string()
-                                                    })
+                                                    }),
+                                                    rbrack: None,
                                                 })),
                                                 right: Expression::Member(Box::new(MemberExpr {
                                                     base: BaseNode {
                                                         location: loc.get(4, 60, 4, 71),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     object: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(4, 60, 4, 61),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         name: "b".to_string()
                                                     }),
+                                                    lbrack: None,
                                                     property: PropertyKey::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(4, 62, 4, 70),
-                                                            errors: vec![]
+                                                            ..BaseNode::default()
                                                         },
                                                         value: "_field".to_string()
-                                                    })
+                                                    }),
+                                                    rbrack: None,
                                                 }))
                                             }
-                                        )))
-                                    })))
+                                        ))),
+                                    }))),
+                                    comma: None,
                                 }
-                            ]
-                        }))]
+                            ],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -8740,7 +9353,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
         File {
             base: BaseNode {
                 location: loc.get(2, 1, 10, 86),
-                errors: vec![]
+                .. BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -8750,578 +9363,656 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(2, 1, 4, 21),
-                        errors: vec![]
+                        .. BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(2, 1, 2, 2),
-                            errors: vec![]
+                            .. BaseNode::default()
                         },
                         name: "a".to_string()
                     },
                     init: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(2, 5, 4, 21),
-                            errors: vec![]
+                            .. BaseNode::default()
                         },
                         argument: Expression::PipeExpr(Box::new(PipeExpr {
                             base: BaseNode {
                                 location: loc.get(2, 5, 3, 48),
-                                errors: vec![]
+                                .. BaseNode::default()
                             },
                             argument: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(2, 5, 2, 32),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(2, 5, 2, 9),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     name: "from".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(2, 10, 2, 31),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(2, 10, 2, 31),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(2, 10, 2, 16),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             name: "bucket".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::StringLit(StringLit {
                                             base: BaseNode {
                                                 location: loc.get(2, 17, 2, 31),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             value: "Flux/autogen".to_string()
-                                        }))
-                                    }]
-                                }))]
+                                        })),
+                                        comma: None,
+                                    }],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             })),
                             call: CallExpr {
                                 base: BaseNode {
                                     location: loc.get(3, 5, 3, 48),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(3, 5, 3, 11),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     name: "filter".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(3, 12, 3, 47),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(3, 12, 3, 47),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(3, 12, 3, 14),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             name: "fn".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::Function(Box::new(FunctionExpr {
                                             base: BaseNode {
                                                 location: loc.get(3, 16, 3, 47),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
+                                            lparen: None,
                                             params: vec![Property {
                                                 base: BaseNode {
                                                     location: loc.get(3, 17, 3, 18),
-                                                    errors: vec![]
+                                                    .. BaseNode::default()
                                                 },
                                                 key: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(3, 17, 3, 18),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     name: "r".to_string()
                                                 }),
-                                                value: None
+                                                separator: None,
+                                                value: None,
+                                                comma: None,
                                             }],
+                                            rparen: None,
+                                            arrow: None,
                                             body: FunctionBody::Expr(Expression::Binary(Box::new(
                                                 BinaryExpr {
                                                     base: BaseNode {
                                                         location: loc.get(3, 23, 3, 47),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     operator: Operator::EqualOperator,
                                                     left: Expression::Member(Box::new(
                                                         MemberExpr {
                                                             base: BaseNode {
                                                                 location: loc.get(3, 23, 3, 40),
-                                                                errors: vec![]
+                                                                .. BaseNode::default()
                                                             },
                                                             object: Expression::Identifier(
                                                                 Identifier {
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(3, 23, 3, 24),
-                                                                        errors: vec![]
+                                                                        .. BaseNode::default()
                                                                     },
                                                                     name: "r".to_string()
                                                                 }
                                                             ),
+                                                            lbrack: None,
                                                             property: PropertyKey::StringLit(
                                                                 StringLit {
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(3, 25, 3, 39),
-                                                                        errors: vec![]
+                                                                        .. BaseNode::default()
                                                                     },
                                                                     value: "_measurement"
                                                                         .to_string()
                                                                 }
-                                                            )
+                                                            ),
+                                                            rbrack: None,
                                                         }
                                                     )),
                                                     right: Expression::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(3, 44, 3, 47),
-                                                            errors: vec![]
+                                                            .. BaseNode::default()
                                                         },
                                                         value: "a".to_string()
                                                     })
                                                 }
-                                            )))
-                                        })))
-                                    }]
-                                }))]
+                                            ))),
+                                        }))),
+                                        comma: None,
+                                    }],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             }
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(4, 5, 4, 21),
-                                errors: vec![]
+                                .. BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(4, 5, 4, 10),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
                                 name: "range".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(4, 11, 4, 20),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(4, 11, 4, 20),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(4, 11, 4, 16),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         name: "start".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Unary(Box::new(UnaryExpr {
                                         base: BaseNode {
                                             location: loc.get(4, 17, 4, 20),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         operator: Operator::SubtractionOperator,
                                         argument: Expression::Duration(DurationLit {
                                             base: BaseNode {
                                                 location: loc.get(4, 18, 4, 20),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             values: vec![Duration {
                                                 magnitude: 1,
                                                 unit: "h".to_string()
                                             }]
                                         })
-                                    })))
-                                }]
-                            }))]
+                                    }))),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }
                     }))
                 })),
                 Statement::Variable(Box::new(VariableAssgn {
                     base: BaseNode {
                         location: loc.get(6, 1, 8, 21),
-                        errors: vec![]
+                        .. BaseNode::default()
                     },
                     id: Identifier {
                         base: BaseNode {
                             location: loc.get(6, 1, 6, 2),
-                            errors: vec![]
+                            .. BaseNode::default()
                         },
                         name: "b".to_string()
                     },
                     init: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(6, 5, 8, 21),
-                            errors: vec![]
+                            .. BaseNode::default()
                         },
                         argument: Expression::PipeExpr(Box::new(PipeExpr {
                             base: BaseNode {
                                 location: loc.get(6, 5, 7, 48),
-                                errors: vec![]
+                                .. BaseNode::default()
                             },
                             argument: Expression::Call(Box::new(CallExpr {
                                 base: BaseNode {
                                     location: loc.get(6, 5, 6, 32),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(6, 5, 6, 9),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     name: "from".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(6, 10, 6, 31),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(6, 10, 6, 31),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(6, 10, 6, 16),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             name: "bucket".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::StringLit(StringLit {
                                             base: BaseNode {
                                                 location: loc.get(6, 17, 6, 31),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             value: "Flux/autogen".to_string()
-                                        }))
-                                    }]
-                                }))]
+                                        })),
+                                        comma: None,
+                                    }],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             })),
                             call: CallExpr {
                                 base: BaseNode {
                                     location: loc.get(7, 5, 7, 48),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
                                 callee: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(7, 5, 7, 11),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     name: "filter".to_string()
                                 }),
+                                lparen: None,
                                 arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                     base: BaseNode {
                                         location: loc.get(7, 12, 7, 47),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
+                                    lbrace: None,
                                     with: None,
                                     properties: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(7, 12, 7, 47),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(7, 12, 7, 14),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             name: "fn".to_string()
                                         }),
+                                        separator: None,
                                         value: Some(Expression::Function(Box::new(FunctionExpr {
                                             base: BaseNode {
                                                 location: loc.get(7, 16, 7, 47),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
+                                            lparen: None,
                                             params: vec![Property {
                                                 base: BaseNode {
                                                     location: loc.get(7, 17, 7, 18),
-                                                    errors: vec![]
+                                                    .. BaseNode::default()
                                                 },
                                                 key: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(7, 17, 7, 18),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     name: "r".to_string()
                                                 }),
-                                                value: None
+                                                separator: None,
+                                                value: None,
+                                                comma: None,
                                             }],
+                                            rparen: None,
+                                            arrow: None,
                                             body: FunctionBody::Expr(Expression::Binary(Box::new(
                                                 BinaryExpr {
                                                     base: BaseNode {
                                                         location: loc.get(7, 23, 7, 47),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     operator: Operator::EqualOperator,
                                                     left: Expression::Member(Box::new(
                                                         MemberExpr {
                                                             base: BaseNode {
                                                                 location: loc.get(7, 23, 7, 40),
-                                                                errors: vec![]
+                                                                .. BaseNode::default()
                                                             },
                                                             object: Expression::Identifier(
                                                                 Identifier {
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(7, 23, 7, 24),
-                                                                        errors: vec![]
+                                                                        .. BaseNode::default()
                                                                     },
                                                                     name: "r".to_string()
                                                                 }
                                                             ),
+                                                            lbrack: None,
                                                             property: PropertyKey::StringLit(
                                                                 StringLit {
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(7, 25, 7, 39),
-                                                                        errors: vec![]
+                                                                        .. BaseNode::default()
                                                                     },
                                                                     value: "_measurement"
                                                                         .to_string()
                                                                 }
-                                                            )
+                                                            ),
+                                                            rbrack: None,
                                                         }
                                                     )),
                                                     right: Expression::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(7, 44, 7, 47),
-                                                            errors: vec![]
+                                                            .. BaseNode::default()
                                                         },
                                                         value: "b".to_string()
                                                     })
                                                 }
-                                            )))
-                                        })))
-                                    }]
-                                }))]
+                                            ))),
+                                        }))),
+                                        comma: None,
+                                    }],
+                                    rbrace: None,
+                                }))],
+                                rparen: None,
                             }
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(8, 5, 8, 21),
-                                errors: vec![]
+                                .. BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(8, 5, 8, 10),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
                                 name: "range".to_string()
                             }),
+                            lparen: None,
                             arguments: vec![Expression::Object(Box::new(ObjectExpr {
                                 base: BaseNode {
                                     location: loc.get(8, 11, 8, 20),
-                                    errors: vec![]
+                                    .. BaseNode::default()
                                 },
+                                lbrace: None,
                                 with: None,
                                 properties: vec![Property {
                                     base: BaseNode {
                                         location: loc.get(8, 11, 8, 20),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(8, 11, 8, 16),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         name: "start".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Unary(Box::new(UnaryExpr {
                                         base: BaseNode {
                                             location: loc.get(8, 17, 8, 20),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         operator: Operator::SubtractionOperator,
                                         argument: Expression::Duration(DurationLit {
                                             base: BaseNode {
                                                 location: loc.get(8, 18, 8, 20),
-                                                errors: vec![]
+                                                .. BaseNode::default()
                                             },
                                             values: vec![Duration {
                                                 magnitude: 1,
                                                 unit: "h".to_string()
                                             }]
                                         })
-                                    })))
-                                }]
-                            }))]
+                                    }))),
+                                    comma: None,
+                                }],
+                                rbrace: None,
+                            }))],
+                            rparen: None,
                         }
                     }))
                 })),
-                Statement::Expr(ExprStmt {
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(10, 1, 10, 86),
-                        errors: vec![]
+                        .. BaseNode::default()
                     },
                     expression: Expression::Call(Box::new(CallExpr {
                         base: BaseNode {
                             location: loc.get(10, 1, 10, 86),
-                            errors: vec![]
+                            .. BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(10, 1, 10, 5),
-                                errors: vec![]
+                                .. BaseNode::default()
                             },
                             name: "join".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(10, 6, 10, 85),
-                                errors: vec![]
+                                .. BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(10, 6, 10, 18),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(10, 6, 10, 12),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         name: "tables".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Array(Box::new(ArrayExpr {
                                         base: BaseNode {
                                             location: loc.get(10, 13, 10, 18),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
+                                        lbrack: None,
                                         elements: vec![
-                                            Expression::Identifier(Identifier {
-                                                base: BaseNode {
-                                                    location: loc.get(10, 14, 10, 15),
-                                                    errors: vec![]
-                                                },
-                                                name: "a".to_string()
-                                            }),
-                                            Expression::Identifier(Identifier {
-                                                base: BaseNode {
-                                                    location: loc.get(10, 16, 10, 17),
-                                                    errors: vec![]
-                                                },
-                                                name: "b".to_string()
-                                            })
-                                        ]
-                                    })))
+                                            ArrayItem {
+                                                expression: Expression::Identifier(Identifier {
+                                                    base: BaseNode {
+                                                        location: loc.get(10, 14, 10, 15),
+                                                        .. BaseNode::default()
+                                                    },
+                                                    name: "a".to_string()
+                                                }),
+                                                comma: None,
+                                            },
+                                            ArrayItem {
+                                                expression: Expression::Identifier(Identifier {
+                                                    base: BaseNode {
+                                                        location: loc.get(10, 16, 10, 17),
+                                                        .. BaseNode::default()
+                                                    },
+                                                    name: "b".to_string()
+                                                }),
+                                                comma: None,
+                                            }
+                                        ],
+                                        rbrack: None,
+                                    }))),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(10, 20, 10, 29),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(10, 20, 10, 22),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         name: "on".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Array(Box::new(ArrayExpr {
                                         base: BaseNode {
                                             location: loc.get(10, 23, 10, 29),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
-                                        elements: vec![Expression::StringLit(StringLit {
-                                            base: BaseNode {
-                                                location: loc.get(10, 24, 10, 28),
-                                                errors: vec![]
-                                            },
-                                            value: "t1".to_string()
-                                        })]
-                                    })))
+                                        lbrack: None,
+                                        elements: vec![ArrayItem {
+                                            expression: Expression::StringLit(StringLit {
+                                                base: BaseNode {
+                                                    location: loc.get(10, 24, 10, 28),
+                                                    .. BaseNode::default()
+                                                },
+                                                value: "t1".to_string()
+                                            }),
+                                            comma: None,
+                                        }],
+                                        rbrack: None,
+                                    }))),
+                                    comma: None,
                                 },
                                 Property {
                                     base: BaseNode {
                                         location: loc.get(10, 31, 10, 85),
-                                        errors: vec![]
+                                        .. BaseNode::default()
                                     },
                                     key: PropertyKey::Identifier(Identifier {
                                         base: BaseNode {
                                             location: loc.get(10, 31, 10, 33),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
                                         name: "fn".to_string()
                                     }),
+                                    separator: None,
                                     value: Some(Expression::Function(Box::new(FunctionExpr {
                                         base: BaseNode {
                                             location: loc.get(10, 35, 10, 85),
-                                            errors: vec![]
+                                            .. BaseNode::default()
                                         },
+                                        lparen: None,
                                         params: vec![
                                             Property {
                                                 base: BaseNode {
                                                     location: loc.get(10, 36, 10, 37),
-                                                    errors: vec![]
+                                                    .. BaseNode::default()
                                                 },
                                                 key: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(10, 36, 10, 37),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     name: "a".to_string()
                                                 }),
-                                                value: None
+                                                separator: None,
+                                                value: None,
+                                                comma: None,
                                             },
                                             Property {
                                                 base: BaseNode {
                                                     location: loc.get(10, 38, 10, 39),
-                                                    errors: vec![]
+                                                    .. BaseNode::default()
                                                 },
                                                 key: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(10, 38, 10, 39),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     name: "b".to_string()
                                                 }),
-                                                value: None
+                                                separator: None,
+                                                value: None,
+                                                comma: None,
                                             }
                                         ],
+                                        rparen: None,
+                                        arrow: None,
                                         body: FunctionBody::Expr(Expression::Binary(Box::new(
                                             BinaryExpr {
                                                 base: BaseNode {
                                                     location: loc.get(10, 44, 10, 85),
-                                                    errors: vec![]
+                                                    .. BaseNode::default()
                                                 },
                                                 operator: Operator::DivisionOperator,
                                                 left: Expression::Paren(Box::new(ParenExpr {
                                                     base: BaseNode {
                                                         location: loc.get(10, 44, 10, 71),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
+                                                    lparen: None,
                                                     expression: Expression::Binary(Box::new(
                                                         BinaryExpr {
                                                             base: BaseNode {
                                                                 location: loc.get(10, 45, 10, 70),
-                                                                errors: vec![]
+                                                                .. BaseNode::default()
                                                             },
                                                             operator: Operator::SubtractionOperator,
                                                             left: Expression::Member(Box::new(
@@ -9329,7 +10020,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(10, 45, 10, 56),
-                                                                        errors: vec![]
+                                                                        .. BaseNode::default()
                                                                     },
                                                                     object: Expression::Identifier(
                                                                         Identifier {
@@ -9337,11 +10028,12 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                                                                                 location: loc.get(
                                                                                     10, 45, 10, 46
                                                                                 ),
-                                                                                errors: vec![]
+                                                                                .. BaseNode::default()
                                                                             },
                                                                             name: "a".to_string()
                                                                         }
                                                                     ),
+                                                                    lbrack: None,
                                                                     property:
                                                                         PropertyKey::StringLit(
                                                                             StringLit {
@@ -9351,12 +10043,13 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                                                                                             10, 47,
                                                                                             10, 55
                                                                                         ),
-                                                                                    errors: vec![]
+                                                                                    .. BaseNode::default()
                                                                                 },
                                                                                 value: "_field"
                                                                                     .to_string()
                                                                             }
-                                                                        )
+                                                                        ),
+                                                                    rbrack: None,
                                                                 }
                                                             )),
                                                             right: Expression::Member(Box::new(
@@ -9364,7 +10057,7 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                                                                     base: BaseNode {
                                                                         location: loc
                                                                             .get(10, 59, 10, 70),
-                                                                        errors: vec![]
+                                                                        .. BaseNode::default()
                                                                     },
                                                                     object: Expression::Identifier(
                                                                         Identifier {
@@ -9372,11 +10065,12 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                                                                                 location: loc.get(
                                                                                     10, 59, 10, 60
                                                                                 ),
-                                                                                errors: vec![]
+                                                                                .. BaseNode::default()
                                                                             },
                                                                             name: "b".to_string()
                                                                         }
                                                                     ),
+                                                                    lbrack: None,
                                                                     property:
                                                                         PropertyKey::StringLit(
                                                                             StringLit {
@@ -9386,46 +10080,54 @@ join(tables:[a,b], on:["t1"], fn: (a,b) => (a["_field"] - b["_field"]) / b["_fie
                                                                                             10, 61,
                                                                                             10, 69
                                                                                         ),
-                                                                                    errors: vec![]
+                                                                                    .. BaseNode::default()
                                                                                 },
                                                                                 value: "_field"
                                                                                     .to_string()
                                                                             }
-                                                                        )
+                                                                        ),
+                                                                    rbrack: None,
                                                                 }
                                                             ))
                                                         }
-                                                    ))
+                                                    )),
+                                                    rparen: None,
                                                 })),
                                                 right: Expression::Member(Box::new(MemberExpr {
                                                     base: BaseNode {
                                                         location: loc.get(10, 74, 10, 85),
-                                                        errors: vec![]
+                                                        .. BaseNode::default()
                                                     },
                                                     object: Expression::Identifier(Identifier {
                                                         base: BaseNode {
                                                             location: loc.get(10, 74, 10, 75),
-                                                            errors: vec![]
+                                                            .. BaseNode::default()
                                                         },
                                                         name: "b".to_string()
                                                     }),
+                                                    lbrack: None,
                                                     property: PropertyKey::StringLit(StringLit {
                                                         base: BaseNode {
                                                             location: loc.get(10, 76, 10, 84),
-                                                            errors: vec![]
+                                                            .. BaseNode::default()
                                                         },
                                                         value: "_field".to_string()
-                                                    })
+                                                    }),
+                                                    rbrack: None,
                                                 }))
                                             }
-                                        )))
-                                    })))
+                                        ))),
+                                    }))),
+                                    comma: None,
                                 }
-                            ]
-                        }))]
+                            ],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }))
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -9440,7 +10142,7 @@ fn duration_literal_all_units() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 34),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9449,19 +10151,19 @@ fn duration_literal_all_units() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 34),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "dur".to_string()
                 },
                 init: Expression::Duration(DurationLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 34),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     values: vec![
                         Duration {
@@ -9506,7 +10208,8 @@ fn duration_literal_all_units() {
                         }
                     ]
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9521,7 +10224,7 @@ fn duration_literal_months() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 10),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9530,26 +10233,27 @@ fn duration_literal_months() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 10),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "dur".to_string()
                 },
                 init: Expression::Duration(DurationLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 10),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     values: vec![Duration {
                         magnitude: 6,
                         unit: "mo".to_string()
                     }]
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9564,7 +10268,7 @@ fn duration_literal_milliseconds() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9573,26 +10277,27 @@ fn duration_literal_milliseconds() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "dur".to_string()
                 },
                 init: Expression::Duration(DurationLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     values: vec![Duration {
                         magnitude: 500,
                         unit: "ms".to_string()
                     }]
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9607,7 +10312,7 @@ fn duration_literal_months_minutes_milliseconds() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 18),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9616,19 +10321,19 @@ fn duration_literal_months_minutes_milliseconds() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 18),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "dur".to_string()
                 },
                 init: Expression::Duration(DurationLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 18),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     values: vec![
                         Duration {
@@ -9645,7 +10350,8 @@ fn duration_literal_months_minutes_milliseconds() {
                         }
                     ]
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9660,7 +10366,7 @@ fn date_literal_in_the_default_location() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 17),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9669,23 +10375,24 @@ fn date_literal_in_the_default_location() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 17),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "now".to_string()
                 },
                 init: Expression::DateTime(DateTimeLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 17),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: chrono::DateTime::parse_from_rfc3339("2018-11-29T00:00:00Z").unwrap()
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9700,7 +10407,7 @@ fn date_time_literal() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 27),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9709,23 +10416,24 @@ fn date_time_literal() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 27),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "now".to_string()
                 },
                 init: Expression::DateTime(DateTimeLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 27),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: chrono::DateTime::parse_from_rfc3339("2018-11-29T09:00:00Z").unwrap()
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9740,7 +10448,7 @@ fn date_time_literal_with_fractional_seconds() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 37),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -9749,24 +10457,25 @@ fn date_time_literal_with_fractional_seconds() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 37),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "now".to_string()
                 },
                 init: Expression::DateTime(DateTimeLit {
                     base: BaseNode {
                         location: loc.get(1, 7, 1, 37),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: chrono::DateTime::parse_from_rfc3339("2018-11-29T09:00:00.100000000Z")
                         .unwrap()
                 })
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9781,143 +10490,164 @@ fn function_call_with_unbalanced_braces() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 56),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 56),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::PipeExpr(Box::new(PipeExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 56),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     argument: Expression::PipeExpr(Box::new(PipeExpr {
                         base: BaseNode {
                             location: loc.get(1, 1, 1, 18),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         argument: Expression::Call(Box::new(CallExpr {
                             base: BaseNode {
                                 location: loc.get(1, 1, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 1, 1, 5),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "from".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         })),
                         call: CallExpr {
                             base: BaseNode {
                                 location: loc.get(1, 11, 1, 18),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             callee: Expression::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 11, 1, 16),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "range".to_string()
                             }),
-                            arguments: vec![]
+                            lparen: None,
+                            arguments: vec![],
+                            rparen: None,
                         }
                     })),
                     call: CallExpr {
                         base: BaseNode {
                             location: loc.get(1, 22, 1, 56),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         callee: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 22, 1, 25),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "map".to_string()
                         }),
+                        lparen: None,
                         arguments: vec![Expression::Object(Box::new(ObjectExpr {
                             base: BaseNode {
                                 location: loc.get(1, 26, 1, 56),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
+                            lbrace: None,
                             with: None,
                             properties: vec![Property {
                                 base: BaseNode {
                                     location: loc.get(1, 26, 1, 56),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 key: PropertyKey::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 26, 1, 28),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "fn".to_string()
                                 }),
+                                separator: None,
                                 value: Some(Expression::Function(Box::new(FunctionExpr {
                                     base: BaseNode {
                                         location: loc.get(1, 30, 1, 56),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
+                                    lparen: None,
                                     params: vec![Property {
                                         base: BaseNode {
                                             location: loc.get(1, 31, 1, 32),
-                                            errors: vec![]
+                                            ..BaseNode::default()
                                         },
                                         key: PropertyKey::Identifier(Identifier {
                                             base: BaseNode {
                                                 location: loc.get(1, 31, 1, 32),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             name: "r".to_string()
                                         }),
-                                        value: None
+                                        separator: None,
+                                        value: None,
+                                        comma: None,
                                     }],
+                                    rparen: None,
+                                    arrow: None,
                                     body: FunctionBody::Block(Block {
                                         base: BaseNode {
                                             location: loc.get(1, 37, 1, 56),
-                                            errors: vec!["expected RBRACE, got RPAREN".to_string()]
+                                            errors: vec!["expected RBRACE, got RPAREN".to_string()],
+                                            ..BaseNode::default()
                                         },
-                                        body: vec![Statement::Return(ReturnStmt {
+                                        lbrace: None,
+                                        body: vec![Statement::Return(Box::new(ReturnStmt {
                                             base: BaseNode {
                                                 location: loc.get(1, 39, 1, 54),
-                                                errors: vec![]
+                                                ..BaseNode::default()
                                             },
                                             argument: Expression::Member(Box::new(MemberExpr {
                                                 base: BaseNode {
                                                     location: loc.get(1, 46, 1, 54),
-                                                    errors: vec![]
+                                                    ..BaseNode::default()
                                                 },
                                                 object: Expression::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(1, 46, 1, 47),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     name: "r".to_string()
                                                 }),
+                                                lbrack: None,
                                                 property: PropertyKey::Identifier(Identifier {
                                                     base: BaseNode {
                                                         location: loc.get(1, 48, 1, 54),
-                                                        errors: vec![]
+                                                        ..BaseNode::default()
                                                     },
                                                     name: "_value".to_string()
-                                                })
+                                                }),
+                                                rbrack: None,
                                             }))
-                                        })]
-                                    })
-                                })))
-                            }]
-                        }))]
+                                        }))],
+                                        rbrace: None,
+                                    }),
+                                }))),
+                                comma: None,
+                            }],
+                            rbrace: None,
+                        }))],
+                        rparen: None,
                     }
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9932,25 +10662,26 @@ fn string_with_utf_8() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringLit(StringLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "日本語".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9965,25 +10696,26 @@ fn string_with_byte_values() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 39),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 39),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringLit(StringLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 39),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "日本語".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -9998,25 +10730,26 @@ fn string_with_mixed_values() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 63),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 63),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringLit(StringLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 63),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "hello 日x本 日本語 µs".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10036,18 +10769,19 @@ backslash \\
     assert_eq!(
         parsed,
         File {
-            base: BaseNode {location: loc.get(1, 1, 6, 2), errors: vec![] },
+            base: BaseNode {location: loc.get(1, 1, 6, 2), .. BaseNode::default() },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
-                base: BaseNode {location: loc.get(1, 1, 6, 2), errors: vec![] },
+            body: vec![Statement::Expr(Box::new(ExprStmt {
+                base: BaseNode {location: loc.get(1, 1, 6, 2), .. BaseNode::default() },
                 expression: Expression::StringLit(StringLit {
-                    base: BaseNode {location: loc.get(1, 1, 6, 2), errors: vec![] },
+                    base: BaseNode {location: loc.get(1, 1, 6, 2), .. BaseNode::default() },
                     value: "newline \n\ncarriage return \r\nhorizontal tab \t\ndouble quote \"\nbackslash \\\n".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10068,25 +10802,26 @@ string"
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 4, 8),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 4, 8),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::StringLit(StringLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 4, 8),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     value: "\n this is a\nmultiline\nstring".to_string()
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10102,35 +10837,36 @@ fn illegal_statement_token() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 8),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
             body: vec![
-                Statement::Bad(BadStmt {
+                Statement::Bad(Box::new(BadStmt {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
                         // errors: vec!["invalid statement @1:1-1:2: @".to_string()]
-                        errors: vec![],
+                        ..BaseNode::default()
                     },
                     text: "@".to_string()
-                }),
-                Statement::Expr(ExprStmt {
+                })),
+                Statement::Expr(Box::new(ExprStmt {
                     base: BaseNode {
                         location: loc.get(1, 3, 1, 8),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     expression: Expression::Identifier(Identifier {
                         base: BaseNode {
                             location: loc.get(1, 3, 1, 8),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         name: "ident".to_string()
                     })
-                })
-            ]
+                }))
+            ],
+            eof: None,
         },
     )
 }
@@ -10146,46 +10882,49 @@ fn multiple_idents_in_parens() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Paren(Box::new(ParenExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     expression: Expression::Binary(Box::new(BinaryExpr {
                         // TODO(affo): ast.Check would add the error "expected an operator between two expressions".
                         base: BaseNode {
                             location: loc.get(1, 2, 1, 5),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::InvalidOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 3),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 4, 1, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
-                    }))
+                    })),
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10202,34 +10941,35 @@ fn missing_left_hand_side() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 5),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 5),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Paren(Box::new(ParenExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 5),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     expression: Expression::Binary(Box::new(BinaryExpr {
                         // TODO(affo): this should be like this:
                         // base: BaseNode {location: ..., errors: vec!["missing left hand side of expression".to_string()] },
                         base: BaseNode {
                             location: loc.get(1, 2, 1, 4),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::MultiplicationOperator,
                         left: Expression::Bad(Box::new(BadExpr {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 3),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             text: "invalid token for primary expression: MUL".to_string(),
                             expression: None
@@ -10237,13 +10977,15 @@ fn missing_left_hand_side() {
                         right: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 3, 1, 4),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "b".to_string()
                         })
-                    }))
+                    })),
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10260,48 +11002,51 @@ fn missing_right_hand_side() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 5),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 5),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Paren(Box::new(ParenExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 5),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     expression: Expression::Binary(Box::new(BinaryExpr {
                         // TODO(affo): this should be like this:
                         // base: BaseNode {location: ..., errors: vec!["missing right hand side of expression".to_string()] },
                         base: BaseNode {
                             location: loc.get(1, 2, 1, 5),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         operator: Operator::MultiplicationOperator,
                         left: Expression::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 3),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
                         right: Expression::Bad(Box::new(BadExpr {
                             base: BaseNode {
                                 location: loc.get(1, 4, 1, 5),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             text: "invalid token for primary expression: RPAREN".to_string(),
                             expression: None
                         })),
-                    }))
+                    })),
+                    rparen: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10316,32 +11061,36 @@ fn illegal_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 4),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 4),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Paren(Box::new(ParenExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 4),
-                        errors: vec!["invalid expression @1:2-1:3: @".to_string()]
+                        errors: vec!["invalid expression @1:2-1:3: @".to_string()],
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     expression: Expression::Bad(Box::new(BadExpr {
                         base: BaseNode {
                             location: loc.get(1, 2, 1, 3),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         text: "@".to_string(),
                         expression: None
-                    }))
+                    })),
+                    rparen: None,
                 }))
-            }),]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10357,16 +11106,16 @@ fn missing_arrow_in_function_expression() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 13),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 13),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Function(Box::new(FunctionExpr {
                     base: BaseNode {
@@ -10376,48 +11125,57 @@ fn missing_arrow_in_function_expression() {
                             "expected ARROW, got ADD (+) at 1:10".to_string(),
                             "expected ARROW, got IDENT (b) at 1:12".to_string(),
                             "expected ARROW, got EOF".to_string()
-                        ]
+                        ],
+                        ..BaseNode::default()
                     },
+                    lparen: None,
                     params: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 2, 1, 3),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 2, 1, 3),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 5, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 5, 1, 6),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         }
                     ],
+                    rparen: None,
+                    arrow: None,
                     body: FunctionBody::Expr(Expression::Bad(Box::new(BadExpr {
                         base: BaseNode {
                             location: loc.get(1, 13, 1, 13),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         text: "invalid token for primary expression: EOF".to_string(),
                         expression: None
-                    })))
+                    }))),
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10432,7 +11190,7 @@ fn property_list_missing_property() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 20),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -10441,79 +11199,89 @@ fn property_list_missing_property() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 20),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "o".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 20),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "a".to_string()
-                            }))
+                            })),
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 13, 1, 13),
-                                errors: vec!["missing property in property list".to_string()]
+                                errors: vec!["missing property in property list".to_string()],
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 13, 1, 13),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "<invalid>".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 15, 1, 19),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 15, 1, 16),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 18, 1, 19),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 7
-                            }))
+                            })),
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10528,7 +11296,7 @@ fn property_list_missing_key() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 12),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -10537,43 +11305,49 @@ fn property_list_missing_key() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 12),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "o".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 12),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 11),
-                            errors: vec!["missing property key".to_string()]
+                            errors: vec!["missing property key".to_string()],
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 6),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "<invalid>".to_string()
                         }),
+                        separator: None,
                         value: Some(Expression::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 8, 1, 11),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a".to_string()
-                        }))
-                    }]
+                        })),
+                        comma: None,
+                    }],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10588,7 +11362,7 @@ fn property_list_missing_value() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 9),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -10597,37 +11371,43 @@ fn property_list_missing_value() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 9),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "o".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 9),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 7),
-                            errors: vec!["missing property value".to_string()]
+                            errors: vec!["missing property value".to_string()],
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
-                        value: None
-                    }]
+                        separator: None,
+                        value: None,
+                        comma: None,
+                    }],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10643,7 +11423,7 @@ fn property_list_missing_comma() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 19),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -10652,82 +11432,91 @@ fn property_list_missing_comma() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 19),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "o".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 19),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 14),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
+                            separator: None,
                             // TODO(affo): ast.Check would add the error "expected an operator between two expressions".
                             value: Some(Expression::Binary(Box::new(BinaryExpr {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 operator: Operator::InvalidOperator,
                                 left: Expression::StringLit(StringLit {
                                     base: BaseNode {
                                         location: loc.get(1, 9, 1, 12),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     value: "a".to_string()
                                 }),
                                 right: Expression::Identifier(Identifier {
                                     base: BaseNode {
                                         location: loc.get(1, 13, 1, 14),
-                                        errors: vec![]
+                                        ..BaseNode::default()
                                     },
                                     name: "b".to_string()
                                 })
-                            })))
+                            }))),
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 14, 1, 18),
-                                errors: vec!["missing property key".to_string()]
+                                errors: vec!["missing property key".to_string()],
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 14, 1, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "<invalid>".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 16, 1, 18),
                                     errors: vec![
                                         "expected comma in property list, got COLON".to_string()
-                                    ]
+                                    ],
+                                    ..BaseNode::default()
                                 },
                                 value: 30
-                            }))
+                            })),
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10742,7 +11531,7 @@ fn property_list_trailing_comma() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 14),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -10751,43 +11540,48 @@ fn property_list_trailing_comma() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 14),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "o".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 14),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![Property {
                         base: BaseNode {
                             location: loc.get(1, 6, 1, 12),
-                            errors: vec![]
+                            ..BaseNode::default()
                         },
                         key: PropertyKey::Identifier(Identifier {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 7),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             name: "a".to_string()
                         }),
+                        separator: None,
                         value: Some(Expression::StringLit(StringLit {
                             base: BaseNode {
                                 location: loc.get(1, 9, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             value: "a".to_string()
-                        }))
-                    }]
+                        })),
+                        comma: None,
+                    }],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10802,7 +11596,7 @@ fn property_list_bad_property() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 23),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
@@ -10811,81 +11605,91 @@ fn property_list_bad_property() {
             body: vec![Statement::Variable(Box::new(VariableAssgn {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 23),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 id: Identifier {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 2),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
                     name: "o".to_string()
                 },
                 init: Expression::Object(Box::new(ObjectExpr {
                     base: BaseNode {
                         location: loc.get(1, 5, 1, 23),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
+                    lbrace: None,
                     with: None,
                     properties: vec![
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 6, 1, 12),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 6, 1, 7),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "a".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 9, 1, 12),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "a".to_string()
-                            }))
+                            })),
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 14, 1, 16),
                                 errors: vec![
                                     "unexpected token for property key: INT (30)".to_string()
-                                ]
+                                ],
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::StringLit(StringLit {
                                 base: BaseNode {
                                     location: loc.get(1, 14, 1, 14),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: "<invalid>".to_string()
                             }),
-                            value: None
+                            separator: None,
+                            value: None,
+                            comma: None,
                         },
                         Property {
                             base: BaseNode {
                                 location: loc.get(1, 18, 1, 22),
-                                errors: vec![]
+                                ..BaseNode::default()
                             },
                             key: PropertyKey::Identifier(Identifier {
                                 base: BaseNode {
                                     location: loc.get(1, 18, 1, 19),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 name: "b".to_string()
                             }),
+                            separator: None,
                             value: Some(Expression::Integer(IntegerLit {
                                 base: BaseNode {
                                     location: loc.get(1, 21, 1, 22),
-                                    errors: vec![]
+                                    ..BaseNode::default()
                                 },
                                 value: 7
-                            }))
+                            })),
+                            comma: None,
                         }
-                    ]
+                    ],
+                    rbrace: None,
                 }))
-            }))]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10902,31 +11706,37 @@ fn invalid_expression_in_array() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 6),
-                errors: vec![]
+                ..BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 6),
-                    errors: vec![]
+                    ..BaseNode::default()
                 },
                 expression: Expression::Array(Box::new(ArrayExpr {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 6),
-                        errors: vec![]
+                        ..BaseNode::default()
                     },
-                    elements: vec![Expression::Identifier(Identifier {
-                        base: BaseNode {
-                            location: loc.get(1, 3, 1, 4),
-                            errors: vec![]
-                        },
-                        name: "a".to_string()
-                    })]
+                    lbrack: None,
+                    elements: vec![ArrayItem {
+                        expression: Expression::Identifier(Identifier {
+                            base: BaseNode {
+                                location: loc.get(1, 3, 1, 4),
+                                ..BaseNode::default()
+                            },
+                            name: "a".to_string()
+                        }),
+                        comma: None,
+                    }],
+                    rbrack: None,
                 }))
-            })]
+            }))],
+            eof: None,
         },
     )
 }
@@ -10941,24 +11751,26 @@ fn integer_literal_overflow() {
         File {
             base: BaseNode {
                 location: loc.get(1, 1, 1, 31),
-                errors: vec![]
+                .. BaseNode::default()
             },
             name: "".to_string(),
             metadata: "parser-type=rust".to_string(),
             package: None,
             imports: vec![],
-            body: vec![Statement::Expr(ExprStmt {
+            body: vec![Statement::Expr(Box::new(ExprStmt {
                 base: BaseNode {
                     location: loc.get(1, 1, 1, 31),
-                    errors: vec![] },
+                    .. BaseNode::default() },
                 expression: Expression::Integer(IntegerLit {
                     base: BaseNode {
                         location: loc.get(1, 1, 1, 31),
-                        errors: vec!["invalid integer literal \"100000000000000000000000000000\": value out of range".to_string()]
+                        errors: vec!["invalid integer literal \"100000000000000000000000000000\": value out of range".to_string()],
+                        .. BaseNode::default()
                     },
                     value: 0,
                 })
-            })]
+            }))],
+            eof: None,
         },
     )
 }

--- a/libflux/src/flux/scanner/tests.rs
+++ b/libflux/src/flux/scanner/tests.rs
@@ -14,7 +14,8 @@ fn test_scan() {
             start_offset: 0,
             end_offset: 4,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 5 }
+            end_pos: Position { line: 1, column: 5 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -25,7 +26,8 @@ fn test_scan() {
             start_offset: 4,
             end_offset: 5,
             start_pos: Position { line: 1, column: 5 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -39,7 +41,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 12
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -56,7 +59,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 13
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -73,7 +77,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 18
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -90,7 +95,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 19
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -107,7 +113,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 22
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -124,7 +131,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 28
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -141,7 +149,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 29
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -158,7 +167,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 34
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -175,7 +185,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 35
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -192,7 +203,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 37
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -209,7 +221,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 39
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -226,7 +239,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 40
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -243,7 +257,8 @@ fn test_scan() {
             end_pos: Position {
                 line: 1,
                 column: 40
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -261,7 +276,8 @@ fn test_scan_with_regex() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -272,7 +288,8 @@ fn test_scan_with_regex() {
             start_offset: 2,
             end_offset: 3,
             start_pos: Position { line: 1, column: 3 },
-            end_pos: Position { line: 1, column: 4 }
+            end_pos: Position { line: 1, column: 4 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -283,7 +300,8 @@ fn test_scan_with_regex() {
             start_offset: 4,
             end_offset: 5,
             start_pos: Position { line: 1, column: 5 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -294,7 +312,8 @@ fn test_scan_with_regex() {
             start_offset: 6,
             end_offset: 8,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 9 }
+            end_pos: Position { line: 1, column: 9 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -311,7 +330,8 @@ fn test_scan_with_regex() {
             end_pos: Position {
                 line: 1,
                 column: 19
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -328,7 +348,8 @@ fn test_scan_with_regex() {
             end_pos: Position {
                 line: 1,
                 column: 21
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -345,7 +366,8 @@ fn test_scan_with_regex() {
             end_pos: Position {
                 line: 1,
                 column: 23
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -362,7 +384,8 @@ fn test_scan_with_regex() {
             end_pos: Position {
                 line: 1,
                 column: 23
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -380,7 +403,8 @@ fn test_scan_string_expr_simple() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -391,7 +415,8 @@ fn test_scan_string_expr_simple() {
             start_offset: 1,
             end_offset: 3,
             start_pos: Position { line: 1, column: 2 },
-            end_pos: Position { line: 1, column: 4 }
+            end_pos: Position { line: 1, column: 4 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -405,7 +430,8 @@ fn test_scan_string_expr_simple() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -422,7 +448,8 @@ fn test_scan_string_expr_simple() {
             end_pos: Position {
                 line: 1,
                 column: 11
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -440,7 +467,8 @@ fn test_scan_string_expr_start_with_text() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -454,7 +482,8 @@ fn test_scan_string_expr_start_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -471,7 +500,8 @@ fn test_scan_string_expr_start_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 12
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -488,7 +518,8 @@ fn test_scan_string_expr_start_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 18
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -505,7 +536,8 @@ fn test_scan_string_expr_start_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 19
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -523,7 +555,8 @@ fn test_scan_string_expr_multiple() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -537,7 +570,8 @@ fn test_scan_string_expr_multiple() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -554,7 +588,8 @@ fn test_scan_string_expr_multiple() {
             end_pos: Position {
                 line: 1,
                 column: 12
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -571,7 +606,8 @@ fn test_scan_string_expr_multiple() {
             end_pos: Position {
                 line: 1,
                 column: 31
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -588,7 +624,8 @@ fn test_scan_string_expr_multiple() {
             end_pos: Position {
                 line: 1,
                 column: 33
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -605,7 +642,8 @@ fn test_scan_string_expr_multiple() {
             end_pos: Position {
                 line: 1,
                 column: 39
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -622,7 +660,8 @@ fn test_scan_string_expr_multiple() {
             end_pos: Position {
                 line: 1,
                 column: 40
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -640,7 +679,8 @@ fn test_scan_string_expr_end_with_text() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -654,7 +694,8 @@ fn test_scan_string_expr_end_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -671,7 +712,8 @@ fn test_scan_string_expr_end_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 12
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -688,7 +730,8 @@ fn test_scan_string_expr_end_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 32
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -705,7 +748,8 @@ fn test_scan_string_expr_end_with_text() {
             end_pos: Position {
                 line: 1,
                 column: 33
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -723,7 +767,8 @@ fn test_scan_string_expr_escaped_quotes() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -737,7 +782,8 @@ fn test_scan_string_expr_escaped_quotes() {
             end_pos: Position {
                 line: 1,
                 column: 31
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -754,7 +800,8 @@ fn test_scan_string_expr_escaped_quotes() {
             end_pos: Position {
                 line: 1,
                 column: 32
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -772,7 +819,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -783,7 +831,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             start_offset: 1,
             end_offset: 6,
             start_pos: Position { line: 1, column: 2 },
-            end_pos: Position { line: 1, column: 7 }
+            end_pos: Position { line: 1, column: 7 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -794,7 +843,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -808,7 +858,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             end_pos: Position {
                 line: 1,
                 column: 32
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -825,7 +876,8 @@ fn test_scan_string_expr_not_escaped_quotes() {
             end_pos: Position {
                 line: 1,
                 column: 33
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -843,7 +895,8 @@ fn test_scan_unread() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
     s.unread();
@@ -855,7 +908,8 @@ fn test_scan_unread() {
             start_offset: 0,
             end_offset: 1,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 2 }
+            end_pos: Position { line: 1, column: 2 },
+            comments: None,
         }
     );
 
@@ -867,7 +921,8 @@ fn test_scan_unread() {
             start_offset: 2,
             end_offset: 7,
             start_pos: Position { line: 1, column: 3 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     s.unread();
@@ -879,7 +934,8 @@ fn test_scan_unread() {
             start_offset: 2,
             end_offset: 3,
             start_pos: Position { line: 1, column: 3 },
-            end_pos: Position { line: 1, column: 4 }
+            end_pos: Position { line: 1, column: 4 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -890,7 +946,8 @@ fn test_scan_unread() {
             start_offset: 4,
             end_offset: 5,
             start_pos: Position { line: 1, column: 5 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -901,7 +958,8 @@ fn test_scan_unread() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -915,7 +973,8 @@ fn test_scan_unread() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     // test unread idempotence
@@ -935,7 +994,8 @@ fn test_scan_unread() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -952,7 +1012,8 @@ fn test_scan_unread() {
             end_pos: Position {
                 line: 1,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -974,6 +1035,7 @@ fn test_scan_unread_with_newlines() {
             end_offset: 5,
             start_pos: Position { line: 1, column: 1 },
             end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -985,6 +1047,7 @@ fn test_scan_unread_with_newlines() {
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
             end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -996,6 +1059,7 @@ fn test_scan_unread_with_newlines() {
             end_offset: 11,
             start_pos: Position { line: 4, column: 1 },
             end_pos: Position { line: 4, column: 2 },
+            comments: None,
         }
     );
     s.unread();
@@ -1008,6 +1072,7 @@ fn test_scan_unread_with_newlines() {
             end_offset: 15,
             start_pos: Position { line: 4, column: 1 },
             end_pos: Position { line: 4, column: 6 },
+            comments: None,
         }
     );
 }
@@ -1041,6 +1106,7 @@ fn test_scan_with_regex_unread() {
                 end_offset: 1,
                 start_pos: Position { line: 1, column: 1 },
                 end_pos: Position { line: 1, column: 2 },
+                comments: None,
             },
             Token {
                 tok: TOK_MUL,
@@ -1049,6 +1115,7 @@ fn test_scan_with_regex_unread() {
                 end_offset: 3,
                 start_pos: Position { line: 1, column: 3 },
                 end_pos: Position { line: 1, column: 4 },
+                comments: None,
             },
             Token {
                 tok: TOK_DIV,
@@ -1057,6 +1124,7 @@ fn test_scan_with_regex_unread() {
                 end_offset: 5,
                 start_pos: Position { line: 1, column: 5 },
                 end_pos: Position { line: 1, column: 6 },
+                comments: None,
             },
             Token {
                 tok: TOK_DIV,
@@ -1065,6 +1133,7 @@ fn test_scan_with_regex_unread() {
                 end_offset: 5,
                 start_pos: Position { line: 1, column: 5 },
                 end_pos: Position { line: 1, column: 6 },
+                comments: None,
             },
             Token {
                 tok: TOK_INT,
@@ -1073,6 +1142,7 @@ fn test_scan_with_regex_unread() {
                 end_offset: 7,
                 start_pos: Position { line: 1, column: 7 },
                 end_pos: Position { line: 1, column: 8 },
+                comments: None,
             },
             Token {
                 tok: TOK_IDENT,
@@ -1087,6 +1157,7 @@ fn test_scan_with_regex_unread() {
                     line: 2,
                     column: 11
                 },
+                comments: None,
             },
             Token {
                 tok: TOK_EOF,
@@ -1095,6 +1166,7 @@ fn test_scan_with_regex_unread() {
                 end_offset: 23,
                 start_pos: Position { line: 3, column: 5 },
                 end_pos: Position { line: 3, column: 5 },
+                comments: None,
             },
         ],
         toks
@@ -1125,6 +1197,7 @@ fn test_unclosed_quote() {
                 end_offset: 1,
                 start_pos: Position { line: 1, column: 1 },
                 end_pos: Position { line: 1, column: 2 },
+                comments: None,
             },
             Token {
                 tok: TOK_ASSIGN,
@@ -1133,6 +1206,7 @@ fn test_unclosed_quote() {
                 end_offset: 3,
                 start_pos: Position { line: 1, column: 3 },
                 end_pos: Position { line: 1, column: 4 },
+                comments: None,
             },
             Token {
                 tok: TOK_QUOTE,
@@ -1141,6 +1215,7 @@ fn test_unclosed_quote() {
                 end_offset: 5,
                 start_pos: Position { line: 1, column: 5 },
                 end_pos: Position { line: 1, column: 6 },
+                comments: None,
             },
             Token {
                 tok: TOK_IDENT,
@@ -1149,6 +1224,7 @@ fn test_unclosed_quote() {
                 end_offset: 8,
                 start_pos: Position { line: 1, column: 6 },
                 end_pos: Position { line: 1, column: 9 },
+                comments: None,
             },
             Token {
                 tok: TOK_IDENT,
@@ -1160,6 +1236,7 @@ fn test_unclosed_quote() {
                     line: 2,
                     column: 12,
                 },
+                comments: None,
             },
             Token {
                 tok: TOK_IDENT,
@@ -1171,6 +1248,7 @@ fn test_unclosed_quote() {
                     line: 3,
                     column: 12,
                 },
+                comments: None,
             },
             Token {
                 tok: TOK_EOF,
@@ -1185,6 +1263,7 @@ fn test_unclosed_quote() {
                     line: 3,
                     column: 12
                 },
+                comments: None,
             }
         ],
         toks
@@ -1210,7 +1289,16 @@ a
             start_offset: 22,
             end_offset: 23,
             start_pos: Position { line: 2, column: 1 },
-            end_pos: Position { line: 2, column: 2 }
+            end_pos: Position { line: 2, column: 2 },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// this is a comment.\n"),
+                start_offset: 0,
+                end_offset: 22,
+                start_pos: Position { line: 1, column: 1 },
+                end_pos: Position { line: 2, column: 1 },
+                comments: None
+            })),
         }
     );
     assert_eq!(
@@ -1221,7 +1309,32 @@ a
             start_offset: 95,
             end_offset: 96,
             start_pos: Position { line: 6, column: 1 },
-            end_pos: Position { line: 6, column: 2 }
+            end_pos: Position { line: 6, column: 2 },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// last but not least.\n"),
+                start_offset: 72,
+                end_offset: 95,
+                start_pos: Position { line: 5, column: 1 },
+                end_pos: Position { line: 6, column: 1 },
+                comments: Some(Box::new(Token {
+                    tok: 2,
+                    lit: String::from("// one more.\n"),
+                    start_offset: 59,
+                    end_offset: 72,
+                    start_pos: Position { line: 4, column: 1 },
+                    end_pos: Position { line: 5, column: 1 },
+                    comments: Some(Box::new(Token {
+                        tok: 2,
+                        lit: String::from("// comment with // nested comment.\n"),
+                        start_offset: 24,
+                        end_offset: 59,
+                        start_pos: Position { line: 3, column: 1 },
+                        end_pos: Position { line: 4, column: 1 },
+                        comments: None,
+                    }))
+                }))
+            }))
         }
     );
     assert_eq!(
@@ -1238,7 +1351,19 @@ a
             end_pos: Position {
                 line: 7,
                 column: 18
-            }
+            },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// ok, that\'s it."),
+                start_offset: 97,
+                end_offset: 114,
+                start_pos: Position { line: 7, column: 1 },
+                end_pos: Position {
+                    line: 7,
+                    column: 18
+                },
+                comments: None
+            }))
         }
     );
 
@@ -1253,7 +1378,16 @@ a
             start_offset: 22,
             end_offset: 23,
             start_pos: Position { line: 2, column: 1 },
-            end_pos: Position { line: 2, column: 2 }
+            end_pos: Position { line: 2, column: 2 },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// this is a comment.\n"),
+                start_offset: 0,
+                end_offset: 22,
+                start_pos: Position { line: 1, column: 1 },
+                end_pos: Position { line: 2, column: 1 },
+                comments: None
+            })),
         }
     );
     assert_eq!(
@@ -1264,7 +1398,32 @@ a
             start_offset: 95,
             end_offset: 96,
             start_pos: Position { line: 6, column: 1 },
-            end_pos: Position { line: 6, column: 2 }
+            end_pos: Position { line: 6, column: 2 },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// last but not least.\n"),
+                start_offset: 72,
+                end_offset: 95,
+                start_pos: Position { line: 5, column: 1 },
+                end_pos: Position { line: 6, column: 1 },
+                comments: Some(Box::new(Token {
+                    tok: 2,
+                    lit: String::from("// one more.\n"),
+                    start_offset: 59,
+                    end_offset: 72,
+                    start_pos: Position { line: 4, column: 1 },
+                    end_pos: Position { line: 5, column: 1 },
+                    comments: Some(Box::new(Token {
+                        tok: 2,
+                        lit: String::from("// comment with // nested comment.\n"),
+                        start_offset: 24,
+                        end_offset: 59,
+                        start_pos: Position { line: 3, column: 1 },
+                        end_pos: Position { line: 4, column: 1 },
+                        comments: None
+                    }))
+                }))
+            }))
         }
     );
     assert_eq!(
@@ -1281,7 +1440,19 @@ a
             end_pos: Position {
                 line: 7,
                 column: 18
-            }
+            },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// ok, that\'s it."),
+                start_offset: 97,
+                end_offset: 114,
+                start_pos: Position { line: 7, column: 1 },
+                end_pos: Position {
+                    line: 7,
+                    column: 18
+                },
+                comments: None
+            }))
         }
     );
 }
@@ -1300,7 +1471,8 @@ fn test_scan_eof() {
             start_offset: 0,
             end_offset: 0,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 1 }
+            end_pos: Position { line: 1, column: 1 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1311,7 +1483,8 @@ fn test_scan_eof() {
             start_offset: 0,
             end_offset: 0,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 1 }
+            end_pos: Position { line: 1, column: 1 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1322,7 +1495,8 @@ fn test_scan_eof() {
             start_offset: 0,
             end_offset: 0,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 1 }
+            end_pos: Position { line: 1, column: 1 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1333,7 +1507,8 @@ fn test_scan_eof() {
             start_offset: 0,
             end_offset: 0,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 1 }
+            end_pos: Position { line: 1, column: 1 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1344,7 +1519,8 @@ fn test_scan_eof() {
             start_offset: 0,
             end_offset: 0,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 1 }
+            end_pos: Position { line: 1, column: 1 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1355,7 +1531,8 @@ fn test_scan_eof() {
             start_offset: 0,
             end_offset: 0,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 1 }
+            end_pos: Position { line: 1, column: 1 },
+            comments: None,
         }
     );
 }
@@ -1380,7 +1557,8 @@ fn test_scan_eof_trailing_spaces() {
             start_offset: 7,
             end_offset: 7,
             start_pos: Position { line: 2, column: 5 },
-            end_pos: Position { line: 2, column: 5 }
+            end_pos: Position { line: 2, column: 5 },
+            comments: None,
         }
     );
 
@@ -1394,7 +1572,8 @@ fn test_scan_eof_trailing_spaces() {
             start_offset: 7,
             end_offset: 7,
             start_pos: Position { line: 2, column: 5 },
-            end_pos: Position { line: 2, column: 5 }
+            end_pos: Position { line: 2, column: 5 },
+            comments: None,
         }
     );
 }
@@ -1412,7 +1591,8 @@ fn test_illegal() {
             start_offset: 0,
             end_offset: 5,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1423,7 +1603,8 @@ fn test_illegal() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1437,7 +1618,8 @@ fn test_illegal() {
             end_pos: Position {
                 line: 1,
                 column: 16
-            }
+            },
+            comments: None,
         }
     );
 
@@ -1451,7 +1633,8 @@ fn test_illegal() {
             start_offset: 0,
             end_offset: 5,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1462,7 +1645,8 @@ fn test_illegal() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     s.unread();
@@ -1474,7 +1658,8 @@ fn test_illegal() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1488,7 +1673,8 @@ fn test_illegal() {
             end_pos: Position {
                 line: 1,
                 column: 16
-            }
+            },
+            comments: None,
         }
     );
 
@@ -1502,7 +1688,8 @@ fn test_illegal() {
             start_offset: 0,
             end_offset: 5,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1513,7 +1700,8 @@ fn test_illegal() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1527,7 +1715,8 @@ fn test_illegal() {
             end_pos: Position {
                 line: 1,
                 column: 16
-            }
+            },
+            comments: None,
         }
     );
 
@@ -1541,7 +1730,8 @@ fn test_illegal() {
             start_offset: 0,
             end_offset: 5,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1552,7 +1742,8 @@ fn test_illegal() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     s.unread();
@@ -1564,7 +1755,8 @@ fn test_illegal() {
             start_offset: 6,
             end_offset: 7,
             start_pos: Position { line: 1, column: 7 },
-            end_pos: Position { line: 1, column: 8 }
+            end_pos: Position { line: 1, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1578,7 +1770,8 @@ fn test_illegal() {
             end_pos: Position {
                 line: 1,
                 column: 16
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -1596,7 +1789,8 @@ fn test_scan_duration() {
             start_offset: 0,
             end_offset: 3,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 4 }
+            end_pos: Position { line: 1, column: 4 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1607,7 +1801,8 @@ fn test_scan_duration() {
             start_offset: 4,
             end_offset: 5,
             start_pos: Position { line: 1, column: 5 },
-            end_pos: Position { line: 1, column: 6 }
+            end_pos: Position { line: 1, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1621,7 +1816,8 @@ fn test_scan_duration() {
             end_pos: Position {
                 line: 1,
                 column: 34
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(
@@ -1638,7 +1834,8 @@ fn test_scan_duration() {
             end_pos: Position {
                 line: 1,
                 column: 34
-            }
+            },
+            comments: None,
         }
     );
 }
@@ -1667,7 +1864,8 @@ c = 1 + 2
             start_offset: 0,
             end_offset: 2,
             start_pos: Position { line: 1, column: 1 },
-            end_pos: Position { line: 1, column: 3 }
+            end_pos: Position { line: 1, column: 3 },
+            comments: None,
         }
     );
     assert_eq!(0, s.offset(&Position { line: 1, column: 1 }));
@@ -1679,7 +1877,8 @@ c = 1 + 2
             start_offset: 3,
             end_offset: 4,
             start_pos: Position { line: 1, column: 4 },
-            end_pos: Position { line: 1, column: 5 }
+            end_pos: Position { line: 1, column: 5 },
+            comments: None,
         }
     );
     assert_eq!(3, s.offset(&Position { line: 1, column: 4 }));
@@ -1691,7 +1890,8 @@ c = 1 + 2
             start_offset: 5,
             end_offset: 24,
             start_pos: Position { line: 1, column: 6 },
-            end_pos: Position { line: 3, column: 2 }
+            end_pos: Position { line: 3, column: 2 },
+            comments: None,
         }
     );
     assert_eq!(5, s.offset(&Position { line: 1, column: 6 }));
@@ -1704,7 +1904,16 @@ c = 1 + 2
             start_offset: 38,
             end_offset: 39,
             start_pos: Position { line: 7, column: 1 },
-            end_pos: Position { line: 7, column: 2 }
+            end_pos: Position { line: 7, column: 2 },
+            comments: Some(Box::new(Token {
+                tok: 2,
+                lit: String::from("// comment\n"),
+                start_offset: 26,
+                end_offset: 37,
+                start_pos: Position { line: 5, column: 1 },
+                end_pos: Position { line: 6, column: 1 },
+                comments: None
+            }))
         }
     );
     assert_eq!(38, s.offset(&Position { line: 7, column: 1 }));
@@ -1716,7 +1925,8 @@ c = 1 + 2
             start_offset: 40,
             end_offset: 41,
             start_pos: Position { line: 7, column: 3 },
-            end_pos: Position { line: 7, column: 4 }
+            end_pos: Position { line: 7, column: 4 },
+            comments: None,
         }
     );
     assert_eq!(40, s.offset(&Position { line: 7, column: 3 }));
@@ -1728,7 +1938,8 @@ c = 1 + 2
             start_offset: 42,
             end_offset: 43,
             start_pos: Position { line: 7, column: 5 },
-            end_pos: Position { line: 7, column: 6 }
+            end_pos: Position { line: 7, column: 6 },
+            comments: None,
         }
     );
     assert_eq!(42, s.offset(&Position { line: 7, column: 5 }));
@@ -1740,7 +1951,8 @@ c = 1 + 2
             start_offset: 44,
             end_offset: 45,
             start_pos: Position { line: 7, column: 7 },
-            end_pos: Position { line: 7, column: 8 }
+            end_pos: Position { line: 7, column: 8 },
+            comments: None,
         }
     );
     assert_eq!(44, s.offset(&Position { line: 7, column: 7 }));
@@ -1755,7 +1967,8 @@ c = 1 + 2
             end_pos: Position {
                 line: 7,
                 column: 10
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(46, s.offset(&Position { line: 7, column: 9 }));
@@ -1773,7 +1986,8 @@ c = 1 + 2
             end_pos: Position {
                 line: 12,
                 column: 1
-            }
+            },
+            comments: None,
         }
     );
     assert_eq!(


### PR DESCRIPTION
Collecting comments during scanning and storing them in the AST. Including the
comments in AST formatting. In general, comments are placed on their own line
and are therefore assumed to apply to the code that follows. Updates to the
formatting rules can be added as desired.

Comments are collected in the scan function, where they were previously
discarded. The comments are arranged into a linked list as they are encountered
and then attached to the next real token that is generated by the parser.
Comments at the end of the file are attached to the EOF token.

During parsing, these comments are extracted from the tokens and stored in the
AST, generally at locations where the tokens they were attached to would be
stored in the AST, if they were kept. This requires adding comment list
optionals to the AST in various locaitons. To minimize AST changes, they are
also stored in the baseNode, if there is just one comment list to store. For
example, comments ahead of identifiers are stored in the base node. But
comments ahead of ( and ) are added to the AST.

Regexes need some special care. There is an unread() call once in the parser
when we've got a DIV and really want a REGEX open. At this time we need to put
the comments back as well, otherwise they are lost.

Preserving comments ahead of , in array expressions requires adding a new AST
struct to wrap the expressions in the ArrayExpr. We cannot use the base node in
the comment, since the expression may be only a nonterminal and the base node's
comment field may be in use for leading comments.

Preserving comments ahead of WITH requires adding a new AST struct to wrap the
identifier and keep any comments that appear ahead of the WITH keyword.

This commit also includes a boxing of all the variants in enum Statement. Since
we are changing the size of some of the AST data structures, clippy warns about
enum variant sizes.

Fixes #1959