### PR TITLE
fix(libflux): tweak Rust JSON serialization and add tests

### DIFF
--- a/libflux/src/core/ast/mod.rs
+++ b/libflux/src/core/ast/mod.rs
@@ -64,9 +64,11 @@ impl Default for Position {
 // SourceLocation represents the location of a node in the AST
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 pub struct SourceLocation {
-    pub file: Option<String>,   // File is the optional file name.
-    pub start: Position,        // Start is the location in the source the node starts.
-    pub end: Position,          // End is the location in the source the node ends.
+    #[serde(skip_serializing_if = "skip_string_option")]
+    pub file: Option<String>, // File is the optional file name.
+    pub start: Position, // Start is the location in the source the node starts.
+    pub end: Position,   // End is the location in the source the node ends.
+    #[serde(skip_serializing_if = "skip_string_option")]
     pub source: Option<String>, // Source is optional raw source.
 }
 
@@ -74,6 +76,10 @@ impl SourceLocation {
     pub fn is_valid(&self) -> bool {
         self.start.is_valid() && self.end.is_valid()
     }
+}
+
+fn skip_string_option(opt_str: &Option<String>) -> bool {
+    opt_str.is_none() || opt_str.as_ref().unwrap().is_empty()
 }
 
 impl fmt::Display for SourceLocation {
@@ -862,6 +868,7 @@ pub struct ObjectExpr {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub with: Option<Identifier>,
+    #[serde(deserialize_with = "deserialize_default_from_null")]
     pub properties: Vec<Property>,
 }
 

--- a/libflux/src/core/ast/tests.rs
+++ b/libflux/src/core/ast/tests.rs
@@ -43,6 +43,7 @@ ff = (i=<-, j) => {
 b = z and y
 b = z or y
 o = {red: "red", "blue": 30}
+empty_obj = {}
 m = o.red
 i = arr[0]
 n = 10 - 5 + 10
@@ -60,6 +61,8 @@ e = exists o.red
 tables |> f()
 fncall = id(v: 20)
 fncall2 = foo(v: 20, w: "bar")
+fncall_short_form_arg(arg)
+fncall_short_form_args(arg0, arg1)
 v = if true then 70.0 else 140.0
 ans = "the answer is ${v}"
 paren = (1)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -196,7 +196,7 @@ func TestHandleToJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `{"type":"Package","package":"main","files":[{"type":"File","location":{"file":"","start":{"line":1,"column":1},"end":{"line":1,"column":6},"source":"x = 0"},"metadata":"parser-type=rust","package":null,"imports":[],"body":[{"type":"VariableAssignment","location":{"file":"","start":{"line":1,"column":1},"end":{"line":1,"column":6},"source":"x = 0"},"id":{"location":{"file":"","start":{"line":1,"column":1},"end":{"line":1,"column":2},"source":"x"},"name":"x"},"init":{"type":"IntegerLiteral","location":{"file":"","start":{"line":1,"column":5},"end":{"line":1,"column":6},"source":"0"},"value":"0"}}]}]}`
+	want := `{"type":"Package","package":"main","files":[{"type":"File","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":6},"source":"x = 0"},"metadata":"parser-type=rust","package":null,"imports":[],"body":[{"type":"VariableAssignment","location":{"start":{"line":1,"column":1},"end":{"line":1,"column":6},"source":"x = 0"},"id":{"location":{"start":{"line":1,"column":1},"end":{"line":1,"column":2},"source":"x"},"name":"x"},"init":{"type":"IntegerLiteral","location":{"start":{"line":1,"column":5},"end":{"line":1,"column":6},"source":"0"},"value":"0"}}]}]}`
 	if want, got := want, string(json); want != got {
 		t.Errorf("unexpected JSON: -want/+got:\n%v", cmp.Diff(want, got))
 	}


### PR DESCRIPTION
If we serialize the Flux empty object `{}` from Go, and deserialize in Rust, an error occurred because the JSON contained `null` for the properties.  This fixes that and some other minor issues, and adds tests.