### PR TITLE
fix(monitor): make sort optional with default by `_source_timestamp`

### DIFF
--- a/stdlib/influxdata/influxdb/monitor/flux_gen.go
+++ b/stdlib/influxdata/influxdb/monitor/flux_gen.go
@@ -25,7 +25,7 @@ var pkgAST = &ast.Package{
 					Line:   145,
 				},
 				File:   "monitor.flux",
-				Source: "package monitor\n\nimport \"experimental\"\nimport \"influxdata/influxdb/v1\"\nimport \"influxdata/influxdb\"\n\nbucket = \"_monitoring\"\n\n// Write persists the check statuses\noption write = (tables=<-) => tables |> experimental.to(bucket: bucket)\n\n// Log records notification events\noption log = (tables=<-) => tables |> experimental.to(bucket: bucket)\n\n// Column by which to sort statuses by\noption sortBy = \"_source_timestamp\"\n\n// From retrieves the check statuses that have been stored.\nfrom = (start, stop=now(), fn=(r) => true) =>\n    influxdb.from(bucket: bucket)\n        |> range(start: start, stop: stop)\n        |> filter(fn: (r) => r._measurement == \"statuses\")\n        |> filter(fn: fn)\n        |> v1.fieldsAsCols()\n\n// levels describing the result of a check\nlevelOK = \"ok\"\nlevelInfo = \"info\"\nlevelWarn = \"warn\"\nlevelCrit = \"crit\"\nlevelUnknown = \"unknown\"\n\n_stateChanges = (fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}\n\n// stateChangesOnly takes a stream of tables that contains a _level column and\n// returns a stream of tables where each record in a table represents a state change\n// of the _level column.\nstateChangesOnly = (tables=<-) => {\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}\n\n// StateChanges takes a stream of tables, fromLevel, and toLevel and returns\n// a stream of tables where status has gone from fromLevel to toLevel.\n//\n// StateChanges only operates on data with data where r._level exists.\nstateChanges = (fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    return if fromLevel == \"any\" and toLevel == \"any\" then tables |> stateChangesOnly()\n           else tables |> _stateChanges(fromLevel: fromLevel, toLevel: toLevel)\n}\n\n// Notify will call the endpoint and log the results.\nnotify = (tables=<-, endpoint, data={}) =>\n    tables\n        |> experimental.set(o: data)\n        |> experimental.group(mode: \"extend\", columns: experimental.objectKeys(o: data))\n        |> map(fn: (r) => ({r with\n            _measurement: \"notifications\",\n            _status_timestamp: int(v: r._time),\n            _time: now(),\n        }))\n        |> endpoint()\n        |> experimental.group(mode: \"extend\", columns: [\"_sent\"])\n        |> log()\n\n// Logs retrieves notification events that have been logged.\nlogs = (start, stop=now(), fn) =>\n    influxdb.from(bucket: bucket)\n        |> range(start: start, stop: stop)\n        |> filter(fn: (r) => r._measurement == \"notifications\")\n        |> filter(fn: fn)\n        |> v1.fieldsAsCols()\n\n// Deadman takes in a stream of tables and reports which tables\n// were observed strictly before t and which were observed after.\n//\ndeadman = (t, tables=<-) => tables\n    |> max(column: \"_time\")\n    |> map(fn: (r) => ( {r with dead: r._time < t} ))\n\n// Check performs a check against its input using the given ok, info, warn and crit functions\n// and writes the result to a system bucket.\ncheck = (\n    tables=<-,\n    data,\n    messageFn,\n    crit=(r) => false,\n    warn=(r) => false,\n    info=(r) => false,\n    ok=(r) => true\n) =>\n    tables\n        |> experimental.set(o: data.tags)\n        |> experimental.group(mode: \"extend\", columns: experimental.objectKeys(o: data.tags))\n        |> map(fn: (r) => ({r with\n            _measurement: \"statuses\",\n            _source_measurement: r._measurement,\n            _type: data._type,\n            _check_id:  data._check_id,\n            _check_name: data._check_name,\n            _level:\n                if crit(r: r) then levelCrit\n                else if warn(r: r) then levelWarn\n                else if info(r: r) then levelInfo\n                else if ok(r: r) then levelOK\n                else levelUnknown,\n            _source_timestamp: int(v:r._time),\n            _time: now(),\n        }))\n        |> map(fn: (r) => ({r with\n            _message: messageFn(r: r),\n        }))\n        |> experimental.group(mode: \"extend\", columns: [\"_source_measurement\", \"_type\", \"_check_id\", \"_check_name\", \"_level\"])\n        |> write()",
+				Source: "package monitor\n\nimport \"experimental\"\nimport \"influxdata/influxdb/v1\"\nimport \"influxdata/influxdb\"\n\nbucket = \"_monitoring\"\n\n// Write persists the check statuses\noption write = (tables=<-) => tables |> experimental.to(bucket: bucket)\n\n// Log records notification events\noption log = (tables=<-) => tables |> experimental.to(bucket: bucket)\n\n// Reorder sorts statuses before difference computation\noption reorder = (tables=<-) => tables |> sort(columns: [\"_source_timestamp\"], desc: false)\n\n// From retrieves the check statuses that have been stored.\nfrom = (start, stop=now(), fn=(r) => true) =>\n    influxdb.from(bucket: bucket)\n        |> range(start: start, stop: stop)\n        |> filter(fn: (r) => r._measurement == \"statuses\")\n        |> filter(fn: fn)\n        |> v1.fieldsAsCols()\n\n// levels describing the result of a check\nlevelOK = \"ok\"\nlevelInfo = \"info\"\nlevelWarn = \"warn\"\nlevelCrit = \"crit\"\nlevelUnknown = \"unknown\"\n\n_stateChanges = (fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}\n\n// stateChangesOnly takes a stream of tables that contains a _level column and\n// returns a stream of tables where each record in a table represents a state change\n// of the _level column.\nstateChangesOnly = (tables=<-) => {\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}\n\n// StateChanges takes a stream of tables, fromLevel, and toLevel and returns\n// a stream of tables where status has gone from fromLevel to toLevel.\n//\n// StateChanges only operates on data with data where r._level exists.\nstateChanges = (fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    return if fromLevel == \"any\" and toLevel == \"any\" then tables |> stateChangesOnly()\n           else tables |> _stateChanges(fromLevel: fromLevel, toLevel: toLevel)\n}\n\n// Notify will call the endpoint and log the results.\nnotify = (tables=<-, endpoint, data={}) =>\n    tables\n        |> experimental.set(o: data)\n        |> experimental.group(mode: \"extend\", columns: experimental.objectKeys(o: data))\n        |> map(fn: (r) => ({r with\n            _measurement: \"notifications\",\n            _status_timestamp: int(v: r._time),\n            _time: now(),\n        }))\n        |> endpoint()\n        |> experimental.group(mode: \"extend\", columns: [\"_sent\"])\n        |> log()\n\n// Logs retrieves notification events that have been logged.\nlogs = (start, stop=now(), fn) =>\n    influxdb.from(bucket: bucket)\n        |> range(start: start, stop: stop)\n        |> filter(fn: (r) => r._measurement == \"notifications\")\n        |> filter(fn: fn)\n        |> v1.fieldsAsCols()\n\n// Deadman takes in a stream of tables and reports which tables\n// were observed strictly before t and which were observed after.\n//\ndeadman = (t, tables=<-) => tables\n    |> max(column: \"_time\")\n    |> map(fn: (r) => ( {r with dead: r._time < t} ))\n\n// Check performs a check against its input using the given ok, info, warn and crit functions\n// and writes the result to a system bucket.\ncheck = (\n    tables=<-,\n    data,\n    messageFn,\n    crit=(r) => false,\n    warn=(r) => false,\n    info=(r) => false,\n    ok=(r) => true\n) =>\n    tables\n        |> experimental.set(o: data.tags)\n        |> experimental.group(mode: \"extend\", columns: experimental.objectKeys(o: data.tags))\n        |> map(fn: (r) => ({r with\n            _measurement: \"statuses\",\n            _source_measurement: r._measurement,\n            _type: data._type,\n            _check_id:  data._check_id,\n            _check_name: data._check_name,\n            _level:\n                if crit(r: r) then levelCrit\n                else if warn(r: r) then levelWarn\n                else if info(r: r) then levelInfo\n                else if ok(r: r) then levelOK\n                else levelUnknown,\n            _source_timestamp: int(v:r._time),\n            _time: now(),\n        }))\n        |> map(fn: (r) => ({r with\n            _message: messageFn(r: r),\n        }))\n        |> experimental.group(mode: \"extend\", columns: [\"_source_measurement\", \"_type\", \"_check_id\", \"_check_name\", \"_level\"])\n        |> write()",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -678,11 +678,11 @@ var pkgAST = &ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 36,
+							Column: 92,
 							Line:   16,
 						},
 						File:   "monitor.flux",
-						Source: "sortBy = \"_source_timestamp\"",
+						Source: "reorder = (tables=<-) => tables |> sort(columns: [\"_source_timestamp\"], desc: false)",
 						Start: ast.Position{
 							Column: 8,
 							Line:   16,
@@ -694,47 +694,306 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 14,
+								Column: 15,
 								Line:   16,
 							},
 							File:   "monitor.flux",
-							Source: "sortBy",
+							Source: "reorder",
 							Start: ast.Position{
 								Column: 8,
 								Line:   16,
 							},
 						},
 					},
-					Name: "sortBy",
+					Name: "reorder",
 				},
-				Init: &ast.StringLiteral{
+				Init: &ast.FunctionExpression{
 					BaseNode: ast.BaseNode{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 36,
+								Column: 92,
 								Line:   16,
 							},
 							File:   "monitor.flux",
-							Source: "\"_source_timestamp\"",
+							Source: "(tables=<-) => tables |> sort(columns: [\"_source_timestamp\"], desc: false)",
 							Start: ast.Position{
-								Column: 17,
+								Column: 18,
 								Line:   16,
 							},
 						},
 					},
-					Value: "_source_timestamp",
+					Body: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 39,
+										Line:   16,
+									},
+									File:   "monitor.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 33,
+										Line:   16,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 92,
+									Line:   16,
+								},
+								File:   "monitor.flux",
+								Source: "tables |> sort(columns: [\"_source_timestamp\"], desc: false)",
+								Start: ast.Position{
+									Column: 33,
+									Line:   16,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 91,
+											Line:   16,
+										},
+										File:   "monitor.flux",
+										Source: "columns: [\"_source_timestamp\"], desc: false",
+										Start: ast.Position{
+											Column: 48,
+											Line:   16,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 78,
+												Line:   16,
+											},
+											File:   "monitor.flux",
+											Source: "columns: [\"_source_timestamp\"]",
+											Start: ast.Position{
+												Column: 48,
+												Line:   16,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 55,
+													Line:   16,
+												},
+												File:   "monitor.flux",
+												Source: "columns",
+												Start: ast.Position{
+													Column: 48,
+													Line:   16,
+												},
+											},
+										},
+										Name: "columns",
+									},
+									Value: &ast.ArrayExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 78,
+													Line:   16,
+												},
+												File:   "monitor.flux",
+												Source: "[\"_source_timestamp\"]",
+												Start: ast.Position{
+													Column: 57,
+													Line:   16,
+												},
+											},
+										},
+										Elements: []ast.Expression{&ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 77,
+														Line:   16,
+													},
+													File:   "monitor.flux",
+													Source: "\"_source_timestamp\"",
+													Start: ast.Position{
+														Column: 58,
+														Line:   16,
+													},
+												},
+											},
+											Value: "_source_timestamp",
+										}},
+									},
+								}, &ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 91,
+												Line:   16,
+											},
+											File:   "monitor.flux",
+											Source: "desc: false",
+											Start: ast.Position{
+												Column: 80,
+												Line:   16,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 84,
+													Line:   16,
+												},
+												File:   "monitor.flux",
+												Source: "desc",
+												Start: ast.Position{
+													Column: 80,
+													Line:   16,
+												},
+											},
+										},
+										Name: "desc",
+									},
+									Value: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 91,
+													Line:   16,
+												},
+												File:   "monitor.flux",
+												Source: "false",
+												Start: ast.Position{
+													Column: 86,
+													Line:   16,
+												},
+											},
+										},
+										Name: "false",
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 92,
+										Line:   16,
+									},
+									File:   "monitor.flux",
+									Source: "sort(columns: [\"_source_timestamp\"], desc: false)",
+									Start: ast.Position{
+										Column: 43,
+										Line:   16,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 47,
+											Line:   16,
+										},
+										File:   "monitor.flux",
+										Source: "sort",
+										Start: ast.Position{
+											Column: 43,
+											Line:   16,
+										},
+									},
+								},
+								Name: "sort",
+							},
+						},
+					},
+					Params: []*ast.Property{&ast.Property{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 28,
+									Line:   16,
+								},
+								File:   "monitor.flux",
+								Source: "tables=<-",
+								Start: ast.Position{
+									Column: 19,
+									Line:   16,
+								},
+							},
+						},
+						Key: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 25,
+										Line:   16,
+									},
+									File:   "monitor.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 19,
+										Line:   16,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 28,
+									Line:   16,
+								},
+								File:   "monitor.flux",
+								Source: "<-",
+								Start: ast.Position{
+									Column: 26,
+									Line:   16,
+								},
+							},
+						}},
+					}},
 				},
 			},
 			BaseNode: ast.BaseNode{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 36,
+						Column: 92,
 						Line:   16,
 					},
 					File:   "monitor.flux",
-					Source: "option sortBy = \"_source_timestamp\"",
+					Source: "option reorder = (tables=<-) => tables |> sort(columns: [\"_source_timestamp\"], desc: false)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   16,
@@ -2046,7 +2305,7 @@ var pkgAST = &ast.Package{
 						Line:   52,
 					},
 					File:   "monitor.flux",
