### PR TITLE
feat: add findColumn and findRecord functions

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4155,6 +4155,60 @@ r0 = from(bucket:"telegraf/autogen")
 x = r0._field + "--" + r0._measurement
 ```
 
+##### FindColumn
+
+FindColumn extracts the first table from a stream of tables where the group key
+values match a given predicate, and from that table extracts a specified column.
+The column is returned as an array. The function returns an empty array if no
+table is found, or if the column label is not present in the set of columns.
+
+It has the following parameters:
+
+| Name   | Type   | Description                                                                                                   |
+| ----   | ----   | -----------                                                                                                   |
+| fn     | (key: object) -> bool | Fn is a predicate function. The column is extracted from the first table for which fn is true. |
+| column | string                | Column is the name of the column to extract.                                                   |
+
+_NOTE_: make sure that `fn`'s parameter names match the ones specified above (see [why](#Transformations)).
+
+Example:
+
+```
+vs = from(bucket:"telegraf/autogen")
+    |> range(start: -5m)
+    |> filter(fn:(r) => r._measurement == "cpu")
+    |> findColumn(fn: (key) => key._field == "usage_idle", column: "_value")
+
+// use values
+x = vs[0] + vs[1]
+```
+
+##### FindRecord
+
+FindRecord extracts the first table from a stream of tables where the group key
+values match a given predicate, and from that table extracts a record at a
+specified index. The record is returned as an object. The function returns an
+empty object if no table is found, or if the index is out of bounds.
+
+It has the following parameters:
+
+| Name | Type | Description                                                                                                     |
+| ---- | ---- | -----------                                                                                                     |
+| fn   | (key: object) -> bool | Fn is a predicate function. The record is extracted from the first table for which fn is true. |
+| idx  | int                   | Idx is the index of the record to extract.                                                     |
+
+Example:
+
+```
+r0 = from(bucket:"telegraf/autogen")
+    |> range(start: -5m)
+    |> filter(fn:(r) => r._measurement == "cpu")
+    |> findRecord(fn: (key) => key._field == "usage_idle", idx: 0)
+
+// use values
+x = r0._field + "--" + r0._measurement
+```
+
 ##### truncateTimeColumn 
 
 Truncates all entries in a given time column to a specified unit.

--- a/libflux/src/core/semantic/builtins.rs
+++ b/libflux/src/core/semantic/builtins.rs
@@ -508,6 +508,20 @@ pub fn builtins() -> Builtins<'static> {
                         idx: int
                     ) -> t0
                 "#,
+                "findColumn" => r#"
+                    forall [t0, t1, t2] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        fn: (key: t1) -> bool,
+                        column: string
+                    ) -> [t2]
+                "#,
+                "findRecord" => r#"
+                    forall [t0, t1] where t0: Row, t1: Row (
+                        <-tables: [t0],
+                        fn: (key: t1) -> bool,
+                        idx: int
+                    ) -> t0
+                "#,
                 "group" => r#"
                     forall [t0] where t0: Row (
                         <-tables: [t0],

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -74,6 +74,8 @@ builtin yield
 builtin tableFind
 builtin getColumn
 builtin getRecord
+builtin findColumn
+builtin findRecord
 
 // type conversion functions
 builtin bool


### PR DESCRIPTION
Add findColumn and findRecord functions, which are semantically equivalent to

```
tableFind(...) |> getColumn(...)
tableFind(...) |> getRecord(...)
```

Except that they are allowed to not find a table, column or record. In these
cases they return an empty array or an empty object. The tableFind and friends
functions will return an error in these cases.

The rationale for combining these two steps into one is that it eliminates the
need to return something from tableFind which represents "no table found".
Doing that means we need to enhance the type system with a concept of a table
(not a stream) so we can prevent this thing from becomming the input to other
functions. This is a bigger undertaking and can be considered part of the next
generation of flux. Combining the two functions into one gives us the
functionality we desire without dragging in this additional work or incorrectly
exposing a nil table with the type of a stream (which is what tableFind
currently does).

More information in #2730