### PR TITLE
fix(stdlib/influxdata/influxdb/monitor): drop _start and _stop before union()

### DIFF
--- a/stdlib/influxdata/influxdb/monitor/monitor.flux
+++ b/stdlib/influxdata/influxdb/monitor/monitor.flux
@@ -32,6 +32,7 @@ stateChanges = (fromLevel="any", toLevel, tables=<-) => {
         |> duplicate(column: "_level", as: "l2")
         |> drop(columns: ["_level"])
         |> rename(columns: {"l2": "_level"})
+        |> drop(columns: ["_start", "_stop"])
 
     levelFilter = if fromLevel == "any" then (r) => r._level != toLevel and exists r._level
                    else (r) => r._level == fromLevel
@@ -42,6 +43,7 @@ stateChanges = (fromLevel="any", toLevel, tables=<-) => {
         |> duplicate(column: "_level", as: "l2")
         |> drop(columns: ["_level"])
         |> rename(columns: {"l2": "_level"})
+        |> drop(columns: ["_start", "_stop"])
 
      allStatuses = union(tables: [toStatuses, fromStatuses])
         |> sort(columns: ["_time"])


### PR DESCRIPTION
This PR attempts to fix minor defect in `monitor.stateChanges()` function.

The columns `_state` and `_stop` should be dropped before `union()`, otherwise the result is two tables for two different `_level` values, and then `difference` result is always 0 and therefore the function always returns empty result.

With this fix, notification rules with "when status changes from x to y" condition work.

`|> drop(columns: ["_start", "_stop"])` is also used in `union()` example in the doc (although without explanation).