-					Source: "_stateChanges = (fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
+					Source: "_stateChanges = (fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
 					Start: ast.Position{
 						Column: 1,
 						Line:   33,
@@ -2080,7 +2339,7 @@ var pkgAST = &ast.Package{
 							Line:   52,
 						},
 						File:   "monitor.flux",
-						Source: "(fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
+						Source: "(fromLevel=\"any\", toLevel=\"any\", tables=<-) => {\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
 						Start: ast.Position{
 							Column: 17,
 							Line:   33,
@@ -2096,7 +2355,7 @@ var pkgAST = &ast.Package{
 								Line:   52,
 							},
 							File:   "monitor.flux",
-							Source: "{\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
+							Source: "{\n    toLevelFilter = if toLevel == \"any\" then (r) => r._level != fromLevel and exists r._level\n                   else (r) => r._level == toLevel\n\n    fromLevelFilter = if fromLevel == \"any\" then (r) => r._level != toLevel and exists r._level\n                   else (r) => r._level == fromLevel\n\n    return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
 							Start: ast.Position{
 								Column: 64,
 								Line:   33,
@@ -4141,11 +4400,11 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 48,
+														Column: 21,
 														Line:   47,
 													},
 													File:   "monitor.flux",
-													Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)",
+													Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()",
 													Start: ast.Position{
 														Column: 12,
 														Line:   40,
@@ -4153,155 +4412,16 @@ var pkgAST = &ast.Package{
 												},
 											},
 											Call: &ast.CallExpression{
-												Arguments: []ast.Expression{&ast.ObjectExpression{
-													BaseNode: ast.BaseNode{
-														Errors: nil,
-														Loc: &ast.SourceLocation{
-															End: ast.Position{
-																Column: 47,
-																Line:   47,
-															},
-															File:   "monitor.flux",
-															Source: "columns: [sortBy], desc: false",
-															Start: ast.Position{
-																Column: 17,
-																Line:   47,
-															},
-														},
-													},
-													Properties: []*ast.Property{&ast.Property{
-														BaseNode: ast.BaseNode{
-															Errors: nil,
-															Loc: &ast.SourceLocation{
-																End: ast.Position{
-																	Column: 34,
-																	Line:   47,
-																},
-																File:   "monitor.flux",
-																Source: "columns: [sortBy]",
-																Start: ast.Position{
-																	Column: 17,
-																	Line:   47,
-																},
-															},
-														},
-														Key: &ast.Identifier{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 24,
-																		Line:   47,
-																	},
-																	File:   "monitor.flux",
-																	Source: "columns",
-																	Start: ast.Position{
-																		Column: 17,
-																		Line:   47,
-																	},
-																},
-															},
-															Name: "columns",
-														},
-														Value: &ast.ArrayExpression{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 34,
-																		Line:   47,
-																	},
-																	File:   "monitor.flux",
-																	Source: "[sortBy]",
-																	Start: ast.Position{
-																		Column: 26,
-																		Line:   47,
-																	},
-																},
-															},
-															Elements: []ast.Expression{&ast.Identifier{
-																BaseNode: ast.BaseNode{
-																	Errors: nil,
-																	Loc: &ast.SourceLocation{
-																		End: ast.Position{
-																			Column: 33,
-																			Line:   47,
-																		},
-																		File:   "monitor.flux",
-																		Source: "sortBy",
-																		Start: ast.Position{
-																			Column: 27,
-																			Line:   47,
-																		},
-																	},
-																},
-																Name: "sortBy",
-															}},
-														},
-													}, &ast.Property{
-														BaseNode: ast.BaseNode{
-															Errors: nil,
-															Loc: &ast.SourceLocation{
-																End: ast.Position{
-																	Column: 47,
-																	Line:   47,
-																},
-																File:   "monitor.flux",
-																Source: "desc: false",
-																Start: ast.Position{
-																	Column: 36,
-																	Line:   47,
-																},
-															},
-														},
-														Key: &ast.Identifier{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 40,
-																		Line:   47,
-																	},
-																	File:   "monitor.flux",
-																	Source: "desc",
-																	Start: ast.Position{
-																		Column: 36,
-																		Line:   47,
-																	},
-																},
-															},
-															Name: "desc",
-														},
-														Value: &ast.Identifier{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 47,
-																		Line:   47,
-																	},
-																	File:   "monitor.flux",
-																	Source: "false",
-																	Start: ast.Position{
-																		Column: 42,
-																		Line:   47,
-																	},
-																},
-															},
-															Name: "false",
-														},
-													}},
-													With: nil,
-												}},
+												Arguments: nil,
 												BaseNode: ast.BaseNode{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 48,
+															Column: 21,
 															Line:   47,
 														},
 														File:   "monitor.flux",
-														Source: "sort(columns: [sortBy], desc: false)",
+														Source: "reorder()",
 														Start: ast.Position{
 															Column: 12,
 															Line:   47,
@@ -4313,18 +4433,18 @@ var pkgAST = &ast.Package{
 														Errors: nil,
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
-																Column: 16,
+																Column: 19,
 																Line:   47,
 															},
 															File:   "monitor.flux",
-															Source: "sort",
+															Source: "reorder",
 															Start: ast.Position{
 																Column: 12,
 																Line:   47,
 															},
 														},
 													},
-													Name: "sort",
+													Name: "reorder",
 												},
 											},
 										},
@@ -4336,7 +4456,7 @@ var pkgAST = &ast.Package{
 													Line:   48,
 												},
 												File:   "monitor.flux",
-												Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])",
+												Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])",
 												Start: ast.Position{
 													Column: 12,
 													Line:   40,
@@ -4475,7 +4595,7 @@ var pkgAST = &ast.Package{
 												Line:   49,
 											},
 											File:   "monitor.flux",
-											Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)",
+											Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)",
 											Start: ast.Position{
 												Column: 12,
 												Line:   40,
@@ -4721,7 +4841,7 @@ var pkgAST = &ast.Package{
 											Line:   50,
 										},
 										File:   "monitor.flux",
-										Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])",
+										Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])",
 										Start: ast.Position{
 											Column: 12,
 											Line:   40,
@@ -4860,7 +4980,7 @@ var pkgAST = &ast.Package{
 										Line:   51,
 									},
 									File:   "monitor.flux",
-									Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
+									Source: "tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
 									Start: ast.Position{
 										Column: 12,
 										Line:   40,
@@ -5086,7 +5206,7 @@ var pkgAST = &ast.Package{
 									Line:   51,
 								},
 								File:   "monitor.flux",
-								Source: "return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
+								Source: "return tables\n        |> map(fn: (r) => ({r with level_value: if toLevelFilter(r: r) then 1\n                                                else if fromLevelFilter(r: r) then 0\n                                                else -10}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value == 1)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
 								Start: ast.Position{
 									Column: 5,
 									Line:   40,
@@ -5259,7 +5379,7 @@ var pkgAST = &ast.Package{
 						Line:   72,
 					},
 					File:   "monitor.flux",
-					Source: "stateChangesOnly = (tables=<-) => {\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
+					Source: "stateChangesOnly = (tables=<-) => {\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
 					Start: ast.Position{
 						Column: 1,
 						Line:   57,
@@ -5293,7 +5413,7 @@ var pkgAST = &ast.Package{
 							Line:   72,
 						},
 						File:   "monitor.flux",
-						Source: "(tables=<-) => {\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
+						Source: "(tables=<-) => {\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
 						Start: ast.Position{
 							Column: 20,
 							Line:   57,
@@ -5309,7 +5429,7 @@ var pkgAST = &ast.Package{
 								Line:   72,
 							},
 							File:   "monitor.flux",
-							Source: "{\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
+							Source: "{\n    return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])\n}",
 							Start: ast.Position{
 								Column: 35,
 								Line:   57,
@@ -6594,11 +6714,11 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 48,
+														Column: 21,
 														Line:   67,
 													},
 													File:   "monitor.flux",
-													Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)",
+													Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()",
 													Start: ast.Position{
 														Column: 12,
 														Line:   58,
@@ -6606,155 +6726,16 @@ var pkgAST = &ast.Package{
 												},
 											},
 											Call: &ast.CallExpression{
-												Arguments: []ast.Expression{&ast.ObjectExpression{
-													BaseNode: ast.BaseNode{
-														Errors: nil,
-														Loc: &ast.SourceLocation{
-															End: ast.Position{
-																Column: 47,
-																Line:   67,
-															},
-															File:   "monitor.flux",
-															Source: "columns: [sortBy], desc: false",
-															Start: ast.Position{
-																Column: 17,
-																Line:   67,
-															},
-														},
-													},
-													Properties: []*ast.Property{&ast.Property{
-														BaseNode: ast.BaseNode{
-															Errors: nil,
-															Loc: &ast.SourceLocation{
-																End: ast.Position{
-																	Column: 34,
-																	Line:   67,
-																},
-																File:   "monitor.flux",
-																Source: "columns: [sortBy]",
-																Start: ast.Position{
-																	Column: 17,
-																	Line:   67,
-																},
-															},
-														},
-														Key: &ast.Identifier{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 24,
-																		Line:   67,
-																	},
-																	File:   "monitor.flux",
-																	Source: "columns",
-																	Start: ast.Position{
-																		Column: 17,
-																		Line:   67,
-																	},
-																},
-															},
-															Name: "columns",
-														},
-														Value: &ast.ArrayExpression{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 34,
-																		Line:   67,
-																	},
-																	File:   "monitor.flux",
-																	Source: "[sortBy]",
-																	Start: ast.Position{
-																		Column: 26,
-																		Line:   67,
-																	},
-																},
-															},
-															Elements: []ast.Expression{&ast.Identifier{
-																BaseNode: ast.BaseNode{
-																	Errors: nil,
-																	Loc: &ast.SourceLocation{
-																		End: ast.Position{
-																			Column: 33,
-																			Line:   67,
-																		},
-																		File:   "monitor.flux",
-																		Source: "sortBy",
-																		Start: ast.Position{
-																			Column: 27,
-																			Line:   67,
-																		},
-																	},
-																},
-																Name: "sortBy",
-															}},
-														},
-													}, &ast.Property{
-														BaseNode: ast.BaseNode{
-															Errors: nil,
-															Loc: &ast.SourceLocation{
-																End: ast.Position{
-																	Column: 47,
-																	Line:   67,
-																},
-																File:   "monitor.flux",
-																Source: "desc: false",
-																Start: ast.Position{
-																	Column: 36,
-																	Line:   67,
-																},
-															},
-														},
-														Key: &ast.Identifier{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 40,
-																		Line:   67,
-																	},
-																	File:   "monitor.flux",
-																	Source: "desc",
-																	Start: ast.Position{
-																		Column: 36,
-																		Line:   67,
-																	},
-																},
-															},
-															Name: "desc",
-														},
-														Value: &ast.Identifier{
-															BaseNode: ast.BaseNode{
-																Errors: nil,
-																Loc: &ast.SourceLocation{
-																	End: ast.Position{
-																		Column: 47,
-																		Line:   67,
-																	},
-																	File:   "monitor.flux",
-																	Source: "false",
-																	Start: ast.Position{
-																		Column: 42,
-																		Line:   67,
-																	},
-																},
-															},
-															Name: "false",
-														},
-													}},
-													With: nil,
-												}},
+												Arguments: nil,
 												BaseNode: ast.BaseNode{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 48,
+															Column: 21,
 															Line:   67,
 														},
 														File:   "monitor.flux",
-														Source: "sort(columns: [sortBy], desc: false)",
+														Source: "reorder()",
 														Start: ast.Position{
 															Column: 12,
 															Line:   67,
@@ -6766,18 +6747,18 @@ var pkgAST = &ast.Package{
 														Errors: nil,
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
-																Column: 16,
+																Column: 19,
 																Line:   67,
 															},
 															File:   "monitor.flux",
-															Source: "sort",
+															Source: "reorder",
 															Start: ast.Position{
 																Column: 12,
 																Line:   67,
 															},
 														},
 													},
-													Name: "sort",
+													Name: "reorder",
 												},
 											},
 										},
@@ -6789,7 +6770,7 @@ var pkgAST = &ast.Package{
 													Line:   68,
 												},
 												File:   "monitor.flux",
-												Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])",
+												Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])",
 												Start: ast.Position{
 													Column: 12,
 													Line:   58,
@@ -6928,7 +6909,7 @@ var pkgAST = &ast.Package{
 												Line:   69,
 											},
 											File:   "monitor.flux",
-											Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)",
+											Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)",
 											Start: ast.Position{
 												Column: 12,
 												Line:   58,
@@ -7174,7 +7155,7 @@ var pkgAST = &ast.Package{
 											Line:   70,
 										},
 										File:   "monitor.flux",
-										Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])",
+										Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])",
 										Start: ast.Position{
 											Column: 12,
 											Line:   58,
@@ -7313,7 +7294,7 @@ var pkgAST = &ast.Package{
 										Line:   71,
 									},
 									File:   "monitor.flux",
-									Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
+									Source: "tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
 									Start: ast.Position{
 										Column: 12,
 										Line:   58,
@@ -7539,7 +7520,7 @@ var pkgAST = &ast.Package{
 									Line:   71,
 								},
 								File:   "monitor.flux",
-								Source: "return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> sort(columns: [sortBy], desc: false)\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
+								Source: "return tables\n        |> map(fn: (r) => ({r with level_value: if r._level == levelCrit then 4\n                                                else if r._level == levelWarn then 3\n                                                else if r._level == levelInfo then 2\n                                                else if r._level == levelOK then 1\n                                                else 0}))\n        |> duplicate(column: \"_level\", as: \"____temp_level____\")\n        |> drop(columns: [\"_level\"])\n        |> rename(columns: {\"____temp_level____\": \"_level\"})\n        |> reorder()\n        |> difference(columns: [\"level_value\"])\n        |> filter(fn: (r) => r.level_value != 0)\n        |> drop(columns: [\"level_value\"])\n        |> experimental.group(mode: \"extend\", columns: [\"_level\"])",
 								Start: ast.Position{
 									Column: 5,
 									Line:   58,

--- a/stdlib/influxdata/influxdb/monitor/flux_test_gen.go
+++ b/stdlib/influxdata/influxdb/monitor/flux_test_gen.go
@@ -9322,7 +9322,7 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Line:   62,
 				},
 				File:   "state_changes_any_to_any_test.flux",
-				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.\noption monitor.sortBy = \"_time\"\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,whoa!,cpu,1527018860000000000,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,7.05\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
+				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Expected result is based on order by `_time` (order by `_source_timestamp` differs).\noption monitor.reorder = (tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,whoa!,cpu,1527018860000000000,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,7.05\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -9750,45 +9750,304 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 32,
+							Column: 88,
 							Line:   13,
 						},
 						File:   "state_changes_any_to_any_test.flux",
-						Source: "monitor.sortBy = \"_time\"",
+						Source: "monitor.reorder = (tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)",
 						Start: ast.Position{
 							Column: 8,
 							Line:   13,
 						},
 					},
 				},
-				Init: &ast.StringLiteral{
+				Init: &ast.FunctionExpression{
 					BaseNode: ast.BaseNode{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 32,
+								Column: 88,
 								Line:   13,
 							},
 							File:   "state_changes_any_to_any_test.flux",
-							Source: "\"_time\"",
+							Source: "(tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)",
 							Start: ast.Position{
-								Column: 25,
+								Column: 26,
 								Line:   13,
 							},
 						},
 					},
