### PR TITLE
fix(compiler): apply substitution fully when compiling lambda

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -202,7 +202,7 @@ func findProperty(name string, t semantic.MonoType) (*semantic.RowProperty, bool
 	return nil, false, nil
 }
 
-// apply applies a subsitution to a type.
+// apply applies a substitution to a type.
 // It will ignore any errors when reading a type.
 // This is safe becase we already validated that the function type is a mono type.
 func apply(sub map[uint64]semantic.MonoType, props []semantic.PropertyType, t semantic.MonoType) semantic.MonoType {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -202,14 +202,62 @@ func findProperty(name string, t semantic.MonoType) (*semantic.RowProperty, bool
 	return nil, false, nil
 }
 
-// monoType ignores any errors when reading the type of a node.
+// apply applies a subsitution to a type.
+// It will ignore any errors when reading a type.
 // This is safe becase we already validated that the function type is a mono type.
-func monoType(subst map[uint64]semantic.MonoType, t semantic.MonoType) semantic.MonoType {
-	tv, err := t.VarNum()
-	if err != nil {
-		return t
+func apply(sub map[uint64]semantic.MonoType, props []semantic.PropertyType, t semantic.MonoType) semantic.MonoType {
+	switch t.Kind() {
+	case semantic.Var:
+		tv, err := t.VarNum()
+		if err != nil {
+			return t
+		}
+		return sub[tv]
+	case semantic.Arr:
+		element, err := t.ElemType()
+		if err != nil {
+			return t
+		}
+		return semantic.NewArrayType(apply(sub, props, element))
+	case semantic.Row:
+		n, err := t.NumProperties()
+		if err != nil {
+			return t
+		}
+		for i := 0; i < n; i++ {
+			pr, err := t.RowProperty(i)
+			if err != nil {
+				return t
+			}
+			ty, err := pr.TypeOf()
+			if err != nil {
+				return t
+			}
+			props = append(props, semantic.PropertyType{
+				Key:   []byte(pr.Name()),
+				Value: apply(sub, nil, ty),
+			})
+		}
+		r, extends, err := t.Extends()
+		if err != nil {
+			return t
+		}
+		if !extends {
+			return semantic.NewObjectType(props)
+		}
+		r = apply(sub, nil, r)
+		switch r.Kind() {
+		case semantic.Row:
+			return apply(sub, props, r)
+		case semantic.Var:
+			tv, err := r.VarNum()
+			if err != nil {
+				return t
+			}
+			return semantic.ExtendObjectType(props, &tv)
+		}
 	}
-	return subst[tv]
+	return t
 }
 
 // compile recursively compiles semantic nodes into evaluators.
@@ -225,7 +273,7 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			body[i] = node
 		}
 		return &blockEvaluator{
-			t:    monoType(subst, n.ReturnStatement().Argument.TypeOf()),
+			t:    apply(subst, nil, n.ReturnStatement().Argument.TypeOf()),
 			body: body,
 		}, nil
 	case *semantic.ExpressionStatement:
@@ -244,15 +292,12 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			return nil, err
 		}
 		return &declarationEvaluator{
-			t:    monoType(subst, n.Init.TypeOf()),
+			t:    apply(subst, nil, n.Init.TypeOf()),
 			id:   n.Identifier.Name,
 			init: node,
 		}, nil
 	case *semantic.ObjectExpression:
 		properties := make(map[string]Evaluator, len(n.Properties))
-		obj := &objEvaluator{
-			t: monoType(subst, n.TypeOf()),
-		}
 
 		for _, p := range n.Properties {
 			node, err := compile(p.Value, subst, scope)
@@ -261,8 +306,8 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			}
 			properties[p.Key.Key()] = node
 		}
-		obj.properties = properties
 
