### PR TITLE
fix: use RandomAccessGroupLookup in testing.diff

### DIFF
--- a/stdlib/testing/diff.go
+++ b/stdlib/testing/diff.go
@@ -111,7 +111,7 @@ type DiffTransformation struct {
 	cache execute.TableBuilderCache
 	alloc *memory.Allocator
 
-	inputCache *execute.GroupLookup
+	inputCache *execute.RandomAccessGroupLookup
 }
 
 type tableBuffer struct {
@@ -293,7 +293,7 @@ func NewDiffTransformation(d execute.Dataset, cache execute.TableBuilderCache, s
 		gotID:      gotID,
 		d:          d,
 		cache:      cache,
-		inputCache: execute.NewGroupLookup(),
+		inputCache: execute.NewRandomAccessGroupLookup(),
 		finished:   make(map[execute.DatasetID]bool, 2),
 		alloc:      a,
 	}


### PR DESCRIPTION
This patch changes `DiffTransformation` to use
`execute.RandomAccessGroupLookup` for its cache. Since
`DiffTransformation` treats group lookup like a map, where it might not
have the groups in order, `RandomAccessGroupLookup` is better for the
transformation.

Fixes #2700