### PR TITLE
feat(semantic): add semantic nodes for bad statement and bad expression

### DIFF
--- a/libflux/src/core/semantic/flatbuffers/mod.rs
+++ b/libflux/src/core/semantic/flatbuffers/mod.rs
@@ -229,6 +229,9 @@ impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
                 ))
             }
 
+            walk::Node::BadStmt(e) => unimplemented!(),
+            walk::Node::BadExpr(e) => unimplemented!(),
+
             walk::Node::IdentifierExpr(id) => {
                 let name = v.create_string(&id.name);
                 let id_typ = id.typ.clone();

--- a/libflux/src/core/semantic/infer.rs
+++ b/libflux/src/core/semantic/infer.rs
@@ -62,7 +62,7 @@ impl From<Constraint> for Constraints {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Error {
     msg: String,
 }

--- a/libflux/src/core/semantic/nodes.rs
+++ b/libflux/src/core/semantic/nodes.rs
@@ -33,7 +33,7 @@ use std::vec::Vec;
 // updated type environment and a set of type constraints to be solved.
 pub type Result = std::result::Result<(Environment, Constraints), Error>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     Inference(infer::Error),
     UndefinedBuiltin(String, ast::SourceLocation),
@@ -42,6 +42,7 @@ pub enum Error {
     InvalidUnaryOp(ast::Operator, ast::SourceLocation),
     InvalidImportPath(String, ast::SourceLocation),
     InvalidReturn(ast::SourceLocation),
+    ASTError(String, ast::SourceLocation),
 }
 
 impl fmt::Display for Error {
@@ -70,6 +71,7 @@ impl fmt::Display for Error {
                 write!(f, "error {}: invalid import path {}", loc, path)
             }
             Error::InvalidReturn(loc) => write!(f, "error {}: return not valid in file block", loc),
+            Error::ASTError(s, loc) => write!(f, "error {}: {}", loc, s),
         }
     }
 }
@@ -88,6 +90,7 @@ pub enum Statement {
     Return(ReturnStmt),
     Test(Box<TestStmt>),
     Builtin(BuiltinStmt),
+    Bad(Box<BadStmt>),
 }
 
 impl Statement {
@@ -99,6 +102,7 @@ impl Statement {
             Statement::Return(stmt) => Statement::Return(stmt.apply(&sub)),
             Statement::Test(stmt) => Statement::Test(Box::new(stmt.apply(&sub))),
             Statement::Builtin(stmt) => Statement::Builtin(stmt.apply(&sub)),
+            Statement::Bad(stmt) => Statement::Bad(Box::new(stmt.apply(&sub))),
         }
     }
 }
@@ -115,6 +119,19 @@ impl Assignment {
             Assignment::Variable(assign) => Assignment::Variable(assign.apply(&sub)),
             Assignment::Member(assign) => Assignment::Member(assign.apply(&sub)),
         }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct BadStmt {
+    pub loc: ast::SourceLocation,
+    pub errors: Vec<Error>,
+    pub statement: Option<Statement>,
+}
+
+impl BadStmt {
+    fn apply(self, _sub: &Substitution) -> Self {
+        self
     }
 }
 
@@ -141,6 +158,7 @@ pub enum Expression {
     Boolean(BooleanLit),
     DateTime(DateTimeLit),
     Regexp(RegexpLit),
+    Bad(Box<BadExpr>),
 }
 
 impl Expression {
@@ -166,6 +184,7 @@ impl Expression {
             Expression::Boolean(lit) => &lit.typ,
             Expression::DateTime(lit) => &lit.typ,
             Expression::Regexp(lit) => &lit.typ,
+            Expression::Bad(e) => &e.typ,
         }
     }
     pub fn loc(&self) -> &ast::SourceLocation {
@@ -190,6 +209,7 @@ impl Expression {
             Expression::Boolean(lit) => &lit.loc,
             Expression::DateTime(lit) => &lit.loc,
             Expression::Regexp(lit) => &lit.loc,
+            Expression::Bad(e) => &e.loc,
         }
     }
     fn infer(&mut self, env: Environment, f: &mut Fresher) -> Result {
@@ -214,6 +234,7 @@ impl Expression {
             Expression::Boolean(lit) => lit.infer(env),
             Expression::DateTime(lit) => lit.infer(env),
             Expression::Regexp(lit) => lit.infer(env),
+            Expression::Bad(e) => e.infer(env),
         }
     }
     fn apply(self, sub: &Substitution) -> Self {
@@ -238,6 +259,7 @@ impl Expression {
             Expression::Boolean(lit) => Expression::Boolean(lit.apply(&sub)),
             Expression::DateTime(lit) => Expression::DateTime(lit.apply(&sub)),
             Expression::Regexp(lit) => Expression::Regexp(lit.apply(&sub)),
+            Expression::Bad(e) => Expression::Bad(Box::new(e.apply(&sub))),
         }
     }
 }