-					Value: "_time",
+					Body: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 47,
+										Line:   13,
+									},
+									File:   "state_changes_any_to_any_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 41,
+										Line:   13,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 88,
+									Line:   13,
+								},
+								File:   "state_changes_any_to_any_test.flux",
+								Source: "tables |> sort(columns: [\"_time\"], desc: false)",
+								Start: ast.Position{
+									Column: 41,
+									Line:   13,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 87,
+											Line:   13,
+										},
+										File:   "state_changes_any_to_any_test.flux",
+										Source: "columns: [\"_time\"], desc: false",
+										Start: ast.Position{
+											Column: 56,
+											Line:   13,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 74,
+												Line:   13,
+											},
+											File:   "state_changes_any_to_any_test.flux",
+											Source: "columns: [\"_time\"]",
+											Start: ast.Position{
+												Column: 56,
+												Line:   13,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 63,
+													Line:   13,
+												},
+												File:   "state_changes_any_to_any_test.flux",
+												Source: "columns",
+												Start: ast.Position{
+													Column: 56,
+													Line:   13,
+												},
+											},
+										},
+										Name: "columns",
+									},
+									Value: &ast.ArrayExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 74,
+													Line:   13,
+												},
+												File:   "state_changes_any_to_any_test.flux",
+												Source: "[\"_time\"]",
+												Start: ast.Position{
+													Column: 65,
+													Line:   13,
+												},
+											},
+										},
+										Elements: []ast.Expression{&ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 73,
+														Line:   13,
+													},
+													File:   "state_changes_any_to_any_test.flux",
+													Source: "\"_time\"",
+													Start: ast.Position{
+														Column: 66,
+														Line:   13,
+													},
+												},
+											},
+											Value: "_time",
+										}},
+									},
+								}, &ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 87,
+												Line:   13,
+											},
+											File:   "state_changes_any_to_any_test.flux",
+											Source: "desc: false",
+											Start: ast.Position{
+												Column: 76,
+												Line:   13,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 80,
+													Line:   13,
+												},
+												File:   "state_changes_any_to_any_test.flux",
+												Source: "desc",
+												Start: ast.Position{
+													Column: 76,
+													Line:   13,
+												},
+											},
+										},
+										Name: "desc",
+									},
+									Value: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 87,
+													Line:   13,
+												},
+												File:   "state_changes_any_to_any_test.flux",
+												Source: "false",
+												Start: ast.Position{
+													Column: 82,
+													Line:   13,
+												},
+											},
+										},
+										Name: "false",
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 88,
+										Line:   13,
+									},
+									File:   "state_changes_any_to_any_test.flux",
+									Source: "sort(columns: [\"_time\"], desc: false)",
+									Start: ast.Position{
+										Column: 51,
+										Line:   13,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 55,
+											Line:   13,
+										},
+										File:   "state_changes_any_to_any_test.flux",
+										Source: "sort",
+										Start: ast.Position{
+											Column: 51,
+											Line:   13,
+										},
+									},
+								},
+								Name: "sort",
+							},
+						},
+					},
+					Params: []*ast.Property{&ast.Property{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   13,
+								},
+								File:   "state_changes_any_to_any_test.flux",
+								Source: "tables=<-",
+								Start: ast.Position{
+									Column: 27,
+									Line:   13,
+								},
+							},
+						},
+						Key: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 33,
+										Line:   13,
+									},
+									File:   "state_changes_any_to_any_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 27,
+										Line:   13,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   13,
+								},
+								File:   "state_changes_any_to_any_test.flux",
+								Source: "<-",
+								Start: ast.Position{
+									Column: 34,
+									Line:   13,
+								},
+							},
+						}},
+					}},
 				},
 				Member: &ast.MemberExpression{
 					BaseNode: ast.BaseNode{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 22,
+								Column: 23,
 								Line:   13,
 							},
 							File:   "state_changes_any_to_any_test.flux",
-							Source: "monitor.sortBy",
+							Source: "monitor.reorder",
 							Start: ast.Position{
 								Column: 8,
 								Line:   13,
@@ -9818,18 +10077,18 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 22,
+									Column: 23,
 									Line:   13,
 								},
 								File:   "state_changes_any_to_any_test.flux",
-								Source: "sortBy",
+								Source: "reorder",
 								Start: ast.Position{
 									Column: 16,
 									Line:   13,
 								},
 							},
 						},
-						Name: "sortBy",
+						Name: "reorder",
 					},
 				},
 			},
@@ -9837,11 +10096,11 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 32,
+						Column: 88,
 						Line:   13,
 					},
 					File:   "state_changes_any_to_any_test.flux",
-					Source: "option monitor.sortBy = \"_time\"",
+					Source: "option monitor.reorder = (tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   13,
@@ -19925,7 +20184,7 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Line:   60,
 				},
 				File:   "state_changes_invalid_any_to_any_test.flux",
-				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.\noption monitor.sortBy = \"_time\"\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
+				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Expected result is based on order by `_time` (order by `_source_timestamp` differs).\noption monitor.reorder = (tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -20353,45 +20612,304 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 32,
+							Column: 88,
 							Line:   13,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
-						Source: "monitor.sortBy = \"_time\"",
+						Source: "monitor.reorder = (tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)",
 						Start: ast.Position{
 							Column: 8,
 							Line:   13,
 						},
 					},
 				},
-				Init: &ast.StringLiteral{
+				Init: &ast.FunctionExpression{
 					BaseNode: ast.BaseNode{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 32,
+								Column: 88,
 								Line:   13,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
-							Source: "\"_time\"",
+							Source: "(tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)",
 							Start: ast.Position{
-								Column: 25,
+								Column: 26,
 								Line:   13,
 							},
 						},
 					},
-					Value: "_time",
+					Body: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 47,
+										Line:   13,
+									},
+									File:   "state_changes_invalid_any_to_any_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 41,
+										Line:   13,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 88,
+									Line:   13,
+								},
+								File:   "state_changes_invalid_any_to_any_test.flux",
+								Source: "tables |> sort(columns: [\"_time\"], desc: false)",
+								Start: ast.Position{
+									Column: 41,
+									Line:   13,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 87,
+											Line:   13,
+										},
+										File:   "state_changes_invalid_any_to_any_test.flux",
+										Source: "columns: [\"_time\"], desc: false",
+										Start: ast.Position{
+											Column: 56,
+											Line:   13,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 74,
+												Line:   13,
+											},
+											File:   "state_changes_invalid_any_to_any_test.flux",
+											Source: "columns: [\"_time\"]",
+											Start: ast.Position{
+												Column: 56,
+												Line:   13,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 63,
+													Line:   13,
+												},
+												File:   "state_changes_invalid_any_to_any_test.flux",
+												Source: "columns",
+												Start: ast.Position{
+													Column: 56,
+													Line:   13,
+												},
+											},
+										},
+										Name: "columns",
+									},
+									Value: &ast.ArrayExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 74,
+													Line:   13,
+												},
+												File:   "state_changes_invalid_any_to_any_test.flux",
+												Source: "[\"_time\"]",
+												Start: ast.Position{
+													Column: 65,
+													Line:   13,
+												},
+											},
+										},
+										Elements: []ast.Expression{&ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 73,
+														Line:   13,
+													},
+													File:   "state_changes_invalid_any_to_any_test.flux",
+													Source: "\"_time\"",
+													Start: ast.Position{
+														Column: 66,
+														Line:   13,
+													},
+												},
+											},
+											Value: "_time",
+										}},
+									},
+								}, &ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 87,
+												Line:   13,
+											},
+											File:   "state_changes_invalid_any_to_any_test.flux",
+											Source: "desc: false",
+											Start: ast.Position{
+												Column: 76,
+												Line:   13,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 80,
+													Line:   13,
+												},
+												File:   "state_changes_invalid_any_to_any_test.flux",
+												Source: "desc",
+												Start: ast.Position{
+													Column: 76,
+													Line:   13,
+												},
+											},
+										},
+										Name: "desc",
+									},
+									Value: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 87,
+													Line:   13,
+												},
+												File:   "state_changes_invalid_any_to_any_test.flux",
+												Source: "false",
+												Start: ast.Position{
+													Column: 82,
+													Line:   13,
+												},
+											},
+										},
+										Name: "false",
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 88,
+										Line:   13,
+									},
+									File:   "state_changes_invalid_any_to_any_test.flux",
+									Source: "sort(columns: [\"_time\"], desc: false)",
+									Start: ast.Position{
+										Column: 51,
+										Line:   13,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 55,
+											Line:   13,
+										},
+										File:   "state_changes_invalid_any_to_any_test.flux",
+										Source: "sort",
+										Start: ast.Position{
+											Column: 51,
+											Line:   13,
+										},
+									},
+								},
+								Name: "sort",
+							},
+						},
+					},
+					Params: []*ast.Property{&ast.Property{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   13,
+								},
+								File:   "state_changes_invalid_any_to_any_test.flux",
+								Source: "tables=<-",
+								Start: ast.Position{
+									Column: 27,
+									Line:   13,
+								},
+							},
+						},
+						Key: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 33,
+										Line:   13,
+									},
+									File:   "state_changes_invalid_any_to_any_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 27,
+										Line:   13,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   13,
+								},
+								File:   "state_changes_invalid_any_to_any_test.flux",
+								Source: "<-",
+								Start: ast.Position{
+									Column: 34,
+									Line:   13,
+								},
+							},
+						}},
+					}},
 				},
 				Member: &ast.MemberExpression{
 					BaseNode: ast.BaseNode{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 22,
+								Column: 23,
 								Line:   13,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
-							Source: "monitor.sortBy",
+							Source: "monitor.reorder",
 							Start: ast.Position{
 								Column: 8,
 								Line:   13,
@@ -20421,18 +20939,18 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 22,
+									Column: 23,
 									Line:   13,
 								},
 								File:   "state_changes_invalid_any_to_any_test.flux",
-								Source: "sortBy",
+								Source: "reorder",
 								Start: ast.Position{
 									Column: 16,
 									Line:   13,
 								},
 							},
 						},
-						Name: "sortBy",
+						Name: "reorder",
 					},
 				},
 			},
@@ -20440,11 +20958,11 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 32,
+						Column: 88,
 						Line:   13,
 					},
 					File:   "state_changes_invalid_any_to_any_test.flux",
-					Source: "option monitor.sortBy = \"_time\"",
+					Source: "option monitor.reorder = (tables=<-) => tables |> sort(columns: [\"_time\"], desc: false)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   13,

--- a/stdlib/influxdata/influxdb/monitor/flux_test_gen.go
+++ b/stdlib/influxdata/influxdb/monitor/flux_test_gen.go
@@ -9319,10 +9319,10 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 117,
-					Line:   59,
+					Line:   62,
 				},
 				File:   "state_changes_any_to_any_test.flux",
-				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,whoa!,cpu,1527018860000000000,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,7.05\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
+				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.\noption monitor.sortBy = \"_time\"\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,whoa!,cpu,1527018860000000000,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,7.05\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -9744,19 +9744,123 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					},
 				},
 			},
+		}, &ast.OptionStatement{
+			Assignment: &ast.MemberAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 32,
+							Line:   13,
+						},
+						File:   "state_changes_any_to_any_test.flux",
+						Source: "monitor.sortBy = \"_time\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   13,
+						},
+					},
+				},
+				Init: &ast.StringLiteral{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 32,
+								Line:   13,
+							},
+							File:   "state_changes_any_to_any_test.flux",
+							Source: "\"_time\"",
+							Start: ast.Position{
+								Column: 25,
+								Line:   13,
+							},
+						},
+					},
+					Value: "_time",
+				},
+				Member: &ast.MemberExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 22,
+								Line:   13,
+							},
+							File:   "state_changes_any_to_any_test.flux",
+							Source: "monitor.sortBy",
+							Start: ast.Position{
+								Column: 8,
+								Line:   13,
+							},
+						},
+					},
+					Object: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   13,
+								},
+								File:   "state_changes_any_to_any_test.flux",
+								Source: "monitor",
+								Start: ast.Position{
+									Column: 8,
+									Line:   13,
+								},
+							},
+						},
+						Name: "monitor",
+					},
+					Property: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 22,
+									Line:   13,
+								},
+								File:   "state_changes_any_to_any_test.flux",
+								Source: "sortBy",
+								Start: ast.Position{
+									Column: 16,
+									Line:   13,
+								},
+							},
+						},
+						Name: "sortBy",
+					},
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 32,
+						Line:   13,
+					},
+					File:   "state_changes_any_to_any_test.flux",
+					Source: "option monitor.sortBy = \"_time\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   13,
+					},
+				},
+			},
 		}, &ast.VariableAssignment{
 			BaseNode: ast.BaseNode{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 2,
-						Line:   37,
+						Line:   40,
 					},
 					File:   "state_changes_any_to_any_test.flux",
 					Source: "inData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"",
 					Start: ast.Position{
 						Column: 1,
-						Line:   13,
+						Line:   16,
 					},
 				},
 			},
@@ -9766,13 +9870,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   13,
+							Line:   16,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "inData",
 						Start: ast.Position{
 							Column: 1,
-							Line:   13,
+							Line:   16,
 						},
 					},
 				},
@@ -9784,13 +9888,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 2,
-							Line:   37,
+							Line:   40,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "\"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,2,000000000000000a,cpu threshold check,warn,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"",
 						Start: ast.Position{
 							Column: 10,
-							Line:   13,
+							Line:   16,
 						},
 					},
 				},
@@ -9802,13 +9906,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 2,
-						Line:   47,
+						Line:   50,
 					},
 					File:   "state_changes_any_to_any_test.flux",
 					Source: "outData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,whoa!,cpu,1527018860000000000,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,7.05\n\"",
 					Start: ast.Position{
 						Column: 1,
-						Line:   40,
+						Line:   43,
 					},
 				},
 			},
@@ -9818,13 +9922,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 8,
-							Line:   40,
+							Line:   43,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "outData",
 						Start: ast.Position{
 							Column: 1,
-							Line:   40,
+							Line:   43,
 						},
 					},
 				},
@@ -9836,13 +9940,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 2,
-							Line:   47,
+							Line:   50,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "\"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n,,2,000000000000000a,cpu threshold check,warn,statuses,whoa!,cpu,1527018860000000000,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,7.05\n\"",
 						Start: ast.Position{
 							Column: 11,
-							Line:   40,
+							Line:   43,
 						},
 					},
 				},
@@ -9854,13 +9958,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 41,
-						Line:   56,
+						Line:   59,
 					},
 					File:   "state_changes_any_to_any_test.flux",
 					Source: "t_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
 					Start: ast.Position{
 						Column: 1,
-						Line:   49,
+						Line:   52,
 					},
 				},
 			},
@@ -9870,13 +9974,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 27,
-							Line:   49,
+							Line:   52,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "t_state_changes_any_to_any",
 						Start: ast.Position{
 							Column: 1,
-							Line:   49,
+							Line:   52,
 						},
 					},
 				},
@@ -9888,13 +9992,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 41,
-							Line:   56,
+							Line:   59,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "(table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
 						Start: ast.Position{
 							Column: 30,
-							Line:   49,
+							Line:   52,
 						},
 					},
 				},
@@ -9908,13 +10012,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 49,
-												Line:   49,
+												Line:   52,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "table",
 											Start: ast.Position{
 												Column: 44,
-												Line:   49,
+												Line:   52,
 											},
 										},
 									},
