### PR TITLE
refactor: remove an empty file from the influxdb package

### DIFF
--- a/stdlib/influxdata/influxdb/testing.go
+++ b/stdlib/influxdata/influxdb/testing.go
@@ -1,1 +1,0 @@
-package influxdb


### PR DESCRIPTION
As part of some work, some code was in that file. During development and
testing, that code was moved to a different file and package and this
file was left empty. It was accidentally left inside of the PR even
though it had no content.

Removing this file as it was never supposed to be committed.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written