### PR TITLE
fix(stdlib): fix concurrent map write in filter transformation

### DIFF
--- a/execute/group_lookup_test.go
+++ b/execute/group_lookup_test.go
@@ -1,6 +1,7 @@
 package execute_test
 
 import (
+	"context"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -261,7 +262,7 @@ func testGroupLookupHelper(tb testing.TB, run func(name string, keys []flux.Grou
 		},
 		Seed: func(x int64) *int64 { return &x }(0),
 	}
-	input, err := gen.Input(schema)
+	input, err := gen.Input(context.Background(), schema)
 	if err != nil {
 		tb.Fatalf("unexpected error: %s", err)
 	}

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -326,7 +326,7 @@ func TestColListTable_SetNil(t *testing.T) {
 func TestCopyTable(t *testing.T) {
 	alloc := &memory.Allocator{}
 
-	input, err := gen.Input(gen.Schema{
+	input, err := gen.Input(context.Background(), gen.Schema{
 		Tags: []gen.Tag{
 			{Name: "t0", Cardinality: 1},
 		},

--- a/internal/gen/input_test.go
+++ b/internal/gen/input_test.go
@@ -22,7 +22,7 @@ func TestInput_TableTest(t *testing.T) {
 				NumPoints: 100,
 				Alloc:     alloc,
 			}
-			tables, err := gen.Input(schema)
+			tables, err := gen.Input(context.Background(), schema)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -47,12 +47,13 @@ func benchmarkInput(b *testing.B, n int) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		ti, err := gen.Input(schema)
+		ti, err := gen.Input(context.Background(), schema)
 		if err != nil {
 			b.Fatal(err)
 		}
 
 		if err := ti.Do(func(tbl flux.Table) error {
+			tbl.Done()
 			return nil
 		}); err != nil {
 			b.Fatal(err)

--- a/stdlib/internal/gen/tables.go
+++ b/stdlib/internal/gen/tables.go
@@ -160,7 +160,7 @@ func (s *Source) Run(ctx context.Context) {
 	schema := s.schema
 	schema.Alloc = s.alloc
 
-	tables, err := gen.Input(schema)
+	tables, err := gen.Input(ctx, schema)
 	if err != nil {
 		for _, t := range s.ts {
 			t.Finish(s.id, err)

--- a/stdlib/universe/group_test.go
+++ b/stdlib/universe/group_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -1005,7 +1006,7 @@ func benchmarkGroup(b *testing.B, n int, spec *universe.GroupProcedureSpec) {
 					{Name: "t1", Cardinality: 50},
 				},
 			}
-			return gen.Input(schema)
+			return gen.Input(context.Background(), schema)
 		},
 		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
 			return universe.NewGroupTransformation(spec, id, alloc)

--- a/stdlib/universe/limit_test.go
+++ b/stdlib/universe/limit_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/influxdata/flux"
@@ -263,7 +264,7 @@ func benchmarkLimit(b *testing.B, n, l int) {
 					{Name: "t1", Cardinality: 50},
 				},
 			}
-			return gen.Input(schema)
+			return gen.Input(context.Background(), schema)
 		},
 		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
 			return universe.NewLimitTransformation(spec, id)

--- a/stdlib/universe/pivot_test.go
+++ b/stdlib/universe/pivot_test.go
@@ -1363,7 +1363,7 @@ func TestPivot2_Process_VariousSchemas(t *testing.T) {
 	store := executetest.NewDataStore()
 	d.AddTransformation(store)
 
-	tables, err := gen.Input(gen.Schema{
+	tables, err := gen.Input(context.Background(), gen.Schema{
 		Tags: []gen.Tag{
 			{Name: "_measurement", Cardinality: 1},
 			{Name: "_field", Cardinality: 10},
@@ -1429,7 +1429,7 @@ func benchmarkPivot(b *testing.B, n int) {
 					{Name: "t1", Cardinality: 50},
 				},
 			}
-			return gen.Input(schema)
+			return gen.Input(context.Background(), schema)
 		},
 		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
 			// cache := execute.NewTableBuilderCache(alloc)


### PR DESCRIPTION
The filter transformation reused the same function between multiple
table process calls. This shared state meant that multiple tables could
be processed at the same time and use the same state when processing
rows within the tables.

The filter transformation should be fixed to use distinct state for each
table. There's no reason why they need to share state and it is not for
performance. It is an oversight from the original design which doesn't
process tables concurrently. But, that code is more complicated than the
process code so it is easier for us to prevent multiple tables from
being processed in filter. This prevents the race condition by
preventing multiple tables from being processed at the same time.

This also addresses a similar problem in the `internal/gen` package.
The table generation would reuse the same random number generator
between tables and the random number generator isn't thread safe and, if
we added a lock to it to make it thread safe, it wouldn't be consistent
when used with the same seed. We use the same technique to prevent more
than one table from being created at the same time.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written