@@ -9925,13 +10029,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 25,
-											Line:   50,
+											Line:   53,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "table\n    |> range(start: -1m)",
 										Start: ast.Position{
 											Column: 44,
-											Line:   49,
+											Line:   52,
 										},
 									},
 								},
@@ -9942,13 +10046,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 24,
-													Line:   50,
+													Line:   53,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "start: -1m",
 												Start: ast.Position{
 													Column: 14,
-													Line:   50,
+													Line:   53,
 												},
 											},
 										},
@@ -9958,13 +10062,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 24,
-														Line:   50,
+														Line:   53,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "start: -1m",
 													Start: ast.Position{
 														Column: 14,
-														Line:   50,
+														Line:   53,
 													},
 												},
 											},
@@ -9974,13 +10078,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 19,
-															Line:   50,
+															Line:   53,
 														},
 														File:   "state_changes_any_to_any_test.flux",
 														Source: "start",
 														Start: ast.Position{
 															Column: 14,
-															Line:   50,
+															Line:   53,
 														},
 													},
 												},
@@ -9993,13 +10097,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 24,
-																Line:   50,
+																Line:   53,
 															},
 															File:   "state_changes_any_to_any_test.flux",
 															Source: "1m",
 															Start: ast.Position{
 																Column: 22,
-																Line:   50,
+																Line:   53,
 															},
 														},
 													},
@@ -10013,13 +10117,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 24,
-															Line:   50,
+															Line:   53,
 														},
 														File:   "state_changes_any_to_any_test.flux",
 														Source: "-1m",
 														Start: ast.Position{
 															Column: 21,
-															Line:   50,
+															Line:   53,
 														},
 													},
 												},
@@ -10033,13 +10137,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 25,
-												Line:   50,
+												Line:   53,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "range(start: -1m)",
 											Start: ast.Position{
 												Column: 8,
-												Line:   50,
+												Line:   53,
 											},
 										},
 									},
@@ -10049,13 +10153,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 13,
-													Line:   50,
+													Line:   53,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "range",
 												Start: ast.Position{
 													Column: 8,
-													Line:   50,
+													Line:   53,
 												},
 											},
 										},
@@ -10068,13 +10172,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 25,
-										Line:   51,
+										Line:   54,
 									},
 									File:   "state_changes_any_to_any_test.flux",
 									Source: "table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()",
 									Start: ast.Position{
 										Column: 44,
-										Line:   49,
+										Line:   52,
 									},
 								},
 							},
@@ -10085,13 +10189,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 25,
-											Line:   51,
+											Line:   54,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "v1.fieldsAsCols()",
 										Start: ast.Position{
 											Column: 8,
-											Line:   51,
+											Line:   54,
 										},
 									},
 								},
@@ -10101,13 +10205,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   51,
+												Line:   54,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "v1.fieldsAsCols",
 											Start: ast.Position{
 												Column: 8,
-												Line:   51,
+												Line:   54,
 											},
 										},
 									},
@@ -10117,13 +10221,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 10,
-													Line:   51,
+													Line:   54,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "v1",
 												Start: ast.Position{
 													Column: 8,
-													Line:   51,
+													Line:   54,
 												},
 											},
 										},
@@ -10135,13 +10239,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 23,
-													Line:   51,
+													Line:   54,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "fieldsAsCols",
 												Start: ast.Position{
 													Column: 11,
-													Line:   51,
+													Line:   54,
 												},
 											},
 										},
@@ -10155,13 +10259,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   55,
+									Line:   58,
 								},
 								File:   "state_changes_any_to_any_test.flux",
 								Source: "table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )",
 								Start: ast.Position{
 									Column: 44,
-									Line:   49,
+									Line:   52,
 								},
 							},
 						},
@@ -10172,13 +10276,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 23,
-											Line:   54,
+											Line:   57,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "fromLevel: \"any\",\n        toLevel: \"any\"",
 										Start: ast.Position{
 											Column: 9,
-											Line:   53,
+											Line:   56,
 										},
 									},
 								},
@@ -10188,13 +10292,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 25,
-												Line:   53,
+												Line:   56,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "fromLevel: \"any\"",
 											Start: ast.Position{
 												Column: 9,
-												Line:   53,
+												Line:   56,
 											},
 										},
 									},
@@ -10204,13 +10308,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 18,
-													Line:   53,
+													Line:   56,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "fromLevel",
 												Start: ast.Position{
 													Column: 9,
-													Line:   53,
+													Line:   56,
 												},
 											},
 										},
@@ -10222,13 +10326,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 25,
-													Line:   53,
+													Line:   56,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "\"any\"",
 												Start: ast.Position{
 													Column: 20,
-													Line:   53,
+													Line:   56,
 												},
 											},
 										},
@@ -10240,13 +10344,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   54,
+												Line:   57,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "toLevel: \"any\"",
 											Start: ast.Position{
 												Column: 9,
-												Line:   54,
+												Line:   57,
 											},
 										},
 									},
@@ -10256,13 +10360,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 16,
-													Line:   54,
+													Line:   57,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "toLevel",
 												Start: ast.Position{
 													Column: 9,
-													Line:   54,
+													Line:   57,
 												},
 											},
 										},
@@ -10274,13 +10378,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 23,
-													Line:   54,
+													Line:   57,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "\"any\"",
 												Start: ast.Position{
 													Column: 18,
-													Line:   54,
+													Line:   57,
 												},
 											},
 										},
@@ -10294,13 +10398,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 6,
-										Line:   55,
+										Line:   58,
 									},
 									File:   "state_changes_any_to_any_test.flux",
 									Source: "monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )",
 									Start: ast.Position{
 										Column: 8,
-										Line:   52,
+										Line:   55,
 									},
 								},
 							},
@@ -10310,13 +10414,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 28,
-											Line:   52,
+											Line:   55,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "monitor.stateChanges",
 										Start: ast.Position{
 											Column: 8,
-											Line:   52,
+											Line:   55,
 										},
 									},
 								},
@@ -10326,13 +10430,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 15,
-												Line:   52,
+												Line:   55,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "monitor",
 											Start: ast.Position{
 												Column: 8,
-												Line:   52,
+												Line:   55,
 											},
 										},
 									},
@@ -10344,13 +10448,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 28,
-												Line:   52,
+												Line:   55,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "stateChanges",
 											Start: ast.Position{
 												Column: 16,
-												Line:   52,
+												Line:   55,
 											},
 										},
 									},
@@ -10364,13 +10468,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 41,
-								Line:   56,
+								Line:   59,
 							},
 							File:   "state_changes_any_to_any_test.flux",
 							Source: "table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
 							Start: ast.Position{
 								Column: 44,
-								Line:   49,
+								Line:   52,
 							},
 						},
 					},
@@ -10381,13 +10485,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 40,
-										Line:   56,
+										Line:   59,
 									},
 									File:   "state_changes_any_to_any_test.flux",
 									Source: "columns: [\"_start\",\"_stop\"]",
 									Start: ast.Position{
 										Column: 13,
-										Line:   56,
+										Line:   59,
 									},
 								},
 							},
@@ -10397,13 +10501,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 40,
-											Line:   56,
+											Line:   59,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "columns: [\"_start\",\"_stop\"]",
 										Start: ast.Position{
 											Column: 13,
-											Line:   56,
+											Line:   59,
 										},
 									},
 								},
@@ -10413,13 +10517,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   56,
+												Line:   59,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 13,
-												Line:   56,
+												Line:   59,
 											},
 										},
 									},
@@ -10431,13 +10535,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 40,
-												Line:   56,
+												Line:   59,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "[\"_start\",\"_stop\"]",
 											Start: ast.Position{
 												Column: 22,
-												Line:   56,
+												Line:   59,
 											},
 										},
 									},
@@ -10447,13 +10551,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 31,
-													Line:   56,
+													Line:   59,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "\"_start\"",
 												Start: ast.Position{
 													Column: 23,
-													Line:   56,
+													Line:   59,
 												},
 											},
 										},
@@ -10464,13 +10568,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 39,
-													Line:   56,
+													Line:   59,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "\"_stop\"",
 												Start: ast.Position{
 													Column: 32,
-													Line:   56,
+													Line:   59,
 												},
 											},
 										},
@@ -10485,13 +10589,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 41,
-									Line:   56,
+									Line:   59,
 								},
 								File:   "state_changes_any_to_any_test.flux",
 								Source: "drop(columns: [\"_start\",\"_stop\"])",
 								Start: ast.Position{
 									Column: 8,
-									Line:   56,
+									Line:   59,
 								},
 							},
 						},
@@ -10501,13 +10605,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 12,
-										Line:   56,
+										Line:   59,
 									},
 									File:   "state_changes_any_to_any_test.flux",
 									Source: "drop",
 									Start: ast.Position{
 										Column: 8,
-										Line:   56,
+										Line:   59,
 									},
 								},
 							},
@@ -10521,13 +10625,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 39,
-								Line:   49,
+								Line:   52,
 							},
 							File:   "state_changes_any_to_any_test.flux",
 							Source: "table=<-",
 							Start: ast.Position{
 								Column: 31,
-								Line:   49,
+								Line:   52,
 							},
 						},
 					},
@@ -10537,13 +10641,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 36,
-									Line:   49,
+									Line:   52,
 								},
 								File:   "state_changes_any_to_any_test.flux",
 								Source: "table",
 								Start: ast.Position{
 									Column: 31,
-									Line:   49,
+									Line:   52,
 								},
 							},
 						},
@@ -10554,13 +10658,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 39,
-								Line:   49,
+								Line:   52,
 							},
 							File:   "state_changes_any_to_any_test.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 37,
-								Line:   49,
+								Line:   52,
 							},
 						},
 					}},
@@ -10573,13 +10677,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 117,
-							Line:   59,
+							Line:   62,
 						},
 						File:   "state_changes_any_to_any_test.flux",
 						Source: "monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 						Start: ast.Position{
 							Column: 6,
-							Line:   58,
+							Line:   61,
 						},
 					},
 				},
@@ -10589,13 +10693,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 38,
-								Line:   58,
+								Line:   61,
 							},
 							File:   "state_changes_any_to_any_test.flux",
 							Source: "monitor_state_changes_any_to_any",
 							Start: ast.Position{
 								Column: 6,
-								Line:   58,
+								Line:   61,
 							},
 						},
 					},
@@ -10607,13 +10711,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 117,
-								Line:   59,
+								Line:   62,
 							},
 							File:   "state_changes_any_to_any_test.flux",
 							Source: "() =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 							Start: ast.Position{
 								Column: 41,
-								Line:   58,
+								Line:   61,
 							},
 						},
 					},
@@ -10623,13 +10727,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 117,
-									Line:   59,
+									Line:   62,
 								},
 								File:   "state_changes_any_to_any_test.flux",
 								Source: "({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 								Start: ast.Position{
 									Column: 5,
-									Line:   59,
+									Line:   62,
 								},
 							},
 						},
@@ -10639,13 +10743,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 116,
-										Line:   59,
+										Line:   62,
 									},
 									File:   "state_changes_any_to_any_test.flux",
 									Source: "{input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any}",
 									Start: ast.Position{
 										Column: 6,
-										Line:   59,
+										Line:   62,
 									},
 								},
 							},
@@ -10655,13 +10759,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 46,
-											Line:   59,
+											Line:   62,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "input: testing.loadStorage(csv: inData)",
 										Start: ast.Position{
 											Column: 7,
-											Line:   59,
+											Line:   62,
 										},
 									},
 								},
@@ -10671,13 +10775,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 12,
-												Line:   59,
+												Line:   62,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "input",
 											Start: ast.Position{
 												Column: 7,
-												Line:   59,
+												Line:   62,
 											},
 										},
 									},
@@ -10690,13 +10794,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 45,
-													Line:   59,
+													Line:   62,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "csv: inData",
 												Start: ast.Position{
 													Column: 34,
-													Line:   59,
+													Line:   62,
 												},
 											},
 										},
@@ -10706,13 +10810,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 45,
-														Line:   59,
+														Line:   62,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "csv: inData",
 													Start: ast.Position{
 														Column: 34,
-														Line:   59,
+														Line:   62,
 													},
 												},
 											},
@@ -10722,13 +10826,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 37,
-															Line:   59,
+															Line:   62,
 														},
 														File:   "state_changes_any_to_any_test.flux",
 														Source: "csv",
 														Start: ast.Position{
 															Column: 34,
-															Line:   59,
+															Line:   62,
 														},
 													},
 												},
@@ -10740,13 +10844,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 45,
-															Line:   59,
+															Line:   62,
 														},
 														File:   "state_changes_any_to_any_test.flux",
 														Source: "inData",
 														Start: ast.Position{
 															Column: 39,
-															Line:   59,
+															Line:   62,
 														},
 													},
 												},
@@ -10760,13 +10864,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 46,
-												Line:   59,
+												Line:   62,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "testing.loadStorage(csv: inData)",
 											Start: ast.Position{
 												Column: 14,
-												Line:   59,
+												Line:   62,
 											},
 										},
 									},
@@ -10776,13 +10880,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 33,
-													Line:   59,
+													Line:   62,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "testing.loadStorage",
 												Start: ast.Position{
 													Column: 14,
-													Line:   59,
+													Line:   62,
 												},
 											},
 										},
@@ -10792,13 +10896,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 21,
-														Line:   59,
+														Line:   62,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "testing",
 													Start: ast.Position{
 														Column: 14,
-														Line:   59,
+														Line:   62,
 													},
 												},
 											},
@@ -10810,13 +10914,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   59,
+														Line:   62,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "loadStorage",
 													Start: ast.Position{
 														Column: 22,
-														Line:   59,
+														Line:   62,
 													},
 												},
 											},
@@ -10830,13 +10934,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 83,
-											Line:   59,
+											Line:   62,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "want: testing.loadMem(csv: outData)",
 										Start: ast.Position{
 											Column: 48,
-											Line:   59,
+											Line:   62,
 										},
 									},
 								},
@@ -10846,13 +10950,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 52,
-												Line:   59,
+												Line:   62,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "want",
 											Start: ast.Position{
 												Column: 48,
-												Line:   59,
+												Line:   62,
 											},
 										},
 									},
@@ -10865,13 +10969,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 82,
-													Line:   59,
+													Line:   62,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "csv: outData",
 												Start: ast.Position{
 													Column: 70,
-													Line:   59,
+													Line:   62,
 												},
 											},
 										},
@@ -10881,13 +10985,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 82,
-														Line:   59,
+														Line:   62,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "csv: outData",
 													Start: ast.Position{
 														Column: 70,
-														Line:   59,
+														Line:   62,
 													},
 												},
 											},
@@ -10897,13 +11001,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 73,
-															Line:   59,
+															Line:   62,
 														},
 														File:   "state_changes_any_to_any_test.flux",
 														Source: "csv",
 														Start: ast.Position{
 															Column: 70,
-															Line:   59,
+															Line:   62,
 														},
 													},
 												},
