### PR TITLE
fix(compiler): compute function's return type after substitution

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -62,7 +62,6 @@ func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) 
 	}
 	return compiledFn{
 		root:       root,
-		fnType:     fnType,
 		inputScope: nestScope(scope),
 	}, nil
 }

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -26,7 +26,6 @@ type Evaluator interface {
 
 type compiledFn struct {
 	root       Evaluator
-	fnType     semantic.MonoType
 	inputScope Scope
 }
 
@@ -38,13 +37,8 @@ func (c compiledFn) buildScope(input values.Object) error {
 }
 
 // Type returns the return type of the compiled function.
-// Will panic if assigned type is not a function type.
 func (c compiledFn) Type() semantic.MonoType {
-	rt, err := c.fnType.ReturnType()
-	if err != nil {
-		panic(err)
-	}
-	return rt
+	return c.root.Type()
 }
 
 func (c compiledFn) Eval(ctx context.Context, input values.Object) (values.Value, error) {

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -124,6 +124,41 @@ func TestMap_Process(t *testing.T) {
 		wantErr error
 	}{
 		{
+			name: `identity function`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, "(r) => r"),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+					{execute.Time(3), nil},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), nil},
+				},
+			}},
+			want: []*executetest.Table{{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), 1.0},
+					{execute.Time(2), 6.0},
+					{execute.Time(3), nil},
+					{execute.Time(4), 7.0},
+					{execute.Time(5), nil},
+				},
+			}},
+		},
+		{
 			name: `_value+5`,
 			spec: &universe.MapProcedureSpec{
 				Fn: interpreter.ResolvedFunction{


### PR DESCRIPTION
Fixes https://github.com/influxdata/flux/issues/2690.

The identify function's type is `forall [t0] (r: t0) -> t0`. However when evaluating the identity function inside `map`, we instantiate it with a new type for every table. Previously we were not using the instantiated type and so `map` would error when it saw a type variable as the output type. Now `compiledFn` returns the instantiated type as its return type.