### PR TITLE
fix: convert HashMap in semantic package to BTreeMap (#2585)

### DIFF
--- a/libflux/src/flux/semantic/env.rs
+++ b/libflux/src/flux/semantic/env.rs
@@ -1,7 +1,6 @@
 use crate::semantic::import::Importer;
 use crate::semantic::sub::{Substitutable, Substitution};
-use crate::semantic::types::{union, PolyType, Tvar};
-use std::collections::HashMap;
+use crate::semantic::types::{union, PolyType, PolyTypeMap, Tvar};
 
 // A type environment maps program identifiers to their polymorphic types.
 //
@@ -12,7 +11,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Environment {
     pub parent: Option<Box<Environment>>,
-    pub values: HashMap<String, PolyType>,
+    pub values: PolyTypeMap,
 }
 
 impl Substitutable for Environment {
@@ -43,8 +42,8 @@ impl Importer for Environment {
 }
 
 // Derive a type environment from a hash map
-impl From<HashMap<String, PolyType>> for Environment {
-    fn from(bindings: HashMap<String, PolyType>) -> Environment {
+impl From<PolyTypeMap> for Environment {
+    fn from(bindings: PolyTypeMap) -> Environment {
         Environment {
             parent: None,
             values: bindings,
@@ -56,7 +55,7 @@ impl Environment {
     pub fn empty() -> Environment {
         Environment {
             parent: None,
-            values: HashMap::new(),
+            values: PolyTypeMap::new(),
         }
     }
     // The following clippy lint is ignored due to taking a `Self` type as the
@@ -67,7 +66,7 @@ impl Environment {
     pub fn new(from: Self) -> Environment {
         Environment {
             parent: Some(Box::new(from)),
-            values: HashMap::new(),
+            values: PolyTypeMap::new(),
         }
     }
     pub fn lookup(&self, v: &str) -> Option<&PolyType> {

--- a/libflux/src/flux/semantic/import.rs
+++ b/libflux/src/flux/semantic/import.rs
@@ -1,5 +1,4 @@
-use crate::semantic::types::PolyType;
-use std::collections::HashMap;
+use crate::semantic::types::{PolyType, PolyTypeMap};
 
 pub trait Importer {
     fn import(&self, _name: &str) -> Option<PolyType> {
@@ -7,7 +6,7 @@ pub trait Importer {
     }
 }
 
-impl<S: std::hash::BuildHasher> Importer for HashMap<String, PolyType, S> {
+impl Importer for PolyTypeMap {
     fn import(&self, name: &str) -> Option<PolyType> {
         match self.get(name) {
             Some(pty) => Some(pty.clone()),

--- a/libflux/src/flux/semantic/mod.rs
+++ b/libflux/src/flux/semantic/mod.rs
@@ -5,6 +5,8 @@ mod import;
 
 mod infer;
 
+#[macro_use]
+pub mod types;
 pub mod bootstrap;
 pub mod check;
 pub mod env;
@@ -12,7 +14,6 @@ pub mod fresh;
 pub mod nodes;
 pub mod parser;
 pub mod sub;
-pub mod types;
 pub mod walk;
 
 #[cfg(test)]

--- a/libflux/src/flux/semantic/sub.rs
+++ b/libflux/src/flux/semantic/sub.rs
@@ -1,5 +1,4 @@
-use crate::semantic::types::{MonoType, Tvar};
-use std::collections::HashMap;
+use crate::semantic::types::{MonoType, SubstitutionMap, Tvar};
 
 // A substitution defines a function that takes a monotype as input
 // and returns a monotype as output. The output type is interpreted
@@ -9,11 +8,11 @@ use std::collections::HashMap;
 // type x, we have s(s(x)) = s(x).
 //
 #[derive(Debug, PartialEq)]
-pub struct Substitution(HashMap<Tvar, MonoType>);
+pub struct Substitution(SubstitutionMap);
 
 // Derive a substitution from a hash map.
-impl From<HashMap<Tvar, MonoType>> for Substitution {
-    fn from(values: HashMap<Tvar, MonoType>) -> Substitution {
+impl From<SubstitutionMap> for Substitution {
+    fn from(values: SubstitutionMap) -> Substitution {
         Substitution(values)
     }
 }
@@ -24,15 +23,15 @@ impl From<HashMap<Tvar, MonoType>> for Substitution {
 
 // Derive a hash map from a substitution.
 #[allow(clippy::implicit_hasher)]
-impl From<Substitution> for HashMap<Tvar, MonoType> {
-    fn from(sub: Substitution) -> HashMap<Tvar, MonoType> {
+impl From<Substitution> for SubstitutionMap {
+    fn from(sub: Substitution) -> SubstitutionMap {
         sub.0
     }
 }
 
 impl Substitution {
     pub fn empty() -> Substitution {
-        Substitution(HashMap::new())
+        Substitution(SubstitutionMap::new())
     }
 
     pub fn apply(&self, tv: Tvar) -> MonoType {
@@ -43,7 +42,7 @@ impl Substitution {
     }
 
     pub fn merge(self, with: Substitution) -> Substitution {
-        let applied: HashMap<Tvar, MonoType> = self
+        let applied: SubstitutionMap = self
             .0
             .into_iter()
             .map(|(k, v)| (k, v.apply(&with)))

--- a/libflux/src/flux/semantic/tests.rs
+++ b/libflux/src/flux/semantic/tests.rs
@@ -31,7 +31,7 @@ use crate::semantic::import::Importer;
 use crate::semantic::nodes;
 use crate::semantic::parser::parse;
 use crate::semantic::sub::Substitutable;
-use crate::semantic::types::{MaxTvar, MonoType, PolyType};
+use crate::semantic::types::{MaxTvar, MonoType, PolyType, PolyTypeMap, SemanticMap};
 
 use crate::ast;
 use crate::parser::parse_string;
@@ -65,7 +65,7 @@ fn validate(t: PolyType) -> Result<PolyType, String> {
     return Ok(t);
 }
 
-fn parse_map(m: HashMap<&str, &str>) -> HashMap<String, PolyType> {
+fn parse_map(m: HashMap<&str, &str>) -> PolyTypeMap {
     m.into_iter()
         .map(|(name, expr)| {
             let init = parse(expr).expect(format!("failed to parse {}", name).as_str());
@@ -91,7 +91,7 @@ fn infer_types(
     want: Option<HashMap<&str, &str>>,
 ) -> Result<Environment, nodes::Error> {
     // Parse polytype expressions in external packages.
-    let imports: HashMap<&str, HashMap<String, PolyType>> = imp
+    let imports: SemanticMap<&str, SemanticMap<String, PolyType>> = imp
         .into_iter()
         .map(|(path, pkg)| (path, parse_map(pkg)))
         .collect();
@@ -292,7 +292,7 @@ macro_rules! test_error_msg {
 
 macro_rules! map {
     ($( $key: expr => $val: expr ),*$(,)?) => {{
-         let mut map = ::std::collections::HashMap::new();
+         let mut map = HashMap::new();
          $( map.insert($key, $val); )*
          map
     }}
@@ -300,7 +300,7 @@ macro_rules! map {
 
 macro_rules! package {
     ($( $key: expr => $val: expr ),*$(,)?) => {{
-         let mut map = ::std::collections::HashMap::new();
+         let mut map = HashMap::new();
          $( map.insert($key, $val); )*
          map
     }}

--- a/libflux/src/flux/tests/analyze_test.rs
+++ b/libflux/src/flux/tests/analyze_test.rs
@@ -1,10 +1,8 @@
 use flux::ast;
 use flux::semantic::convert_source;
 use flux::semantic::nodes::*;
-use flux::semantic::types::{Function, MonoType, Tvar};
+use flux::semantic::types::{Function, MonoType, SemanticMap, Tvar};
 use flux::semantic::walk::{walk_mut, NodeMut};
-use maplit;
-use std::collections::BTreeMap;
 
 use pretty_assertions::assert_eq;
 
@@ -21,26 +19,26 @@ f(a: s)
     )
     .unwrap();
     let f_type = Function {
-        req: maplit::btreemap! {
+        req: flux::semantic_map! {
             "a".to_string() => MonoType::Var(Tvar(4)),
         },
-        opt: BTreeMap::new(),
+        opt: SemanticMap::new(),
         pipe: None,
         retn: MonoType::Var(Tvar(4)),
     };
     let f_call_int_type = Function {
-        req: maplit::btreemap! {
+        req: flux::semantic_map! {
             "a".to_string() => MonoType::Int,
         },
-        opt: BTreeMap::new(),
+        opt: SemanticMap::new(),
         pipe: None,
         retn: MonoType::Int,
     };
     let f_call_string_type = Function {
-        req: maplit::btreemap! {
+        req: flux::semantic_map! {
             "a".to_string() => MonoType::String,
         },
-        opt: BTreeMap::new(),
+        opt: SemanticMap::new(),
         pipe: None,
         retn: MonoType::String,
     };


### PR DESCRIPTION
The artifacts of Algorithm W, specifically the final fresher value and the TVar
values in the envrironment, were changing from run-to-run of the algorithm.
This was a result of use of HashMap in Algo W, probably caused by an iteration
embedded in the algorithm. Since the environment is serialized and included in
each build, we lost repeatable builds.

This patch adds type aliases for all hash maps in the semantic package and then
changes the type to BTreeMap. This stabilizes the algorithm and gives us
repeatable builds.

This patch changes all hash maps to btree maps. It is possible that a more
selective switch would suffice, however there is some common generic code
shared among the map types (found in use of the SemanticMap type). That code
would need to be cloned to complete a selective switch.