@@ -10915,13 +11019,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 82,
-															Line:   59,
+															Line:   62,
 														},
 														File:   "state_changes_any_to_any_test.flux",
 														Source: "outData",
 														Start: ast.Position{
 															Column: 75,
-															Line:   59,
+															Line:   62,
 														},
 													},
 												},
@@ -10935,13 +11039,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 83,
-												Line:   59,
+												Line:   62,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "testing.loadMem(csv: outData)",
 											Start: ast.Position{
 												Column: 54,
-												Line:   59,
+												Line:   62,
 											},
 										},
 									},
@@ -10951,13 +11055,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 69,
-													Line:   59,
+													Line:   62,
 												},
 												File:   "state_changes_any_to_any_test.flux",
 												Source: "testing.loadMem",
 												Start: ast.Position{
 													Column: 54,
-													Line:   59,
+													Line:   62,
 												},
 											},
 										},
@@ -10967,13 +11071,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 61,
-														Line:   59,
+														Line:   62,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "testing",
 													Start: ast.Position{
 														Column: 54,
-														Line:   59,
+														Line:   62,
 													},
 												},
 											},
@@ -10985,13 +11089,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 69,
-														Line:   59,
+														Line:   62,
 													},
 													File:   "state_changes_any_to_any_test.flux",
 													Source: "loadMem",
 													Start: ast.Position{
 														Column: 62,
-														Line:   59,
+														Line:   62,
 													},
 												},
 											},
@@ -11005,13 +11109,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 115,
-											Line:   59,
+											Line:   62,
 										},
 										File:   "state_changes_any_to_any_test.flux",
 										Source: "fn: t_state_changes_any_to_any",
 										Start: ast.Position{
 											Column: 85,
-											Line:   59,
+											Line:   62,
 										},
 									},
 								},
@@ -11021,13 +11125,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 87,
-												Line:   59,
+												Line:   62,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 85,
-												Line:   59,
+												Line:   62,
 											},
 										},
 									},
@@ -11039,13 +11143,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 115,
-												Line:   59,
+												Line:   62,
 											},
 											File:   "state_changes_any_to_any_test.flux",
 											Source: "t_state_changes_any_to_any",
 											Start: ast.Position{
 												Column: 89,
-												Line:   59,
+												Line:   62,
 											},
 										},
 									},
@@ -11063,13 +11167,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 117,
-						Line:   59,
+						Line:   62,
 					},
 					File:   "state_changes_any_to_any_test.flux",
 					Source: "test monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 					Start: ast.Position{
 						Column: 1,
-						Line:   58,
+						Line:   61,
 					},
 				},
 			},
@@ -16171,6 +16275,1713 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 			Errors: nil,
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
+					Column: 124,
+					Line:   54,
+				},
+				File:   "state_changes_custom_any_to_any_test.flux",
+				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// These statuses were produce by custom check query\ninData = \"\n#group,false,false,false,true,true,true,true,true,true,true,false,false,false,false\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,string,string,string,string,long,double,double\n#default,_result,,,,,,,,,,,,,\n,result,table,_time,_check_id,_check_name,_level,_measurement,_source_measurement,_type,id,_message,_source_timestamp,lat,lon\n,,0,2020-04-01T13:19:00.734009512Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:19:00.734068665Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055589553Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055681722Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055731206Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747151000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055757119Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747168000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055841776Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747185000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120735321Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747203000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120827394Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747219000000000,40.676922,-73.76787\n,,1,2020-04-01T13:25:01.119696459Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747271000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119812609Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747288000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119843339Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747304000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119944446Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747322000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119986133Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747339000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.12003354Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747356000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120075771Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747374000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120119872Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747390000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120620071Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747237000000000,40.70075,-73.804858\n,,1,2020-04-01T13:25:01.120707032Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747254000000000,40.70075,-73.804858\"\n\noutData = \"\n#group,false,false,true,true,true,false,true,false,false,true,true,false,false,true\n#datatype,string,long,string,string,string,string,string,long,dateTime:RFC3339,string,string,double,double,string\n#default,_result,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,id,lat,lon,_level\n,,0,000000000000000a,LLIR,statuses,GO506_20_8813 is out,mta,1585747237000000000,2020-04-01T13:25:01.120620071Z,custom,GO506_20_8813,40.70075,-73.804858,warn\n\"\n\nt_state_changes_custom_any_to_any = (table=<-) => table\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_custom_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any})",
+				Start: ast.Position{
+					Column: 1,
+					Line:   1,
+				},
+			},
+		},
+		Body: []ast.Statement{&ast.OptionStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 40,
+							Line:   8,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "now = () => 2018-05-22T19:54:40Z",
+						Start: ast.Position{
+							Column: 8,
+							Line:   8,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 11,
+								Line:   8,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "now",
+							Start: ast.Position{
+								Column: 8,
+								Line:   8,
+							},
+						},
+					},
+					Name: "now",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 40,
+								Line:   8,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "() => 2018-05-22T19:54:40Z",
+							Start: ast.Position{
+								Column: 14,
+								Line:   8,
+							},
+						},
+					},
+					Body: &ast.DateTimeLiteral{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 40,
+									Line:   8,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "2018-05-22T19:54:40Z",
+								Start: ast.Position{
+									Column: 20,
+									Line:   8,
+								},
+							},
+						},
+						Value: parser.MustParseTime("2018-05-22T19:54:40Z"),
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 40,
+						Line:   8,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "option now = () => 2018-05-22T19:54:40Z",
+					Start: ast.Position{
+						Column: 1,
+						Line:   8,
+					},
+				},
+			},
+		}, &ast.OptionStatement{
+			Assignment: &ast.MemberAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 80,
+							Line:   10,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])",
+						Start: ast.Position{
+							Column: 8,
+							Line:   10,
+						},
+					},
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 80,
+								Line:   10,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "(tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])",
+							Start: ast.Position{
+								Column: 22,
+								Line:   10,
+							},
+						},
+					},
+					Body: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 43,
+										Line:   10,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 37,
+										Line:   10,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 80,
+									Line:   10,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "tables |> drop(columns:[\"_start\", \"_stop\"])",
+								Start: ast.Position{
+									Column: 37,
+									Line:   10,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 79,
+											Line:   10,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "columns:[\"_start\", \"_stop\"]",
+										Start: ast.Position{
+											Column: 52,
+											Line:   10,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 79,
+												Line:   10,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "columns:[\"_start\", \"_stop\"]",
+											Start: ast.Position{
+												Column: 52,
+												Line:   10,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 59,
+													Line:   10,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "columns",
+												Start: ast.Position{
+													Column: 52,
+													Line:   10,
+												},
+											},
+										},
+										Name: "columns",
+									},
+									Value: &ast.ArrayExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 79,
+													Line:   10,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "[\"_start\", \"_stop\"]",
+												Start: ast.Position{
+													Column: 60,
+													Line:   10,
+												},
+											},
+										},
+										Elements: []ast.Expression{&ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 69,
+														Line:   10,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "\"_start\"",
+													Start: ast.Position{
+														Column: 61,
+														Line:   10,
+													},
+												},
+											},
+											Value: "_start",
+										}, &ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 78,
+														Line:   10,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "\"_stop\"",
+													Start: ast.Position{
+														Column: 71,
+														Line:   10,
+													},
+												},
+											},
+											Value: "_stop",
+										}},
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 80,
+										Line:   10,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "drop(columns:[\"_start\", \"_stop\"])",
+									Start: ast.Position{
+										Column: 47,
+										Line:   10,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 51,
+											Line:   10,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "drop",
+										Start: ast.Position{
+											Column: 47,
+											Line:   10,
+										},
+									},
+								},
+								Name: "drop",
+							},
+						},
+					},
+					Params: []*ast.Property{&ast.Property{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 32,
+									Line:   10,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "tables=<-",
+								Start: ast.Position{
+									Column: 23,
+									Line:   10,
+								},
+							},
+						},
+						Key: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 29,
+										Line:   10,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 23,
+										Line:   10,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 32,
+									Line:   10,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "<-",
+								Start: ast.Position{
+									Column: 30,
+									Line:   10,
+								},
+							},
+						}},
+					}},
+				},
+				Member: &ast.MemberExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 19,
+								Line:   10,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "monitor.log",
+							Start: ast.Position{
+								Column: 8,
+								Line:   10,
+							},
+						},
+					},
+					Object: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   10,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "monitor",
+								Start: ast.Position{
+									Column: 8,
+									Line:   10,
+								},
+							},
+						},
+						Name: "monitor",
+					},
+					Property: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 19,
+									Line:   10,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "log",
+								Start: ast.Position{
+									Column: 16,
+									Line:   10,
+								},
+							},
+						},
+						Name: "log",
+					},
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 80,
+						Line:   10,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "option monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])",
+					Start: ast.Position{
+						Column: 1,
+						Line:   10,
+					},
+				},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 158,
+						Line:   36,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "inData = \"\n#group,false,false,false,true,true,true,true,true,true,true,false,false,false,false\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,string,string,string,string,long,double,double\n#default,_result,,,,,,,,,,,,,\n,result,table,_time,_check_id,_check_name,_level,_measurement,_source_measurement,_type,id,_message,_source_timestamp,lat,lon\n,,0,2020-04-01T13:19:00.734009512Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:19:00.734068665Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055589553Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055681722Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055731206Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747151000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055757119Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747168000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055841776Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747185000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120735321Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747203000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120827394Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747219000000000,40.676922,-73.76787\n,,1,2020-04-01T13:25:01.119696459Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747271000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119812609Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747288000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119843339Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747304000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119944446Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747322000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119986133Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747339000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.12003354Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747356000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120075771Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747374000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120119872Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747390000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120620071Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747237000000000,40.70075,-73.804858\n,,1,2020-04-01T13:25:01.120707032Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747254000000000,40.70075,-73.804858\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   13,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 7,
+							Line:   13,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "inData",
+						Start: ast.Position{
+							Column: 1,
+							Line:   13,
+						},
+					},
+				},
+				Name: "inData",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 158,
+							Line:   36,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "\"\n#group,false,false,false,true,true,true,true,true,true,true,false,false,false,false\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,string,string,string,string,long,double,double\n#default,_result,,,,,,,,,,,,,\n,result,table,_time,_check_id,_check_name,_level,_measurement,_source_measurement,_type,id,_message,_source_timestamp,lat,lon\n,,0,2020-04-01T13:19:00.734009512Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:19:00.734068665Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055589553Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055681722Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055731206Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747151000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055757119Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747168000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055841776Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747185000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120735321Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747203000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120827394Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747219000000000,40.676922,-73.76787\n,,1,2020-04-01T13:25:01.119696459Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747271000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119812609Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747288000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119843339Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747304000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119944446Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747322000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119986133Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747339000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.12003354Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747356000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120075771Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747374000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120119872Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747390000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120620071Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747237000000000,40.70075,-73.804858\n,,1,2020-04-01T13:25:01.120707032Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747254000000000,40.70075,-73.804858\"",
+						Start: ast.Position{
+							Column: 10,
+							Line:   13,
+						},
+					},
+				},
+				Value: "\n#group,false,false,false,true,true,true,true,true,true,true,false,false,false,false\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,string,string,string,string,long,double,double\n#default,_result,,,,,,,,,,,,,\n,result,table,_time,_check_id,_check_name,_level,_measurement,_source_measurement,_type,id,_message,_source_timestamp,lat,lon\n,,0,2020-04-01T13:19:00.734009512Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:19:00.734068665Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055589553Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055681722Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055731206Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747151000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055757119Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747168000000000,40.676922,-73.76787\n,,0,2020-04-01T13:20:01.055841776Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747185000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120735321Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747203000000000,40.676922,-73.76787\n,,0,2020-04-01T13:25:01.120827394Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747219000000000,40.676922,-73.76787\n,,1,2020-04-01T13:25:01.119696459Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747271000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119812609Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747288000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119843339Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747304000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119944446Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747322000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.119986133Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747339000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.12003354Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747356000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120075771Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747374000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120119872Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747390000000000,40.699608,-73.80853\n,,1,2020-04-01T13:25:01.120620071Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747237000000000,40.70075,-73.804858\n,,1,2020-04-01T13:25:01.120707032Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747254000000000,40.70075,-73.804858",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   44,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "outData = \"\n#group,false,false,true,true,true,false,true,false,false,true,true,false,false,true\n#datatype,string,long,string,string,string,string,string,long,dateTime:RFC3339,string,string,double,double,string\n#default,_result,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,id,lat,lon,_level\n,,0,000000000000000a,LLIR,statuses,GO506_20_8813 is out,mta,1585747237000000000,2020-04-01T13:25:01.120620071Z,custom,GO506_20_8813,40.70075,-73.804858,warn\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   38,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 8,
+							Line:   38,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "outData",
+						Start: ast.Position{
+							Column: 1,
+							Line:   38,
+						},
+					},
+				},
+				Name: "outData",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   44,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "\"\n#group,false,false,true,true,true,false,true,false,false,true,true,false,false,true\n#datatype,string,long,string,string,string,string,string,long,dateTime:RFC3339,string,string,double,double,string\n#default,_result,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,id,lat,lon,_level\n,,0,000000000000000a,LLIR,statuses,GO506_20_8813 is out,mta,1585747237000000000,2020-04-01T13:25:01.120620071Z,custom,GO506_20_8813,40.70075,-73.804858,warn\n\"",
+						Start: ast.Position{
+							Column: 11,
+							Line:   38,
+						},
+					},
+				},
+				Value: "\n#group,false,false,true,true,true,false,true,false,false,true,true,false,false,true\n#datatype,string,long,string,string,string,string,string,long,dateTime:RFC3339,string,string,double,double,string\n#default,_result,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,id,lat,lon,_level\n,,0,000000000000000a,LLIR,statuses,GO506_20_8813 is out,mta,1585747237000000000,2020-04-01T13:25:01.120620071Z,custom,GO506_20_8813,40.70075,-73.804858,warn\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 41,
+						Line:   51,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "t_state_changes_custom_any_to_any = (table=<-) => table\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
+					Start: ast.Position{
+						Column: 1,
+						Line:   46,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 34,
+							Line:   46,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "t_state_changes_custom_any_to_any",
+						Start: ast.Position{
+							Column: 1,
+							Line:   46,
+						},
+					},
+				},
+				Name: "t_state_changes_custom_any_to_any",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 41,
+							Line:   51,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "(table=<-) => table\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
+						Start: ast.Position{
+							Column: 37,
+							Line:   46,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 56,
+										Line:   46,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "table",
+									Start: ast.Position{
+										Column: 51,
+										Line:   46,
+									},
+								},
+							},
+							Name: "table",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 6,
+									Line:   50,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "table\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )",
+								Start: ast.Position{
+									Column: 51,
+									Line:   46,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 23,
+											Line:   49,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "fromLevel: \"any\",\n        toLevel: \"any\"",
+										Start: ast.Position{
+											Column: 9,
+											Line:   48,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 25,
+												Line:   48,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "fromLevel: \"any\"",
+											Start: ast.Position{
+												Column: 9,
+												Line:   48,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 18,
+													Line:   48,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "fromLevel",
+												Start: ast.Position{
+													Column: 9,
+													Line:   48,
+												},
+											},
+										},
+										Name: "fromLevel",
+									},
+									Value: &ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 25,
+													Line:   48,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "\"any\"",
+												Start: ast.Position{
+													Column: 20,
+													Line:   48,
+												},
+											},
+										},
+										Value: "any",
+									},
+								}, &ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 23,
+												Line:   49,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "toLevel: \"any\"",
+											Start: ast.Position{
+												Column: 9,
+												Line:   49,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 16,
+													Line:   49,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "toLevel",
+												Start: ast.Position{
+													Column: 9,
+													Line:   49,
+												},
+											},
+										},
+										Name: "toLevel",
+									},
+									Value: &ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 23,
+													Line:   49,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "\"any\"",
+												Start: ast.Position{
+													Column: 18,
+													Line:   49,
+												},
+											},
+										},
+										Value: "any",
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 6,
+										Line:   50,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )",
+									Start: ast.Position{
+										Column: 8,
+										Line:   47,
+									},
+								},
+							},
+							Callee: &ast.MemberExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 28,
+											Line:   47,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "monitor.stateChanges",
+										Start: ast.Position{
+											Column: 8,
+											Line:   47,
+										},
+									},
+								},
+								Object: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 15,
+												Line:   47,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "monitor",
+											Start: ast.Position{
+												Column: 8,
+												Line:   47,
+											},
+										},
+									},
+									Name: "monitor",
+								},
+								Property: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 28,
+												Line:   47,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "stateChanges",
+											Start: ast.Position{
+												Column: 16,
+												Line:   47,
+											},
+										},
+									},
+									Name: "stateChanges",
+								},
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 41,
+								Line:   51,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "table\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
+							Start: ast.Position{
+								Column: 51,
+								Line:   46,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: []ast.Expression{&ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 40,
+										Line:   51,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "columns: [\"_start\",\"_stop\"]",
+									Start: ast.Position{
+										Column: 13,
+										Line:   51,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 40,
+											Line:   51,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "columns: [\"_start\",\"_stop\"]",
+										Start: ast.Position{
+											Column: 13,
+											Line:   51,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 20,
+												Line:   51,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "columns",
+											Start: ast.Position{
+												Column: 13,
+												Line:   51,
+											},
+										},
+									},
+									Name: "columns",
+								},
+								Value: &ast.ArrayExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 40,
+												Line:   51,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "[\"_start\",\"_stop\"]",
+											Start: ast.Position{
+												Column: 22,
+												Line:   51,
+											},
+										},
+									},
+									Elements: []ast.Expression{&ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 31,
+													Line:   51,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "\"_start\"",
+												Start: ast.Position{
+													Column: 23,
+													Line:   51,
+												},
+											},
+										},
+										Value: "_start",
+									}, &ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 39,
+													Line:   51,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "\"_stop\"",
+												Start: ast.Position{
+													Column: 32,
+													Line:   51,
+												},
+											},
+										},
+										Value: "_stop",
+									}},
+								},
+							}},
+							With: nil,
+						}},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 41,
+									Line:   51,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "drop(columns: [\"_start\",\"_stop\"])",
+								Start: ast.Position{
+									Column: 8,
+									Line:   51,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 12,
+										Line:   51,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "drop",
+									Start: ast.Position{
+										Column: 8,
+										Line:   51,
+									},
+								},
+							},
+							Name: "drop",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 46,
+								Line:   46,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "table=<-",
+							Start: ast.Position{
+								Column: 38,
+								Line:   46,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 43,
+									Line:   46,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "table",
+								Start: ast.Position{
+									Column: 38,
+									Line:   46,
+								},
+							},
+						},
+						Name: "table",
+					},
+					Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 46,
+								Line:   46,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "<-",
+							Start: ast.Position{
+								Column: 44,
+								Line:   46,
+							},
+						},
+					}},
+				}},
+			},
+		}, &ast.TestStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 124,
+							Line:   54,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "monitor_state_changes_custom_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any})",
+						Start: ast.Position{
+							Column: 6,
+							Line:   53,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 45,
+								Line:   53,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "monitor_state_changes_custom_any_to_any",
+							Start: ast.Position{
+								Column: 6,
+								Line:   53,
+							},
+						},
+					},
+					Name: "monitor_state_changes_custom_any_to_any",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 124,
+								Line:   54,
+							},
+							File:   "state_changes_custom_any_to_any_test.flux",
+							Source: "() =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any})",
+							Start: ast.Position{
+								Column: 48,
+								Line:   53,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 124,
+									Line:   54,
+								},
+								File:   "state_changes_custom_any_to_any_test.flux",
+								Source: "({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any})",
+								Start: ast.Position{
+									Column: 5,
+									Line:   54,
+								},
+							},
+						},
+						Expression: &ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 123,
+										Line:   54,
+									},
+									File:   "state_changes_custom_any_to_any_test.flux",
+									Source: "{input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any}",
+									Start: ast.Position{
+										Column: 6,
+										Line:   54,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 46,
+											Line:   54,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "input: testing.loadStorage(csv: inData)",
+										Start: ast.Position{
+											Column: 7,
+											Line:   54,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 12,
+												Line:   54,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "input",
+											Start: ast.Position{
+												Column: 7,
+												Line:   54,
+											},
+										},
+									},
+									Name: "input",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 45,
+													Line:   54,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "csv: inData",
+												Start: ast.Position{
+													Column: 34,
+													Line:   54,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 45,
+														Line:   54,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "csv: inData",
+													Start: ast.Position{
+														Column: 34,
+														Line:   54,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 37,
+															Line:   54,
+														},
+														File:   "state_changes_custom_any_to_any_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 34,
+															Line:   54,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 45,
+															Line:   54,
+														},
+														File:   "state_changes_custom_any_to_any_test.flux",
+														Source: "inData",
+														Start: ast.Position{
+															Column: 39,
+															Line:   54,
+														},
+													},
+												},
+												Name: "inData",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 46,
+												Line:   54,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "testing.loadStorage(csv: inData)",
+											Start: ast.Position{
+												Column: 14,
+												Line:   54,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   54,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "testing.loadStorage",
+												Start: ast.Position{
+													Column: 14,
+													Line:   54,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 21,
+														Line:   54,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 14,
+														Line:   54,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 33,
+														Line:   54,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "loadStorage",
+													Start: ast.Position{
+														Column: 22,
+														Line:   54,
+													},
+												},
+											},
+											Name: "loadStorage",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 83,
+											Line:   54,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "want: testing.loadMem(csv: outData)",
+										Start: ast.Position{
+											Column: 48,
+											Line:   54,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 52,
+												Line:   54,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "want",
+											Start: ast.Position{
+												Column: 48,
+												Line:   54,
+											},
+										},
+									},
+									Name: "want",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 82,
+													Line:   54,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "csv: outData",
+												Start: ast.Position{
+													Column: 70,
+													Line:   54,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 82,
+														Line:   54,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "csv: outData",
+													Start: ast.Position{
+														Column: 70,
+														Line:   54,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 73,
+															Line:   54,
+														},
+														File:   "state_changes_custom_any_to_any_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 70,
+															Line:   54,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 82,
+															Line:   54,
+														},
+														File:   "state_changes_custom_any_to_any_test.flux",
+														Source: "outData",
+														Start: ast.Position{
+															Column: 75,
+															Line:   54,
+														},
+													},
+												},
+												Name: "outData",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 83,
+												Line:   54,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "testing.loadMem(csv: outData)",
+											Start: ast.Position{
+												Column: 54,
+												Line:   54,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 69,
+													Line:   54,
+												},
+												File:   "state_changes_custom_any_to_any_test.flux",
+												Source: "testing.loadMem",
+												Start: ast.Position{
+													Column: 54,
+													Line:   54,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 61,
+														Line:   54,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 54,
+														Line:   54,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 69,
+														Line:   54,
+													},
+													File:   "state_changes_custom_any_to_any_test.flux",
+													Source: "loadMem",
+													Start: ast.Position{
+														Column: 62,
+														Line:   54,
+													},
+												},
+											},
+											Name: "loadMem",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 122,
+											Line:   54,
+										},
+										File:   "state_changes_custom_any_to_any_test.flux",
+										Source: "fn: t_state_changes_custom_any_to_any",
+										Start: ast.Position{
+											Column: 85,
+											Line:   54,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 87,
+												Line:   54,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "fn",
+											Start: ast.Position{
+												Column: 85,
+												Line:   54,
+											},
+										},
+									},
+									Name: "fn",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 122,
+												Line:   54,
+											},
+											File:   "state_changes_custom_any_to_any_test.flux",
+											Source: "t_state_changes_custom_any_to_any",
+											Start: ast.Position{
+												Column: 89,
+												Line:   54,
+											},
+										},
+									},
+									Name: "t_state_changes_custom_any_to_any",
+								},
+							}},
+							With: nil,
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 124,
+						Line:   54,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "test monitor_state_changes_custom_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any})",
+					Start: ast.Position{
+						Column: 1,
+						Line:   53,
+					},
+				},
+			},
+		}},
+		Imports: []*ast.ImportDeclaration{&ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 37,
+						Line:   3,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "import \"influxdata/influxdb/monitor\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   3,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 37,
+							Line:   3,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "\"influxdata/influxdb/monitor\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   3,
+						},
+					},
+				},
+				Value: "influxdata/influxdb/monitor",
+			},
+		}, &ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 32,
+						Line:   4,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "import \"influxdata/influxdb/v1\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   4,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 32,
+							Line:   4,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "\"influxdata/influxdb/v1\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   4,
+						},
+					},
+				},
+				Value: "influxdata/influxdb/v1",
+			},
+		}, &ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   5,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "import \"testing\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   5,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   5,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "\"testing\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   5,
+						},
+					},
+				},
+				Value: "testing",
+			},
+		}, &ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 22,
+						Line:   6,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "import \"experimental\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   6,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 22,
+							Line:   6,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "\"experimental\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   6,
+						},
+					},
+				},
+				Value: "experimental",
+			},
+		}},
+		Metadata: "parser-type=go",
+		Name:     "state_changes_custom_any_to_any_test.flux",
+		Package: &ast.PackageClause{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 21,
+						Line:   1,
+					},
+					File:   "state_changes_custom_any_to_any_test.flux",
+					Source: "package monitor_test",
+					Start: ast.Position{
+						Column: 1,
+						Line:   1,
+					},
+				},
+			},
+			Name: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 21,
+							Line:   1,
+						},
+						File:   "state_changes_custom_any_to_any_test.flux",
+						Source: "monitor_test",
+						Start: ast.Position{
+							Column: 9,
+							Line:   1,
+						},
+					},
+				},
+				Name: "monitor_test",
+			},
+		},
+	}, &ast.File{
+		BaseNode: ast.BaseNode{
+			Errors: nil,
+			Loc: &ast.SourceLocation{
+				End: ast.Position{
 					Column: 118,
 					Line:   69,
 				},
@@ -18111,10 +19922,10 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 117,
-					Line:   57,
+					Line:   60,
 				},
 				File:   "state_changes_invalid_any_to_any_test.flux",
-				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
+				Source: "package monitor_test\n\nimport \"influxdata/influxdb/monitor\"\nimport \"influxdata/influxdb/v1\"\nimport \"testing\"\nimport \"experimental\"\n\noption now = () => 2018-05-22T19:54:40Z\n\noption monitor.log = (tables=<-) => tables |> drop(columns:[\"_start\", \"_stop\"])\n\n// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.\noption monitor.sortBy = \"_time\"\n\n// Note this input data is identical to the output data of the check test case, post pivot.\ninData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"\n\noutData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n\"\n\nt_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])\n\ntest monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -18536,19 +20347,123 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					},
 				},
 			},
