### PR TITLE
revert: add semantic nodes for bad statement and bad expression

### DIFF
--- a/libflux/src/core/semantic/convert.rs
+++ b/libflux/src/core/semantic/convert.rs
@@ -107,7 +107,9 @@ fn convert_statement(stmt: ast::Statement, fresher: &mut Fresher) -> Result<Stat
         ast::Statement::Variable(s) => Ok(Statement::Variable(Box::new(
             convert_variable_assignment(*s, fresher)?,
         ))),
-        ast::Statement::Bad(s) => Ok(Statement::Bad(convert_bad_statement(s))),
+        ast::Statement::Bad(_) => {
+            Err("BadStatement is not supported in semantic analysis".to_string())
+        }
     }
 }
 
@@ -176,17 +178,6 @@ fn convert_member_assignment(stmt: ast::MemberAssgn, fresher: &mut Fresher) -> R
     })
 }
 
-fn convert_bad_statement(e: ast::BadStmt) -> Box<BadStmt> {
-    let loc = e.base.location;
-    let errors = vec![Error::ASTError(e.text, loc.clone())];
-    let statement = None;
-    Box::new(BadStmt {
-        loc,
-        errors,
-        statement,
-    })
-}
-
 fn convert_expression(expr: ast::Expression, fresher: &mut Fresher) -> Result<Expression> {
     match expr {
         ast::Expression::Function(expr) => Ok(Expression::Function(Box::new(convert_function_expression(*expr, fresher)?))),
@@ -212,7 +203,7 @@ fn convert_expression(expr: ast::Expression, fresher: &mut Fresher) -> Result<Ex
         ast::Expression::Duration(lit) => Ok(Expression::Duration(convert_duration_literal(lit, fresher)?)),
         ast::Expression::DateTime(lit) => Ok(Expression::DateTime(convert_date_time_literal(lit, fresher)?)),
         ast::Expression::PipeLit(_) => Err("a pipe literal may only be used as a default value for an argument in a function definition".to_string()),
-        ast::Expression::Bad(e) => Ok(Expression::Bad(convert_bad_expression(e, fresher))),
+        ast::Expression::Bad(_) => Err("BadExpression is not supported in semantic analysis".to_string())
     }
 }
 
@@ -584,22 +575,6 @@ fn convert_date_time_literal(lit: ast::DateTimeLit, fresher: &mut Fresher) -> Re
         loc: lit.base.location,
         typ: MonoType::Var(fresher.fresh()),
         value: lit.value,
-    })
-}
-
-fn convert_bad_expression(e: Box<ast::BadExpr>, fresher: &mut Fresher) -> Box<BadExpr> {
-    let loc = e.base.location;
-    let errors = vec![Error::ASTError(e.text, loc.clone())];
-    let typ = MonoType::Var(fresher.fresh());
-    let expression = match e.expression {
-        Some(e) => Some(convert_expression(e, fresher).unwrap()),
-        None => None,
-    };
-    Box::new(BadExpr {
-        loc,
-        errors,
-        expression,
-        typ,
     })
 }
 
@@ -2622,88 +2597,6 @@ mod tests {
                             arguments: Vec::new(),
                         })),
                         property: "c".to_string(),
