### PR TITLE
ci: goreleaser cross compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.12
+      - image: quay.io/influxdb/flux-build:latest
     environment:
       GOCACHE: /tmp/go-cache
       GOFLAGS: -p=8
@@ -105,10 +105,16 @@ jobs:
                 --commit-url https://github.com/influxdata/flux/commit \
                 -o release-notes.txt
       - run:
+          name: Install pkg-config
+          command: go build -o /go/bin/pkg-config github.com/influxdata/pkg-config
+      - run:
+          # Parallelism for goreleaser must be set to 1 so it doesn't
+          # attempt to invoke pkg-config, which invokes cargo,
+          # for multiple targets at the same time.
           name: Perform release
           command: |
             ./gotool.sh github.com/goreleaser/goreleaser release \
-                --rm-dist --release-notes release-notes.txt
+                --rm-dist -p 1 --release-notes release-notes.txt
 
 workflows:
   version: 2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,10 +2,12 @@ project_name: flux
 builds:
   - goos:
     - linux
-    - darwin
+    # Darwin cross compilation involves installing
+    # a compiler toolchain for it.
+    # https://github.com/influxdata/flux/issues/2654
+    # - darwin
     goarch:
     - amd64
-    - 386
     - arm
     - arm64
     goarm:
@@ -19,6 +21,9 @@ builds:
     main: ./cmd/flux
     env:
       - GO111MODULE=on
+      - CGO_ENABLED=1
+      - CC=xcc
+      - PKG_CONFIG=/go/bin/pkg-config
     ldflags: -s -w -X main.commit={{.Commit}}
     binary: flux
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/go-cmp v0.3.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e
-	github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422
+	github.com/influxdata/pkg-config v0.1.1
 	github.com/influxdata/promql/v2 v2.12.0
 	github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9
 	github.com/lib/pq v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e h1:/o3vQtpWJhvnIbXley4/jwzzqNeigJK9z+LZcJZ9zfM=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
-github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422 h1:Klga1qfXOkwEWJ9J0/yDuMjILR1MPIJE4mWbw4Xr6bQ=
-github.com/influxdata/pkg-config v0.0.0-20200317185359-0515d8c3d422/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
+github.com/influxdata/pkg-config v0.1.1 h1:UxXDeFvMzJJX8oRVfTNZCITqMimq97lQNVBRu3FTqxk=
+github.com/influxdata/pkg-config v0.1.1/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0 h1:kXn3p0D7zPw16rOtfDR+wo6aaiH8tSMfhPwONTxrlEc=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9 h1:MHTrDWmQpHq/hkq+7cw9oYAt2PqUw52TZazRA0N7PGE=


### PR DESCRIPTION
`goreleaser` uses the `flux-build` image and will perform cross
compilation using rust and cgo.

Fixes #2245.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written