+		}, &ast.OptionStatement{
+			Assignment: &ast.MemberAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 32,
+							Line:   13,
+						},
+						File:   "state_changes_invalid_any_to_any_test.flux",
+						Source: "monitor.sortBy = \"_time\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   13,
+						},
+					},
+				},
+				Init: &ast.StringLiteral{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 32,
+								Line:   13,
+							},
+							File:   "state_changes_invalid_any_to_any_test.flux",
+							Source: "\"_time\"",
+							Start: ast.Position{
+								Column: 25,
+								Line:   13,
+							},
+						},
+					},
+					Value: "_time",
+				},
+				Member: &ast.MemberExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 22,
+								Line:   13,
+							},
+							File:   "state_changes_invalid_any_to_any_test.flux",
+							Source: "monitor.sortBy",
+							Start: ast.Position{
+								Column: 8,
+								Line:   13,
+							},
+						},
+					},
+					Object: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   13,
+								},
+								File:   "state_changes_invalid_any_to_any_test.flux",
+								Source: "monitor",
+								Start: ast.Position{
+									Column: 8,
+									Line:   13,
+								},
+							},
+						},
+						Name: "monitor",
+					},
+					Property: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 22,
+									Line:   13,
+								},
+								File:   "state_changes_invalid_any_to_any_test.flux",
+								Source: "sortBy",
+								Start: ast.Position{
+									Column: 16,
+									Line:   13,
+								},
+							},
+						},
+						Name: "sortBy",
+					},
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 32,
+						Line:   13,
+					},
+					File:   "state_changes_invalid_any_to_any_test.flux",
+					Source: "option monitor.sortBy = \"_time\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   13,
+					},
+				},
+			},
 		}, &ast.VariableAssignment{
 			BaseNode: ast.BaseNode{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 2,
-						Line:   37,
+						Line:   40,
 					},
 					File:   "state_changes_invalid_any_to_any_test.flux",
 					Source: "inData = \"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"",
 					Start: ast.Position{
 						Column: 1,
-						Line:   13,
+						Line:   16,
 					},
 				},
 			},
@@ -18558,13 +20473,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 7,
-							Line:   13,
+							Line:   16,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "inData",
 						Start: ast.Position{
 							Column: 1,
-							Line:   13,
+							Line:   16,
 						},
 					},
 				},
@@ -18576,13 +20491,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 2,
-							Line:   37,
+							Line:   40,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "\"\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,4.800000000000001\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,90.62382797849732\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,usage_idle,7.05\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,string\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_message,whoa!\n\n#datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,long\n#group,false,false,true,true,true,true,true,false,true,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_source_measurement,_time,_type,aaa,bbb,cpu,host,_field,_value\n,,0,000000000000000a,cpu threshold check,crit,statuses,cpu,2018-05-22T19:54:20Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018840000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018820000000000\n,,1,000000000000000a,cpu threshold check,ok,statuses,cpu,2018-05-22T19:54:22Z,threshold,vaaa,vbbb,cpu-total,host.local,_source_timestamp,1527018860000000000\n\"",
 						Start: ast.Position{
 							Column: 10,
-							Line:   13,
+							Line:   16,
 						},
 					},
 				},
