### PR TITLE
fix(semantic): more descriptive error messages

### DIFF
--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -63,7 +63,7 @@ func TestFluxCompiler(t *testing.T) {
 		{
 			name:     "type error",
 			q:        `t=0 t.s`,
-			startErr: "type error: @1:5-1:6",
+			startErr: "type error @1:5-1:6",
 		},
 		{
 			name:     "from with no streaming data",
@@ -105,7 +105,7 @@ func TestFluxCompiler(t *testing.T) {
 			q: `twentySeven = twentyFive + 2
 				twentySeven
 				from(bucket: "foo") |> range(start: -5m)`,
-			startErr: "undeclared variable twentyFive",
+			startErr: "undefined identifier twentyFive",
 		},
 		{
 			name: "with now",
@@ -629,7 +629,7 @@ option planner.disableLogicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error: @4:1-4:52 [string] != string`,
+			wantErr: `type error @4:1-4:52: [string] != string`,
 		},
 		{
 			name: "physical planner option must be an array",
@@ -640,7 +640,7 @@ option planner.disablePhysicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error: @4:1-4:53 [string] != string`,
+			wantErr: `type error @4:1-4:53: [string] != string`,
 		},
 		{
 			name: "logical planner option must be an array of strings",
@@ -651,7 +651,7 @@ option planner.disableLogicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error: @4:1-4:43 string != float`,
+			wantErr: `type error @4:1-4:43: string != float`,
 		},
 		{
 			name: "physical planner option must be an array of strings",
@@ -662,7 +662,7 @@ option planner.disablePhysicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error: @4:1-4:44 string != float`,
+			wantErr: `type error @4:1-4:44: string != float`,
 		},
 		{
 			name: "planner is an object defined by the user",

--- a/libflux/go/libflux/analyze_test.go
+++ b/libflux/go/libflux/analyze_test.go
@@ -26,7 +26,7 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = "foo" + 10`,
-			err:  errors.New("type error: @1:13-1:15 string != int"),
+			err:  errors.New("type error @1:13-1:15: string != int"),
 		},
 	}
 	for _, tc := range tcs {

--- a/libflux/src/core/lib.rs
+++ b/libflux/src/core/lib.rs
@@ -54,7 +54,9 @@ impl From<&str> for Error {
 
 impl From<semantic::nodes::Error> for Error {
     fn from(sn_err: semantic::nodes::Error) -> Self {
-        Error { msg: sn_err.msg }
+        Error {
+            msg: sn_err.to_string(),
+        }
     }
 }
 

--- a/libflux/src/core/semantic/bootstrap.rs
+++ b/libflux/src/core/semantic/bootstrap.rs
@@ -57,6 +57,14 @@ impl From<types::Error> for Error {
     }
 }
 
+impl From<infer::Error> for Error {
+    fn from(err: infer::Error) -> Error {
+        Error {
+            msg: err.to_string(),
+        }
+    }
+}
+
 impl From<String> for Error {
     fn from(msg: String) -> Error {
         Error { msg }

--- a/libflux/src/core/semantic/infer.rs
+++ b/libflux/src/core/semantic/infer.rs
@@ -2,7 +2,8 @@ use crate::ast::SourceLocation;
 use crate::semantic::env::Environment;
 use crate::semantic::fresh::Fresher;
 use crate::semantic::sub::{Substitutable, Substitution};
-use crate::semantic::types::{minus, Error, Kind, MonoType, PolyType, SubstitutionMap, TvarKinds};
+use crate::semantic::types::{minus, Kind, MonoType, PolyType, SubstitutionMap, TvarKinds};
+use std::fmt;
 use std::ops;
 
 // Type constraints are produced during type inference and come
@@ -61,6 +62,17 @@ impl From<Constraint> for Constraints {
     }
 }
 
+#[derive(Debug)]
+pub struct Error {
+    msg: String,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
 // Solve a set of type constraints
 pub fn solve(
     cons: &Constraints,
@@ -74,7 +86,7 @@ pub fn solve(
                 // Apply the current substitution to the type, then constrain
                 let s = match monotype.clone().apply(&sub).constrain(*kind, with) {
                     Err(e) => Err(Error {
-                        msg: format!("type error: {} {}", loc, e),
+                        msg: format!("type error {}: {}", loc, e),
                     }),
                     Ok(s) => Ok(s),
                 }?;
@@ -86,7 +98,7 @@ pub fn solve(
                 let r = second.clone().apply(&sub);
                 let s = match l.unify(r, with, fresher) {
                     Err(e) => Err(Error {
-                        msg: format!("type error: {} {}", loc, e),
+                        msg: format!("type error {}: {}", loc, e),
                     }),
                     Ok(s) => Ok(s),
                 }?;

--- a/libflux/src/core/semantic/tests.rs
+++ b/libflux/src/core/semantic/tests.rs
@@ -250,7 +250,7 @@ macro_rules! test_infer_err {
         if let Ok(env) = infer_types($src, env, imp, None) {
             panic!(
                 "\n\n{}\n\n{}\n",
-                "expected type error but instead inferred the following types:"
+                "expected type error but instead inferred the: following types:"
                     .red()
                     .bold(),
                 env.values
@@ -273,7 +273,7 @@ macro_rules! test_infer_err {
 ///     src: r#"
 ///         1 + "1"
 ///     "#,
-///     err: "type error: @2:17-2:20 int != string",
+///     err: "type error @2:17-2:20: int != string",
 /// }
 /// ```
 ///
@@ -3246,21 +3246,21 @@ fn test_error_messages() {
             1 + "1"
         "#,
         // Location points to right expression expression
-        err: "type error: @2:17-2:20 int != string",
+        err: "type error @2:17-2:20: int != string",
     }
     test_error_msg! {
         src: r#"
             -"s"
         "#,
         // Location points to argument of unary expression
-        err: "type error: @2:14-2:17 string is not Negatable",
+        err: "type error @2:14-2:17: string is not Negatable",
     }
     test_error_msg! {
         src: r#"
             1h + 2h
         "#,
         // Location points to entire binary expression
-        err: "type error: @2:13-2:20 duration is not Addable",
+        err: "type error @2:13-2:20: duration is not Addable",
     }
     test_error_msg! {
         src: r#"
@@ -3269,28 +3269,28 @@ fn test_error_messages() {
             "Hey ${bob} it's me ${joe}!"
         "#,
         // Location points to second interpolated expression
-        err: "type error: @4:35-4:38 int != string",
+        err: "type error @4:35-4:38: int != string",
     }
     test_error_msg! {
         src: r#"
             if 0 then "a" else "b"
         "#,
         // Location points to if expression
-        err: "type error: @2:16-2:17 int != bool",
+        err: "type error @2:16-2:17: int != bool",
     }
     test_error_msg! {
         src: r#"
             if exists 0 then 0 else "b"
         "#,
         // Location points to else expression
-        err: "type error: @2:37-2:40 int != string",
+        err: "type error @2:37-2:40: int != string",
     }
     test_error_msg! {
         src: r#"
             [1, "2"]
         "#,
         // Location points to second element of array
-        err: "type error: @2:17-2:20 string != int",
+        err: "type error @2:17-2:20: string != int",
     }
     test_error_msg! {
         src: r#"
@@ -3298,7 +3298,7 @@ fn test_error_messages() {
             a[1.1]
         "#,
         // Location points to expression representing the index
-        err: "type error: @3:15-3:18 float != int",
+        err: "type error @3:15-3:18: float != int",
     }
     test_error_msg! {
         src: r#"
@@ -3306,7 +3306,7 @@ fn test_error_messages() {
             a[1] + 1.1
         "#,
         // Location points to right expression
-        err: "type error: @3:20-3:23 int != float",
+        err: "type error @3:20-3:23: int != float",
     }
     test_error_msg! {
         src: r#"
@@ -3314,7 +3314,7 @@ fn test_error_messages() {
             a.x
         "#,
         // Location points to the identifier a
-        err: "type error: @3:13-3:14 [int] != {x:t6 | t8}",
+        err: "type error @3:13-3:14: [int] != {x:t6 | t8}",
     }
     test_error_msg! {
         src: r#"
@@ -3322,7 +3322,7 @@ fn test_error_messages() {
             f(x: "x", y: "y")
         "#,
         // Location points to entire call expression
-        err: "type error: @3:13-3:30 @argument x: string is not Subtractable",
+        err: "type error @3:13-3:30: string is not Subtractable (argument x)",
     }
     test_error_msg! {
         src: r#"
@@ -3330,6 +3330,22 @@ fn test_error_messages() {
             f(r: {b: 1})
         "#,
         // Location points to entire call expression
-        err: "type error: @3:13-3:25 @argument r: {a:t12 | t11} != {b:int | {}}",
+        err: "type error @3:13-3:25: record is missing label a (argument r)",
+    }
+    test_error_msg! {
+        src: r#"
+            x = 1 + 1
+            a
+        "#,
+        // Location points to the identifier a
+        err: "error @3:13-3:14: undefined identifier a",
+    }
+    test_error_msg! {
+        src: r#"
+            match = (o) => o.name =~ /^a/
+            fn = (r) => match(r)
+        "#,
+        // Location points to call expression `match(r)`
+        err: "type error @3:25-3:33: missing required argument o",
     }
 }

--- a/runtime/analyze_libflux_test.go
+++ b/runtime/analyze_libflux_test.go
@@ -20,7 +20,7 @@ func TestAnalyzeSource(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = 10 + "foo"`,
-			err:  errors.New("type error: @1:10-1:15 int != string"),
+			err:  errors.New("type error @1:10-1:15: int != string"),
 		},
 	}
 	for _, tc := range tcs {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -64,7 +64,7 @@ func TestEval_error(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
-	if want, got := "type error: @1:11-1:16 float != string", err.Error(); want != got {
+	if want, got := "type error @1:11-1:16: float != string", err.Error(); want != got {
 		t.Errorf("wanted error %q, got %q", want, got)
 	}
 

--- a/semantic/flatbuffers_test.go
+++ b/semantic/flatbuffers_test.go
@@ -843,7 +843,7 @@ func TestFlatBuffersRoundTrip(t *testing.T) {
 		{
 			name:    "option with member assignment error",
 			fluxSrc: `option o.m = "hello"`,
-			err:     errors.New("undeclared variable o"),
+			err:     errors.New("error @1:8-1:9: undefined identifier o"),
 		},
 		{
 			name: "option with member assignment",
@@ -854,7 +854,7 @@ func TestFlatBuffersRoundTrip(t *testing.T) {
 		{
 			name:    "builtin statement",
 			fluxSrc: `builtin foo`,
-			err:     errors.New("builtin identifier foo not defined"),
+			err:     errors.New("error @1:1-1:12: undefined builtin identifier foo"),
 		},
 		{
 			name: "test statement",
@@ -1089,7 +1089,7 @@ func TestFlatBuffersRoundTrip(t *testing.T) {
 		{
 			name:    "exists operator",
 			fluxSrc: `e = exists {foo: 30}.bar`,
-			err:     errors.New("type error: @1:12-1:21 {foo:int | {}} != {bar:t0 | t1}"),
+			err:     errors.New("type error @1:12-1:21: record is missing label bar"),
 		},
 		{
 			name:    "exists operator with tvar",


### PR DESCRIPTION
Updates the error type in `types.rs` and `nodes.rs` to be an enum. Also gives a better error message in the case of a missing record label. 