### PR TITLE
feat: add all linux cross to release docker image

### DIFF
--- a/Dockerfile_release
+++ b/Dockerfile_release
@@ -1,28 +1,27 @@
 FROM golang:1.13
 
-ENV PATH="/root/.cargo/bin:${PATH}"
+ENV PATH="/root/.cargo/bin:$GOPATH/bin:${PATH}"
 ENV GO111MODULE=on
 ENV CGO_ENABLED=1
 
-COPY . /go/src/github.com/influxdata/flux
-WORKDIR /go/src/github.com/influxdata/flux
+ENV CC_FOR_LINUX_ARM=arm-linux-gnueabihf-gcc
+ENV CC_FOR_LINUX_ARM64=aarch64-linux-gnu-gcc
+ENV CC_FOR_LINUX_386=i686-linux-gnu-gcc
+ENV CC_FOR_LINUX_AMD64=gcc
+ENV CARGO_TARGET_I686_UNKNOWN_LINUX_GNU=i686-linux-gnu-gcc
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 
 # Install common packages
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
         clang \
-        gcc-arm-linux-gnueabihf \
-        gcc-arm-linux-gnueabi \
-        gcc-aarch64-linux-gnu \
-        gcc-i686-linux-gnu && \
+        gcc-arm-linux-gnueabihf libc6-dev-armhf-cross \
+        gcc-aarch64-linux-gnu libc6-dev-arm64-cross \
+        gcc-i686-linux-gnu libc6-dev-i386-cross && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- --default-toolchain stable -y
-
-RUN cd libflux && cargo build
-RUN go build \
-        -ldflags '-extldflags "-fno-PIC -static"' \
-        -buildmode pie \
-        -tags 'libflux static_build' \
-        -o flux \
-        .
+RUN rustup target add aarch64-unknown-linux-gnu arm-unknown-linux-gnueabihf armv7-unknown-linux-gnueabihf i686-unknown-linux-gnu

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e
-	github.com/influxdata/pkg-config v0.0.0-20200311192704-3d8a0f604ad9
+	github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422
 	github.com/influxdata/promql/v2 v2.12.0
 	github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9
 	github.com/lib/pq v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e h1:/o3vQtpWJhvnIbXley4/jwzzqNeigJK9z+LZcJZ9zfM=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
-github.com/influxdata/pkg-config v0.0.0-20200311192704-3d8a0f604ad9 h1:twC48hvgBsgFut9vSiAhQUtTFHLRxY4WYR79IJmF+KQ=
-github.com/influxdata/pkg-config v0.0.0-20200311192704-3d8a0f604ad9/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
+github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422 h1:Klga1qfXOkwEWJ9J0/yDuMjILR1MPIJE4mWbw4Xr6bQ=
+github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0 h1:kXn3p0D7zPw16rOtfDR+wo6aaiH8tSMfhPwONTxrlEc=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9 h1:MHTrDWmQpHq/hkq+7cw9oYAt2PqUw52TZazRA0N7PGE=


### PR DESCRIPTION
This patch adds all the tools and configuration needed to cross compile
flux from a docker container. The image generated from
`Dockerfile_release` can be used with goreleaser to build final binaries
for all the linux targets (windows and macOS binding still TBD)