### PR TITLE
fix: make compilers robust to "null" keyword in extern field

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -173,7 +173,7 @@ func wrapFileJSONInPkg(bs []byte) []byte {
 
 func (c FluxCompiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Program, error) {
 	// Ignore context, it will be provided upon Program Start.
-	if c.Extern != nil {
+	if c.Extern != nil && string(c.Extern) != "null" {
 		hdl, err := runtime.JSONToHandle(wrapFileJSONInPkg(c.Extern))
 		if err != nil {
 			return nil, err
@@ -208,7 +208,7 @@ func (c ASTCompiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Pr
 	}
 
 	// Ignore context, it will be provided upon Program Start.
-	if c.Extern != nil {
+	if c.Extern != nil && string(c.Extern) != "null" {
 		extHdl, err := runtime.JSONToHandle(wrapFileJSONInPkg(c.Extern))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The implementations of `Compiler` contain an `Extern` field that is a `json.RawMessage`.  If there is data present, then we need to wrap the file in a package for it to be deserialized by Rust.

The problem was that it is valid JSON to put the `null` keyword in the `Extern` field, but when we wrap `null` in a package, Rust's JSON unmarshaling complains that it's expecting a `File`.

The fix is to not attempt to unmarshal if the `Extern` field is set to a `null` JSON literal.