### PR TITLE
feat: planner Pattern interface supplies a set of ProcedureKind as root

### DIFF
--- a/plan/heuristic_planner.go
+++ b/plan/heuristic_planner.go
@@ -21,8 +21,10 @@ func newHeuristicPlanner() *heuristicPlanner {
 
 func (p *heuristicPlanner) addRules(rules ...Rule) {
 	for _, rule := range rules {
-		ruleSlice := p.rules[rule.Pattern().Root()]
-		p.rules[rule.Pattern().Root()] = append(ruleSlice, rule)
+		for _, root := range rule.Pattern().Roots() {
+			ruleSlice := p.rules[root]
+			p.rules[root] = append(ruleSlice, rule)
+		}
 	}
 }
 

--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -141,6 +141,31 @@ func (ccr CreateCycleRule) Rewrite(ctx context.Context, node plan.Node) (plan.No
 	return node.ShallowCopy(), changed, nil
 }
 
+// MultiRoot matches a set of plan nodes at the root and stores the NodeIDs of
+// nodes it has visited in SeenNodes.
+type MultiRootRule struct {
+	SeenNodes []plan.NodeID
+}
+
+func (sr *MultiRootRule) Pattern() plan.Pattern {
+	return plan.OneOf(
+		[]plan.ProcedureKind{
+			universe.MinKind,
+			universe.MaxKind,
+			universe.MeanKind,
+		},
+		plan.Any())
+}
+
+func (sr *MultiRootRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
+	sr.SeenNodes = append(sr.SeenNodes, node.ID())
+	return node, false, nil
+}
+
+func (sr *MultiRootRule) Name() string {
+	return "multiroot"
+}
+
 // RuleTestCase allows for concise creation of test cases that exercise rules
 type RuleTestCase struct {
 	Name     string

--- a/plan/registration.go
+++ b/plan/registration.go
@@ -92,3 +92,8 @@ func registerRule(ruleMap map[string]Rule, rules ...Rule) {
 		ruleMap[name] = rule
 	}
 }
+
+func ClearRegisteredRules() {
+	ruleNameToLogicalRule = make(map[string]Rule)
+	ruleNameToPhysicalRule = make(map[string]Rule)
+}


### PR DESCRIPTION
Modified the planner Pattern interface to supply a set of ProcedureKind roots.
The pattern matcher adds the rule to multiple entries in the root-kind -> []rule
map.

The OneKindPattern was modfied to store a set of roots and was renamed to
UnionKindPattern. It is still used to implement plan.Pat and is now also used
to implement plan.UnionPat.

This change lets us create a pattern that is rooted at a set of ProcedureKind,
allowing us to make a single rule covering many window-aggregate combinations.
