### PR TITLE
refactor(libflux): add method to retrieve errors from AST

### DIFF
--- a/libflux/go/libflux/parser.go
+++ b/libflux/go/libflux/parser.go
@@ -30,6 +30,18 @@ type ASTPkg struct {
 	ptr *C.struct_flux_ast_pkg_t
 }
 
+// GetError will return the first error in the AST, if any
+func (p ASTPkg) GetError() error {
+	if err := C.flux_ast_get_error(p.ptr); err != nil {
+		defer C.flux_free_error(err)
+		cstr := C.flux_error_str(err)
+		defer C.flux_free_bytes(cstr)
+		str := C.GoString(cstr)
+		return errors.Newf(codes.Invalid, str)
+	}
+	return nil
+}
+
 func (p *ASTPkg) MarshalJSON() ([]byte, error) {
 	var buf C.struct_flux_buffer_t
 	if err := C.flux_ast_marshal_json(p.ptr, &buf); err != nil {

--- a/libflux/go/libflux/parser_test.go
+++ b/libflux/go/libflux/parser_test.go
@@ -21,6 +21,9 @@ from(bucket: "telegraf")
 	|> mean()
 `
 	ast := libflux.ParseString(text)
+	if err := ast.GetError(); err != nil {
+		t.Fatal(err)
+	}
 
 	jsonBuf, err := ast.MarshalJSON()
 	if err != nil {
@@ -35,6 +38,20 @@ from(bucket: "telegraf")
 	fmt.Printf("flatbuffer has %v bytes\n", len(fbBuf))
 
 	ast.Free()
+}
+
+func TestASTPkg_GetError(t *testing.T) {
+	src := `x = 1 + / 3`
+	ast := libflux.ParseString(src)
+	defer ast.Free()
+	err := ast.GetError()
+	if err == nil {
+		t.Fatal("expected parse error, got none")
+	}
+	if want, got := "error at @1:9-1:10: invalid expression: invalid token for primary expression: DIV", err.Error(); want != got {
+		t.Error("unexpected parse error; -want/+got:\n ", cmp.Diff(want, got))
+	}
+
 }
 
 func TestMergePackages(t *testing.T) {

--- a/libflux/include/influxdata/flux.h
+++ b/libflux/include/influxdata/flux.h
@@ -37,6 +37,9 @@ struct flux_ast_pkg_t;
 // return the AST representation of the query.
 struct flux_ast_pkg_t *flux_parse(const char *file_name, const char *flux_source);
 
+// flux_ast_get_error will return the first error in the AST, if any.
+struct flux_error_t *flux_ast_get_error(struct flux_ast_pkg_t *);
+
 // flux_free_ast_pkg will release the memory associated with the given pointer.
 void flux_free_ast_pkg(struct flux_ast_pkg_t *);
 

--- a/libflux/src/flux/ast/check/mod.rs
+++ b/libflux/src/flux/ast/check/mod.rs
@@ -20,6 +20,10 @@ pub fn check(node: walk::Node) -> Vec<Error> {
                     location: n.base.location.clone(),
                     message: format!("invalid statement: {}", n.text),
                 }),
+                walk::Node::BadExpr(n) => errors.push(Error {
+                    location: n.base.location.clone(),
+                    message: format!("invalid expression: {}", n.text),
+                }),
                 walk::Node::ObjectExpr(n) => {
                     let mut has_implicit = false;
                     let mut has_explicit = false;
@@ -70,6 +74,8 @@ impl fmt::Display for Error {
         write!(f, "error at {}: {}", self.location, self.message)
     }
 }
+
+impl std::error::Error for Error {}
 
 #[cfg(test)]
 mod tests;

--- a/libflux/src/flux/ast/check/tests.rs
+++ b/libflux/src/flux/ast/check/tests.rs
@@ -24,17 +24,36 @@ fn test_object_check() {
 }
 
 #[test]
-fn test_bad_expr() {
-    let file = parse_string("bad_expr_test", "a = 1\nb = \nc=2");
+fn test_bad_stmt() {
+    let file = parse_string("bad_stmt_test", "a = 1\nb = \nc=2");
     let got = check(walk::Node::File(&file));
     let want = vec![Error {
         location: SourceLocation {
-            file: Some(String::from("bad_expr_test")),
+            file: Some(String::from("bad_stmt_test")),
             start: Position { line: 3, column: 2 },
             end: Position { line: 3, column: 3 },
             source: Some(String::from("=")),
         },
         message: String::from("invalid statement: ="),
+    }];
+    assert_eq!(want, got);
+}
+
+#[test]
+fn test_bad_expr() {
+    let file = parse_string("bad_expr_test", "a = 3 + / 10");
+    let got = check(walk::Node::File(&file));
+    let want = vec![Error {
+        location: SourceLocation {
+            file: Some(String::from("bad_expr_test")),
+            start: Position { line: 1, column: 9 },
+            end: Position {
+                line: 1,
+                column: 10,
+            },
+            source: Some(String::from("/")),
+        },
+        message: String::from("invalid expression: invalid token for primary expression: DIV"),
     }];
     assert_eq!(want, got);
 }


### PR DESCRIPTION
This adds a `flux_ast_get_error()` to the libflux API to get the first error from an AST. We'll need this to return errors to users without deserializing the AST.