### PR TITLE
fix(libflux): force the go libflux wrapper to rebuild using go generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ target
 /libflux/pkg
 /libflux/site/node_modules
 /libflux/.cache
+/libflux/go/libflux/hack.gen.go
 /release-notes.txt

--- a/README.md
+++ b/README.md
@@ -59,9 +59,15 @@ $ go build ./cmd/flux
 $ ./flux repl
 ```
 
-If you create or change any flux functions, you will need to rebuild the stdlib:
+If you modify any Rust code, you will need to force Go to rebuild the library.
+
 ```
-$ go generate ./stdlib
+$ go generate ./libflux/go/libflux
+```
+
+If you create or change any flux functions, you will need to rebuild the stdlib and inform Go that it must rebuild libflux:
+```
+$ go generate ./stdlib ./libflux/go/libflux
 ```
 
 Your new Flux's code should be formatted to coexist nicely with the existing codebase with go fmt.  For example, if you add code to stdlib/universe:

--- a/libflux/go/libflux/gen.go
+++ b/libflux/go/libflux/gen.go
@@ -1,0 +1,3 @@
+package libflux
+
+//go:generate ./genhack.sh

--- a/libflux/go/libflux/genhack.sh
+++ b/libflux/go/libflux/genhack.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+function tmpl() {
+    ../../../gotool.sh github.com/benbjohnson/tmpl "$@"
+}
+
+now=$(date +%s)
+tmpl -data="\"${now}\"" -o hack.gen.go hack.gen.go.tmpl

--- a/libflux/go/libflux/hack.gen.go.tmpl
+++ b/libflux/go/libflux/hack.gen.go.tmpl
@@ -1,0 +1,14 @@
+package libflux
+
+// const int FLUX_BUILD_TIMESTAMP = {{.}};
+import "C"
+
+// This is a hack to ensure that libflux gets rebuilt.
+// To rebuild libflux, run go generate on this package
+// and it will output a file with a constant that causes
+// the build output to change. This forces Go to recompile
+// the package and then libflux takes care of the rest.
+// The file this generates is never intended to be checked
+// in and isn't meant to be part of the final build product
+// except when compiling flux from source.
+// This attribute should not be used in any code.


### PR DESCRIPTION
A generate script has been added that will inject the current time into
the libflux go wrapper to force Go to recompile the wrapper. This will
force `pkg-config` to rerun and ensure that Go is using the version of
the Rust code from the current directory.

The output of the script is never meant to be checked into version
control and isn't listed on the list of build outputs. It will never be
up to date because the output isn't consistent.

This is a hopefully temporary hack until we get a better method of
generating this output in a way that is consistent. But, this is being
done because it is the easiest method of forcing a build and this
problem only occurs when building locally from source.

Fixes #2511.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written