### PR TITLE
feat(execute): add random access group lookup

### DIFF
--- a/internal/execute/table/buffered_builder.go
+++ b/internal/execute/table/buffered_builder.go
@@ -38,9 +38,10 @@ func GetBufferedBuilder(key flux.GroupKey, cache *BuilderCache) (builder *Buffer
 // It ensures the schemas are compatible and will backfill previous
 // buffers with nil for new columns that didn't previously exist.
 func (b *BufferedBuilder) AppendBuffer(cr flux.ColReader) error {
-	if len(b.Buffers) == 0 {
-		// If there are no buffers, then take the columns
-		// from the column reader and append the buffer directly.
+	if b.Columns == nil {
+		// If the columns have not been set, then take the columns
+		// from the column reader and append the buffer directly
+		// since we know it matches the table schema.
 		b.Columns = cr.Cols()
 		buffer := &arrow.TableBuffer{
 			GroupKey: b.GroupKey,

--- a/internal/execute/table/builder_cache.go
+++ b/internal/execute/table/builder_cache.go
@@ -21,6 +21,34 @@ type Builder interface {
 	Release()
 }
 
+// KeyLookup is an interface for storing and retrieving
+// items by their group key.
+type KeyLookup interface {
+	// Lookup will retrieve the value associated with the given key if it exists.
+	Lookup(key flux.GroupKey) (interface{}, bool)
+
+	// LookupOrCreate will retrieve the value associated with the given key or,
+	// if it does not exist, will invoke the function to create one and set
+	// it in the group lookup.
+	LookupOrCreate(key flux.GroupKey, fn func() interface{}) interface{}
+
+	// Set will set the value for the given key.
+	// It will overwrite an existing value.
+	Set(key flux.GroupKey, value interface{})
+
+	// Delete will remove the key from this KeyLookup.
+	// It will return the same thing as a call to Lookup.
+	Delete(key flux.GroupKey) (v interface{}, found bool)
+
+	// Range will iterate over all groups keys in a stable ordering.
+	// Range must not be called within another call to Range.
+	// It is safe to call Set/Delete while ranging.
+	Range(f func(key flux.GroupKey, value interface{}))
+
+	// Clear will clear the lookup and reset it to contain nothing.
+	Clear()
+}
+
 // BuilderCache hold a mapping of group keys to Builder.
 // When a Builder is requested for a specific group key,
 // the BuilderCache will return a Builder that is unique
@@ -31,7 +59,12 @@ type BuilderCache struct {
 	// requested. The returned Builder should be empty.
 	New func(key flux.GroupKey) Builder
 
-	tables *execute.GroupLookup
+	// Tables contains the cached builders.
+	// This can be set before use to customize the
+	// method for storing data. If this is null,
+	// the default execute.GroupLookup is initialized
+	// when the cache is first used.
+	Tables KeyLookup
 }
 
 // Get retrieves the Builder for this group key.
@@ -45,11 +78,11 @@ type BuilderCache struct {
 func (d *BuilderCache) Get(key flux.GroupKey, b interface{}) bool {
 	builder, ok := d.lookupState(key)
 	if !ok {
-		if d.tables == nil {
-			d.tables = execute.NewGroupLookup()
+		if d.Tables == nil {
+			d.Tables = execute.NewGroupLookup()
 		}
 		builder = d.New(key)
-		d.tables.Set(key, builder)
+		d.Tables.Set(key, builder)
 	}
 	r := reflect.ValueOf(b)
 	r.Elem().Set(reflect.ValueOf(builder))
@@ -67,11 +100,11 @@ func (d *BuilderCache) Table(key flux.GroupKey) (flux.Table, error) {
 }
 
 func (d *BuilderCache) ForEach(f func(key flux.GroupKey, builder Builder) error) error {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return nil
 	}
 	var err error
-	d.tables.Range(func(key flux.GroupKey, value interface{}) {
+	d.Tables.Range(func(key flux.GroupKey, value interface{}) {
 		if err != nil {
 			return
 		}
@@ -82,10 +115,10 @@ func (d *BuilderCache) ForEach(f func(key flux.GroupKey, builder Builder) error)
 }
 
 func (d *BuilderCache) lookupState(key flux.GroupKey) (Builder, bool) {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return nil, false
 	}
-	v, ok := d.tables.Lookup(key)
+	v, ok := d.Tables.Lookup(key)
 	if !ok {
 		return nil, false
 	}
@@ -93,7 +126,7 @@ func (d *BuilderCache) lookupState(key flux.GroupKey) (Builder, bool) {
 }
 
 func (d *BuilderCache) DiscardTable(key flux.GroupKey) {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return
 	}
 
@@ -106,16 +139,16 @@ func (d *BuilderCache) DiscardTable(key flux.GroupKey) {
 		} else {
 			// Release the table and construct a new one.
 			b.Release()
-			d.tables.Set(key, d.New(key))
+			d.Tables.Set(key, d.New(key))
 		}
 	}
 }
 
 func (d *BuilderCache) ExpireTable(key flux.GroupKey) {
-	if d.tables == nil {
+	if d.Tables == nil {
 		return
 	}
-	ts, ok := d.tables.Delete(key)
+	ts, ok := d.Tables.Delete(key)
 	if ok {
 		ts.(Builder).Release()
 	}

--- a/internal/execute/table/dataset.go
+++ b/internal/execute/table/dataset.go
@@ -32,11 +32,11 @@ func (d *dataset) SetTriggerSpec(spec plan.TriggerSpec) {
 }
 
 func (d *dataset) UpdateWatermark(mark execute.Time) error {
-	return nil
+	return d.ts.UpdateWatermark(d.id, mark)
 }
 
 func (d *dataset) UpdateProcessingTime(time execute.Time) error {
-	return nil
+	return d.ts.UpdateProcessingTime(d.id, time)
 }
 
 func (d *dataset) RetractTable(key flux.GroupKey) error {


### PR DESCRIPTION
The random access group lookup is a group lookup that works better with
random access rather than sorted inserts. It creates a key and then
indexes into that key rather than attempting to keep the group lookup
sorted.

This is a partial reapplication of 922f531 by only reapplying the parts
that allowed multiple group lookup implementations but doesn't include
the window changes.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written