### PR TITLE
feat: add location information to type error messages

### DIFF
--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -61,7 +61,7 @@ func TestFluxCompiler(t *testing.T) {
 		{
 			name: "type error",
 			q:    `t=0 t.s`,
-			err:  "cannot unify",
+			err:  "type error: @1:5-1:6",
 		},
 		{
 			name: "from with no streaming data",
@@ -517,7 +517,7 @@ option planner.disableLogicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `cannot unify [string] with string`,
+			wantErr: `type error: @4:1-4:52 [string] != string`,
 		},
 		{
 			name: "physical planner option must be an array",
@@ -528,7 +528,7 @@ option planner.disablePhysicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `cannot unify [string] with string`,
+			wantErr: `type error: @4:1-4:53 [string] != string`,
 		},
 		{
 			name: "logical planner option must be an array of strings",
@@ -539,7 +539,7 @@ option planner.disableLogicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `cannot unify string with float`,
+			wantErr: `type error: @4:1-4:43 string != float`,
 		},
 		{
 			name: "physical planner option must be an array of strings",
@@ -550,7 +550,7 @@ option planner.disablePhysicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `cannot unify string with float`,
+			wantErr: `type error: @4:1-4:44 string != float`,
 		},
 		{
 			name: "planner is an object defined by the user",

--- a/libflux/go/libflux/analyze_test.go
+++ b/libflux/go/libflux/analyze_test.go
@@ -26,7 +26,7 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = "foo" + 10`,
-			err:  errors.New("cannot unify string with int"),
+			err:  errors.New("type error: @1:13-1:15 string != int"),
 		},
 	}
 	for _, tc := range tcs {

--- a/libflux/src/flux/semantic/bootstrap.rs
+++ b/libflux/src/flux/semantic/bootstrap.rs
@@ -244,7 +244,16 @@ fn build_row<S: ::std::hash::BuildHasher>(
     let mut cons = Constraints::empty();
 
     for (name, poly) in from {
-        let (ty, constraints) = infer::instantiate(poly.clone(), f);
+        let (ty, constraints) = infer::instantiate(
+            poly.clone(),
+            f,
+            ast::SourceLocation {
+                file: None,
+                start: ast::Position::default(),
+                end: ast::Position::default(),
+                source: None,
+            },
+        );
         r = Row::Extension {
             head: Property { k: name, v: ty },
             tail: MonoType::Row(Box::new(r)),

--- a/libflux/src/flux/semantic/flatbuffers/types.rs
+++ b/libflux/src/flux/semantic/flatbuffers/types.rs
@@ -5,7 +5,7 @@ use crate::semantic::env::Environment;
 use crate::semantic::flatbuffers::semantic_generated::fbsemantic as fb;
 
 use flatbuffers;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::semantic::fresh::Fresher;
 
@@ -189,8 +189,8 @@ impl From<fb::Prop<'_>> for Option<Property> {
 impl From<fb::Fun<'_>> for Option<Function> {
     fn from(t: fb::Fun) -> Option<Function> {
         let args = t.args()?;
-        let mut req = HashMap::new();
-        let mut opt = HashMap::new();
+        let mut req = BTreeMap::new();
+        let mut opt = BTreeMap::new();
         let mut pipe = None;
         for i in 0..args.len() {
             match args.get(i).into() {

--- a/libflux/src/flux/semantic/fresh.rs
+++ b/libflux/src/flux/semantic/fresh.rs
@@ -67,6 +67,22 @@ impl<T: Hash + Ord + Eq + Fresh, S> Fresh for HashMap<T, S> {
     }
 }
 
+impl<T: Fresh> Fresh for BTreeMap<String, T> {
+    fn fresh(self, f: &mut Fresher, sub: &mut HashMap<Tvar, Tvar>) -> Self {
+        self.into_iter()
+            .map(|(s, t)| (s, t.fresh(f, sub)))
+            .collect::<Self>()
+    }
+}
+
+impl<T: Hash + Ord + Eq + Fresh, S> Fresh for BTreeMap<T, S> {
+    fn fresh(self, f: &mut Fresher, sub: &mut HashMap<Tvar, Tvar>) -> Self {
+        self.into_iter()
+            .map(|(t, s)| (t.fresh(f, sub), s))
+            .collect::<Self>()
+    }
+}
+
 impl<T: Fresh> Fresh for Box<T> {
     fn fresh(self, f: &mut Fresher, sub: &mut HashMap<Tvar, Tvar>) -> Self {
         Box::new((*self).fresh(f, sub))

--- a/libflux/src/flux/semantic/parser/mod.rs
+++ b/libflux/src/flux/semantic/parser/mod.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, iter::Peekable, slice::Iter, str::Chars};
+use std::{
+    collections::{BTreeMap, HashMap},
+    iter::Peekable,
+    slice::Iter,
+    str::Chars,
+};
 
 use crate::semantic::types::{Array, Function, Kind, MonoType, PolyType, Property, Row, Tvar};
 
@@ -502,8 +507,8 @@ impl Parser<'_> {
         self.next();
         let mut token = self.next();
 
-        let mut req_args = HashMap::new();
-        let mut opt_args = HashMap::new();
+        let mut req_args = BTreeMap::new();
+        let mut opt_args = BTreeMap::new();
         let mut pipe_arg = None;
         let mut need_comma = false;
         loop {
@@ -701,7 +706,7 @@ mod tests {
     fn parse_primitives_test() {
         let parse_text = "forall [t0] (x: t0, y: float) -> t0";
 
-        let mut req_args = HashMap::new();
+        let mut req_args = BTreeMap::new();
         req_args.insert("x".to_string(), MonoType::Var(Tvar(0)));
         req_args.insert("y".to_string(), MonoType::Float);
 
@@ -710,7 +715,7 @@ mod tests {
             cons: HashMap::new(),
             expr: MonoType::Fun(Box::new(Function {
                 req: req_args,
-                opt: HashMap::new(),
+                opt: BTreeMap::new(),
                 pipe: None,
                 retn: MonoType::Var(Tvar(0)),
             })),
@@ -963,10 +968,10 @@ mod tests {
         kinds.push(Kind::Subtractable);
         bounds.insert(Tvar(12), kinds);
 
-        let mut req_arg = HashMap::new();
+        let mut req_arg = BTreeMap::new();
         req_arg.insert("x".to_string(), MonoType::Var(Tvar(12)));
 
-        let mut opt_arg = HashMap::new();
+        let mut opt_arg = BTreeMap::new();
         opt_arg.insert("y".to_string(), MonoType::Int);
 
         let pipe_arg = Some(Property {
@@ -995,7 +1000,7 @@ mod tests {
         kinds.push(Kind::Subtractable);
         bounds.insert(Tvar(0), kinds);
 
-        let mut req_arg = HashMap::new();
+        let mut req_arg = BTreeMap::new();
         req_arg.insert("x".to_string(), MonoType::Var(Tvar(0)));
 
         let output = PolyType {
@@ -1003,7 +1008,7 @@ mod tests {
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
                 req: req_arg,
-                opt: HashMap::new(),
+                opt: BTreeMap::new(),
                 pipe: None,
                 retn: MonoType::Var(Tvar(0)),
             })),
@@ -1024,10 +1029,10 @@ mod tests {
         kinds.push(Kind::Subtractable);
         bounds.insert(Tvar(10), kinds);
 
-        let mut req_args = HashMap::new();
+        let mut req_args = BTreeMap::new();
         req_args.insert("x".to_string(), MonoType::Var(Tvar(1)));
 
-        let mut opt_args = HashMap::new();
+        let mut opt_args = BTreeMap::new();
         opt_args.insert("y".to_string(), MonoType::Var(Tvar(10)));
 
         let output = PolyType {
@@ -1060,8 +1065,8 @@ mod tests {
             vars: vec![Tvar(0)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
-                req: HashMap::new(),
-                opt: HashMap::new(),
+                req: BTreeMap::new(),
+                opt: BTreeMap::new(),
                 pipe: pipe_arg,
                 retn: MonoType::Var(Tvar(0)),
             })),
@@ -1086,8 +1091,8 @@ mod tests {
             vars: vec![Tvar(0), Tvar(1)],
             cons: bounds,
             expr: MonoType::Fun(Box::new(Function {
-                req: HashMap::new(),
-                opt: HashMap::new(),
+                req: BTreeMap::new(),
+                opt: BTreeMap::new(),
                 pipe: pipe_arg,
                 retn: MonoType::Var(Tvar(0)),
             })),
@@ -1097,12 +1102,12 @@ mod tests {
 
         let text = "forall [] (_p1: int, ?p_2: int, <-_p3: string) -> int";
         let req = {
-            let mut m = HashMap::new();
+            let mut m = BTreeMap::new();
             m.insert("_p1".to_string(), MonoType::Int);
             m
         };
         let opt = {
-            let mut m = HashMap::new();
+            let mut m = BTreeMap::new();
             m.insert("p_2".to_string(), MonoType::Int);
             m
         };
@@ -1127,8 +1132,8 @@ mod tests {
             vars: vec![],
             cons: HashMap::new(),
             expr: MonoType::Fun(Box::new(Function {
-                req: HashMap::new(),
-                opt: HashMap::new(),
+                req: BTreeMap::new(),
+                opt: BTreeMap::new(),
                 pipe: None,
                 retn: MonoType::Bytes,
             })),

--- a/libflux/src/flux/tests/analyze_test.rs
+++ b/libflux/src/flux/tests/analyze_test.rs
@@ -4,7 +4,7 @@ use flux::semantic::nodes::*;
 use flux::semantic::types::{Function, MonoType, Tvar};
 use flux::semantic::walk::{walk_mut, NodeMut};
 use maplit;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use pretty_assertions::assert_eq;
 
@@ -21,26 +21,26 @@ f(a: s)
     )
     .unwrap();
     let f_type = Function {
-        req: maplit::hashmap! {
+        req: maplit::btreemap! {
             "a".to_string() => MonoType::Var(Tvar(4)),
         },
-        opt: HashMap::new(),
+        opt: BTreeMap::new(),
         pipe: None,
         retn: MonoType::Var(Tvar(4)),
     };
     let f_call_int_type = Function {
-        req: maplit::hashmap! {
+        req: maplit::btreemap! {
             "a".to_string() => MonoType::Int,
         },
-        opt: HashMap::new(),
+        opt: BTreeMap::new(),
         pipe: None,
         retn: MonoType::Int,
     };
     let f_call_string_type = Function {
-        req: maplit::hashmap! {
+        req: maplit::btreemap! {
             "a".to_string() => MonoType::String,
         },
-        opt: HashMap::new(),
+        opt: BTreeMap::new(),
         pipe: None,
         retn: MonoType::String,
     };

--- a/runtime/analyze_libflux_test.go
+++ b/runtime/analyze_libflux_test.go
@@ -20,7 +20,7 @@ func TestAnalyzeSource(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = 10 + "foo"`,
-			err:  errors.New("cannot unify int with string"),
+			err:  errors.New("type error: @1:10-1:15 int != string"),
 		},
 	}
 	for _, tc := range tcs {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -64,7 +64,7 @@ func TestEval_error(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
-	if want, got := "cannot unify float with string", err.Error(); want != got {
+	if want, got := "type error: @1:11-1:16 float != string", err.Error(); want != got {
 		t.Errorf("wanted error %q, got %q", want, got)
 	}
 

--- a/semantic/flatbuffers_test.go
+++ b/semantic/flatbuffers_test.go
@@ -893,7 +893,7 @@ func TestFlatBuffersRoundTrip(t *testing.T) {
 		{
 			name:    "exists operator",
 			fluxSrc: `e = exists {foo: 30}.bar`,
-			err:     errors.New("cannot unify {{}} with {bar:t0 | t1}"),
+			err:     errors.New("type error: @1:12-1:21 {foo:int | {}} != {bar:t0 | t1}"),
 		},
 		{
 			name:    "exists operator with tvar",


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written

This PR adds source location to type error messages. Note there appears to be a lot of additions. Most of them come from `rustfmt` in `nodes.rs` where I have added `SourceLocation` to each type constraint.

I have also updated record and function unification in `types.rs`. The unification process hasn't changed, but I have updated the code to give more descriptive error messages.