### PR TITLE
feat: return false if contains is called with an empty set

### DIFF
--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -24,7 +24,7 @@ func MakeContainsFunc() values.Function {
 				return nil, err
 			}
 
-			setarg, err := a.GetRequiredArray("set", v.Type().Nature())
+			setarg, err := a.GetRequiredArrayAllowEmpty("set", v.Type().Nature())
 			if err != nil {
 				return nil, err
 			}

--- a/stdlib/universe/contains_test.go
+++ b/stdlib/universe/contains_test.go
@@ -121,3 +121,14 @@ func containsTestHelper(t *testing.T, tc containsCase) {
 		t.Error("expected true, got false")
 	}
 }
+
+func TestContains_Empty(t *testing.T) {
+	script := `
+		ok = not contains( value: "nothing", set: [] )
+	`
+	s := evalOrFail(t, script)
+
+	if !mustLookup(s, "ok").Bool() {
+		t.Errorf("ok was not OK indeed")
+	}
+}


### PR DESCRIPTION
The contains function would throw an error if called with an empty set. Since
the set can be computed by other functions, which may supply an empty set, it
makes sense to simply return false.