-                    })),
-                })],
-            }],
-        };
-        let got = test_convert(pkg).unwrap();
-        assert_eq!(want, got);
-    }
-
-    #[test]
-    fn test_convert_bad_statement() {
-        let b = ast::BaseNode::default();
-        let pkg = ast::Package {
-            base: b.clone(),
-            path: "path".to_string(),
-            package: "main".to_string(),
-            files: vec![ast::File {
-                base: b.clone(),
-                name: "foo.flux".to_string(),
-                metadata: String::new(),
-                package: None,
-                imports: Vec::new(),
-                body: vec![ast::Statement::Bad(ast::BadStmt {
-                    base: b.clone(),
-                    text: "expected".to_string(),
-                })],
-            }],
-        };
-        let want = Package {
-            loc: b.location.clone(),
-            package: "main".to_string(),
-            files: vec![File {
-                loc: b.location.clone(),
-                package: None,
-                imports: Vec::new(),
-                body: vec![Statement::Bad(Box::new(BadStmt {
-                    loc: b.location.clone(),
-                    errors: vec![Error::ASTError("expected".to_string(), b.location.clone())],
-                    statement: None,
-                }))],
-            }],
-        };
-        let got = test_convert(pkg).unwrap();
-        assert_eq!(want, got);
-    }
-
-    #[test]
-    fn test_convert_bad_expression() {
-        let b = ast::BaseNode::default();
-        let pkg = ast::Package {
-            base: b.clone(),
-            path: "path".to_string(),
-            package: "main".to_string(),
-            files: vec![ast::File {
-                base: b.clone(),
-                name: "foo.flux".to_string(),
-                metadata: String::new(),
-                package: None,
-                imports: Vec::new(),
-                body: vec![ast::Statement::Expr(ast::ExprStmt {
-                    base: b.clone(),
-                    expression: ast::Expression::Bad(Box::new(ast::BadExpr {
-                        base: b.clone(),
-                        text: "expected".to_string(),
-                        expression: None,
-                    })),
-                })],
-            }],
-        };
-        let want = Package {
-            loc: b.location.clone(),
-            package: "main".to_string(),
-            files: vec![File {
-                loc: b.location.clone(),
-                package: None,
-                imports: Vec::new(),
-                body: vec![Statement::Expr(ExprStmt {
-                    loc: b.location.clone(),
-                    expression: Expression::Bad(Box::new(BadExpr {
-                        loc: b.location.clone(),
-                        errors: vec![Error::ASTError("expected".to_string(), b.location.clone())],
-                        expression: None,
-                        typ: type_info(),
                     })),
                 })],
             }],

--- a/libflux/src/core/semantic/flatbuffers/mod.rs
+++ b/libflux/src/core/semantic/flatbuffers/mod.rs
@@ -229,9 +229,6 @@ impl<'a> semantic::walk::Visitor<'_> for SerializingVisitor<'a> {
                 ))
             }
 
-            walk::Node::BadStmt(e) => unimplemented!(),
-            walk::Node::BadExpr(e) => unimplemented!(),
-
             walk::Node::IdentifierExpr(id) => {
                 let name = v.create_string(&id.name);
                 let id_typ = id.typ.clone();

--- a/libflux/src/core/semantic/infer.rs
+++ b/libflux/src/core/semantic/infer.rs
@@ -62,7 +62,7 @@ impl From<Constraint> for Constraints {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug)]
 pub struct Error {
     msg: String,
 }