@@ -18594,13 +20509,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 2,
-						Line:   45,
+						Line:   48,
 					},
 					File:   "state_changes_invalid_any_to_any_test.flux",
 					Source: "outData = \"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n\"",
 					Start: ast.Position{
 						Column: 1,
-						Line:   39,
+						Line:   42,
 					},
 				},
 			},
@@ -18610,13 +20525,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 8,
-							Line:   39,
+							Line:   42,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "outData",
 						Start: ast.Position{
 							Column: 1,
-							Line:   39,
+							Line:   42,
 						},
 					},
 				},
@@ -18628,13 +20543,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 2,
-							Line:   45,
+							Line:   48,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "\"\n#datatype,string,long,string,string,string,string,string,string,long,dateTime:RFC3339,string,string,string,string,string,double\n#group,false,false,true,true,true,true,false,true,false,false,true,true,true,true,true,false\n#default,got,,,,,,,,,,,,,,,\n,result,table,_check_id,_check_name,_level,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,aaa,bbb,cpu,host,usage_idle\n,,1,000000000000000a,cpu threshold check,ok,statuses,whoa!,cpu,1527018820000000000,2018-05-22T19:54:21Z,threshold,vaaa,vbbb,cpu-total,host.local,90.62382797849732\n\"",
 						Start: ast.Position{
 							Column: 11,
-							Line:   39,
+							Line:   42,
 						},
 					},
 				},
@@ -18646,13 +20561,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 41,
-						Line:   54,
+						Line:   57,
 					},
 					File:   "state_changes_invalid_any_to_any_test.flux",
 					Source: "t_state_changes_any_to_any = (table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
 					Start: ast.Position{
 						Column: 1,
-						Line:   47,
+						Line:   50,
 					},
 				},
 			},
@@ -18662,13 +20577,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 27,
-							Line:   47,
+							Line:   50,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "t_state_changes_any_to_any",
 						Start: ast.Position{
 							Column: 1,
-							Line:   47,
+							Line:   50,
 						},
 					},
 				},
@@ -18680,13 +20595,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 41,
-							Line:   54,
+							Line:   57,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "(table=<-) => table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
 						Start: ast.Position{
 							Column: 30,
-							Line:   47,
+							Line:   50,
 						},
 					},
 				},
@@ -18700,13 +20615,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 49,
-												Line:   47,
+												Line:   50,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "table",
 											Start: ast.Position{
 												Column: 44,
-												Line:   47,
+												Line:   50,
 											},
 										},
 									},
@@ -18717,13 +20632,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 25,
-											Line:   48,
+											Line:   51,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "table\n    |> range(start: -1m)",
 										Start: ast.Position{
 											Column: 44,
-											Line:   47,
+											Line:   50,
 										},
 									},
 								},
@@ -18734,13 +20649,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 24,
-													Line:   48,
+													Line:   51,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "start: -1m",
 												Start: ast.Position{
 													Column: 14,
-													Line:   48,
+													Line:   51,
 												},
 											},
 										},
@@ -18750,13 +20665,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 24,
-														Line:   48,
+														Line:   51,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "start: -1m",
 													Start: ast.Position{
 														Column: 14,
-														Line:   48,
+														Line:   51,
 													},
 												},
 											},
@@ -18766,13 +20681,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 19,
-															Line:   48,
+															Line:   51,
 														},
 														File:   "state_changes_invalid_any_to_any_test.flux",
 														Source: "start",
 														Start: ast.Position{
 															Column: 14,
-															Line:   48,
+															Line:   51,
 														},
 													},
 												},
@@ -18785,13 +20700,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 24,
-																Line:   48,
+																Line:   51,
 															},
 															File:   "state_changes_invalid_any_to_any_test.flux",
 															Source: "1m",
 															Start: ast.Position{
 																Column: 22,
-																Line:   48,
+																Line:   51,
 															},
 														},
 													},
@@ -18805,13 +20720,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 24,
-															Line:   48,
+															Line:   51,
 														},
 														File:   "state_changes_invalid_any_to_any_test.flux",
 														Source: "-1m",
 														Start: ast.Position{
 															Column: 21,
-															Line:   48,
+															Line:   51,
 														},
 													},
 												},
@@ -18825,13 +20740,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 25,
-												Line:   48,
+												Line:   51,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "range(start: -1m)",
 											Start: ast.Position{
 												Column: 8,
-												Line:   48,
+												Line:   51,
 											},
 										},
 									},
@@ -18841,13 +20756,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 13,
-													Line:   48,
+													Line:   51,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "range",
 												Start: ast.Position{
 													Column: 8,
-													Line:   48,
+													Line:   51,
 												},
 											},
 										},
@@ -18860,13 +20775,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 25,
-										Line:   49,
+										Line:   52,
 									},
 									File:   "state_changes_invalid_any_to_any_test.flux",
 									Source: "table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()",
 									Start: ast.Position{
 										Column: 44,
-										Line:   47,
+										Line:   50,
 									},
 								},
 							},
@@ -18877,13 +20792,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 25,
-											Line:   49,
+											Line:   52,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "v1.fieldsAsCols()",
 										Start: ast.Position{
 											Column: 8,
-											Line:   49,
+											Line:   52,
 										},
 									},
 								},
@@ -18893,13 +20808,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   49,
+												Line:   52,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "v1.fieldsAsCols",
 											Start: ast.Position{
 												Column: 8,
-												Line:   49,
+												Line:   52,
 											},
 										},
 									},
@@ -18909,13 +20824,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 10,
-													Line:   49,
+													Line:   52,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "v1",
 												Start: ast.Position{
 													Column: 8,
-													Line:   49,
+													Line:   52,
 												},
 											},
 										},
@@ -18927,13 +20842,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 23,
-													Line:   49,
+													Line:   52,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "fieldsAsCols",
 												Start: ast.Position{
 													Column: 11,
-													Line:   49,
+													Line:   52,
 												},
 											},
 										},
@@ -18947,13 +20862,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   53,
+									Line:   56,
 								},
 								File:   "state_changes_invalid_any_to_any_test.flux",
 								Source: "table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )",
 								Start: ast.Position{
 									Column: 44,
-									Line:   47,
+									Line:   50,
 								},
 							},
 						},
@@ -18964,13 +20879,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 23,
-											Line:   52,
+											Line:   55,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "fromLevel: \"any\",\n        toLevel: \"any\"",
 										Start: ast.Position{
 											Column: 9,
-											Line:   51,
+											Line:   54,
 										},
 									},
 								},
@@ -18980,13 +20895,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 25,
-												Line:   51,
+												Line:   54,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "fromLevel: \"any\"",
 											Start: ast.Position{
 												Column: 9,
-												Line:   51,
+												Line:   54,
 											},
 										},
 									},
@@ -18996,13 +20911,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 18,
-													Line:   51,
+													Line:   54,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "fromLevel",
 												Start: ast.Position{
 													Column: 9,
-													Line:   51,
+													Line:   54,
 												},
 											},
 										},
@@ -19014,13 +20929,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 25,
-													Line:   51,
+													Line:   54,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "\"any\"",
 												Start: ast.Position{
 													Column: 20,
-													Line:   51,
+													Line:   54,
 												},
 											},
 										},
@@ -19032,13 +20947,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   52,
+												Line:   55,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "toLevel: \"any\"",
 											Start: ast.Position{
 												Column: 9,
-												Line:   52,
+												Line:   55,
 											},
 										},
 									},
@@ -19048,13 +20963,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 16,
-													Line:   52,
+													Line:   55,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "toLevel",
 												Start: ast.Position{
 													Column: 9,
-													Line:   52,
+													Line:   55,
 												},
 											},
 										},
@@ -19066,13 +20981,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 23,
-													Line:   52,
+													Line:   55,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "\"any\"",
 												Start: ast.Position{
 													Column: 18,
-													Line:   52,
+													Line:   55,
 												},
 											},
 										},
@@ -19086,13 +21001,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 6,
-										Line:   53,
+										Line:   56,
 									},
 									File:   "state_changes_invalid_any_to_any_test.flux",
 									Source: "monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )",
 									Start: ast.Position{
 										Column: 8,
-										Line:   50,
+										Line:   53,
 									},
 								},
 							},
@@ -19102,13 +21017,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 28,
-											Line:   50,
+											Line:   53,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "monitor.stateChanges",
 										Start: ast.Position{
 											Column: 8,
-											Line:   50,
+											Line:   53,
 										},
 									},
 								},
@@ -19118,13 +21033,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 15,
-												Line:   50,
+												Line:   53,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "monitor",
 											Start: ast.Position{
 												Column: 8,
-												Line:   50,
+												Line:   53,
 											},
 										},
 									},
@@ -19136,13 +21051,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 28,
-												Line:   50,
+												Line:   53,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "stateChanges",
 											Start: ast.Position{
 												Column: 16,
-												Line:   50,
+												Line:   53,
 											},
 										},
 									},
@@ -19156,13 +21071,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 41,
-								Line:   54,
+								Line:   57,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
 							Source: "table\n    |> range(start: -1m)\n    |> v1.fieldsAsCols()\n    |> monitor.stateChanges(\n        fromLevel: \"any\",\n        toLevel: \"any\",\n    )\n    |> drop(columns: [\"_start\",\"_stop\"])",
 							Start: ast.Position{
 								Column: 44,
-								Line:   47,
+								Line:   50,
 							},
 						},
 					},
@@ -19173,13 +21088,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 40,
-										Line:   54,
+										Line:   57,
 									},
 									File:   "state_changes_invalid_any_to_any_test.flux",
 									Source: "columns: [\"_start\",\"_stop\"]",
 									Start: ast.Position{
 										Column: 13,
-										Line:   54,
+										Line:   57,
 									},
 								},
 							},
@@ -19189,13 +21104,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 40,
-											Line:   54,
+											Line:   57,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "columns: [\"_start\",\"_stop\"]",
 										Start: ast.Position{
 											Column: 13,
-											Line:   54,
+											Line:   57,
 										},
 									},
 								},
@@ -19205,13 +21120,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 20,
-												Line:   54,
+												Line:   57,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "columns",
 											Start: ast.Position{
 												Column: 13,
-												Line:   54,
+												Line:   57,
 											},
 										},
 									},
@@ -19223,13 +21138,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 40,
-												Line:   54,
+												Line:   57,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "[\"_start\",\"_stop\"]",
 											Start: ast.Position{
 												Column: 22,
-												Line:   54,
+												Line:   57,
 											},
 										},
 									},
@@ -19239,13 +21154,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 31,
-													Line:   54,
+													Line:   57,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "\"_start\"",
 												Start: ast.Position{
 													Column: 23,
-													Line:   54,
+													Line:   57,
 												},
 											},
 										},
@@ -19256,13 +21171,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 39,
-													Line:   54,
+													Line:   57,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "\"_stop\"",
 												Start: ast.Position{
 													Column: 32,
-													Line:   54,
+													Line:   57,
 												},
 											},
 										},
@@ -19277,13 +21192,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 41,
-									Line:   54,
+									Line:   57,
 								},
 								File:   "state_changes_invalid_any_to_any_test.flux",
 								Source: "drop(columns: [\"_start\",\"_stop\"])",
 								Start: ast.Position{
 									Column: 8,
-									Line:   54,
+									Line:   57,
 								},
 							},
 						},
@@ -19293,13 +21208,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 12,
-										Line:   54,
+										Line:   57,
 									},
 									File:   "state_changes_invalid_any_to_any_test.flux",
 									Source: "drop",
 									Start: ast.Position{
 										Column: 8,
-										Line:   54,
+										Line:   57,
 									},
 								},
 							},
@@ -19313,13 +21228,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 39,
-								Line:   47,
+								Line:   50,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
 							Source: "table=<-",
 							Start: ast.Position{
 								Column: 31,
-								Line:   47,
+								Line:   50,
 							},
 						},
 					},
@@ -19329,13 +21244,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 36,
-									Line:   47,
+									Line:   50,
 								},
 								File:   "state_changes_invalid_any_to_any_test.flux",
 								Source: "table",
 								Start: ast.Position{
 									Column: 31,
-									Line:   47,
+									Line:   50,
 								},
 							},
 						},
@@ -19346,13 +21261,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 39,
-								Line:   47,
+								Line:   50,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
 							Source: "<-",
 							Start: ast.Position{
 								Column: 37,
-								Line:   47,
+								Line:   50,
 							},
 						},
 					}},
@@ -19365,13 +21280,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 117,
-							Line:   57,
+							Line:   60,
 						},
 						File:   "state_changes_invalid_any_to_any_test.flux",
 						Source: "monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 						Start: ast.Position{
 							Column: 6,
-							Line:   56,
+							Line:   59,
 						},
 					},
 				},
@@ -19381,13 +21296,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 38,
-								Line:   56,
+								Line:   59,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
 							Source: "monitor_state_changes_any_to_any",
 							Start: ast.Position{
 								Column: 6,
-								Line:   56,
+								Line:   59,
 							},
 						},
 					},
@@ -19399,13 +21314,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 117,
-								Line:   57,
+								Line:   60,
 							},
 							File:   "state_changes_invalid_any_to_any_test.flux",
 							Source: "() =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 							Start: ast.Position{
 								Column: 41,
-								Line:   56,
+								Line:   59,
 							},
 						},
 					},
@@ -19415,13 +21330,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 117,
-									Line:   57,
+									Line:   60,
 								},
 								File:   "state_changes_invalid_any_to_any_test.flux",
 								Source: "({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 								Start: ast.Position{
 									Column: 5,
-									Line:   57,
+									Line:   60,
 								},
 							},
 						},
@@ -19431,13 +21346,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 116,
-										Line:   57,
+										Line:   60,
 									},
 									File:   "state_changes_invalid_any_to_any_test.flux",
 									Source: "{input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any}",
 									Start: ast.Position{
 										Column: 6,
-										Line:   57,
+										Line:   60,
 									},
 								},
 							},
@@ -19447,13 +21362,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 46,
-											Line:   57,
+											Line:   60,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "input: testing.loadStorage(csv: inData)",
 										Start: ast.Position{
 											Column: 7,
-											Line:   57,
+											Line:   60,
 										},
 									},
 								},
@@ -19463,13 +21378,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 12,
-												Line:   57,
+												Line:   60,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "input",
 											Start: ast.Position{
 												Column: 7,
-												Line:   57,
+												Line:   60,
 											},
 										},
 									},
@@ -19482,13 +21397,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 45,
-													Line:   57,
+													Line:   60,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "csv: inData",
 												Start: ast.Position{
 													Column: 34,
-													Line:   57,
+													Line:   60,
 												},
 											},
 										},
@@ -19498,13 +21413,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 45,
-														Line:   57,
+														Line:   60,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "csv: inData",
 													Start: ast.Position{
 														Column: 34,
-														Line:   57,
+														Line:   60,
 													},
 												},
 											},
@@ -19514,13 +21429,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 37,
-															Line:   57,
+															Line:   60,
 														},
 														File:   "state_changes_invalid_any_to_any_test.flux",
 														Source: "csv",
 														Start: ast.Position{
 															Column: 34,
-															Line:   57,
+															Line:   60,
 														},
 													},
 												},
