### PR TITLE
fix(libflux): simplify libflux C API and resolve memory leaks

### DIFF
--- a/libflux/c/main.c
+++ b/libflux/c/main.c
@@ -26,15 +26,15 @@ void test_ast() {
   struct flux_error_t *err = flux_ast_marshal_json(ast_pkg_foo, &buf);
   assert(err == NULL);
   printf("  json buffer is length %ld\n", buf.len);
-  flux_free(buf.data);
+  flux_free_bytes(buf.data);
 
   printf("Marshaling to FlatBuffer\n");
   err = flux_ast_marshal_fb(ast_pkg_foo, &buf);
   assert(err == NULL);
   printf("  FlatBuffer is length %ld\n", buf.len);
-  flux_free(buf.data);
+  flux_free_bytes(buf.data);
 
-  flux_free(ast_pkg_foo);
+  flux_free_ast_pkg(ast_pkg_foo);
   printf("\n");
 }
 
@@ -56,9 +56,9 @@ void test_semantic() {
     err = flux_semantic_marshal_fb(sem_pkg, &buf);
     assert(err == NULL);
     printf("  FlatBuffer is length %ld\n", buf.len);
-    flux_free(buf.data);
+    flux_free_bytes(buf.data);
 
-    flux_free(sem_pkg);
+    flux_free_semantic_pkg(sem_pkg);
   }
 
   {
@@ -73,8 +73,8 @@ void test_semantic() {
     assert(sem_pkg == NULL);
     const char* err_str = flux_error_str(err);
     printf("  error: %s\n", err_str);
-    flux_free(err_str);
-    flux_free(err);
+    flux_free_bytes(err_str);
+    flux_free_error(err);
   }
 
   printf("\n");

--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -23,23 +23,23 @@ type SemanticPkg struct {
 func (p *SemanticPkg) MarshalFB() ([]byte, error) {
 	var buf C.struct_flux_buffer_t
 	if err := C.flux_semantic_marshal_fb(p.ptr, &buf); err != nil {
-		defer C.flux_free(unsafe.Pointer(err))
+		defer C.flux_free_error(err)
 		cstr := C.flux_error_str(err)
-		defer C.flux_free(unsafe.Pointer(cstr))
+		defer C.flux_free_bytes(cstr)
 
 		str := C.GoString(cstr)
 		return nil, errors.New(str)
 	}
-	defer C.flux_free(buf.data)
+	defer C.flux_free_bytes(buf.data)
 
-	data := C.GoBytes(buf.data, C.int(buf.len))
+	data := C.GoBytes(unsafe.Pointer(buf.data), C.int(buf.len))
 	return data, nil
 }
 
 // Free frees the memory allocated by Rust for the semantic graph.
 func (p *SemanticPkg) Free() {
 	if p.ptr != nil {
-		C.flux_free(unsafe.Pointer(p.ptr))
+		C.flux_free_semantic_pkg(p.ptr)
 	}
 	p.ptr = nil
 }
@@ -57,9 +57,9 @@ func Analyze(astPkg *ASTPkg) (*SemanticPkg, error) {
 		astPkg.ptr = nil
 	}()
 	if err := C.flux_analyze(astPkg.ptr, &semPkg); err != nil {
-		defer C.flux_free(unsafe.Pointer(err))
+		defer C.flux_free_error(err)
 		cstr := C.flux_error_str(err)
-		defer C.flux_free(unsafe.Pointer(cstr))
+		defer C.flux_free_bytes(cstr)
 
 		str := C.GoString(cstr)
 		return nil, errors.New(str)

--- a/libflux/go/libflux/flux.h
+++ b/libflux/go/libflux/flux.h
@@ -10,7 +10,7 @@ extern "C" {
 // flux_buffer_t is a reference to a byte-slice.
 struct flux_buffer_t {
 	// data is a pointer to the data contained within the buffer.
-	void *data;
+	char *data;
 
 	// len is the length of the buffer.
 	size_t len;
@@ -19,12 +19,16 @@ struct flux_buffer_t {
 // flux_error_t represents a flux error.
 struct flux_error_t;
 
+// flux_free_error will release memory associated with an error.
+void flux_free_error(struct flux_error_t *);
+
 // flux_error_str will return a string representation of the error.
-// This will allocate memory for the returned string.
+// This will allocate memory for the returned string, which must be
+// freed wtih flux_free_bytes.
 const char *flux_error_str(struct flux_error_t *);
 
-// flux_free will free a resource.
-void flux_free(const void *);
+// flux_free_bytes will release the memory pointed to by the pointer argument.
+void flux_free_bytes(const char *);
 
 // flux_ast_pkg_t is the AST representation of a flux query as a package.
 struct flux_ast_pkg_t;
@@ -33,18 +37,21 @@ struct flux_ast_pkg_t;
 // of the query.
 struct flux_ast_pkg_t *flux_parse(const char *);
 
+// flux_free_ast_pkg will release the memory associated with the given pointer.
+void flux_free_ast_pkg(struct flux_ast_pkg_t *);
+
 // flux_ast_marshal_json will marshal json and fill in the given buffer
 // with the data. If successful, memory will be allocated for the data
 // within the buffer and it is the caller's responsibility to free this
 // data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
+// using flux_free_error if it is non-null.
 struct flux_error_t *flux_ast_marshal_json(struct flux_ast_pkg_t *, struct flux_buffer_t *);
 
 // flux_ast_marshal_fb will marshal the given AST as a flatbuffer into
 // the given buffer. If successful, memory will be allocated for the data
 // within the buffer and it is the caller's responsibility to free this
 // data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
+// using flux_free_error if it is non-null.
 struct flux_error_t *flux_ast_marshal_fb(struct flux_ast_pkg_t *, struct flux_buffer_t *);
 
 // flux_semantic_pkg_t represents a semantic graph package node, including all of its files
@@ -53,20 +60,23 @@ struct flux_semantic_pkg_t;
 
 // flux_analyze analyzes the given AST and will populate the second pointer argument with
 // a pointer to the resulting semantic graph.
-// It is the caller's responsibility to free the resulting semantic graph with a call to flux_free().
+// It is the caller's responsibility to free the resulting semantic graph with a call to flux_free_semantic_pkg().
 // Note that the caller should free the pointer to the semantic graph, not the pointer to the pointer
 // to the semantic graph.  It is the former that references memory allocated by Rust.
 // If analysis fails, the second pointer argument wil be pointed at 0, and an error will be returned.
-// Any non-null error must be freed by calling flux_free.
+// Any non-null error must be freed by calling flux_free_error.
 // Regardless of whether an error is returned, this function will consume and free its
 // flux_ast_pkg_t* argument, so it should not be reused after calling this function.
 struct flux_error_t *flux_analyze(struct flux_ast_pkg_t *, struct flux_semantic_pkg_t **);
+
+// flux_free_semantic_pkg will release the memory associated with the given pointer.
+void flux_free_semantic_pkg(struct flux_semantic_pkg_t*);
 
 // flux_semantic_marshal_fb will marshal the given semantic graph as a flatbuffer into
 // the given buffer. If successful, memory will be allocated for the data
 // within the buffer and it is the caller's responsibility to free this
 // data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
+// using flux_free_error if it is non-null.
 struct flux_error_t *flux_semantic_marshal_fb(struct flux_semantic_pkg_t *, struct flux_buffer_t *);
 
 #ifdef __cplusplus

--- a/libflux/go/libflux/parser.go
+++ b/libflux/go/libflux/parser.go
@@ -36,38 +36,38 @@ type ASTPkg struct {
 func (p *ASTPkg) MarshalJSON() ([]byte, error) {
 	var buf C.struct_flux_buffer_t
 	if err := C.flux_ast_marshal_json(p.ptr, &buf); err != nil {
-		defer C.flux_free(unsafe.Pointer(err))
+		defer C.flux_free_error(err)
 		cstr := C.flux_error_str(err)
-		defer C.flux_free(unsafe.Pointer(cstr))
+		defer C.flux_free_bytes(cstr)
 
 		str := C.GoString(cstr)
 		return nil, errors.New(str)
 	}
-	defer C.flux_free(buf.data)
+	defer C.flux_free_bytes(buf.data)
 
-	data := C.GoBytes(buf.data, C.int(buf.len))
+	data := C.GoBytes(unsafe.Pointer(buf.data), C.int(buf.len))
 	return data, nil
 }
 
 func (p *ASTPkg) MarshalFB() ([]byte, error) {
 	var buf C.struct_flux_buffer_t
 	if err := C.flux_ast_marshal_fb(p.ptr, &buf); err != nil {
-		defer C.flux_free(unsafe.Pointer(err))
+		defer C.flux_free_error(err)
 		cstr := C.flux_error_str(err)
-		defer C.flux_free(unsafe.Pointer(cstr))
+		defer C.flux_free_bytes(cstr)
 
 		str := C.GoString(cstr)
 		return nil, errors.New(str)
 	}
-	defer C.flux_free(buf.data)
+	defer C.flux_free_bytes(buf.data)
 
-	data := C.GoBytes(buf.data, C.int(buf.len))
+	data := C.GoBytes(unsafe.Pointer(buf.data), C.int(buf.len))
 	return data, nil
 }
 
 func (p *ASTPkg) Free() {
 	if p.ptr != nil {
-		C.flux_free(unsafe.Pointer(p.ptr))
+		C.flux_free_ast_pkg(p.ptr)
 	}
 	p.ptr = nil
 }

--- a/libflux/include/influxdata/flux.h
+++ b/libflux/include/influxdata/flux.h
@@ -10,7 +10,7 @@ extern "C" {
 // flux_buffer_t is a reference to a byte-slice.
 struct flux_buffer_t {
 	// data is a pointer to the data contained within the buffer.
-	void *data;
+	char *data;
 
 	// len is the length of the buffer.
 	size_t len;
@@ -19,12 +19,16 @@ struct flux_buffer_t {
 // flux_error_t represents a flux error.
 struct flux_error_t;
 
+// flux_free_error will release memory associated with an error.
+void flux_free_error(struct flux_error_t *);
+
 // flux_error_str will return a string representation of the error.
-// This will allocate memory for the returned string.
+// This will allocate memory for the returned string, which must be
+// freed wtih flux_free_bytes.
 const char *flux_error_str(struct flux_error_t *);
 
-// flux_free will free a resource.
-void flux_free(const void *);
+// flux_free_bytes will release the memory pointed to by the pointer argument.
+void flux_free_bytes(const char *);
 
 // flux_ast_pkg_t is the AST representation of a flux query as a package.
 struct flux_ast_pkg_t;
@@ -33,18 +37,21 @@ struct flux_ast_pkg_t;
 // of the query.
 struct flux_ast_pkg_t *flux_parse(const char *);
 
+// flux_free_ast_pkg will release the memory associated with the given pointer.
+void flux_free_ast_pkg(struct flux_ast_pkg_t *);
+
 // flux_ast_marshal_json will marshal json and fill in the given buffer
 // with the data. If successful, memory will be allocated for the data
 // within the buffer and it is the caller's responsibility to free this
 // data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
+// using flux_free_error if it is non-null.
 struct flux_error_t *flux_ast_marshal_json(struct flux_ast_pkg_t *, struct flux_buffer_t *);
 
 // flux_ast_marshal_fb will marshal the given AST as a flatbuffer into
 // the given buffer. If successful, memory will be allocated for the data
 // within the buffer and it is the caller's responsibility to free this
 // data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
+// using flux_free_error if it is non-null.
 struct flux_error_t *flux_ast_marshal_fb(struct flux_ast_pkg_t *, struct flux_buffer_t *);
 
 // flux_semantic_pkg_t represents a semantic graph package node, including all of its files
@@ -53,20 +60,23 @@ struct flux_semantic_pkg_t;
 
 // flux_analyze analyzes the given AST and will populate the second pointer argument with
 // a pointer to the resulting semantic graph.
-// It is the caller's responsibility to free the resulting semantic graph with a call to flux_free().
+// It is the caller's responsibility to free the resulting semantic graph with a call to flux_free_semantic_pkg().
 // Note that the caller should free the pointer to the semantic graph, not the pointer to the pointer
 // to the semantic graph.  It is the former that references memory allocated by Rust.
 // If analysis fails, the second pointer argument wil be pointed at 0, and an error will be returned.
-// Any non-null error must be freed by calling flux_free.
+// Any non-null error must be freed by calling flux_free_error.
 // Regardless of whether an error is returned, this function will consume and free its
 // flux_ast_pkg_t* argument, so it should not be reused after calling this function.
 struct flux_error_t *flux_analyze(struct flux_ast_pkg_t *, struct flux_semantic_pkg_t **);
+
+// flux_free_semantic_pkg will release the memory associated with the given pointer.
+void flux_free_semantic_pkg(struct flux_semantic_pkg_t*);
 
 // flux_semantic_marshal_fb will marshal the given semantic graph as a flatbuffer into
 // the given buffer. If successful, memory will be allocated for the data
 // within the buffer and it is the caller's responsibility to free this
 // data. If an error happens it will be returned. The error must be freed
-// using flux_free if it is non-null.
+// using flux_free_error if it is non-null.
 struct flux_error_t *flux_semantic_marshal_fb(struct flux_semantic_pkg_t *, struct flux_buffer_t *);
 
 #ifdef __cplusplus

--- a/libflux/src/flux/build.rs
+++ b/libflux/src/flux/build.rs
@@ -28,15 +28,6 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
-    let ctypes = bindgen::Builder::default()
-        .header("../../include/influxdata/flux.h")
-        .generate()
-        .expect("Unable to generate c type bindings");
-
-    ctypes
-        .write_to_file(out_path.join("ctypes.rs"))
-        .expect("Couldn't write c type bindings!");
-
     copy("../../scanner.c", out_path.join("scanner.c")).expect("Could not copy scanner.c");
 
     // Compile generated scanner

--- a/stdlib/README.md
+++ b/stdlib/README.md
@@ -13,7 +13,7 @@ Package names should be the same name as the directory.
 Test files may placed in the same directory as the packing using the `_test.flux` suffix on the file name.
 The test files must have a `_test` suffix for the package name and the prefix must match the name of the non test package.
 
-Because the above mirrors the Go pacakge structure it is common to also have `.go` file and `_test.go` files that mirror the `.flux` files.
+Because the above mirrors the Go package structure it is common to also have `.go` file and `_test.go` files that mirror the `.flux` files.
 
 
 A typical Flux package structure:


### PR DESCRIPTION
This PR updates the Go/Rust API to address memory leaks found by valgrind.

It turns out that the Rust source code generated from `flux.h` by bindgen was mostly unused, so I removed it.

We were not actually freeing memory allocated from Rust in calls to `flux_free` from the Go side because freeing `void*` doesn't let the Rust compiler know that it should also free pointer fields embedded within structs.

To address this I created separate `flux_free*` functions for each unique type that must be freed.  I tried to use `Box<dyn Any>` to work around this, but `Any` is not sized, so it didn't work right. See the documentation for `std::boxed`, linked just below, for details.

I based these changes on material here:
https://doc.rust-lang.org/std/boxed/index.html#memory-layout

And here: https://doc.rust-lang.org/nomicon/ffi.html#foreign-function-interface