### PR TITLE
fix(stdlib): pivot message passing

### DIFF
--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -435,6 +435,9 @@ type pivotTransformation2 struct {
 	alloc  *memory.Allocator
 	spec   PivotProcedureSpec
 	groups *execute.GroupLookup
+
+	watermark  execute.Time
+	processing execute.Time
 }
 
 func newPivotTransformation2(ctx context.Context, spec PivotProcedureSpec, id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
@@ -609,11 +612,13 @@ func (t *pivotTransformation2) getColumn(cr flux.ColReader, j int) array.Interfa
 }
 
 func (t *pivotTransformation2) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
-	return t.d.UpdateWatermark(mark)
+	t.watermark = mark
+	return nil
 }
 
 func (t *pivotTransformation2) UpdateProcessingTime(id execute.DatasetID, mark execute.Time) error {
-	return t.d.UpdateProcessingTime(mark)
+	t.processing = mark
+	return nil
 }
 
 func (t *pivotTransformation2) Finish(id execute.DatasetID, err error) {
@@ -628,7 +633,15 @@ func (t *pivotTransformation2) Finish(id execute.DatasetID, err error) {
 		if err != nil {
 			return
 		}
-		err = t.d.Process(tbl)
+		if err = t.d.Process(tbl); err != nil {
+			return
+		}
+		if err = t.d.UpdateWatermark(t.watermark); err != nil {
+			return
+		}
+		if err = t.d.UpdateProcessingTime(t.processing); err != nil {
+			return
+		}
 	})
 	t.groups.Clear()
 


### PR DESCRIPTION
Fixes https://github.com/influxdata/flux/issues/2592.

The query engine's internal message queue requires that for every
dataset ID, `process` messages are pushed first and `finished`
messages pushed last. The optimized version of pivot invalidated
this requirement.

This commit fixes pivot so that `watermark` and `processing time`
messages are sent downstream after `process` messages.

Note the message queue itself should error if it recognizes that
the above invariant has been violated.

See https://github.com/influxdata/flux/issues/2623.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
