### PR TITLE
fix: address deleted state GroupLookup

### DIFF
--- a/execute/group_lookup_test.go
+++ b/execute/group_lookup_test.go
@@ -179,6 +179,11 @@ func testGroupLookup(t *testing.T, l table.KeyLookup) {
 	if _, ok := l.Lookup(key3); ok {
 		t.Error("failed to delete key3")
 	}
+
+	l.Set(key1, 1)
+	if v, ok := l.Lookup(key1); !ok || v != 1 {
+		t.Error("failed to lookup key1")
+	}
 }
 
 func TestGroupLookup(t *testing.T) {


### PR DESCRIPTION
When `GroupLookup` needs to insert an item in the middle of a group key,
it must split it into to group keys. When the split happens, the
`deleted` property is not decremented for items moved to another
`groupKeyList`. This patch decrements for those items.