--- a/libflux/src/core/semantic/walk/_walk.rs
+++ b/libflux/src/core/semantic/walk/_walk.rs
@@ -37,7 +37,6 @@ pub enum Node<'a> {
     BooleanLit(&'a BooleanLit),
     DateTimeLit(&'a DateTimeLit),
     RegexpLit(&'a RegexpLit),
-    BadExpr(&'a BadExpr),
 
     // Statements.
     ExprStmt(&'a ExprStmt),
@@ -45,7 +44,6 @@ pub enum Node<'a> {
     ReturnStmt(&'a ReturnStmt),
     TestStmt(&'a TestStmt),
     BuiltinStmt(&'a BuiltinStmt),
-    BadStmt(&'a BadStmt),
 
     // StringExprPart.
     TextPart(&'a TextPart),
@@ -85,7 +83,6 @@ impl<'a> fmt::Display for Node<'a> {
             Node::BooleanLit(_) => write!(f, "BooleanLit"),
             Node::DateTimeLit(_) => write!(f, "DateTimeLit"),
             Node::RegexpLit(_) => write!(f, "RegexpLit"),
-            Node::BadExpr(_) => write!(f, "BadExpr"),
             Node::ExprStmt(_) => write!(f, "ExprStmt"),
             Node::OptionStmt(_) => write!(f, "OptionStmt"),
             Node::ReturnStmt(_) => write!(f, "ReturnStmt"),
@@ -101,7 +98,6 @@ impl<'a> fmt::Display for Node<'a> {
             Node::InterpolatedPart(_) => write!(f, "InterpolatedPart"),
             Node::VariableAssgn(_) => write!(f, "VariableAssgn"),
             Node::MemberAssgn(_) => write!(f, "MemberAssgn"),
-            Node::BadStmt(_) => write!(f, "BadStmt"),
         }
     }
 }
@@ -135,7 +131,6 @@ impl<'a> Node<'a> {
             Node::BooleanLit(n) => &n.loc,
             Node::DateTimeLit(n) => &n.loc,
             Node::RegexpLit(n) => &n.loc,
-            Node::BadExpr(n) => &n.loc,
             Node::ExprStmt(n) => &n.loc,
             Node::OptionStmt(n) => &n.loc,
             Node::ReturnStmt(n) => &n.loc,
@@ -147,7 +142,6 @@ impl<'a> Node<'a> {
             Node::InterpolatedPart(n) => &n.loc,
             Node::VariableAssgn(n) => &n.loc,
             Node::MemberAssgn(n) => &n.loc,
-            Node::BadStmt(n) => &n.loc,
         }
     }
     pub fn type_of(&self) -> Option<&MonoType> {
@@ -172,7 +166,6 @@ impl<'a> Node<'a> {
             Node::BooleanLit(n) => Some(&n.typ),
             Node::DateTimeLit(n) => Some(&n.typ),
             Node::RegexpLit(n) => Some(&n.typ),
-            Node::BadExpr(n) => Some(&n.typ),
             _ => None,
         }
     }
@@ -202,7 +195,6 @@ impl<'a> Node<'a> {
             Expression::Boolean(ref e) => Node::BooleanLit(e),
             Expression::DateTime(ref e) => Node::DateTimeLit(e),
             Expression::Regexp(ref e) => Node::RegexpLit(e),
-            Expression::Bad(ref e) => Node::BadExpr(e),
         }
     }
     pub fn from_stmt(stmt: &'a Statement) -> Node {
@@ -213,7 +205,6 @@ impl<'a> Node<'a> {
             Statement::Return(ref s) => Node::ReturnStmt(s),
             Statement::Test(ref s) => Node::TestStmt(s),
             Statement::Builtin(ref s) => Node::BuiltinStmt(s),
-            Statement::Bad(ref s) => Node::BadStmt(s),
         }
     }
     fn from_string_expr_part(sp: &'a StringExprPart) -> Node {
@@ -420,7 +411,6 @@ where
             Node::BooleanLit(_) => {}
             Node::DateTimeLit(_) => {}
             Node::RegexpLit(_) => {}
-            Node::BadExpr(_) => {}
             Node::ExprStmt(ref n) => {
                 walk(v, Rc::new(Node::from_expr(&n.expression)));
             }
@@ -463,7 +453,6 @@ where
                 walk(v, Rc::new(Node::MemberExpr(&n.member)));
                 walk(v, Rc::new(Node::from_expr(&n.init)));
             }
-            Node::BadStmt(_) => {}
         };
     }
     v.done(node.clone());

--- a/libflux/src/core/semantic/walk/walk_mut.rs
+++ b/libflux/src/core/semantic/walk/walk_mut.rs
@@ -37,7 +37,6 @@ pub enum NodeMut<'a> {
     BooleanLit(&'a mut BooleanLit),
     DateTimeLit(&'a mut DateTimeLit),
     RegexpLit(&'a mut RegexpLit),
-    BadExpr(&'a mut BadExpr),
 
     // Statements.
     ExprStmt(&'a mut ExprStmt),
@@ -45,7 +44,6 @@ pub enum NodeMut<'a> {
     ReturnStmt(&'a mut ReturnStmt),
     TestStmt(&'a mut TestStmt),
     BuiltinStmt(&'a mut BuiltinStmt),
-    BadStmt(&'a mut BadStmt),
 
     // StringExprPart.
     TextPart(&'a mut TextPart),
@@ -85,7 +83,6 @@ impl<'a> fmt::Display for NodeMut<'a> {
             NodeMut::BooleanLit(_) => write!(f, "BooleanLit"),
             NodeMut::DateTimeLit(_) => write!(f, "DateTimeLit"),
             NodeMut::RegexpLit(_) => write!(f, "RegexpLit"),
-            NodeMut::BadExpr(_) => write!(f, "BadExpr"),
             NodeMut::ExprStmt(_) => write!(f, "ExprStmt"),
             NodeMut::OptionStmt(_) => write!(f, "OptionStmt"),
             NodeMut::ReturnStmt(_) => write!(f, "ReturnStmt"),
@@ -101,7 +98,6 @@ impl<'a> fmt::Display for NodeMut<'a> {
             NodeMut::InterpolatedPart(_) => write!(f, "InterpolatedPart"),
             NodeMut::VariableAssgn(_) => write!(f, "VariableAssgn"),
             NodeMut::MemberAssgn(_) => write!(f, "MemberAssgn"),
-            NodeMut::BadStmt(_) => write!(f, "BadStmt"),
         }
     }
 }
@@ -134,7 +130,6 @@ impl<'a> NodeMut<'a> {
             NodeMut::BooleanLit(n) => &n.loc,
             NodeMut::DateTimeLit(n) => &n.loc,
             NodeMut::RegexpLit(n) => &n.loc,
-            NodeMut::BadExpr(n) => &n.loc,
             NodeMut::ExprStmt(n) => &n.loc,
             NodeMut::OptionStmt(n) => &n.loc,
             NodeMut::ReturnStmt(n) => &n.loc,
@@ -146,7 +141,6 @@ impl<'a> NodeMut<'a> {
             NodeMut::InterpolatedPart(n) => &n.loc,
             NodeMut::VariableAssgn(n) => &n.loc,
             NodeMut::MemberAssgn(n) => &n.loc,
-            NodeMut::BadStmt(n) => &n.loc,
         }
     }
     pub fn type_of(&self) -> Option<&MonoType> {
@@ -171,7 +165,6 @@ impl<'a> NodeMut<'a> {
             NodeMut::BooleanLit(n) => Some(&n.typ),
             NodeMut::DateTimeLit(n) => Some(&n.typ),
             NodeMut::RegexpLit(n) => Some(&n.typ),
-            NodeMut::BadExpr(n) => Some(&n.typ),
             _ => None,
         }
     }
@@ -203,7 +196,6 @@ impl<'a> NodeMut<'a> {
             NodeMut::BooleanLit(ref mut n) => n.loc = loc,
             NodeMut::DateTimeLit(ref mut n) => n.loc = loc,
             NodeMut::RegexpLit(ref mut n) => n.loc = loc,
-            NodeMut::BadExpr(ref mut n) => n.loc = loc,
             NodeMut::ExprStmt(ref mut n) => n.loc = loc,
             NodeMut::OptionStmt(ref mut n) => n.loc = loc,
             NodeMut::ReturnStmt(ref mut n) => n.loc = loc,
@@ -215,7 +207,6 @@ impl<'a> NodeMut<'a> {
             NodeMut::InterpolatedPart(ref mut n) => n.loc = loc,
             NodeMut::VariableAssgn(ref mut n) => n.loc = loc,
             NodeMut::MemberAssgn(ref mut n) => n.loc = loc,
-            NodeMut::BadStmt(ref mut n) => n.loc = loc,
         };
     }
 }
@@ -244,7 +235,6 @@ impl<'a> NodeMut<'a> {
             Expression::Boolean(ref mut e) => NodeMut::BooleanLit(e),
             Expression::DateTime(ref mut e) => NodeMut::DateTimeLit(e),
             Expression::Regexp(ref mut e) => NodeMut::RegexpLit(e),
-            Expression::Bad(ref mut e) => NodeMut::BadExpr(e),
         }
     }
     fn from_stmt(stmt: &'a mut Statement) -> NodeMut {
@@ -255,7 +245,6 @@ impl<'a> NodeMut<'a> {
             Statement::Return(ref mut s) => NodeMut::ReturnStmt(s),
             Statement::Test(ref mut s) => NodeMut::TestStmt(s),
             Statement::Builtin(ref mut s) => NodeMut::BuiltinStmt(s),
-            Statement::Bad(ref mut s) => NodeMut::BadStmt(s),
         }
     }
     fn from_string_expr_part(sp: &'a mut StringExprPart) -> NodeMut {
@@ -436,7 +425,6 @@ where
             NodeMut::BooleanLit(_) => {}
             NodeMut::DateTimeLit(_) => {}
             NodeMut::RegexpLit(_) => {}
-            NodeMut::BadExpr(_) => {}
             NodeMut::ExprStmt(ref mut n) => {
                 walk_mut(v, &mut NodeMut::from_expr(&mut n.expression));
             }
@@ -479,7 +467,6 @@ where
                 walk_mut(v, &mut NodeMut::MemberExpr(&mut n.member));
                 walk_mut(v, &mut NodeMut::from_expr(&mut n.init));
             }
-            NodeMut::BadStmt(_) => {}
         };
     }
     v.done(&mut node);


### PR DESCRIPTION
This reverts commit 7ce9cef4eaacffbf9265f7675c2ac84f794676c2.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written