### PR TITLE
tests(semantic): update tests using semantic graph to use the rust analyzer

### DIFF
--- a/execute/executetest/compile.go
+++ b/execute/executetest/compile.go
@@ -2,6 +2,7 @@ package executetest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/influxdata/flux/interpreter"
@@ -19,8 +20,12 @@ var (
 // and return the *semantic.FunctionExpression.
 //
 // This will cause a fatal error in the test on failure.
-func FunctionExpression(t testing.TB, source string) *semantic.FunctionExpression {
+func FunctionExpression(t testing.TB, source string, args ...interface{}) *semantic.FunctionExpression {
 	t.Helper()
+
+	if len(args) > 0 {
+		source = fmt.Sprintf(source, args...)
+	}
 
 	if stdlib == nil {
 		stdlib = runtime.StdLib()

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/repl"
@@ -612,24 +613,7 @@ func TestResolver(t *testing.T) {
 		t.Fatalf("could not resolve function: %s", err)
 	}
 
-	want := &semantic.FunctionExpression{
-		Block: &semantic.FunctionBlock{
-			Parameters: &semantic.FunctionParameters{
-				List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
-			},
-			Body: &semantic.Block{
-				Body: []semantic.Statement{
-					&semantic.ReturnStatement{
-						Argument: &semantic.BinaryExpression{
-							Operator: ast.AdditionOperator,
-							Left:     &semantic.IdentifierExpression{Name: "r"},
-							Right:    &semantic.IntegerLiteral{Value: 42},
-						},
-					},
-				},
-			},
-		},
-	}
+	want := executetest.FunctionExpression(t, `(r) => r + 42`)
 	if !cmp.Equal(want, got, semantictest.CmpOptions...) {
 		t.Errorf("unexpected resoved function: -want/+got\n%s", cmp.Diff(want, got, semantictest.CmpOptions...))
 	}

--- a/plan/format_test.go
+++ b/plan/format_test.go
@@ -5,14 +5,12 @@ import (
 	"testing"
 
 	"github.com/andreyvit/diff"
-	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/plan/plantest"
-	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
-	"github.com/influxdata/flux/values/valuestest"
 )
 
 func TestFormatted(t *testing.T) {
@@ -23,22 +21,7 @@ func TestFormatted(t *testing.T) {
 	// (r) => r._value > 5.0
 	filterSpec := &universe.FilterProcedureSpec{
 		Fn: interpreter.ResolvedFunction{
-			Fn: &semantic.FunctionExpression{
-				Block: &semantic.FunctionBlock{
-					Parameters: &semantic.FunctionParameters{
-						List: []*semantic.FunctionParameter{{Key: &semantic.Identifier{Name: "r"}}},
-					},
-					Body: &semantic.BinaryExpression{
-						Operator: ast.GreaterThanOperator,
-						Left: &semantic.MemberExpression{
-							Object:   &semantic.IdentifierExpression{Name: "r"},
-							Property: "_value",
-						},
-						Right: &semantic.FloatLiteral{Value: 5},
-					},
-				},
-			},
-			Scope: valuestest.Scope(),
+			Fn: executetest.FunctionExpression(t, `(r) => r._value > 5.0`),
 		},
 	}
 

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
@@ -77,24 +78,7 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 		filterSpec = &universe.FilterProcedureSpec{
 			Fn: interpreter.ResolvedFunction{
 				Scope: valuestest.Scope(),
-				Fn: &semantic.FunctionExpression{
-					Block: &semantic.FunctionBlock{
-						Parameters: &semantic.FunctionParameters{
-							List: []*semantic.FunctionParameter{
-								{
-									Key: &semantic.Identifier{Name: "r"},
-								},
-							},
-						},
-						Body: &semantic.Block{
-							Body: []semantic.Statement{
-								&semantic.ReturnStatement{
-									Argument: &semantic.BooleanLiteral{Value: true},
-								},
-							},
-						},
-					},
-				},
+				Fn:    executetest.FunctionExpression(t, `(r) => true`),
 			},
 		}
 		joinSpec = &universe.MergeJoinProcedureSpec{

--- a/semantic/graph.go
+++ b/semantic/graph.go
@@ -554,6 +554,28 @@ func (e *FunctionExpression) TypeOf() MonoType {
 	return e.typ
 }
 
+// GetFunctionBodyExpression will return the return value expression from
+// the function block. This will only return an expression if there
+// is exactly one expression in the block. It will return false
+// as the second argument if the statement is more complex.
+func (e *FunctionExpression) GetFunctionBodyExpression() (Expression, bool) {
+	switch e := e.Block.Body.(type) {
+	case *Block:
+		if len(e.Body) != 1 {
+			return nil, false
+		}
+		returnExpr, ok := e.Body[0].(*ReturnStatement)
+		if !ok {
+			return nil, false
+		}
+		return returnExpr.Argument, true
+	case Expression:
+		return e, true
+	default:
+		return nil, false
+	}
+}
+
 // FunctionBlock represents the function parameters and the function body.
 type FunctionBlock struct {
 	Loc
@@ -574,6 +596,19 @@ func (b *FunctionBlock) Copy() Node {
 
 	return nb
 }
+
+// GetFunctionExpression will return the returned semantic.Expression
+// for this function block if the body is either a semantic.Expression
+// or if there is exactly one statement in the block and it is a
+// return statement.
+//
+// This can be used for reliably getting a semantic.Expression for
+// simple functions.
+//
+// If the function is more complex than a single statement, this will
+// return false.
+// func (b *FunctionBlock) GetFunctionExpression() (Expression, bool) {
+// }
 
 // FunctionParameters represents the list of function parameters and which if any parameter is the pipe parameter.
 type FunctionParameters struct {

--- a/stdlib/experimental/bigtable/bigtable_rewrite.go
+++ b/stdlib/experimental/bigtable/bigtable_rewrite.go
@@ -1,19 +1,25 @@
 package bigtable
 
 import (
+	"time"
+
 	"cloud.google.com/go/bigtable"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
-	"time"
 )
 
 func AddFilterToNode(queryNode plan.Node, filterNode plan.Node) (plan.Node, bool) {
 	querySpec := queryNode.ProcedureSpec().(*FromBigtableProcedureSpec)
 	filterSpec := filterNode.ProcedureSpec().(*universe.FilterProcedureSpec)
 
-	switch body := filterSpec.Fn.Fn.Block.Body.(type) {
+	body, ok := filterSpec.Fn.Fn.GetFunctionBodyExpression()
+	if !ok {
+		return filterNode, false
+	}
+
+	switch body := body.(type) {
 	case *semantic.BinaryExpression:
 		switch body.Operator {
 		case ast.EqualOperator:

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -441,38 +441,17 @@ func TestMergeFilterAnyRule(t *testing.T) {
 		count       = &universe.CountProcedureSpec{}
 		filterOther = &universe.FilterProcedureSpec{
 			Fn: interpreter.ResolvedFunction{
-				Fn: &semantic.FunctionExpression{
-					Block: &semantic.FunctionBlock{
-						Body: &semantic.IdentifierExpression{
-							Name: "foo",
-						},
-					},
-				},
-				Scope: valuestest.Scope(),
+				Fn: executetest.FunctionExpression(t, `() => "foo"`),
 			},
 		}
 		filterTrue = &universe.FilterProcedureSpec{
 			Fn: interpreter.ResolvedFunction{
-				Fn: &semantic.FunctionExpression{
-					Block: &semantic.FunctionBlock{
-						Body: &semantic.BooleanLiteral{
-							Value: true,
-						},
-					},
-				},
-				Scope: valuestest.Scope(),
+				Fn: executetest.FunctionExpression(t, `() => true`),
 			},
 		}
 		filterFalse = &universe.FilterProcedureSpec{
 			Fn: interpreter.ResolvedFunction{
-				Fn: &semantic.FunctionExpression{
-					Block: &semantic.FunctionBlock{
-						Body: &semantic.BooleanLiteral{
-							Value: false,
-						},
-					},
-				},
-				Scope: valuestest.Scope(),
+				Fn: executetest.FunctionExpression(t, `() => false`),
 			},
 		}
 	)


### PR DESCRIPTION
The tests using semantic graph will now use the rust analyzer so that
the semantic graph is the same as the one constructed from the rust
analyzer. This will make our tests more robust.

This also fixes the `bigtable` package to use the same technique as the
other filter push downs when evaluating the expression. It also moves
the code to retrieve the simple expression to a method function so it
can be reused in multiple locations.

This does not remove all usage of semantic graph. There are still some
flatbuffers tests that need semantic graph to be hand-written since the
tests are valid and testing the deserialization of the graph. After
those are hand-written, we can remove `semantic.New` and the tests for
testing `semantic.New`.

Fixes #2664.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written