### PR TITLE
fix: use static linking when creating the valgrind test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,9 @@ test-valgrind: $(LIBFLUX_MEMTEST_BIN)
 
 LIBFLUX_MEMTEST_SOURCES=libflux/c/*.c
 $(LIBFLUX_MEMTEST_BIN): libflux $(LIBFLUX_MEMTEST_SOURCES)
-	$(CC) -g -Wall -Werror $(LIBFLUX_MEMTEST_SOURCES) -I./libflux/include -L./libflux/target/debug -lflux -llibstd -o $@
+	$(CC) -g -Wall -Werror $(LIBFLUX_MEMTEST_SOURCES) -I./libflux/include \
+		./libflux/target/debug/libflux.a ./libflux/target/debug/liblibstd.a \
+		-o $@ -lpthread -ldl
 
 .PHONY: generate \
 	clean \


### PR DESCRIPTION
This changes the valgrind test to use static linking. It makes our test link methods align with production and allows us to convert HashMaps to BTreesMaps in the semantic package without breaking the test.

When dynamic linking, the distinct data segments between the two libs causes problems for the BTreeMap, which is using a static var deep in it implementaiton.

Related to #2636, #2585 and #2655. Is the first step in applying #2657