+		var extends *identifierEvaluator
 		if n.With != nil {
 			node, err := compile(n.With, subst, scope)
 			if err != nil {
@@ -272,11 +317,14 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			if !ok {
 				return nil, errors.New(codes.Internal, "unknown identifier in with expression")
 			}
-			obj.with = with
-
+			extends = with
 		}
 
-		return obj, nil
+		return &objEvaluator{
+			t:          apply(subst, nil, n.TypeOf()),
+			properties: properties,
+			with:       extends,
+		}, nil
 
 	case *semantic.ArrayExpression:
 		var elements []Evaluator
@@ -291,12 +339,12 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			}
 		}
 		return &arrayEvaluator{
-			t:     monoType(subst, n.TypeOf()),
+			t:     apply(subst, nil, n.TypeOf()),
 			array: elements,
 		}, nil
 	case *semantic.IdentifierExpression:
 		return &identifierEvaluator{
-			t:    monoType(subst, n.TypeOf()),
+			t:    apply(subst, nil, n.TypeOf()),
 			name: n.Name,
 		}, nil
 	case *semantic.MemberExpression:
@@ -305,7 +353,7 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			return nil, err
 		}
 		return &memberEvaluator{
-			t:        monoType(subst, n.TypeOf()),
+			t:        apply(subst, nil, n.TypeOf()),
 			object:   object,
 			property: n.Property,
 		}, nil
@@ -319,7 +367,7 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			return nil, err
 		}
 		return &arrayIndexEvaluator{
-			t:     monoType(subst, n.TypeOf()),
+			t:     apply(subst, nil, n.TypeOf()),
 			array: arr,
 			index: idx,
 		}, nil
@@ -389,7 +437,7 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			return nil, err
 		}
 		return &unaryEvaluator{
-			t:    monoType(subst, n.TypeOf()),
+			t:    apply(subst, nil, n.TypeOf()),
 			node: node,
 			op:   n.Operator,
 		}, nil
@@ -450,7 +498,7 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			return nil, err
 		}
 		return &binaryEvaluator{
-			t:     monoType(subst, n.TypeOf()),
+			t:     apply(subst, nil, n.TypeOf()),
 			left:  l,
 			right: r,
 			f:     f,
@@ -465,12 +513,12 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 			return nil, err
 		}
 		return &callEvaluator{
-			t:      monoType(subst, n.TypeOf()),
+			t:      apply(subst, nil, n.TypeOf()),
 			callee: callee,
 			args:   args,
 		}, nil
 	case *semantic.FunctionExpression:
-		fnType := monoType(subst, n.TypeOf())
+		fnType := apply(subst, nil, n.TypeOf())
 		num, err := fnType.NumArguments()
 		if err != nil {
 			return nil, err

--- a/stdlib/universe/map_nulls_test.flux
+++ b/stdlib/universe/map_nulls_test.flux
@@ -1,0 +1,37 @@
+package universe_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,string,long
+#group,false,false,false,true,false
+#default,_result,,,,
+,result,table,_time,_field,_value
+,,0,2018-05-22T19:53:26Z,a,1
+,,0,2018-05-22T19:53:36Z,a,1
+,,0,2018-05-22T19:53:46Z,a,1
+,,1,2018-05-22T19:53:36Z,b,1
+,,1,2018-05-22T19:53:46Z,b,1
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,long
+#group,false,false,false,false
+#default,0,,,
+,result,table,_time,_value
+,,0,2018-05-22T19:53:26Z,
+,,0,2018-05-22T19:53:36Z,1
+,,0,2018-05-22T19:53:46Z,1
+"
+
+t_pivot = (table=<-) =>
+	(table
+		|> range(start: 2018-05-22T19:53:26Z)
+		|> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
+		|> map(fn: (r) => ({_time: r._time, _value: r.a / r.b})))
+
+test _pivot = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_pivot})
+


### PR DESCRIPTION
Fixes an issue where `map` would drop a column if the first value in that column was null. The following query exhibited the bug:
```
... |> pivot(rowKey: ["_time"], columnKey: ["_field"], valueColumn: "_value")
    |> map(fn: (r) => ({_time: r._time, _value: r.a / r.b}))
```
Flux cannot infer the type of any expression following pivot. It waits till it gets an input record and calculates the output type from there. The type substitution that was constructed to do this was not applied fully to all types in map's lambda function, resulting in an unknown type which was subsequently dropped by `map`. The type substitution is now being applied fully to all types.