### PR TITLE
chore: add valgrind to build container

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -9,7 +9,7 @@ RUN apt-get update && \
     ruby \
     ca-certificates curl file \
     build-essential cmake \
-    autoconf automake autotools-dev libtool xutils-dev && \
+    autoconf automake autotools-dev libtool xutils-dev valgrind && \
     rm -rf /var/lib/apt/lists/*
 
 # Install ragel


### PR DESCRIPTION
This just adds valgrind to the build container, so it can run in CI.  I seem to recall that we need to to update the build container and merge to master before anything we add to it can be used.