### PR TITLE
feat(libflux): add small performance optimizations

### DIFF
--- a/libflux/src/core/formatter/mod.rs
+++ b/libflux/src/core/formatter/mod.rs
@@ -96,12 +96,12 @@ impl Formatter {
             }
         }
 
-        for i in 0..n.imports.len() {
+        for (i, value) in n.imports.iter().enumerate() {
             if i != 0 {
                 self.write_rune(sep)
             }
             self.write_indent();
-            self.format_import_declaration(n.imports.get(i).unwrap())
+            self.format_import_declaration(value)
         }
         if !n.imports.is_empty() && !n.body.is_empty() {
             self.write_rune(sep);
@@ -109,7 +109,7 @@ impl Formatter {
         }
 
         let mut prev: i8 = -1;
-        for i in 0..n.body.len() {
+        for (i, value) in n.body.iter().enumerate() {
             let cur = n.body.get(i).unwrap().typ();
             if i != 0 {
                 self.write_rune(sep);
@@ -119,7 +119,7 @@ impl Formatter {
                 }
             }
             self.write_indent();
-            self.format_node(&Node::from_stmt(n.body.get(i).unwrap()));
+            self.format_node(&Node::from_stmt(value));
             prev = cur;
         }
     }
@@ -181,12 +181,11 @@ impl Formatter {
             },
             base: ast::BaseNode::default(),
         });
-        for i in 0..n.files.len() {
+        for (i, file) in n.files.iter().enumerate() {
             if i != 0 {
                 self.write_rune('\n');
                 self.write_rune('\n');
             }
-            let file = n.files.get(i).unwrap();
             if !file.name.is_empty() {
                 self.write_comment(&file.name);
             }
@@ -205,12 +204,12 @@ impl Formatter {
     fn format_function_expression(&mut self, n: &ast::FunctionExpr) {
         self.write_rune('(');
         let sep = ", ";
-        for i in 0..n.params.len() {
+        for (i, value) in n.params.iter().enumerate() {
             if i != 0 {
                 self.write_string(sep)
             }
             // treat properties differently than in general case
-            self.format_function_argument(n.params.get(i).unwrap())
+            self.format_function_argument(value)
         }
         self.write_string(") =>");
         // must wrap body with parenthesis in order to discriminate between:
@@ -284,11 +283,11 @@ impl Formatter {
     fn format_array_expression(&mut self, n: &ast::ArrayExpr) {
         self.write_rune('[');
         let sep = ", ";
-        for i in 0..n.elements.len() {
+        for (i, value) in n.elements.iter().enumerate() {
             if i != 0 {
                 self.write_string(sep)
             }
-            self.format_node(&Node::from_expr(n.elements.get(i).unwrap()));
+            self.format_node(&Node::from_expr(value));
         }
         self.write_rune(']')
     }
@@ -308,8 +307,7 @@ impl Formatter {
         }
 
         let mut prev: i8 = -1;
-        for i in 0..n.body.len() {
-            let smt = n.body.get(i).unwrap();
+        for (i, smt) in n.body.iter().enumerate() {
             let cur = smt.typ();
             self.write_rune(sep);
 
@@ -417,11 +415,10 @@ impl Formatter {
         self.format_child_with_parens(Node::CallExpr(n), Node::from_expr(&n.callee));
         self.write_rune('(');
         let sep = ", ";
-        for i in 0..n.arguments.len() {
+        for (i, c) in n.arguments.iter().enumerate() {
             if i != 0 {
                 self.write_string(sep);
             }
-            let c = n.arguments.get(i).unwrap();
             match c {
                 ast::Expression::Object(s) => self.format_object_expression_as_function_argument(s),
                 _ => self.format_node(&Node::from_expr(c)),
@@ -457,14 +454,14 @@ impl Formatter {
         } else {
             sep = ", "
         }
-        for i in 0..n.properties.len() {
+        for (i, value) in n.properties.iter().enumerate() {
             if i != 0 {
                 self.write_string(sep);
                 if multiline {
                     self.write_indent()
                 }
             }
-            self.format_node(&Node::Property(n.properties.get(i).unwrap()));
+            self.format_node(&Node::Property(value));
         }
         if multiline {
             self.write_string(sep);

--- a/libflux/src/core/semantic/flatbuffers/types.rs
+++ b/libflux/src/core/semantic/flatbuffers/types.rs
@@ -33,8 +33,8 @@ impl From<fb::TypeEnvironment<'_>> for Option<Environment> {
     fn from(env: fb::TypeEnvironment) -> Option<Environment> {
         let env = env.assignments()?;
         let mut types = PolyTypeMap::new();
-        for i in 0..env.len() {
-            let assignment: Option<(String, PolyType)> = env.get(i).into();
+        for value in env.iter() {
+            let assignment: Option<(String, PolyType)> = value.into();
             let (id, ty) = assignment?;
             types.insert(id, ty);
         }
@@ -54,13 +54,13 @@ impl From<fb::PolyType<'_>> for Option<PolyType> {
     fn from(t: fb::PolyType) -> Option<PolyType> {
         let v = t.vars()?;
         let mut vars = Vec::new();
-        for i in 0..v.len() {
-            vars.push(v.get(i).into());
+        for value in v.iter() {
+            vars.push(value.into());
         }
         let c = t.cons()?;
         let mut cons = TvarKinds::new();
-        for i in 0..c.len() {
-            let constraint: Option<(Tvar, Kind)> = c.get(i).into();
+        for value in c.iter() {
+            let constraint: Option<(Tvar, Kind)> = value.into();
             let (tv, kind) = constraint?;
             cons.entry(tv).or_insert_with(Vec::new).push(kind);
         }
@@ -168,8 +168,8 @@ impl From<fb::Row<'_>> for Option<MonoType> {
             Some(tv) => MonoType::Var(tv.into()),
         };
         let p = t.props()?;
-        for i in (0..p.len()).rev() {
-            let prop: Option<Property> = p.get(i).into();
+        for value in p.iter().rev() {
+            let prop: Option<Property> = value.into();
             r = MonoType::Row(Box::new(Row::Extension {
                 head: prop?,
                 tail: r,
@@ -194,8 +194,8 @@ impl From<fb::Fun<'_>> for Option<Function> {
         let mut req = MonoTypeMap::new();
         let mut opt = MonoTypeMap::new();
         let mut pipe = None;
-        for i in 0..args.len() {
-            match args.get(i).into() {
+        for value in args.iter() {
+            match value.into() {
                 None => {
                     return None;
                 }


### PR DESCRIPTION
This patch makes a (very) small performance change by embracing
iterators in rust, making it more idiomatic.

Consider the following:

    for i in 0..my_vec.len() {
      let value = my_vec.get(i).unwrap();
      // do something with value
    }

Since rust prioritizes safety, a call to `get` does a bounds check in
both directions on each call. For a small vector, that's probably not
too much of a performance hit, but a larger sampling would certainly see
the impact of those continued bounds checks. By using rust's iterators,
one can guarantee the safety of the operation with the bounds checks
around `get` as well as the potential runtime failure of `unwrap`.
