### PR TITLE
fix(stdlib): run go generate on libflux when go generate is run on stdlib

### DIFF
--- a/stdlib/gen.go
+++ b/stdlib/gen.go
@@ -1,3 +1,4 @@
 package stdlib
 
 //go:generate go run github.com/influxdata/flux/internal/cmd/builtin generate --go-pkg github.com/influxdata/flux/stdlib --import-file packages.go
+//go:generate go generate ../libflux/go/libflux


### PR DESCRIPTION
A change to the standard library generally involves recompiling libflux.
Instead of requiring the developer to remember that, this changes the
`go generate` step for stdlib to trigger a generate for libflux to force
a rebuild.

This hack will be needed until we consolidate the standard library
either into only Go or only Rust.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written