### PR TITLE
fix: reduce memory usage during CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - image: quay.io/influxdb/flux-build:latest
     environment:
       GOPATH: /tmp/go
-      GOFLAGS: -p=8
+      GOFLAGS: -p=1
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,14 @@ checktidy:
 checkgenerate:
 	./etc/checkgenerate.sh
 
+# Run this in two passes to to keep memory usage down. As of this commit,
+# running on everything (./...) uses just over 4G of memory. Breaking stdlib
+# out keeps memory under 3G.
 staticcheck:
 	GO111MODULE=on go mod vendor # staticcheck looks in vendor for dependencies.
-	GO111MODULE=on ./gotool.sh honnef.co/go/tools/cmd/staticcheck ./...
+	GO111MODULE=on ./gotool.sh honnef.co/go/tools/cmd/staticcheck \
+		`go list ./... | grep -v '\/flux\/stdlib\>'`
+	GO111MODULE=on ./gotool.sh honnef.co/go/tools/cmd/staticcheck ./stdlib/...
 
 test: test-go test-rust
 

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -1092,8 +1092,8 @@ func TestFilter_Process(t *testing.T) {
 }
 
 func BenchmarkFilter_Values(b *testing.B) {
-	b.Run("1000", func(b *testing.B) {
-		benchmarkFilter(b, 1000, &semantic.FunctionExpression{
+	b.Run("500", func(b *testing.B) {
+		benchmarkFilter(b, 500, &semantic.FunctionExpression{
 			Block: &semantic.FunctionBlock{
 				Parameters: &semantic.FunctionParameters{
 					List: []*semantic.FunctionParameter{


### PR DESCRIPTION
1. Run static checking in two passes. As of this commit, running on everything
uses just over 4G of memory. Breaking stdlib out keeps memory under 3G.

2. Reduce the number of iterations of BenchmarkFilter_Values. Brings memory
usage of benchmarking down from 3.8 to ~ 2G.

3. Use -p=1 for the benchmarking. The Filter_Values benchmark uses over 2G,
sometimes compiling and doing other things can fail if also run while this test
is going.
