### PR TITLE
fix(stdlib/system): system.time() should check context for override

### DIFF
--- a/stdlib/system/time.go
+++ b/stdlib/system/time.go
@@ -5,21 +5,27 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/lang/execdeps"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
-var systemTimeFuncName = "time"
+var systemTimeFunc = values.NewFunction(
+	"time",
+	semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
+		Return: semantic.Time,
+	}),
+	func(ctx context.Context, args values.Object) (values.Value, error) {
+		if execdeps.HaveExecutionDependencies(ctx) {
+			if dep := execdeps.GetExecutionDependencies(ctx); dep.Now != nil {
+				return values.NewTime(values.ConvertTime(*dep.Now)), nil
+			}
+		}
+		return values.NewTime(values.ConvertTime(time.Now().UTC())), nil
+	},
+	false,
+)
 
 func init() {
-	flux.RegisterPackageValue("system", systemTimeFuncName, values.NewFunction(
-		systemTimeFuncName,
-		semantic.NewFunctionPolyType(semantic.FunctionPolySignature{
-			Return: semantic.Time,
-		}),
-		func(ctx context.Context, args values.Object) (values.Value, error) {
-			return values.NewTime(values.ConvertTime(time.Now().UTC())), nil
-		},
-		false,
-	))
+	flux.RegisterPackageValue("system", "time", systemTimeFunc)
 }

--- a/stdlib/system/time_test.go
+++ b/stdlib/system/time_test.go
@@ -1,0 +1,24 @@
+package system
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/influxdata/flux/lang/execdeps"
+)
+
+func TestOverrideWithContext(t *testing.T) {
+    dep := execdeps.DefaultExecutionDependencies()
+    now := time.Unix(1, 0)
+
+    dep.Now = &now
+
+    v, err := systemTimeFunc.Function().Call(dep.Inject(context.Background()), nil)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !v.Time().Time().Equal(now) {
+        t.Errorf("expected %v, but got %v", now.UTC(), v.Time().Time().UTC())
+    }
+}


### PR DESCRIPTION
`system.time()` did not check its context to see if the `now` time was overridden. This meant tasks as well as any other external system could not override the default `now` time.