### PR TITLE
refactor: refactor eval methods to avoid roundtrips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ libflux/src/flux/semantic/flatbuffers/semantic_generated.rs: internal/fbsemantic
 ast/asttest/cmpopts.go: ast/ast.go ast/asttest/gen.go $$(call go_deps,./internal/cmd/cmpgen)
 	$(GO_GENERATE) ./ast/asttest
 
-stdlib/packages.go: $(STDLIB_SOURCES) $(LIBFLUX_GENERATED_TARGETS)
+stdlib/packages.go: $(STDLIB_SOURCES) $(LIBFLUX_GENERATED_TARGETS) internal/fbsemantic/semantic_generated.go semantic/flatbuffers_gen.go
 	$(GO_GENERATE) ./stdlib
 
 internal/scanner/unicode.rl: internal/scanner/unicode2ragel.rb

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -165,10 +165,16 @@ type FluxCompiler struct {
 	Query  string          `json:"query"`
 }
 
+func wrapFileJSONInPkg(bs []byte) []byte {
+	return []byte(fmt.Sprintf(
+		`{"type":"Package","package":"main","files":[%s]}`,
+		string(bs)))
+}
+
 func (c FluxCompiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Program, error) {
 	// Ignore context, it will be provided upon Program Start.
 	if c.Extern != nil {
-		hdl, err := runtime.JSONToHandle(c.Extern)
+		hdl, err := runtime.JSONToHandle(wrapFileJSONInPkg(c.Extern))
 		if err != nil {
 			return nil, err
 		}
@@ -203,7 +209,7 @@ func (c ASTCompiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Pr
 
 	// Ignore context, it will be provided upon Program Start.
 	if c.Extern != nil {
-		extHdl, err := runtime.JSONToHandle(c.Extern)
+		extHdl, err := runtime.JSONToHandle(wrapFileJSONInPkg(c.Extern))
 		if err != nil {
 			return nil, err
 		}

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -116,11 +116,8 @@ func TestFluxCompiler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var extern json.RawMessage
 			if tc.extern != nil {
-				pkg := &ast.Package{
-					Files: []*ast.File{tc.extern},
-				}
 				var err error
-				extern, err = json.Marshal(pkg)
+				extern, err = json.Marshal(tc.extern)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -302,10 +299,7 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 			}
 
 			if tc.file != nil {
-				pkg := &ast.Package{
-					Files: []*ast.File{tc.file},
-				}
-				bs, err := json.Marshal(&pkg)
+				bs, err := json.Marshal(tc.file)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/libflux/go/libflux/parser.go
+++ b/libflux/go/libflux/parser.go
@@ -30,6 +30,9 @@ type ASTPkg struct {
 	ptr *C.struct_flux_ast_pkg_t
 }
 
+// ASTHandle makes sure that this type implements the flux.ASTHandle interface.
+func (p ASTPkg) ASTHandle() {}
+
 // GetError will return the first error in the AST, if any
 func (p ASTPkg) GetError() error {
 	if err := C.flux_ast_get_error(p.ptr); err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,14 +1,12 @@
 package parser
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/token"
 	"github.com/influxdata/flux/libflux/go/libflux"
 )
@@ -86,16 +84,17 @@ func ParseSource(source string) *ast.Package {
 	return pkg
 }
 
-func ToHandle(astPkg *ast.Package) (*libflux.ASTPkg, error) {
-	data, err := json.Marshal(astPkg)
-	if err != nil {
-		return nil, errors.Wrap(err, codes.Internal, "could not marshal AST to JSON")
-	}
-	return libflux.ParseJSON(data)
+func HandleToJSON(hdl flux.ASTHandle) ([]byte, error) {
+	libfluxHdl := hdl.(*libflux.ASTPkg)
+	return libfluxHdl.MarshalJSON()
 }
 
-func ParseToHandle(src []byte) *libflux.ASTPkg {
-	return libflux.ParseString(string(src))
+func ParseToHandle(src []byte) (*libflux.ASTPkg, error) {
+	pkg := libflux.ParseString(string(src))
+	if err := pkg.GetError(); err != nil {
+		return nil, err
+	}
+	return pkg, nil
 }
 
 func packageName(f *ast.File) string {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -186,6 +186,22 @@ a = 1
 	}
 }
 
+func TestHandleToJSON(t *testing.T) {
+	src := `x = 0`
+	hdl, err := parser.ParseToHandle([]byte(src))
+	if err != nil {
+		t.Fatal(err)
+	}
+	json, err := parser.HandleToJSON(hdl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"type":"Package","package":"main","files":[{"type":"File","location":{"file":"","start":{"line":1,"column":1},"end":{"line":1,"column":6},"source":"x = 0"},"metadata":"parser-type=rust","package":null,"imports":[],"body":[{"type":"VariableAssignment","location":{"file":"","start":{"line":1,"column":1},"end":{"line":1,"column":6},"source":"x = 0"},"id":{"location":{"file":"","start":{"line":1,"column":1},"end":{"line":1,"column":2},"source":"x"},"name":"x"},"init":{"type":"IntegerLiteral","location":{"file":"","start":{"line":1,"column":5},"end":{"line":1,"column":6},"source":"0"},"value":"0"}}]}]}`
+	if want, got := want, string(json); want != got {
+		t.Errorf("unexpected JSON: -want/+got:\n%v", cmp.Diff(want, got))
+	}
+}
+
 func TestParseTimeLiteral(t *testing.T) {
 	inputTime := "2018-01-01"
 	got, err := parser.ParseTime(inputTime)

--- a/runtime.go
+++ b/runtime.go
@@ -33,8 +33,14 @@ type Runtime interface {
 	LookupBuiltinType(pkg, name string) (semantic.MonoType, error)
 }
 
+// ASTHandle is an opaque type that represents an abstract syntax tree.
 type ASTHandle interface {
+	// ASTHandle is a no-op method whose purpose is to avoid types unintentionally
+	// implementing this interface.
 	ASTHandle()
+
+	// GetError will return the first error encountered when parsing Flux source code,
+	// if any.
 	GetError() error
 }
 

--- a/runtime/analyze_libflux.go
+++ b/runtime/analyze_libflux.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/libflux/go/libflux"
 	"github.com/influxdata/flux/semantic"
 )
@@ -12,9 +13,10 @@ func AnalyzeSource(fluxSrc string) (*semantic.Package, error) {
 	return AnalyzePackage(ast)
 }
 
-func AnalyzePackage(astPkg *libflux.ASTPkg) (*semantic.Package, error) {
-	defer astPkg.Free()
-	sem, err := libflux.Analyze(astPkg)
+func AnalyzePackage(astPkg flux.ASTHandle) (*semantic.Package, error) {
+	hdl := astPkg.(*libflux.ASTPkg)
+	defer hdl.Free()
+	sem, err := libflux.Analyze(hdl)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/parse.go
+++ b/runtime/parse.go
@@ -1,16 +1,29 @@
 package runtime
 
 import (
-	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/libflux/go/libflux"
 	"github.com/influxdata/flux/parser"
 )
 
 // Parse parses a Flux script and produces an ast.Package.
-func Parse(flux string) (*ast.Package, error) {
-	astPkg := parser.ParseSource(flux)
-	if ast.Check(astPkg) > 0 {
-		return nil, ast.GetError(astPkg)
+func Parse(flux string) (flux.ASTHandle, error) {
+	astPkg, err := parser.ParseToHandle([]byte(flux))
+	if err != nil {
+		return nil, err
 	}
-
 	return astPkg, nil
+}
+
+func ParseToJSON(flux string) ([]byte, error) {
+	h, err := Parse(flux)
+	if err != nil {
+		return nil, err
+	}
+	return parser.HandleToJSON(h)
+}
+
+func MergePackages(dst, src flux.ASTHandle) error {
+	dstPkg, srcPkg := dst.(*libflux.ASTPkg), src.(*libflux.ASTPkg)
+	return libflux.MergePackages(dstPkg, srcPkg)
 }

--- a/semantic/format_test.go
+++ b/semantic/format_test.go
@@ -2,6 +2,7 @@ package semantic_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/influxdata/flux/runtime"
@@ -15,6 +16,10 @@ func TestFormatted(t *testing.T) {
 		want string
 	}
 
+	defs := []string{`r = {_measurement: "cpu", _field: "usage_system"}`,
+		`i = 1`,
+		`j = 1.0`,
+	}
 	tcs := []testcase{
 		{
 			name: "filter expression",
@@ -28,23 +33,19 @@ func TestFormatted(t *testing.T) {
 		},
 		{
 			name: "arithmetic expression plus/minus",
-			flux: `i + 3 < 0 and j - 7 <= 37`,
-			want: `i + 3 < 0 and j - 7 <= 37`,
+			flux: `i + 3 < 0 and i - 7 <= 37`,
+			want: `i + 3 < 0 and i - 7 <= 37`,
 		},
 	}
 
 	for _, tc := range tcs {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ast, err := runtime.Parse(tc.flux)
+			semPkg, err := runtime.AnalyzeSource(strings.Join(defs, "\n") + tc.flux)
 			if err != nil {
 				t.Fatal(err)
 			}
-			semPkg, err := semantic.New(ast)
-			if err != nil {
-				t.Fatal(err)
-			}
-			semExpr := semPkg.Files[0].Body[0].(*semantic.ExpressionStatement).Expression
+			semExpr := semPkg.Files[0].Body[len(defs)].(*semantic.ExpressionStatement).Expression
 			got := fmt.Sprintf("%v", semantic.Formatted(semExpr))
 			if tc.want != got {
 				t.Fatalf("unexpected output: -want/+got:\n- %v\n+ %v", tc.want, got)

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -3,6 +3,7 @@ package stdlib_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -118,7 +119,11 @@ func benchEndToEnd(b *testing.B, pkgs []*ast.Package) {
 					if reason, ok := skip[pkgpath][name]; ok {
 						b.Skip(reason)
 					}
-					c := &lang.ASTCompiler{AST: pkg}
+					bs, err := json.Marshal(pkg)
+					if err != nil {
+						b.Fatal(err)
+					}
+					c := &lang.ASTCompiler{AST: bs}
 
 					b.ResetTimer()
 					b.ReportAllocs()
@@ -140,7 +145,11 @@ func benchEndToEnd(b *testing.B, pkgs []*ast.Package) {
 func testFlux(t testing.TB, file *ast.File) flux.Statistics {
 	pkg := makeTestPackage(file)
 	pkg.Files = append(pkg.Files, stdlib.TestingRunCalls(pkg))
-	c := lang.ASTCompiler{AST: pkg}
+	bs, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := lang.ASTCompiler{AST: bs}
 
 	// testing.run
 	stats := doTestRun(t, c)
@@ -149,7 +158,11 @@ func testFlux(t testing.TB, file *ast.File) flux.Statistics {
 	if t.Failed() {
 		// Rerun the test case using testing.inspect
 		pkg.Files[len(pkg.Files)-1] = stdlib.TestingInspectCalls(pkg)
-		c := lang.ASTCompiler{AST: pkg}
+		bs, err := json.Marshal(pkg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c := lang.ASTCompiler{AST: bs}
 		stats = doTestInspect(t, c)
 	}
 	return stats


### PR DESCRIPTION
Also, make FluxCompiler and ASTCompiler use json.RawMessage instead
of *ast.Package, so deserialization can be delayed.
