### PR TITLE
feat(plan): pass the context to the rewrite rules in the planner

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -150,7 +150,7 @@ func buildPlan(ctx context.Context, spec *flux.Spec, opts *compileOptions) (*pla
 	pb.AddLogicalOptions(lopts...)
 	pb.AddPhysicalOptions(popts...)
 
-	ps, err := pb.Build().Plan(spec)
+	ps, err := pb.Build().Plan(ctx, spec)
 	if err != nil {
 		return nil, err
 	}

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -355,7 +355,7 @@ func (rule removeCount) Name() string {
 func (rule removeCount) Pattern() plan.Pattern {
 	return plan.Pat(universe.CountKind, plan.Any())
 }
-func (rule removeCount) Rewrite(node plan.Node) (plan.Node, bool, error) {
+func (rule removeCount) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
 	return node.Predecessors()[0], true, nil
 }
 

--- a/plan/builder.go
+++ b/plan/builder.go
@@ -1,6 +1,8 @@
 package plan
 
 import (
+	"context"
+
 	"github.com/influxdata/flux"
 )
 
@@ -35,16 +37,16 @@ type planner struct {
 	pp PhysicalPlanner
 }
 
-func (p *planner) Plan(fspec *flux.Spec) (*Spec, error) {
+func (p *planner) Plan(ctx context.Context, fspec *flux.Spec) (*Spec, error) {
 	ip, err := p.lp.CreateInitialPlan(fspec)
 	if err != nil {
 		return nil, err
 	}
-	lp, err := p.lp.Plan(ip)
+	lp, err := p.lp.Plan(ctx, ip)
 	if err != nil {
 		return nil, err
 	}
-	pp, err := p.pp.Plan(lp)
+	pp, err := p.pp.Plan(ctx, lp)
 	if err != nil {
 		return nil, err
 	}

--- a/plan/heuristic_planner.go
+++ b/plan/heuristic_planner.go
@@ -1,6 +1,9 @@
 package plan
 
-import "sort"
+import (
+	"context"
+	"sort"
+)
 
 // heuristicPlanner applies a set of rules to the nodes in a Spec
 // until a fixed point is reached and no more rules can be applied.
@@ -35,7 +38,7 @@ func (p *heuristicPlanner) clearRules() {
 
 // matchRules applies any applicable rules to the given plan node,
 // and returns the rewritten plan node and whether or not any rewriting was done.
-func (p *heuristicPlanner) matchRules(node Node) (Node, bool, error) {
+func (p *heuristicPlanner) matchRules(ctx context.Context, node Node) (Node, bool, error) {
 	anyChanged := false
 
 	for _, rule := range p.rules[AnyKind] {
@@ -43,7 +46,7 @@ func (p *heuristicPlanner) matchRules(node Node) (Node, bool, error) {
 			continue
 		}
 		if rule.Pattern().Match(node) {
-			newNode, changed, err := rule.Rewrite(node)
+			newNode, changed, err := rule.Rewrite(ctx, node)
 			if err != nil {
 				return nil, false, err
 			}
@@ -57,7 +60,7 @@ func (p *heuristicPlanner) matchRules(node Node) (Node, bool, error) {
 			continue
 		}
 		if rule.Pattern().Match(node) {
-			newNode, changed, err := rule.Rewrite(node)
+			newNode, changed, err := rule.Rewrite(ctx, node)
 			if err != nil {
 				return nil, false, err
 			}
@@ -75,7 +78,7 @@ func (p *heuristicPlanner) matchRules(node Node) (Node, bool, error) {
 //
 // Plan may change its argument and/or return a new instance of Spec, so the correct way to call Plan is:
 //     plan, err = plan.Plan(plan)
-func (p *heuristicPlanner) Plan(inputPlan *Spec) (*Spec, error) {
+func (p *heuristicPlanner) Plan(ctx context.Context, inputPlan *Spec) (*Spec, error) {
 	for anyChanged := true; anyChanged; {
 		visited := make(map[Node]struct{})
 
@@ -98,7 +101,7 @@ func (p *heuristicPlanner) Plan(inputPlan *Spec) (*Spec, error) {
 			_, alreadyVisited := visited[node]
 
 			if !alreadyVisited {
-				newNode, changed, err := p.matchRules(node)
+				newNode, changed, err := p.matchRules(ctx, node)
 				if err != nil {
 					return nil, err
 				}

--- a/plan/heuristic_planner_test.go
+++ b/plan/heuristic_planner_test.go
@@ -1,6 +1,7 @@
 package plan_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -128,7 +129,7 @@ func TestPlanTraversal(t *testing.T) {
 
 			simpleRule := plantest.SimpleRule{}
 			thePlanner := plan.NewPhysicalPlanner(plan.OnlyPhysicalRules(&simpleRule))
-			_, err := thePlanner.Plan(planSpec)
+			_, err := thePlanner.Plan(context.Background(), planSpec)
 			if err != nil {
 				t.Fatalf("Could not plan: %v", err)
 			}

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 // the actual data being processed.
 type LogicalPlanner interface {
 	CreateInitialPlan(spec *flux.Spec) (*Spec, error)
-	Plan(*Spec) (*Spec, error)
+	Plan(context.Context, *Spec) (*Spec, error)
 }
 
 // NewLogicalPlanner returns a new logical plan with the given options.
@@ -81,7 +82,7 @@ func RemoveLogicalRules(rules ...string) LogicalOption {
 	})
 }
 
-// Disables integrity checks in the logical planner
+// DisableIntegrityChecks disables integrity checks in the logical planner.
 func DisableIntegrityChecks() LogicalOption {
 	return logicalOption(func(lp *logicalPlanner) {
 		lp.disableIntegrityChecks = true
@@ -94,8 +95,8 @@ func (l *logicalPlanner) CreateInitialPlan(spec *flux.Spec) (*Spec, error) {
 }
 
 // Plan transforms the given naive plan by applying rules.
-func (l *logicalPlanner) Plan(logicalPlan *Spec) (*Spec, error) {
-	newLogicalPlan, err := l.heuristicPlanner.Plan(logicalPlan)
+func (l *logicalPlanner) Plan(ctx context.Context, logicalPlan *Spec) (*Spec, error) {
+	newLogicalPlan, err := l.heuristicPlanner.Plan(ctx, logicalPlan)
 	if err != nil {
 		return nil, err
 	}

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -313,7 +313,7 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 
 			if tc.wantErr {
 				if err == nil {
-					_, err = thePlanner.Plan(initPlan)
+					_, err = thePlanner.Plan(context.Background(), initPlan)
 				}
 				if err == nil {
 					t.Fatal("expected error, but got none")
@@ -322,7 +322,7 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				gotPlan, err := thePlanner.Plan(initPlan)
+				gotPlan, err := thePlanner.Plan(context.Background(), initPlan)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -349,7 +349,7 @@ func (MergeFiltersRule) Pattern() plan.Pattern {
 			plan.Any()))
 }
 
-func (MergeFiltersRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
+func (MergeFiltersRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	specTop := pn.ProcedureSpec()
 
 	filterSpecTop := specTop.(*universe.FilterProcedureSpec)
@@ -399,7 +399,7 @@ func (PushFilterThroughMapRule) Pattern() plan.Pattern {
 			plan.Any()))
 }
 
-func (PushFilterThroughMapRule) Rewrite(pn plan.Node) (plan.Node, bool, error) {
+func (PushFilterThroughMapRule) Rewrite(ctx context.Context, pn plan.Node) (plan.Node, bool, error) {
 	// It will not always be possible to push a filter through a map... but this is just a unit test.
 
 	swapped, err := plan.SwapPlanNodes(pn, pn.Predecessors()[0])
@@ -576,7 +576,7 @@ func TestLogicalPlanner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			logicalPlan, err := logicalPlanner.Plan(initPlan)
+			logicalPlan, err := logicalPlanner.Plan(context.Background(), initPlan)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -615,7 +615,7 @@ from(bucket: "telegraf")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = planner.Plan(initPlan)
+	_, err = planner.Plan(context.Background(), initPlan)
 	if err != nil {
 		t.Fatalf("unexpected fail: %v", err)
 	}
@@ -627,7 +627,7 @@ from(bucket: "telegraf")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = planner.Plan(initPlan)
+	_, err = planner.Plan(context.Background(), initPlan)
 	if err == nil {
 		t.Fatal("unexpected pass")
 	}
@@ -639,7 +639,7 @@ from(bucket: "telegraf")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = planner.Plan(initPlan)
+	_, err = planner.Plan(context.Background(), initPlan)
 	if err == nil {
 		t.Fatal("unexpected pass")
 	}

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"context"
 	"fmt"
 	"math"
 )
@@ -8,7 +9,7 @@ import (
 // PhysicalPlanner performs transforms a logical plan to a physical plan,
 // by applying any registered physical rules.
 type PhysicalPlanner interface {
-	Plan(lplan *Spec) (*Spec, error)
+	Plan(ctx context.Context, lplan *Spec) (*Spec, error)
 }
 
 // NewPhysicalPlanner creates a new physical plan with the specified options.
@@ -39,8 +40,8 @@ func NewPhysicalPlanner(options ...PhysicalOption) PhysicalPlanner {
 	return pp
 }
 
-func (pp *physicalPlanner) Plan(spec *Spec) (*Spec, error) {
-	transformedSpec, err := pp.heuristicPlanner.Plan(spec)
+func (pp *physicalPlanner) Plan(ctx context.Context, spec *Spec) (*Spec, error) {
+	transformedSpec, err := pp.heuristicPlanner.Plan(ctx, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +141,7 @@ func RemovePhysicalRules(rules ...string) PhysicalOption {
 	})
 }
 
-// Disables validation in the physical planner
+// DisableValidation disables validation in the physical planner.
 func DisableValidation() PhysicalOption {
 	return physicalOption(func(p *physicalPlanner) {
 		p.disableValidation = true
@@ -161,7 +162,7 @@ func (physicalConverterRule) Pattern() Pattern {
 	return Any()
 }
 
-func (physicalConverterRule) Rewrite(pn Node) (Node, bool, error) {
+func (physicalConverterRule) Rewrite(ctx context.Context, pn Node) (Node, bool, error) {
 	if _, ok := pn.(*PhysicalPlanNode); ok {
 		// Already converted
 		return pn, false, nil

--- a/plan/physical_test.go
+++ b/plan/physical_test.go
@@ -1,6 +1,7 @@
 package plan_test
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestPhysicalOptions(t *testing.T) {
 		inputPlan := plantest.CreatePlanSpec(spec)
 
 		thePlanner := plan.NewPhysicalPlanner(options...)
-		outputPlan, err := thePlanner.Plan(inputPlan)
+		outputPlan, err := thePlanner.Plan(context.Background(), inputPlan)
 		if err != nil {
 			t.Fatalf("Physical planning failed: %v", err)
 		}
@@ -70,7 +71,7 @@ func TestPhysicalIntegrityCheckOption(t *testing.T) {
 		),
 		plan.DisableValidation(),
 	)
-	_, err := planner.Plan(inputPlan)
+	_, err := planner.Plan(context.Background(), inputPlan)
 	if err != nil {
 		t.Fatalf("unexpected fail: %v", err)
 	}
@@ -78,7 +79,7 @@ func TestPhysicalIntegrityCheckOption(t *testing.T) {
 	// let's smash the plan
 	planner = plan.NewPhysicalPlanner(
 		plan.OnlyPhysicalRules(plantest.SmashPlanRule{Intruder: intruder, Node: node1}))
-	_, err = planner.Plan(inputPlan)
+	_, err = planner.Plan(context.Background(), inputPlan)
 	if err == nil {
 		t.Fatal("unexpected pass")
 	}
@@ -86,7 +87,7 @@ func TestPhysicalIntegrityCheckOption(t *testing.T) {
 	// let's introduce a cycle
 	planner = plan.NewPhysicalPlanner(
 		plan.OnlyPhysicalRules(plantest.CreateCycleRule{Node: node1}))
-	_, err = planner.Plan(inputPlan)
+	_, err = planner.Plan(context.Background(), inputPlan)
 	if err == nil {
 		t.Fatal("unexpected pass")
 	}

--- a/plan/rules.go
+++ b/plan/rules.go
@@ -1,15 +1,17 @@
 package plan
 
+import "context"
+
 // Rule is transformation rule for a query operation
 type Rule interface {
-	// The name of this rule (must be unique)
+	// Name of this rule (must be unique).
 	Name() string
 
-	// Pattern for this rule to match against
+	// Pattern for this rule to match against.
 	Pattern() Pattern
 
-	// Rewrite an operation into an equivalent one
+	// Rewrite an operation into an equivalent one.
 	// The returned node is the new root of the sub tree.
 	// The boolean return value should be true if anything changed during the rewrite.
-	Rewrite(Node) (Node, bool, error)
+	Rewrite(context.Context, Node) (Node, bool, error)
 }

--- a/plan/types.go
+++ b/plan/types.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -9,31 +10,31 @@ import (
 )
 
 type Planner interface {
-	Plan(*flux.Spec) (*Spec, error)
+	Plan(context.Context, *flux.Spec) (*Spec, error)
 }
 
 // Node defines the common interface for interacting with
 // logical and physical plan nodes.
 type Node interface {
-	// Returns an identifier for this plan node
+	// ID returns an identifier for this plan node.
 	ID() NodeID
 
-	// Returns the time bounds for this plan node
+	// Bounds returns the time bounds for this plan node.
 	Bounds() *Bounds
 
-	// Plan nodes executed immediately before this node
+	// Predecessors returns plan nodes executed immediately before this node.
 	Predecessors() []Node
 
-	// Plan nodes executed immediately after this node
+	// Successors returns plan nodes executed immediately after this node.
 	Successors() []Node
 
-	// Specification of the procedure represented by this node
+	// ProcedureSpec returns the specification of the procedure represented by this node.
 	ProcedureSpec() ProcedureSpec
 
-	// Replaces the procedure spec of this node with another
+	// ReplaceSpec replaces the procedure spec of this node with another.
 	ReplaceSpec(ProcedureSpec) error
 
-	// Type of procedure represented by this node
+	// Kind returns the type of procedure represented by this node.
 	Kind() ProcedureKind
 
 	// Helper methods for manipulating a plan

--- a/repl/compiler.go
+++ b/repl/compiler.go
@@ -18,7 +18,7 @@ type Compiler struct {
 
 func (c Compiler) Compile(ctx context.Context) (flux.Program, error) {
 	planner := plan.PlannerBuilder{}.Build()
-	ps, err := planner.Plan(c.Spec)
+	ps, err := planner.Plan(ctx, c.Spec)
 	if err != nil {
 		return nil, err
 	}

--- a/stdlib/experimental/bigtable/from.go
+++ b/stdlib/experimental/bigtable/from.go
@@ -249,7 +249,7 @@ func (r BigtableFilterRewriteRule) Pattern() plan.Pattern {
 	return plan.Pat(universe.FilterKind, plan.Pat(FromBigtableKind))
 }
 
-func (r BigtableFilterRewriteRule) Rewrite(filter plan.Node) (plan.Node, bool, error) {
+func (r BigtableFilterRewriteRule) Rewrite(ctx context.Context, filter plan.Node) (plan.Node, bool, error) {
 	query := filter.Predecessors()[0]
 
 	node, changed := AddFilterToNode(query, filter)
@@ -266,7 +266,7 @@ func (r BigtableLimitRewriteRule) Pattern() plan.Pattern {
 	return plan.Pat(universe.LimitKind, plan.Pat(FromBigtableKind))
 }
 
-func (r BigtableLimitRewriteRule) Rewrite(limit plan.Node) (plan.Node, bool, error) {
+func (r BigtableLimitRewriteRule) Rewrite(ctx context.Context, limit plan.Node) (plan.Node, bool, error) {
 	query := limit.Predecessors()[0]
 
 	node, changed := AddLimitToNode(query, limit)

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -307,7 +307,7 @@ func (RemoveTrivialFilterRule) Pattern() plan.Pattern {
 	return plan.Pat(FilterKind, plan.Any())
 }
 
-func (RemoveTrivialFilterRule) Rewrite(filterNode plan.Node) (plan.Node, bool, error) {
+func (RemoveTrivialFilterRule) Rewrite(ctx context.Context, filterNode plan.Node) (plan.Node, bool, error) {
 	filterSpec := filterNode.ProcedureSpec().(*FilterProcedureSpec)
 	if filterSpec.Fn.Fn == nil ||
 		filterSpec.Fn.Fn.Block == nil ||

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"context"
 	"sort"
 
 	"github.com/apache/arrow/go/arrow/array"
@@ -380,7 +381,7 @@ func (r MergeGroupRule) Pattern() plan.Pattern {
 	return plan.Pat(GroupKind, plan.Pat(GroupKind, plan.Any()))
 }
 
-func (r MergeGroupRule) Rewrite(lastGroup plan.Node) (plan.Node, bool, error) {
+func (r MergeGroupRule) Rewrite(ctx context.Context, lastGroup plan.Node) (plan.Node, bool, error) {
 	firstGroup := lastGroup.Predecessors()[0]
 	lastSpec := lastGroup.ProcedureSpec().(*GroupProcedureSpec)
 

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -1,6 +1,7 @@
 package universe
 
 import (
+	"context"
 	"math"
 
 	"github.com/influxdata/flux"
@@ -419,7 +420,7 @@ func (WindowTriggerPhysicalRule) Pattern() plan.Pattern {
 // Rewrite modifies a window's trigger spec so long as it doesn't have any
 // window descendents that occur earlier in the plan and as long as none
 // of its descendents merge multiple streams together like union and join.
-func (WindowTriggerPhysicalRule) Rewrite(window plan.Node) (plan.Node, bool, error) {
+func (WindowTriggerPhysicalRule) Rewrite(ctx context.Context, window plan.Node) (plan.Node, bool, error) {
 	// This rule's pattern ensures us only one predecessor
 	if !hasValidPredecessors(window.Predecessors()[0]) {
 		return window, false, nil

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"context"
 	"sort"
 	"strconv"
 	"testing"
@@ -1158,7 +1159,7 @@ func TestWindowRewriteRule(t *testing.T) {
 				plan.DisableValidation(),
 			)
 
-			pp, err := physicalPlanner.Plan(spec)
+			pp, err := physicalPlanner.Plan(context.Background(), spec)
 			if err != nil {
 				t.Fatalf("unexpected error during physical planning: %v", err)
 			}


### PR DESCRIPTION
This changes the planner rule interface to pass the context to the
rewrite rules so the planner has access to any of the dependencies that
are present.

Fixes #2755.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written