@@ -19532,13 +21447,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 45,
-															Line:   57,
+															Line:   60,
 														},
 														File:   "state_changes_invalid_any_to_any_test.flux",
 														Source: "inData",
 														Start: ast.Position{
 															Column: 39,
-															Line:   57,
+															Line:   60,
 														},
 													},
 												},
@@ -19552,13 +21467,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 46,
-												Line:   57,
+												Line:   60,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "testing.loadStorage(csv: inData)",
 											Start: ast.Position{
 												Column: 14,
-												Line:   57,
+												Line:   60,
 											},
 										},
 									},
@@ -19568,13 +21483,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 33,
-													Line:   57,
+													Line:   60,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "testing.loadStorage",
 												Start: ast.Position{
 													Column: 14,
-													Line:   57,
+													Line:   60,
 												},
 											},
 										},
@@ -19584,13 +21499,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 21,
-														Line:   57,
+														Line:   60,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "testing",
 													Start: ast.Position{
 														Column: 14,
-														Line:   57,
+														Line:   60,
 													},
 												},
 											},
@@ -19602,13 +21517,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 33,
-														Line:   57,
+														Line:   60,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "loadStorage",
 													Start: ast.Position{
 														Column: 22,
-														Line:   57,
+														Line:   60,
 													},
 												},
 											},
@@ -19622,13 +21537,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 83,
-											Line:   57,
+											Line:   60,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "want: testing.loadMem(csv: outData)",
 										Start: ast.Position{
 											Column: 48,
-											Line:   57,
+											Line:   60,
 										},
 									},
 								},
@@ -19638,13 +21553,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 52,
-												Line:   57,
+												Line:   60,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "want",
 											Start: ast.Position{
 												Column: 48,
-												Line:   57,
+												Line:   60,
 											},
 										},
 									},
@@ -19657,13 +21572,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 82,
-													Line:   57,
+													Line:   60,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "csv: outData",
 												Start: ast.Position{
 													Column: 70,
-													Line:   57,
+													Line:   60,
 												},
 											},
 										},
@@ -19673,13 +21588,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 82,
-														Line:   57,
+														Line:   60,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "csv: outData",
 													Start: ast.Position{
 														Column: 70,
-														Line:   57,
+														Line:   60,
 													},
 												},
 											},
@@ -19689,13 +21604,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 73,
-															Line:   57,
+															Line:   60,
 														},
 														File:   "state_changes_invalid_any_to_any_test.flux",
 														Source: "csv",
 														Start: ast.Position{
 															Column: 70,
-															Line:   57,
+															Line:   60,
 														},
 													},
 												},
@@ -19707,13 +21622,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 82,
-															Line:   57,
+															Line:   60,
 														},
 														File:   "state_changes_invalid_any_to_any_test.flux",
 														Source: "outData",
 														Start: ast.Position{
 															Column: 75,
-															Line:   57,
+															Line:   60,
 														},
 													},
 												},
@@ -19727,13 +21642,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 83,
-												Line:   57,
+												Line:   60,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "testing.loadMem(csv: outData)",
 											Start: ast.Position{
 												Column: 54,
-												Line:   57,
+												Line:   60,
 											},
 										},
 									},
@@ -19743,13 +21658,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 69,
-													Line:   57,
+													Line:   60,
 												},
 												File:   "state_changes_invalid_any_to_any_test.flux",
 												Source: "testing.loadMem",
 												Start: ast.Position{
 													Column: 54,
-													Line:   57,
+													Line:   60,
 												},
 											},
 										},
@@ -19759,13 +21674,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 61,
-														Line:   57,
+														Line:   60,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "testing",
 													Start: ast.Position{
 														Column: 54,
-														Line:   57,
+														Line:   60,
 													},
 												},
 											},
@@ -19777,13 +21692,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 69,
-														Line:   57,
+														Line:   60,
 													},
 													File:   "state_changes_invalid_any_to_any_test.flux",
 													Source: "loadMem",
 													Start: ast.Position{
 														Column: 62,
-														Line:   57,
+														Line:   60,
 													},
 												},
 											},
@@ -19797,13 +21712,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 115,
-											Line:   57,
+											Line:   60,
 										},
 										File:   "state_changes_invalid_any_to_any_test.flux",
 										Source: "fn: t_state_changes_any_to_any",
 										Start: ast.Position{
 											Column: 85,
-											Line:   57,
+											Line:   60,
 										},
 									},
 								},
@@ -19813,13 +21728,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 87,
-												Line:   57,
+												Line:   60,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "fn",
 											Start: ast.Position{
 												Column: 85,
-												Line:   57,
+												Line:   60,
 											},
 										},
 									},
@@ -19831,13 +21746,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 115,
-												Line:   57,
+												Line:   60,
 											},
 											File:   "state_changes_invalid_any_to_any_test.flux",
 											Source: "t_state_changes_any_to_any",
 											Start: ast.Position{
 												Column: 89,
-												Line:   57,
+												Line:   60,
 											},
 										},
 									},
@@ -19855,13 +21770,13 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 117,
-						Line:   57,
+						Line:   60,
 					},
 					File:   "state_changes_invalid_any_to_any_test.flux",
 					Source: "test monitor_state_changes_any_to_any = () =>\n    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_any_to_any})",
 					Start: ast.Position{
 						Column: 1,
-						Line:   56,
+						Line:   59,
 					},
 				},
 			},

--- a/stdlib/influxdata/influxdb/monitor/monitor.flux
+++ b/stdlib/influxdata/influxdb/monitor/monitor.flux
@@ -12,6 +12,9 @@ option write = (tables=<-) => tables |> experimental.to(bucket: bucket)
 // Log records notification events
 option log = (tables=<-) => tables |> experimental.to(bucket: bucket)
 
+// Column by which to sort statuses by
+option sortBy = "_source_timestamp"
+
 // From retrieves the check statuses that have been stored.
 from = (start, stop=now(), fn=(r) => true) =>
     influxdb.from(bucket: bucket)
@@ -41,7 +44,7 @@ _stateChanges = (fromLevel="any", toLevel="any", tables=<-) => {
         |> duplicate(column: "_level", as: "____temp_level____")
         |> drop(columns: ["_level"])
         |> rename(columns: {"____temp_level____": "_level"})
-        |> sort(columns: ["_time"], desc: false)
+        |> sort(columns: [sortBy], desc: false)
         |> difference(columns: ["level_value"])
         |> filter(fn: (r) => r.level_value == 1)
         |> drop(columns: ["level_value"])
@@ -61,7 +64,7 @@ stateChangesOnly = (tables=<-) => {
         |> duplicate(column: "_level", as: "____temp_level____")
         |> drop(columns: ["_level"])
         |> rename(columns: {"____temp_level____": "_level"})
-        |> sort(columns: ["_time"], desc: false)
+        |> sort(columns: [sortBy], desc: false)
         |> difference(columns: ["level_value"])
         |> filter(fn: (r) => r.level_value != 0)
         |> drop(columns: ["level_value"])

--- a/stdlib/influxdata/influxdb/monitor/monitor.flux
+++ b/stdlib/influxdata/influxdb/monitor/monitor.flux
@@ -12,8 +12,8 @@ option write = (tables=<-) => tables |> experimental.to(bucket: bucket)
 // Log records notification events
 option log = (tables=<-) => tables |> experimental.to(bucket: bucket)
 
-// Column by which to sort statuses by
-option sortBy = "_source_timestamp"
+// Reorder sorts statuses before difference computation
+option reorder = (tables=<-) => tables |> sort(columns: ["_source_timestamp"], desc: false)
 
 // From retrieves the check statuses that have been stored.
 from = (start, stop=now(), fn=(r) => true) =>
@@ -44,7 +44,7 @@ _stateChanges = (fromLevel="any", toLevel="any", tables=<-) => {
         |> duplicate(column: "_level", as: "____temp_level____")
         |> drop(columns: ["_level"])
         |> rename(columns: {"____temp_level____": "_level"})
-        |> sort(columns: [sortBy], desc: false)
+        |> reorder()
         |> difference(columns: ["level_value"])
         |> filter(fn: (r) => r.level_value == 1)
         |> drop(columns: ["level_value"])
@@ -64,7 +64,7 @@ stateChangesOnly = (tables=<-) => {
         |> duplicate(column: "_level", as: "____temp_level____")
         |> drop(columns: ["_level"])
         |> rename(columns: {"____temp_level____": "_level"})
-        |> sort(columns: [sortBy], desc: false)
+        |> reorder()
         |> difference(columns: ["level_value"])
         |> filter(fn: (r) => r.level_value != 0)
         |> drop(columns: ["level_value"])

--- a/stdlib/influxdata/influxdb/monitor/state_changes_any_to_any_test.flux
+++ b/stdlib/influxdata/influxdb/monitor/state_changes_any_to_any_test.flux
@@ -9,8 +9,8 @@ option now = () => 2018-05-22T19:54:40Z
 
 option monitor.log = (tables=<-) => tables |> drop(columns:["_start", "_stop"])
 
-// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.
-option monitor.sortBy = "_time"
+// Expected result is based on order by `_time` (order by `_source_timestamp` differs).
+option monitor.reorder = (tables=<-) => tables |> sort(columns: ["_time"], desc: false)
 
 // Note this input data is identical to the output data of the check test case, post pivot.
 inData = "

--- a/stdlib/influxdata/influxdb/monitor/state_changes_any_to_any_test.flux
+++ b/stdlib/influxdata/influxdb/monitor/state_changes_any_to_any_test.flux
@@ -9,6 +9,9 @@ option now = () => 2018-05-22T19:54:40Z
 
 option monitor.log = (tables=<-) => tables |> drop(columns:["_start", "_stop"])
 
+// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.
+option monitor.sortBy = "_time"
+
 // Note this input data is identical to the output data of the check test case, post pivot.
 inData = "
 #datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double

--- a/stdlib/influxdata/influxdb/monitor/state_changes_custom_any_to_any_test.flux
+++ b/stdlib/influxdata/influxdb/monitor/state_changes_custom_any_to_any_test.flux
@@ -1,0 +1,54 @@
+package monitor_test
+
+import "influxdata/influxdb/monitor"
+import "influxdata/influxdb/v1"
+import "testing"
+import "experimental"
+
+option now = () => 2018-05-22T19:54:40Z
+
+option monitor.log = (tables=<-) => tables |> drop(columns:["_start", "_stop"])
+
+// These statuses were produce by custom check query
+inData = "
+#group,false,false,false,true,true,true,true,true,true,true,false,false,false,false
+#datatype,string,long,dateTime:RFC3339,string,string,string,string,string,string,string,string,long,double,double
+#default,_result,,,,,,,,,,,,,
+,result,table,_time,_check_id,_check_name,_level,_measurement,_source_measurement,_type,id,_message,_source_timestamp,lat,lon
+,,0,2020-04-01T13:19:00.734009512Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787
+,,0,2020-04-01T13:19:00.734068665Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787
+,,0,2020-04-01T13:20:01.055589553Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747116000000000,40.676922,-73.76787
+,,0,2020-04-01T13:20:01.055681722Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747134000000000,40.676922,-73.76787
+,,0,2020-04-01T13:20:01.055731206Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747151000000000,40.676922,-73.76787
+,,0,2020-04-01T13:20:01.055757119Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747168000000000,40.676922,-73.76787
+,,0,2020-04-01T13:20:01.055841776Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747185000000000,40.676922,-73.76787
+,,0,2020-04-01T13:25:01.120735321Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747203000000000,40.676922,-73.76787
+,,0,2020-04-01T13:25:01.120827394Z,000000000000000a,LLIR,ok,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is in,1585747219000000000,40.676922,-73.76787
+,,1,2020-04-01T13:25:01.119696459Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747271000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.119812609Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747288000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.119843339Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747304000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.119944446Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747322000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.119986133Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747339000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.12003354Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747356000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.120075771Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747374000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.120119872Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747390000000000,40.699608,-73.80853
+,,1,2020-04-01T13:25:01.120620071Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747237000000000,40.70075,-73.804858
+,,1,2020-04-01T13:25:01.120707032Z,000000000000000a,LLIR,warn,statuses,mta,custom,GO506_20_8813,GO506_20_8813 is out,1585747254000000000,40.70075,-73.804858"
+
+outData = "
+#group,false,false,true,true,true,false,true,false,false,true,true,false,false,true
+#datatype,string,long,string,string,string,string,string,long,dateTime:RFC3339,string,string,double,double,string
+#default,_result,,,,,,,,,,,,,
+,result,table,_check_id,_check_name,_measurement,_message,_source_measurement,_source_timestamp,_time,_type,id,lat,lon,_level
+,,0,000000000000000a,LLIR,statuses,GO506_20_8813 is out,mta,1585747237000000000,2020-04-01T13:25:01.120620071Z,custom,GO506_20_8813,40.70075,-73.804858,warn
+"
+
+t_state_changes_custom_any_to_any = (table=<-) => table
+    |> monitor.stateChanges(
+        fromLevel: "any",
+        toLevel: "any",
+    )
+    |> drop(columns: ["_start","_stop"])
+
+test monitor_state_changes_custom_any_to_any = () =>
+    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_state_changes_custom_any_to_any})

--- a/stdlib/influxdata/influxdb/monitor/state_changes_invalid_any_to_any_test.flux
+++ b/stdlib/influxdata/influxdb/monitor/state_changes_invalid_any_to_any_test.flux
@@ -9,8 +9,8 @@ option now = () => 2018-05-22T19:54:40Z
 
 option monitor.log = (tables=<-) => tables |> drop(columns:["_start", "_stop"])
 
-// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.
-option monitor.sortBy = "_time"
+// Expected result is based on order by `_time` (order by `_source_timestamp` differs).
+option monitor.reorder = (tables=<-) => tables |> sort(columns: ["_time"], desc: false)
 
 // Note this input data is identical to the output data of the check test case, post pivot.
 inData = "

--- a/stdlib/influxdata/influxdb/monitor/state_changes_invalid_any_to_any_test.flux
+++ b/stdlib/influxdata/influxdb/monitor/state_changes_invalid_any_to_any_test.flux
@@ -9,6 +9,9 @@ option now = () => 2018-05-22T19:54:40Z
 
 option monitor.log = (tables=<-) => tables |> drop(columns:["_start", "_stop"])
 
+// Change sort column because expected result is based on order by _time, but order by _source_timestamp differs.
+option monitor.sortBy = "_time"
+
 // Note this input data is identical to the output data of the check test case, post pivot.
 inData = "
 #datatype,string,long,string,string,string,string,string,dateTime:RFC3339,string,string,string,string,string,string,double


### PR DESCRIPTION
This PR make the column by which statuses are sorted optional with default `_source_timestamp`. Sort by `_source_timestamp` is the natural order of statuses. The `_time` column is the time when check was run and the order may differ from the original.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
