### PR TITLE
fix: copy all fields of WindowProcedureSpec in Copy()

### DIFF
--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -149,6 +149,10 @@ func (s *WindowProcedureSpec) Kind() plan.ProcedureKind {
 func (s *WindowProcedureSpec) Copy() plan.ProcedureSpec {
 	ns := new(WindowProcedureSpec)
 	ns.Window = s.Window
+	ns.TimeColumn = s.TimeColumn
+	ns.StartColumn = s.StartColumn
+	ns.StopColumn = s.StopColumn
+	ns.CreateEmpty = s.CreateEmpty
 	return ns
 }
 


### PR DESCRIPTION
Complete the Copy() function of WindowProcedureSpec. This is necessary for the 
PushDownWindowAggregate rewrite rule tests to pass.