@@ -375,6 +397,7 @@ impl File {
                             Ok((env, cons + rest))
                         }
                         Statement::Return(stmt) => Err(Error::InvalidReturn(stmt.loc.clone())),
+                        Statement::Bad(_) => Ok((env, Constraints::empty())),
                     },
                 )?;
 
@@ -1769,6 +1792,28 @@ pub struct DurationLit {
 impl DurationLit {
     fn infer(&self, env: Environment) -> Result {
         infer_literal(env, &self.typ, MonoType::Duration, self.loc.clone())
+    }
+    fn apply(mut self, sub: &Substitution) -> Self {
+        self.typ = self.typ.apply(&sub);
+        self
+    }
+}
+
+// BadExpr is a placeholder for an invalid expression.
+#[derive(Derivative)]
+#[derivative(Debug, PartialEq, Clone)]
+pub struct BadExpr {
+    pub loc: ast::SourceLocation,
+    pub errors: Vec<Error>,
+    pub expression: Option<Expression>,
+    #[derivative(PartialEq = "ignore")]
+    pub typ: MonoType,
+}
+
+impl BadExpr {
+    #[allow(unused_variables)]
+    fn infer(&self, env: Environment) -> Result {
+        unimplemented!()
     }
     fn apply(mut self, sub: &Substitution) -> Self {
         self.typ = self.typ.apply(&sub);

--- a/libflux/src/core/semantic/walk/_walk.rs
+++ b/libflux/src/core/semantic/walk/_walk.rs
@@ -37,6 +37,7 @@ pub enum Node<'a> {
     BooleanLit(&'a BooleanLit),
     DateTimeLit(&'a DateTimeLit),
     RegexpLit(&'a RegexpLit),
+    BadExpr(&'a BadExpr),
 
     // Statements.
     ExprStmt(&'a ExprStmt),
@@ -44,6 +45,7 @@ pub enum Node<'a> {
     ReturnStmt(&'a ReturnStmt),
     TestStmt(&'a TestStmt),
     BuiltinStmt(&'a BuiltinStmt),
+    BadStmt(&'a BadStmt),
 
     // StringExprPart.
     TextPart(&'a TextPart),
@@ -83,6 +85,7 @@ impl<'a> fmt::Display for Node<'a> {
             Node::BooleanLit(_) => write!(f, "BooleanLit"),
             Node::DateTimeLit(_) => write!(f, "DateTimeLit"),
             Node::RegexpLit(_) => write!(f, "RegexpLit"),
+            Node::BadExpr(_) => write!(f, "BadExpr"),
             Node::ExprStmt(_) => write!(f, "ExprStmt"),
             Node::OptionStmt(_) => write!(f, "OptionStmt"),
             Node::ReturnStmt(_) => write!(f, "ReturnStmt"),
@@ -98,6 +101,7 @@ impl<'a> fmt::Display for Node<'a> {
             Node::InterpolatedPart(_) => write!(f, "InterpolatedPart"),
             Node::VariableAssgn(_) => write!(f, "VariableAssgn"),
             Node::MemberAssgn(_) => write!(f, "MemberAssgn"),
+            Node::BadStmt(_) => write!(f, "BadStmt"),
         }
     }
 }
@@ -131,6 +135,7 @@ impl<'a> Node<'a> {
             Node::BooleanLit(n) => &n.loc,
             Node::DateTimeLit(n) => &n.loc,
             Node::RegexpLit(n) => &n.loc,
+            Node::BadExpr(n) => &n.loc,
             Node::ExprStmt(n) => &n.loc,
             Node::OptionStmt(n) => &n.loc,
             Node::ReturnStmt(n) => &n.loc,
@@ -142,6 +147,7 @@ impl<'a> Node<'a> {
             Node::InterpolatedPart(n) => &n.loc,
             Node::VariableAssgn(n) => &n.loc,
             Node::MemberAssgn(n) => &n.loc,
+            Node::BadStmt(n) => &n.loc,
         }
     }
     pub fn type_of(&self) -> Option<&MonoType> {
@@ -166,6 +172,7 @@ impl<'a> Node<'a> {
             Node::BooleanLit(n) => Some(&n.typ),
             Node::DateTimeLit(n) => Some(&n.typ),
             Node::RegexpLit(n) => Some(&n.typ),
+            Node::BadExpr(n) => Some(&n.typ),
             _ => None,
         }
     }
@@ -195,6 +202,7 @@ impl<'a> Node<'a> {
             Expression::Boolean(ref e) => Node::BooleanLit(e),
             Expression::DateTime(ref e) => Node::DateTimeLit(e),
             Expression::Regexp(ref e) => Node::RegexpLit(e),
+            Expression::Bad(ref e) => Node::BadExpr(e),
         }
     }
     pub fn from_stmt(stmt: &'a Statement) -> Node {
@@ -205,6 +213,7 @@ impl<'a> Node<'a> {
             Statement::Return(ref s) => Node::ReturnStmt(s),
             Statement::Test(ref s) => Node::TestStmt(s),
             Statement::Builtin(ref s) => Node::BuiltinStmt(s),
+            Statement::Bad(ref s) => Node::BadStmt(s),
         }
     }
     fn from_string_expr_part(sp: &'a StringExprPart) -> Node {
@@ -411,6 +420,7 @@ where
             Node::BooleanLit(_) => {}
             Node::DateTimeLit(_) => {}
             Node::RegexpLit(_) => {}
+            Node::BadExpr(_) => {}
             Node::ExprStmt(ref n) => {
                 walk(v, Rc::new(Node::from_expr(&n.expression)));
             }
@@ -453,6 +463,7 @@ where
                 walk(v, Rc::new(Node::MemberExpr(&n.member)));
                 walk(v, Rc::new(Node::from_expr(&n.init)));
             }
+            Node::BadStmt(_) => {}
         };
     }
     v.done(node.clone());

--- a/libflux/src/core/semantic/walk/walk_mut.rs
+++ b/libflux/src/core/semantic/walk/walk_mut.rs
@@ -37,6 +37,7 @@ pub enum NodeMut<'a> {
     BooleanLit(&'a mut BooleanLit),
     DateTimeLit(&'a mut DateTimeLit),
     RegexpLit(&'a mut RegexpLit),
+    BadExpr(&'a mut BadExpr),
 
     // Statements.
     ExprStmt(&'a mut ExprStmt),
@@ -44,6 +45,7 @@ pub enum NodeMut<'a> {
     ReturnStmt(&'a mut ReturnStmt),
     TestStmt(&'a mut TestStmt),
     BuiltinStmt(&'a mut BuiltinStmt),
+    BadStmt(&'a mut BadStmt),
 
     // StringExprPart.
     TextPart(&'a mut TextPart),
@@ -83,6 +85,7 @@ impl<'a> fmt::Display for NodeMut<'a> {
             NodeMut::BooleanLit(_) => write!(f, "BooleanLit"),
             NodeMut::DateTimeLit(_) => write!(f, "DateTimeLit"),
             NodeMut::RegexpLit(_) => write!(f, "RegexpLit"),
+            NodeMut::BadExpr(_) => write!(f, "BadExpr"),
             NodeMut::ExprStmt(_) => write!(f, "ExprStmt"),
             NodeMut::OptionStmt(_) => write!(f, "OptionStmt"),
             NodeMut::ReturnStmt(_) => write!(f, "ReturnStmt"),
@@ -98,6 +101,7 @@ impl<'a> fmt::Display for NodeMut<'a> {
             NodeMut::InterpolatedPart(_) => write!(f, "InterpolatedPart"),
             NodeMut::VariableAssgn(_) => write!(f, "VariableAssgn"),
             NodeMut::MemberAssgn(_) => write!(f, "MemberAssgn"),
+            NodeMut::BadStmt(_) => write!(f, "BadStmt"),
         }
     }
 }
@@ -130,6 +134,7 @@ impl<'a> NodeMut<'a> {
             NodeMut::BooleanLit(n) => &n.loc,
             NodeMut::DateTimeLit(n) => &n.loc,
             NodeMut::RegexpLit(n) => &n.loc,
+            NodeMut::BadExpr(n) => &n.loc,
             NodeMut::ExprStmt(n) => &n.loc,
             NodeMut::OptionStmt(n) => &n.loc,
             NodeMut::ReturnStmt(n) => &n.loc,
@@ -141,6 +146,7 @@ impl<'a> NodeMut<'a> {
             NodeMut::InterpolatedPart(n) => &n.loc,
             NodeMut::VariableAssgn(n) => &n.loc,
             NodeMut::MemberAssgn(n) => &n.loc,
+            NodeMut::BadStmt(n) => &n.loc,
         }
     }
     pub fn type_of(&self) -> Option<&MonoType> {
@@ -165,6 +171,7 @@ impl<'a> NodeMut<'a> {
             NodeMut::BooleanLit(n) => Some(&n.typ),
             NodeMut::DateTimeLit(n) => Some(&n.typ),
             NodeMut::RegexpLit(n) => Some(&n.typ),
+            NodeMut::BadExpr(n) => Some(&n.typ),
             _ => None,
         }
     }
@@ -196,6 +203,7 @@ impl<'a> NodeMut<'a> {
             NodeMut::BooleanLit(ref mut n) => n.loc = loc,
             NodeMut::DateTimeLit(ref mut n) => n.loc = loc,
             NodeMut::RegexpLit(ref mut n) => n.loc = loc,
+            NodeMut::BadExpr(ref mut n) => n.loc = loc,
             NodeMut::ExprStmt(ref mut n) => n.loc = loc,
             NodeMut::OptionStmt(ref mut n) => n.loc = loc,
             NodeMut::ReturnStmt(ref mut n) => n.loc = loc,
@@ -207,6 +215,7 @@ impl<'a> NodeMut<'a> {
             NodeMut::InterpolatedPart(ref mut n) => n.loc = loc,
             NodeMut::VariableAssgn(ref mut n) => n.loc = loc,
             NodeMut::MemberAssgn(ref mut n) => n.loc = loc,
+            NodeMut::BadStmt(ref mut n) => n.loc = loc,
         };
     }
 }
@@ -235,6 +244,7 @@ impl<'a> NodeMut<'a> {
             Expression::Boolean(ref mut e) => NodeMut::BooleanLit(e),
             Expression::DateTime(ref mut e) => NodeMut::DateTimeLit(e),
             Expression::Regexp(ref mut e) => NodeMut::RegexpLit(e),
+            Expression::Bad(ref mut e) => NodeMut::BadExpr(e),
         }
     }
     fn from_stmt(stmt: &'a mut Statement) -> NodeMut {
@@ -245,6 +255,7 @@ impl<'a> NodeMut<'a> {
             Statement::Return(ref mut s) => NodeMut::ReturnStmt(s),
             Statement::Test(ref mut s) => NodeMut::TestStmt(s),
             Statement::Builtin(ref mut s) => NodeMut::BuiltinStmt(s),
+            Statement::Bad(ref mut s) => NodeMut::BadStmt(s),
         }
     }
     fn from_string_expr_part(sp: &'a mut StringExprPart) -> NodeMut {
@@ -425,6 +436,7 @@ where
             NodeMut::BooleanLit(_) => {}
             NodeMut::DateTimeLit(_) => {}
             NodeMut::RegexpLit(_) => {}
+            NodeMut::BadExpr(_) => {}
             NodeMut::ExprStmt(ref mut n) => {
                 walk_mut(v, &mut NodeMut::from_expr(&mut n.expression));
             }
@@ -467,6 +479,7 @@ where
                 walk_mut(v, &mut NodeMut::MemberExpr(&mut n.member));
                 walk_mut(v, &mut NodeMut::from_expr(&mut n.init));
             }
+            NodeMut::BadStmt(_) => {}
         };
     }
     v.done(&mut node);


### PR DESCRIPTION
Semantic nodes for bad statement and bad expression have been added so
that bad statement and bad expression can be translated into the
semantic graph. They contain the location information and a list of
errors that are associated with the inner statement or expression.

Fixes #2708.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written