### PR TITLE
feat(stdlib/v1): add fieldKeys and measurementFieldKeys to v1 package

### DIFF
--- a/docs/StandardLibrary.md
+++ b/docs/StandardLibrary.md
@@ -8,7 +8,7 @@ The top-level package is called "universe."
 The Flux compiler provides the concept of a "prelude," which is the set of packages whose members
 may be used in a Flux program without namespace qualification.  For example,
 in the vanilla Flux CLI, the prelude includes the `universe` and `influxdata/influxdb`
-packages. 
+packages.
 
 ## The `Universe` Package
 
@@ -110,6 +110,8 @@ Others?
 - `json`
 - `databases`
 - `fieldsAsCols`
+- `fieldKeys`
+- `measurementFieldKeys`
 - `tagValues`
 - `measurementTagValues`
 - `tagKeys`

--- a/stdlib/influxdata/influxdb/v1/flux_gen.go
+++ b/stdlib/influxdata/influxdb/v1/flux_gen.go
@@ -22,10 +22,10 @@ var pkgAST = &ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 51,
-					Line:   45,
+					Line:   60,
 				},
 				File:   "v1.flux",
-				Source: "package v1\n\n// Json parses an InfluxDB 1.x json result into a table stream.\nbuiltin json\n\n// Databases returns the list of available databases, it has no parameters.\nbuiltin databases\n\n// fieldsAsCols is a special application of pivot that will automatically align fields within each measurement that have the same timestamp.\nfieldsAsCols = (tables=<-) =>\n    tables\n        |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\n// TagValues returns the unique values for a given tag.\n// The return value is always a single table with a single column \"_value\".\ntagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)\n\n// MeasurementTagValues returns a single table with a single column \"_value\" that contains the\n// The return value is always a single table with a single column \"_value\".\nmeasurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)\n\n// TagKeys returns the list of tag keys for all series that match the predicate.\n// The return value is always a single table with a single column \"_value\".\ntagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()\n\n// MeasurementTagKeys returns the list of tag keys for a specific measurement.\nmeasurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)\n\n// Measurements returns the list of measurements in a specific bucket.\nmeasurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+				Source: "package v1\n\n// Json parses an InfluxDB 1.x json result into a table stream.\nbuiltin json\n\n// Databases returns the list of available databases, it has no parameters.\nbuiltin databases\n\n// fieldsAsCols is a special application of pivot that will automatically align fields within each measurement that have the same timestamp.\nfieldsAsCols = (tables=<-) =>\n    tables\n        |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\n// FieldKeys returns the list of field keys in a given bucket.\n// The return value is always a single table with a single column, \"_value\".\nfieldKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")\n\n// MeasurementFieldKeys returns field keys in a given measurement.\n// The return value is always a single table with a single column, \"_value\".\nmeasurementFieldKeys = (bucket, measurement, start) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)\n\n// TagValues returns the unique values for a given tag.\n// The return value is always a single table with a single column \"_value\".\ntagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)\n\n// MeasurementTagValues returns a single table with a single column \"_value\" that contains the\n// The return value is always a single table with a single column \"_value\".\nmeasurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)\n\n// TagKeys returns the list of tag keys for all series that match the predicate.\n// The return value is always a single table with a single column \"_value\".\ntagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()\n\n// MeasurementTagKeys returns the list of tag keys for a specific measurement.\nmeasurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)\n\n// Measurements returns the list of measurements in a specific bucket.\nmeasurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -485,11 +485,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 31,
+						Column: 36,
 						Line:   22,
 					},
 					File:   "v1.flux",
-					Source: "tagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
+					Source: "fieldKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")",
 					Start: ast.Position{
 						Column: 1,
 						Line:   16,
@@ -505,25 +505,25 @@ var pkgAST = &ast.Package{
 							Line:   16,
 						},
 						File:   "v1.flux",
-						Source: "tagValues",
+						Source: "fieldKeys",
 						Start: ast.Position{
 							Column: 1,
 							Line:   16,
 						},
 					},
 				},
-				Name: "tagValues",
+				Name: "fieldKeys",
 			},
 			Init: &ast.FunctionExpression{
 				BaseNode: ast.BaseNode{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 31,
+							Column: 36,
 							Line:   22,
 						},
 						File:   "v1.flux",
-						Source: "(bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
+						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")",
 						Start: ast.Position{
 							Column: 13,
 							Line:   16,
@@ -889,11 +889,11 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 30,
+										Column: 35,
 										Line:   20,
 									},
 									File:   "v1.flux",
-									Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])",
+									Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])",
 									Start: ast.Position{
 										Column: 5,
 										Line:   17,
@@ -906,11 +906,11 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 29,
+												Column: 34,
 												Line:   20,
 											},
 											File:   "v1.flux",
-											Source: "columns: [tag]",
+											Source: "columns: [\"_field\"]",
 											Start: ast.Position{
 												Column: 15,
 												Line:   20,
@@ -922,11 +922,11 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 29,
+													Column: 34,
 													Line:   20,
 												},
 												File:   "v1.flux",
-												Source: "columns: [tag]",
+												Source: "columns: [\"_field\"]",
 												Start: ast.Position{
 													Column: 15,
 													Line:   20,
@@ -956,34 +956,34 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 29,
+														Column: 34,
 														Line:   20,
 													},
 													File:   "v1.flux",
-													Source: "[tag]",
+													Source: "[\"_field\"]",
 													Start: ast.Position{
 														Column: 24,
 														Line:   20,
 													},
 												},
 											},
-											Elements: []ast.Expression{&ast.Identifier{
+											Elements: []ast.Expression{&ast.StringLiteral{
 												BaseNode: ast.BaseNode{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 28,
+															Column: 33,
 															Line:   20,
 														},
 														File:   "v1.flux",
-														Source: "tag",
+														Source: "\"_field\"",
 														Start: ast.Position{
 															Column: 25,
 															Line:   20,
 														},
 													},
 												},
-												Name: "tag",
+												Value: "_field",
 											}},
 										},
 									}},
@@ -993,11 +993,11 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 30,
+											Column: 35,
 											Line:   20,
 										},
 										File:   "v1.flux",
-										Source: "keep(columns: [tag])",
+										Source: "keep(columns: [\"_field\"])",
 										Start: ast.Position{
 											Column: 10,
 											Line:   20,
@@ -1032,7 +1032,7 @@ var pkgAST = &ast.Package{
 									Line:   21,
 								},
 								File:   "v1.flux",
-								Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()",
+								Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()",
 								Start: ast.Position{
 									Column: 5,
 									Line:   17,
@@ -1080,11 +1080,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 31,
+								Column: 36,
 								Line:   22,
 							},
 							File:   "v1.flux",
-							Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
+							Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")",
 							Start: ast.Position{
 								Column: 5,
 								Line:   17,
@@ -1097,11 +1097,11 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 30,
+										Column: 35,
 										Line:   22,
 									},
 									File:   "v1.flux",
-									Source: "column: tag",
+									Source: "column: \"_field\"",
 									Start: ast.Position{
 										Column: 19,
 										Line:   22,
@@ -1113,11 +1113,11 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 30,
+											Column: 35,
 											Line:   22,
 										},
 										File:   "v1.flux",
-										Source: "column: tag",
+										Source: "column: \"_field\"",
 										Start: ast.Position{
 											Column: 19,
 											Line:   22,
@@ -1142,23 +1142,23 @@ var pkgAST = &ast.Package{
 									},
 									Name: "column",
 								},
-								Value: &ast.Identifier{
+								Value: &ast.StringLiteral{
 									BaseNode: ast.BaseNode{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 30,
+												Column: 35,
 												Line:   22,
 											},
 											File:   "v1.flux",
-											Source: "tag",
+											Source: "\"_field\"",
 											Start: ast.Position{
 												Column: 27,
 												Line:   22,
 											},
 										},
 									},
-									Name: "tag",
+									Value: "_field",
 								},
 							}},
 							With: nil,
@@ -1167,11 +1167,11 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 31,
+									Column: 36,
 									Line:   22,
 								},
 								File:   "v1.flux",
-								Source: "distinct(column: tag)",
+								Source: "distinct(column: \"_field\")",
 								Start: ast.Position{
 									Column: 10,
 									Line:   22,
@@ -1238,11 +1238,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 25,
+								Column: 43,
 								Line:   16,
 							},
 							File:   "v1.flux",
-							Source: "tag",
+							Source: "predicate=(r) => true",
 							Start: ast.Position{
 								Column: 22,
 								Line:   16,
@@ -1254,48 +1254,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 25,
-									Line:   16,
-								},
-								File:   "v1.flux",
-								Source: "tag",
-								Start: ast.Position{
-									Column: 22,
-									Line:   16,
-								},
-							},
-						},
-						Name: "tag",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 48,
-								Line:   16,
-							},
-							File:   "v1.flux",
-							Source: "predicate=(r) => true",
-							Start: ast.Position{
-								Column: 27,
-								Line:   16,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 36,
+									Column: 31,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "predicate",
 								Start: ast.Position{
-									Column: 27,
+									Column: 22,
 									Line:   16,
 								},
 							},
@@ -1307,13 +1272,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 48,
+									Column: 43,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "(r) => true",
 								Start: ast.Position{
-									Column: 37,
+									Column: 32,
 									Line:   16,
 								},
 							},
@@ -1323,13 +1288,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 48,
+										Column: 43,
 										Line:   16,
 									},
 									File:   "v1.flux",
 									Source: "true",
 									Start: ast.Position{
-										Column: 44,
+										Column: 39,
 										Line:   16,
 									},
 								},
@@ -1341,13 +1306,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 39,
+										Column: 34,
 										Line:   16,
 									},
 									File:   "v1.flux",
 									Source: "r",
 									Start: ast.Position{
-										Column: 38,
+										Column: 33,
 										Line:   16,
 									},
 								},
@@ -1357,13 +1322,13 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 39,
+											Column: 34,
 											Line:   16,
 										},
 										File:   "v1.flux",
 										Source: "r",
 										Start: ast.Position{
-											Column: 38,
+											Column: 33,
 											Line:   16,
 										},
 									},
@@ -1378,13 +1343,13 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 60,
+								Column: 55,
 								Line:   16,
 							},
 							File:   "v1.flux",
 							Source: "start=-30d",
 							Start: ast.Position{
-								Column: 50,
+								Column: 45,
 								Line:   16,
 							},
 						},
@@ -1394,13 +1359,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 55,
+									Column: 50,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "start",
 								Start: ast.Position{
-									Column: 50,
+									Column: 45,
 									Line:   16,
 								},
 							},
@@ -1413,13 +1378,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 60,
+										Column: 55,
 										Line:   16,
 									},
 									File:   "v1.flux",
 									Source: "30d",
 									Start: ast.Position{
-										Column: 57,
+										Column: 52,
 										Line:   16,
 									},
 								},
@@ -1433,13 +1398,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 60,
+									Column: 55,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "-30d",
 								Start: ast.Position{
-									Column: 56,
+									Column: 51,
 									Line:   16,
 								},
 							},
@@ -1453,11 +1418,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 89,
+						Column: 93,
 						Line:   27,
 					},
 					File:   "v1.flux",
-					Source: "measurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
+					Source: "measurementFieldKeys = (bucket, measurement, start) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   26,
@@ -1473,25 +1438,25 @@ var pkgAST = &ast.Package{
 							Line:   26,
 						},
 						File:   "v1.flux",
-						Source: "measurementTagValues",
+						Source: "measurementFieldKeys",
 						Start: ast.Position{
 							Column: 1,
 							Line:   26,
 						},
 					},
 				},
-				Name: "measurementTagValues",
+				Name: "measurementFieldKeys",
 			},
 			Init: &ast.FunctionExpression{
 				BaseNode: ast.BaseNode{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 89,
+							Column: 93,
 							Line:   27,
 						},
 						File:   "v1.flux",
-						Source: "(bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
+						Source: "(bucket, measurement, start) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
 						Start: ast.Position{
 							Column: 24,
 							Line:   26,
@@ -1504,11 +1469,11 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 88,
+									Column: 92,
 									Line:   27,
 								},
 								File:   "v1.flux",
-								Source: "bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement",
+								Source: "bucket: bucket, predicate: (r) => r._measurement == measurement, start: start",
 								Start: ast.Position{
 									Column: 15,
 									Line:   27,
@@ -1572,11 +1537,11 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 39,
+										Column: 78,
 										Line:   27,
 									},
 									File:   "v1.flux",
-									Source: "tag: tag",
+									Source: "predicate: (r) => r._measurement == measurement",
 									Start: ast.Position{
 										Column: 31,
 										Line:   27,
@@ -1588,65 +1553,13 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 34,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "tag",
-										Start: ast.Position{
-											Column: 31,
-											Line:   27,
-										},
-									},
-								},
-								Name: "tag",
-							},
-							Value: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 39,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "tag",
-										Start: ast.Position{
-											Column: 36,
-											Line:   27,
-										},
-									},
-								},
-								Name: "tag",
-							},
-						}, &ast.Property{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 88,
-										Line:   27,
-									},
-									File:   "v1.flux",
-									Source: "predicate: (r) => r._measurement == measurement",
-									Start: ast.Position{
-										Column: 41,
-										Line:   27,
-									},
-								},
-							},
-							Key: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 50,
+											Column: 40,
 											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "predicate",
 										Start: ast.Position{
-											Column: 41,
+											Column: 31,
 											Line:   27,
 										},
 									},
@@ -1658,13 +1571,13 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 88,
+											Column: 78,
 											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "(r) => r._measurement == measurement",
 										Start: ast.Position{
-											Column: 52,
+											Column: 42,
 											Line:   27,
 										},
 									},
@@ -1674,13 +1587,13 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 88,
+												Column: 78,
 												Line:   27,
 											},
 											File:   "v1.flux",
 											Source: "r._measurement == measurement",
 											Start: ast.Position{
-												Column: 59,
+												Column: 49,
 												Line:   27,
 											},
 										},
@@ -1690,13 +1603,13 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 73,
+													Column: 63,
 													Line:   27,
 												},
 												File:   "v1.flux",
 												Source: "r._measurement",
 												Start: ast.Position{
-													Column: 59,
+													Column: 49,
 													Line:   27,
 												},
 											},
@@ -1706,13 +1619,13 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 60,
+														Column: 50,
 														Line:   27,
 													},
 													File:   "v1.flux",
 													Source: "r",
 													Start: ast.Position{
-														Column: 59,
+														Column: 49,
 														Line:   27,
 													},
 												},
@@ -1724,13 +1637,13 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 73,
+														Column: 63,
 														Line:   27,
 													},
 													File:   "v1.flux",
 													Source: "_measurement",
 													Start: ast.Position{
-														Column: 61,
+														Column: 51,
 														Line:   27,
 													},
 												},
@@ -1744,13 +1657,13 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 88,
+													Column: 78,
 													Line:   27,
 												},
 												File:   "v1.flux",
 												Source: "measurement",
 												Start: ast.Position{
-													Column: 77,
+													Column: 67,
 													Line:   27,
 												},
 											},
@@ -1763,13 +1676,13 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 54,
+												Column: 44,
 												Line:   27,
 											},
 											File:   "v1.flux",
 											Source: "r",
 											Start: ast.Position{
-												Column: 53,
+												Column: 43,
 												Line:   27,
 											},
 										},
@@ -1779,13 +1692,13 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 54,
+													Column: 44,
 													Line:   27,
 												},
 												File:   "v1.flux",
 												Source: "r",
 												Start: ast.Position{
-													Column: 53,
+													Column: 43,
 													Line:   27,
 												},
 											},
@@ -1795,6 +1708,58 @@ var pkgAST = &ast.Package{
 									Value: nil,
 								}},
 							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 92,
+										Line:   27,
+									},
+									File:   "v1.flux",
+									Source: "start: start",
+									Start: ast.Position{
+										Column: 80,
+										Line:   27,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 85,
+											Line:   27,
+										},
+										File:   "v1.flux",
+										Source: "start",
+										Start: ast.Position{
+											Column: 80,
+											Line:   27,
+										},
+									},
+								},
+								Name: "start",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 92,
+											Line:   27,
+										},
+										File:   "v1.flux",
+										Source: "start",
+										Start: ast.Position{
+											Column: 87,
+											Line:   27,
+										},
+									},
+								},
+								Name: "start",
+							},
 						}},
 						With: nil,
 					}},
@@ -1802,11 +1767,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 89,
+								Column: 93,
 								Line:   27,
 							},
 							File:   "v1.flux",
-							Source: "tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
+							Source: "fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
 							Start: ast.Position{
 								Column: 5,
 								Line:   27,
@@ -1822,14 +1787,14 @@ var pkgAST = &ast.Package{
 									Line:   27,
 								},
 								File:   "v1.flux",
-								Source: "tagValues",
+								Source: "fieldKeys",
 								Start: ast.Position{
 									Column: 5,
 									Line:   27,
 								},
 							},
 						},
-						Name: "tagValues",
+						Name: "fieldKeys",
 					},
 				},
 				Params: []*ast.Property{&ast.Property{
@@ -1907,11 +1872,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 49,
+								Column: 51,
 								Line:   26,
 							},
 							File:   "v1.flux",
-							Source: "tag",
+							Source: "start",
 							Start: ast.Position{
 								Column: 46,
 								Line:   26,
@@ -1923,18 +1888,18 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 49,
+									Column: 51,
 									Line:   26,
 								},
 								File:   "v1.flux",
-								Source: "tag",
+								Source: "start",
 								Start: ast.Position{
 									Column: 46,
 									Line:   26,
 								},
 							},
 						},
-						Name: "tag",
+						Name: "start",
 					},
 					Value: nil,
 				}},
@@ -1944,11 +1909,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 22,
+						Column: 31,
 						Line:   37,
 					},
 					File:   "v1.flux",
-					Source: "tagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+					Source: "tagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   31,
@@ -1960,31 +1925,31 @@ var pkgAST = &ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 8,
+							Column: 10,
 							Line:   31,
 						},
 						File:   "v1.flux",
-						Source: "tagKeys",
+						Source: "tagValues",
 						Start: ast.Position{
 							Column: 1,
 							Line:   31,
 						},
 					},
 				},
-				Name: "tagKeys",
+				Name: "tagValues",
 			},
 			Init: &ast.FunctionExpression{
 				BaseNode: ast.BaseNode{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 22,
+							Column: 31,
 							Line:   37,
 						},
 						File:   "v1.flux",
-						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+						Source: "(bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
 						Start: ast.Position{
-							Column: 11,
+							Column: 13,
 							Line:   31,
 						},
 					},
@@ -2104,11 +2069,11 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 31,
+												Column: 29,
 												Line:   33,
 											},
 											File:   "v1.flux",
-											Source: "from(bucket: bucket)\n        |> range(start: start)",
+											Source: "from(bucket: bucket)\n      |> range(start: start)",
 											Start: ast.Position{
 												Column: 5,
 												Line:   32,
@@ -2121,13 +2086,13 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 30,
+														Column: 28,
 														Line:   33,
 													},
 													File:   "v1.flux",
 													Source: "start: start",
 													Start: ast.Position{
-														Column: 18,
+														Column: 16,
 														Line:   33,
 													},
 												},
@@ -2137,13 +2102,13 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 30,
+															Column: 28,
 															Line:   33,
 														},
 														File:   "v1.flux",
 														Source: "start: start",
 														Start: ast.Position{
-															Column: 18,
+															Column: 16,
 															Line:   33,
 														},
 													},
@@ -2153,13 +2118,13 @@ var pkgAST = &ast.Package{
 														Errors: nil,
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
-																Column: 23,
+																Column: 21,
 																Line:   33,
 															},
 															File:   "v1.flux",
 															Source: "start",
 															Start: ast.Position{
-																Column: 18,
+																Column: 16,
 																Line:   33,
 															},
 														},
@@ -2171,13 +2136,13 @@ var pkgAST = &ast.Package{
 														Errors: nil,
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
-																Column: 30,
+																Column: 28,
 																Line:   33,
 															},
 															File:   "v1.flux",
 															Source: "start",
 															Start: ast.Position{
-																Column: 25,
+																Column: 23,
 																Line:   33,
 															},
 														},
@@ -2191,13 +2156,13 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 31,
+													Column: 29,
 													Line:   33,
 												},
 												File:   "v1.flux",
 												Source: "range(start: start)",
 												Start: ast.Position{
-													Column: 12,
+													Column: 10,
 													Line:   33,
 												},
 											},
@@ -2207,13 +2172,13 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 17,
+														Column: 15,
 														Line:   33,
 													},
 													File:   "v1.flux",
 													Source: "range",
 													Start: ast.Position{
-														Column: 12,
+														Column: 10,
 														Line:   33,
 													},
 												},
@@ -2226,11 +2191,11 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 33,
+											Column: 31,
 											Line:   34,
 										},
 										File:   "v1.flux",
-										Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)",
+										Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)",
 										Start: ast.Position{
 											Column: 5,
 											Line:   32,
@@ -2243,13 +2208,13 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 32,
+													Column: 30,
 													Line:   34,
 												},
 												File:   "v1.flux",
 												Source: "fn: predicate",
 												Start: ast.Position{
-													Column: 19,
+													Column: 17,
 													Line:   34,
 												},
 											},
@@ -2259,13 +2224,13 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 32,
+														Column: 30,
 														Line:   34,
 													},
 													File:   "v1.flux",
 													Source: "fn: predicate",
 													Start: ast.Position{
-														Column: 19,
+														Column: 17,
 														Line:   34,
 													},
 												},
@@ -2275,13 +2240,13 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 21,
+															Column: 19,
 															Line:   34,
 														},
 														File:   "v1.flux",
 														Source: "fn",
 														Start: ast.Position{
-															Column: 19,
+															Column: 17,
 															Line:   34,
 														},
 													},
@@ -2293,13 +2258,13 @@ var pkgAST = &ast.Package{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 32,
+															Column: 30,
 															Line:   34,
 														},
 														File:   "v1.flux",
 														Source: "predicate",
 														Start: ast.Position{
-															Column: 23,
+															Column: 21,
 															Line:   34,
 														},
 													},
@@ -2313,13 +2278,13 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 33,
+												Column: 31,
 												Line:   34,
 											},
 											File:   "v1.flux",
 											Source: "filter(fn: predicate)",
 											Start: ast.Position{
-												Column: 12,
+												Column: 10,
 												Line:   34,
 											},
 										},
@@ -2329,13 +2294,13 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 18,
+													Column: 16,
 													Line:   34,
 												},
 												File:   "v1.flux",
 												Source: "filter",
 												Start: ast.Position{
-													Column: 12,
+													Column: 10,
 													Line:   34,
 												},
 											},
@@ -2348,11 +2313,11 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 18,
+										Column: 30,
 										Line:   35,
 									},
 									File:   "v1.flux",
-									Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()",
+									Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])",
 									Start: ast.Position{
 										Column: 5,
 										Line:   32,
@@ -2360,18 +2325,105 @@ var pkgAST = &ast.Package{
 								},
 							},
 							Call: &ast.CallExpression{
-								Arguments: nil,
+								Arguments: []ast.Expression{&ast.ObjectExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 29,
+												Line:   35,
+											},
+											File:   "v1.flux",
+											Source: "columns: [tag]",
+											Start: ast.Position{
+												Column: 15,
+												Line:   35,
+											},
+										},
+									},
+									Properties: []*ast.Property{&ast.Property{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 29,
+													Line:   35,
+												},
+												File:   "v1.flux",
+												Source: "columns: [tag]",
+												Start: ast.Position{
+													Column: 15,
+													Line:   35,
+												},
+											},
+										},
+										Key: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 22,
+														Line:   35,
+													},
+													File:   "v1.flux",
+													Source: "columns",
+													Start: ast.Position{
+														Column: 15,
+														Line:   35,
+													},
+												},
+											},
+											Name: "columns",
+										},
+										Value: &ast.ArrayExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 29,
+														Line:   35,
+													},
+													File:   "v1.flux",
+													Source: "[tag]",
+													Start: ast.Position{
+														Column: 24,
+														Line:   35,
+													},
+												},
+											},
+											Elements: []ast.Expression{&ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 28,
+															Line:   35,
+														},
+														File:   "v1.flux",
+														Source: "tag",
+														Start: ast.Position{
+															Column: 25,
+															Line:   35,
+														},
+													},
+												},
+												Name: "tag",
+											}},
+										},
+									}},
+									With: nil,
+								}},
 								BaseNode: ast.BaseNode{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 18,
+											Column: 30,
 											Line:   35,
 										},
 										File:   "v1.flux",
-										Source: "keys()",
+										Source: "keep(columns: [tag])",
 										Start: ast.Position{
-											Column: 12,
+											Column: 10,
 											Line:   35,
 										},
 									},
@@ -2381,18 +2433,18 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 16,
+												Column: 14,
 												Line:   35,
 											},
 											File:   "v1.flux",
-											Source: "keys",
+											Source: "keep",
 											Start: ast.Position{
-												Column: 12,
+												Column: 10,
 												Line:   35,
 											},
 										},
 									},
-									Name: "keys",
+									Name: "keep",
 								},
 							},
 						},
@@ -2400,11 +2452,11 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 37,
+									Column: 17,
 									Line:   36,
 								},
 								File:   "v1.flux",
-								Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
+								Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()",
 								Start: ast.Position{
 									Column: 5,
 									Line:   32,
@@ -2412,105 +2464,18 @@ var pkgAST = &ast.Package{
 							},
 						},
 						Call: &ast.CallExpression{
-							Arguments: []ast.Expression{&ast.ObjectExpression{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 36,
-											Line:   36,
-										},
-										File:   "v1.flux",
-										Source: "columns: [\"_value\"]",
-										Start: ast.Position{
-											Column: 17,
-											Line:   36,
-										},
-									},
-								},
-								Properties: []*ast.Property{&ast.Property{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 36,
-												Line:   36,
-											},
-											File:   "v1.flux",
-											Source: "columns: [\"_value\"]",
-											Start: ast.Position{
-												Column: 17,
-												Line:   36,
-											},
-										},
-									},
-									Key: &ast.Identifier{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 24,
-													Line:   36,
-												},
-												File:   "v1.flux",
-												Source: "columns",
-												Start: ast.Position{
-													Column: 17,
-													Line:   36,
-												},
-											},
-										},
-										Name: "columns",
-									},
-									Value: &ast.ArrayExpression{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 36,
-													Line:   36,
-												},
-												File:   "v1.flux",
-												Source: "[\"_value\"]",
-												Start: ast.Position{
-													Column: 26,
-													Line:   36,
-												},
-											},
-										},
-										Elements: []ast.Expression{&ast.StringLiteral{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 35,
-														Line:   36,
-													},
-													File:   "v1.flux",
-													Source: "\"_value\"",
-													Start: ast.Position{
-														Column: 27,
-														Line:   36,
-													},
-												},
-											},
-											Value: "_value",
-										}},
-									},
-								}},
-								With: nil,
-							}},
+							Arguments: nil,
 							BaseNode: ast.BaseNode{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 37,
+										Column: 17,
 										Line:   36,
 									},
 									File:   "v1.flux",
-									Source: "keep(columns: [\"_value\"])",
+									Source: "group()",
 									Start: ast.Position{
-										Column: 12,
+										Column: 10,
 										Line:   36,
 									},
 								},
@@ -2520,18 +2485,18 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 16,
+											Column: 15,
 											Line:   36,
 										},
 										File:   "v1.flux",
-										Source: "keep",
+										Source: "group",
 										Start: ast.Position{
-											Column: 12,
+											Column: 10,
 											Line:   36,
 										},
 									},
 								},
-								Name: "keep",
+								Name: "group",
 							},
 						},
 					},
@@ -2539,11 +2504,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 22,
+								Column: 31,
 								Line:   37,
 							},
 							File:   "v1.flux",
-							Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+							Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
 							Start: ast.Position{
 								Column: 5,
 								Line:   32,
@@ -2551,18 +2516,88 @@ var pkgAST = &ast.Package{
 						},
 					},
 					Call: &ast.CallExpression{
-						Arguments: nil,
+						Arguments: []ast.Expression{&ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 30,
+										Line:   37,
+									},
+									File:   "v1.flux",
+									Source: "column: tag",
+									Start: ast.Position{
+										Column: 19,
+										Line:   37,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 30,
+											Line:   37,
+										},
+										File:   "v1.flux",
+										Source: "column: tag",
+										Start: ast.Position{
+											Column: 19,
+											Line:   37,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 25,
+												Line:   37,
+											},
+											File:   "v1.flux",
+											Source: "column",
+											Start: ast.Position{
+												Column: 19,
+												Line:   37,
+											},
+										},
+									},
+									Name: "column",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 30,
+												Line:   37,
+											},
+											File:   "v1.flux",
+											Source: "tag",
+											Start: ast.Position{
+												Column: 27,
+												Line:   37,
+											},
+										},
+									},
+									Name: "tag",
+								},
+							}},
+							With: nil,
+						}},
 						BaseNode: ast.BaseNode{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 22,
+									Column: 31,
 									Line:   37,
 								},
 								File:   "v1.flux",
-								Source: "distinct()",
+								Source: "distinct(column: tag)",
 								Start: ast.Position{
-									Column: 12,
+									Column: 10,
 									Line:   37,
 								},
 							},
@@ -2572,13 +2607,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 20,
+										Column: 18,
 										Line:   37,
 									},
 									File:   "v1.flux",
 									Source: "distinct",
 									Start: ast.Position{
-										Column: 12,
+										Column: 10,
 										Line:   37,
 									},
 								},
@@ -2592,13 +2627,13 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 18,
+								Column: 20,
 								Line:   31,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
-								Column: 12,
+								Column: 14,
 								Line:   31,
 							},
 						},
@@ -2608,13 +2643,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 18,
+									Column: 20,
 									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
-									Column: 12,
+									Column: 14,
 									Line:   31,
 								},
 							},
@@ -2627,13 +2662,13 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 41,
+								Column: 25,
 								Line:   31,
 							},
 							File:   "v1.flux",
-							Source: "predicate=(r) => true",
+							Source: "tag",
 							Start: ast.Position{
-								Column: 20,
+								Column: 22,
 								Line:   31,
 							},
 						},
@@ -2643,13 +2678,48 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 29,
+									Column: 25,
+									Line:   31,
+								},
+								File:   "v1.flux",
+								Source: "tag",
+								Start: ast.Position{
+									Column: 22,
+									Line:   31,
+								},
+							},
+						},
+						Name: "tag",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 48,
+								Line:   31,
+							},
+							File:   "v1.flux",
+							Source: "predicate=(r) => true",
+							Start: ast.Position{
+								Column: 27,
+								Line:   31,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
 									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "predicate",
 								Start: ast.Position{
-									Column: 20,
+									Column: 27,
 									Line:   31,
 								},
 							},
@@ -2661,13 +2731,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 41,
+									Column: 48,
 									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "(r) => true",
 								Start: ast.Position{
-									Column: 30,
+									Column: 37,
 									Line:   31,
 								},
 							},
@@ -2677,13 +2747,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 41,
+										Column: 48,
 										Line:   31,
 									},
 									File:   "v1.flux",
 									Source: "true",
 									Start: ast.Position{
-										Column: 37,
+										Column: 44,
 										Line:   31,
 									},
 								},
@@ -2695,13 +2765,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 32,
+										Column: 39,
 										Line:   31,
 									},
 									File:   "v1.flux",
 									Source: "r",
 									Start: ast.Position{
-										Column: 31,
+										Column: 38,
 										Line:   31,
 									},
 								},
@@ -2711,13 +2781,13 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 32,
+											Column: 39,
 											Line:   31,
 										},
 										File:   "v1.flux",
 										Source: "r",
 										Start: ast.Position{
-											Column: 31,
+											Column: 38,
 											Line:   31,
 										},
 									},
@@ -2732,13 +2802,13 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 53,
+								Column: 60,
 								Line:   31,
 							},
 							File:   "v1.flux",
 							Source: "start=-30d",
 							Start: ast.Position{
-								Column: 43,
+								Column: 50,
 								Line:   31,
 							},
 						},
@@ -2748,13 +2818,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 48,
+									Column: 55,
 									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "start",
 								Start: ast.Position{
-									Column: 43,
+									Column: 50,
 									Line:   31,
 								},
 							},
@@ -2767,13 +2837,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 53,
+										Column: 60,
 										Line:   31,
 									},
 									File:   "v1.flux",
 									Source: "30d",
 									Start: ast.Position{
-										Column: 50,
+										Column: 57,
 										Line:   31,
 									},
 								},
@@ -2787,13 +2857,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 53,
+									Column: 60,
 									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "-30d",
 								Start: ast.Position{
-									Column: 49,
+									Column: 56,
 									Line:   31,
 								},
 							},
@@ -2807,14 +2877,1368 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 77,
+						Column: 89,
+						Line:   42,
+					},
+					File:   "v1.flux",
+					Source: "measurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
+					Start: ast.Position{
+						Column: 1,
 						Line:   41,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 21,
+							Line:   41,
+						},
+						File:   "v1.flux",
+						Source: "measurementTagValues",
+						Start: ast.Position{
+							Column: 1,
+							Line:   41,
+						},
+					},
+				},
+				Name: "measurementTagValues",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 89,
+							Line:   42,
+						},
+						File:   "v1.flux",
+						Source: "(bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
+						Start: ast.Position{
+							Column: 24,
+							Line:   41,
+						},
+					},
+				},
+				Body: &ast.CallExpression{
+					Arguments: []ast.Expression{&ast.ObjectExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 88,
+									Line:   42,
+								},
+								File:   "v1.flux",
+								Source: "bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement",
+								Start: ast.Position{
+									Column: 15,
+									Line:   42,
+								},
+							},
+						},
+						Properties: []*ast.Property{&ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 29,
+										Line:   42,
+									},
+									File:   "v1.flux",
+									Source: "bucket: bucket",
+									Start: ast.Position{
+										Column: 15,
+										Line:   42,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 21,
+											Line:   42,
+										},
+										File:   "v1.flux",
+										Source: "bucket",
+										Start: ast.Position{
+											Column: 15,
+											Line:   42,
+										},
+									},
+								},
+								Name: "bucket",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 29,
+											Line:   42,
+										},
+										File:   "v1.flux",
+										Source: "bucket",
+										Start: ast.Position{
+											Column: 23,
+											Line:   42,
+										},
+									},
+								},
+								Name: "bucket",
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 39,
+										Line:   42,
+									},
+									File:   "v1.flux",
+									Source: "tag: tag",
+									Start: ast.Position{
+										Column: 31,
+										Line:   42,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 34,
+											Line:   42,
+										},
+										File:   "v1.flux",
+										Source: "tag",
+										Start: ast.Position{
+											Column: 31,
+											Line:   42,
+										},
+									},
+								},
+								Name: "tag",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 39,
+											Line:   42,
+										},
+										File:   "v1.flux",
+										Source: "tag",
+										Start: ast.Position{
+											Column: 36,
+											Line:   42,
+										},
+									},
+								},
+								Name: "tag",
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 88,
+										Line:   42,
+									},
+									File:   "v1.flux",
+									Source: "predicate: (r) => r._measurement == measurement",
+									Start: ast.Position{
+										Column: 41,
+										Line:   42,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 50,
+											Line:   42,
+										},
+										File:   "v1.flux",
+										Source: "predicate",
+										Start: ast.Position{
+											Column: 41,
+											Line:   42,
+										},
+									},
+								},
+								Name: "predicate",
+							},
+							Value: &ast.FunctionExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 88,
+											Line:   42,
+										},
+										File:   "v1.flux",
+										Source: "(r) => r._measurement == measurement",
+										Start: ast.Position{
+											Column: 52,
+											Line:   42,
+										},
+									},
+								},
+								Body: &ast.BinaryExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 88,
+												Line:   42,
+											},
+											File:   "v1.flux",
+											Source: "r._measurement == measurement",
+											Start: ast.Position{
+												Column: 59,
+												Line:   42,
+											},
+										},
+									},
+									Left: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 73,
+													Line:   42,
+												},
+												File:   "v1.flux",
+												Source: "r._measurement",
+												Start: ast.Position{
+													Column: 59,
+													Line:   42,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 60,
+														Line:   42,
+													},
+													File:   "v1.flux",
+													Source: "r",
+													Start: ast.Position{
+														Column: 59,
+														Line:   42,
+													},
+												},
+											},
+											Name: "r",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 73,
+														Line:   42,
+													},
+													File:   "v1.flux",
+													Source: "_measurement",
+													Start: ast.Position{
+														Column: 61,
+														Line:   42,
+													},
+												},
+											},
+											Name: "_measurement",
+										},
+									},
+									Operator: 17,
+									Right: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 88,
+													Line:   42,
+												},
+												File:   "v1.flux",
+												Source: "measurement",
+												Start: ast.Position{
+													Column: 77,
+													Line:   42,
+												},
+											},
+										},
+										Name: "measurement",
+									},
+								},
+								Params: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 54,
+												Line:   42,
+											},
+											File:   "v1.flux",
+											Source: "r",
+											Start: ast.Position{
+												Column: 53,
+												Line:   42,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 54,
+													Line:   42,
+												},
+												File:   "v1.flux",
+												Source: "r",
+												Start: ast.Position{
+													Column: 53,
+													Line:   42,
+												},
+											},
+										},
+										Name: "r",
+									},
+									Value: nil,
+								}},
+							},
+						}},
+						With: nil,
+					}},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 89,
+								Line:   42,
+							},
+							File:   "v1.flux",
+							Source: "tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
+							Start: ast.Position{
+								Column: 5,
+								Line:   42,
+							},
+						},
+					},
+					Callee: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 14,
+									Line:   42,
+								},
+								File:   "v1.flux",
+								Source: "tagValues",
+								Start: ast.Position{
+									Column: 5,
+									Line:   42,
+								},
+							},
+						},
+						Name: "tagValues",
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 31,
+								Line:   41,
+							},
+							File:   "v1.flux",
+							Source: "bucket",
+							Start: ast.Position{
+								Column: 25,
+								Line:   41,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 31,
+									Line:   41,
+								},
+								File:   "v1.flux",
+								Source: "bucket",
+								Start: ast.Position{
+									Column: 25,
+									Line:   41,
+								},
+							},
+						},
+						Name: "bucket",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 44,
+								Line:   41,
+							},
+							File:   "v1.flux",
+							Source: "measurement",
+							Start: ast.Position{
+								Column: 33,
+								Line:   41,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 44,
+									Line:   41,
+								},
+								File:   "v1.flux",
+								Source: "measurement",
+								Start: ast.Position{
+									Column: 33,
+									Line:   41,
+								},
+							},
+						},
+						Name: "measurement",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 49,
+								Line:   41,
+							},
+							File:   "v1.flux",
+							Source: "tag",
+							Start: ast.Position{
+								Column: 46,
+								Line:   41,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 49,
+									Line:   41,
+								},
+								File:   "v1.flux",
+								Source: "tag",
+								Start: ast.Position{
+									Column: 46,
+									Line:   41,
+								},
+							},
+						},
+						Name: "tag",
+					},
+					Value: nil,
+				}},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 22,
+						Line:   52,
+					},
+					File:   "v1.flux",
+					Source: "tagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+					Start: ast.Position{
+						Column: 1,
+						Line:   46,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 8,
+							Line:   46,
+						},
+						File:   "v1.flux",
+						Source: "tagKeys",
+						Start: ast.Position{
+							Column: 1,
+							Line:   46,
+						},
+					},
+				},
+				Name: "tagKeys",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 22,
+							Line:   52,
+						},
+						File:   "v1.flux",
+						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+						Start: ast.Position{
+							Column: 11,
+							Line:   46,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.PipeExpression{
+							Argument: &ast.PipeExpression{
+								Argument: &ast.PipeExpression{
+									Argument: &ast.CallExpression{
+										Arguments: []ast.Expression{&ast.ObjectExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 24,
+														Line:   47,
+													},
+													File:   "v1.flux",
+													Source: "bucket: bucket",
+													Start: ast.Position{
+														Column: 10,
+														Line:   47,
+													},
+												},
+											},
+											Properties: []*ast.Property{&ast.Property{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 24,
+															Line:   47,
+														},
+														File:   "v1.flux",
+														Source: "bucket: bucket",
+														Start: ast.Position{
+															Column: 10,
+															Line:   47,
+														},
+													},
+												},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 16,
+																Line:   47,
+															},
+															File:   "v1.flux",
+															Source: "bucket",
+															Start: ast.Position{
+																Column: 10,
+																Line:   47,
+															},
+														},
+													},
+													Name: "bucket",
+												},
+												Value: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 24,
+																Line:   47,
+															},
+															File:   "v1.flux",
+															Source: "bucket",
+															Start: ast.Position{
+																Column: 18,
+																Line:   47,
+															},
+														},
+													},
+													Name: "bucket",
+												},
+											}},
+											With: nil,
+										}},
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 25,
+													Line:   47,
+												},
+												File:   "v1.flux",
+												Source: "from(bucket: bucket)",
+												Start: ast.Position{
+													Column: 5,
+													Line:   47,
+												},
+											},
+										},
+										Callee: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 9,
+														Line:   47,
+													},
+													File:   "v1.flux",
+													Source: "from",
+													Start: ast.Position{
+														Column: 5,
+														Line:   47,
+													},
+												},
+											},
+											Name: "from",
+										},
+									},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 31,
+												Line:   48,
+											},
+											File:   "v1.flux",
+											Source: "from(bucket: bucket)\n        |> range(start: start)",
+											Start: ast.Position{
+												Column: 5,
+												Line:   47,
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Arguments: []ast.Expression{&ast.ObjectExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 30,
+														Line:   48,
+													},
+													File:   "v1.flux",
+													Source: "start: start",
+													Start: ast.Position{
+														Column: 18,
+														Line:   48,
+													},
+												},
+											},
+											Properties: []*ast.Property{&ast.Property{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 30,
+															Line:   48,
+														},
+														File:   "v1.flux",
+														Source: "start: start",
+														Start: ast.Position{
+															Column: 18,
+															Line:   48,
+														},
+													},
+												},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 23,
+																Line:   48,
+															},
+															File:   "v1.flux",
+															Source: "start",
+															Start: ast.Position{
+																Column: 18,
+																Line:   48,
+															},
+														},
+													},
+													Name: "start",
+												},
+												Value: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 30,
+																Line:   48,
+															},
+															File:   "v1.flux",
+															Source: "start",
+															Start: ast.Position{
+																Column: 25,
+																Line:   48,
+															},
+														},
+													},
+													Name: "start",
+												},
+											}},
+											With: nil,
+										}},
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 31,
+													Line:   48,
+												},
+												File:   "v1.flux",
+												Source: "range(start: start)",
+												Start: ast.Position{
+													Column: 12,
+													Line:   48,
+												},
+											},
+										},
+										Callee: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 17,
+														Line:   48,
+													},
+													File:   "v1.flux",
+													Source: "range",
+													Start: ast.Position{
+														Column: 12,
+														Line:   48,
+													},
+												},
+											},
+											Name: "range",
+										},
+									},
+								},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   49,
+										},
+										File:   "v1.flux",
+										Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)",
+										Start: ast.Position{
+											Column: 5,
+											Line:   47,
+										},
+									},
+								},
+								Call: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 32,
+													Line:   49,
+												},
+												File:   "v1.flux",
+												Source: "fn: predicate",
+												Start: ast.Position{
+													Column: 19,
+													Line:   49,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 32,
+														Line:   49,
+													},
+													File:   "v1.flux",
+													Source: "fn: predicate",
+													Start: ast.Position{
+														Column: 19,
+														Line:   49,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 21,
+															Line:   49,
+														},
+														File:   "v1.flux",
+														Source: "fn",
+														Start: ast.Position{
+															Column: 19,
+															Line:   49,
+														},
+													},
+												},
+												Name: "fn",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 32,
+															Line:   49,
+														},
+														File:   "v1.flux",
+														Source: "predicate",
+														Start: ast.Position{
+															Column: 23,
+															Line:   49,
+														},
+													},
+												},
+												Name: "predicate",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 33,
+												Line:   49,
+											},
+											File:   "v1.flux",
+											Source: "filter(fn: predicate)",
+											Start: ast.Position{
+												Column: 12,
+												Line:   49,
+											},
+										},
+									},
+									Callee: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 18,
+													Line:   49,
+												},
+												File:   "v1.flux",
+												Source: "filter",
+												Start: ast.Position{
+													Column: 12,
+													Line:   49,
+												},
+											},
+										},
+										Name: "filter",
+									},
+								},
+							},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 18,
+										Line:   50,
+									},
+									File:   "v1.flux",
+									Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()",
+									Start: ast.Position{
+										Column: 5,
+										Line:   47,
+									},
+								},
+							},
+							Call: &ast.CallExpression{
+								Arguments: nil,
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 18,
+											Line:   50,
+										},
+										File:   "v1.flux",
+										Source: "keys()",
+										Start: ast.Position{
+											Column: 12,
+											Line:   50,
+										},
+									},
+								},
+								Callee: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 16,
+												Line:   50,
+											},
+											File:   "v1.flux",
+											Source: "keys",
+											Start: ast.Position{
+												Column: 12,
+												Line:   50,
+											},
+										},
+									},
+									Name: "keys",
+								},
+							},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 37,
+									Line:   51,
+								},
+								File:   "v1.flux",
+								Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
+								Start: ast.Position{
+									Column: 5,
+									Line:   47,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 36,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "columns: [\"_value\"]",
+										Start: ast.Position{
+											Column: 17,
+											Line:   51,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 36,
+												Line:   51,
+											},
+											File:   "v1.flux",
+											Source: "columns: [\"_value\"]",
+											Start: ast.Position{
+												Column: 17,
+												Line:   51,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 24,
+													Line:   51,
+												},
+												File:   "v1.flux",
+												Source: "columns",
+												Start: ast.Position{
+													Column: 17,
+													Line:   51,
+												},
+											},
+										},
+										Name: "columns",
+									},
+									Value: &ast.ArrayExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 36,
+													Line:   51,
+												},
+												File:   "v1.flux",
+												Source: "[\"_value\"]",
+												Start: ast.Position{
+													Column: 26,
+													Line:   51,
+												},
+											},
+										},
+										Elements: []ast.Expression{&ast.StringLiteral{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 35,
+														Line:   51,
+													},
+													File:   "v1.flux",
+													Source: "\"_value\"",
+													Start: ast.Position{
+														Column: 27,
+														Line:   51,
+													},
+												},
+											},
+											Value: "_value",
+										}},
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 37,
+										Line:   51,
+									},
+									File:   "v1.flux",
+									Source: "keep(columns: [\"_value\"])",
+									Start: ast.Position{
+										Column: 12,
+										Line:   51,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 16,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "keep",
+										Start: ast.Position{
+											Column: 12,
+											Line:   51,
+										},
+									},
+								},
+								Name: "keep",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 22,
+								Line:   52,
+							},
+							File:   "v1.flux",
+							Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
+							Start: ast.Position{
+								Column: 5,
+								Line:   47,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: nil,
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 22,
+									Line:   52,
+								},
+								File:   "v1.flux",
+								Source: "distinct()",
+								Start: ast.Position{
+									Column: 12,
+									Line:   52,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 20,
+										Line:   52,
+									},
+									File:   "v1.flux",
+									Source: "distinct",
+									Start: ast.Position{
+										Column: 12,
+										Line:   52,
+									},
+								},
+							},
+							Name: "distinct",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 18,
+								Line:   46,
+							},
+							File:   "v1.flux",
+							Source: "bucket",
+							Start: ast.Position{
+								Column: 12,
+								Line:   46,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 18,
+									Line:   46,
+								},
+								File:   "v1.flux",
+								Source: "bucket",
+								Start: ast.Position{
+									Column: 12,
+									Line:   46,
+								},
+							},
+						},
+						Name: "bucket",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 41,
+								Line:   46,
+							},
+							File:   "v1.flux",
+							Source: "predicate=(r) => true",
+							Start: ast.Position{
+								Column: 20,
+								Line:   46,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 29,
+									Line:   46,
+								},
+								File:   "v1.flux",
+								Source: "predicate",
+								Start: ast.Position{
+									Column: 20,
+									Line:   46,
+								},
+							},
+						},
+						Name: "predicate",
+					},
+					Value: &ast.FunctionExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 41,
+									Line:   46,
+								},
+								File:   "v1.flux",
+								Source: "(r) => true",
+								Start: ast.Position{
+									Column: 30,
+									Line:   46,
+								},
+							},
+						},
+						Body: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 41,
+										Line:   46,
+									},
+									File:   "v1.flux",
+									Source: "true",
+									Start: ast.Position{
+										Column: 37,
+										Line:   46,
+									},
+								},
+							},
+							Name: "true",
+						},
+						Params: []*ast.Property{&ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 32,
+										Line:   46,
+									},
+									File:   "v1.flux",
+									Source: "r",
+									Start: ast.Position{
+										Column: 31,
+										Line:   46,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 32,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "r",
+										Start: ast.Position{
+											Column: 31,
+											Line:   46,
+										},
+									},
+								},
+								Name: "r",
+							},
+							Value: nil,
+						}},
+					},
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 53,
+								Line:   46,
+							},
+							File:   "v1.flux",
+							Source: "start=-30d",
+							Start: ast.Position{
+								Column: 43,
+								Line:   46,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 48,
+									Line:   46,
+								},
+								File:   "v1.flux",
+								Source: "start",
+								Start: ast.Position{
+									Column: 43,
+									Line:   46,
+								},
+							},
+						},
+						Name: "start",
+					},
+					Value: &ast.UnaryExpression{
+						Argument: &ast.DurationLiteral{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 53,
+										Line:   46,
+									},
+									File:   "v1.flux",
+									Source: "30d",
+									Start: ast.Position{
+										Column: 50,
+										Line:   46,
+									},
+								},
+							},
+							Values: []ast.Duration{ast.Duration{
+								Magnitude: int64(30),
+								Unit:      "d",
+							}},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 53,
+									Line:   46,
+								},
+								File:   "v1.flux",
+								Source: "-30d",
+								Start: ast.Position{
+									Column: 49,
+									Line:   46,
+								},
+							},
+						},
+						Operator: 6,
+					},
+				}},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 77,
+						Line:   56,
 					},
 					File:   "v1.flux",
 					Source: "measurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   40,
+						Line:   55,
 					},
 				},
 			},
@@ -2824,13 +4248,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 19,
-							Line:   40,
+							Line:   55,
 						},
 						File:   "v1.flux",
 						Source: "measurementTagKeys",
 						Start: ast.Position{
 							Column: 1,
-							Line:   40,
+							Line:   55,
 						},
 					},
 				},
@@ -2842,13 +4266,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 77,
-							Line:   41,
+							Line:   56,
 						},
 						File:   "v1.flux",
 						Source: "(bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 						Start: ast.Position{
 							Column: 22,
-							Line:   40,
+							Line:   55,
 						},
 					},
 				},
@@ -2859,13 +4283,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 76,
-									Line:   41,
+									Line:   56,
 								},
 								File:   "v1.flux",
 								Source: "bucket: bucket, predicate: (r) => r._measurement == measurement",
 								Start: ast.Position{
 									Column: 13,
-									Line:   41,
+									Line:   56,
 								},
 							},
 						},
@@ -2875,13 +4299,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 27,
-										Line:   41,
+										Line:   56,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 13,
-										Line:   41,
+										Line:   56,
 									},
 								},
 							},
@@ -2891,13 +4315,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 19,
-											Line:   41,
+											Line:   56,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 13,
-											Line:   41,
+											Line:   56,
 										},
 									},
 								},
@@ -2909,13 +4333,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 27,
-											Line:   41,
+											Line:   56,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 21,
-											Line:   41,
+											Line:   56,
 										},
 									},
 								},
@@ -2927,13 +4351,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 76,
-										Line:   41,
+										Line:   56,
 									},
 									File:   "v1.flux",
 									Source: "predicate: (r) => r._measurement == measurement",
 									Start: ast.Position{
 										Column: 29,
-										Line:   41,
+										Line:   56,
 									},
 								},
 							},
@@ -2943,13 +4367,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 38,
-											Line:   41,
+											Line:   56,
 										},
 										File:   "v1.flux",
 										Source: "predicate",
 										Start: ast.Position{
 											Column: 29,
-											Line:   41,
+											Line:   56,
 										},
 									},
 								},
@@ -2961,13 +4385,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 76,
-											Line:   41,
+											Line:   56,
 										},
 										File:   "v1.flux",
 										Source: "(r) => r._measurement == measurement",
 										Start: ast.Position{
 											Column: 40,
-											Line:   41,
+											Line:   56,
 										},
 									},
 								},
@@ -2977,13 +4401,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 76,
-												Line:   41,
+												Line:   56,
 											},
 											File:   "v1.flux",
 											Source: "r._measurement == measurement",
 											Start: ast.Position{
 												Column: 47,
-												Line:   41,
+												Line:   56,
 											},
 										},
 									},
@@ -2993,13 +4417,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 61,
-													Line:   41,
+													Line:   56,
 												},
 												File:   "v1.flux",
 												Source: "r._measurement",
 												Start: ast.Position{
 													Column: 47,
-													Line:   41,
+													Line:   56,
 												},
 											},
 										},
@@ -3009,13 +4433,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   41,
+														Line:   56,
 													},
 													File:   "v1.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   41,
+														Line:   56,
 													},
 												},
 											},
@@ -3027,13 +4451,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 61,
-														Line:   41,
+														Line:   56,
 													},
 													File:   "v1.flux",
 													Source: "_measurement",
 													Start: ast.Position{
 														Column: 49,
-														Line:   41,
+														Line:   56,
 													},
 												},
 											},
@@ -3047,13 +4471,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 76,
-													Line:   41,
+													Line:   56,
 												},
 												File:   "v1.flux",
 												Source: "measurement",
 												Start: ast.Position{
 													Column: 65,
-													Line:   41,
+													Line:   56,
 												},
 											},
 										},
@@ -3066,13 +4490,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   41,
+												Line:   56,
 											},
 											File:   "v1.flux",
 											Source: "r",
 											Start: ast.Position{
 												Column: 41,
-												Line:   41,
+												Line:   56,
 											},
 										},
 									},
@@ -3082,13 +4506,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 42,
-													Line:   41,
+													Line:   56,
 												},
 												File:   "v1.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 41,
-													Line:   41,
+													Line:   56,
 												},
 											},
 										},
@@ -3105,13 +4529,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 77,
-								Line:   41,
+								Line:   56,
 							},
 							File:   "v1.flux",
 							Source: "tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   41,
+								Line:   56,
 							},
 						},
 					},
@@ -3121,13 +4545,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 12,
-									Line:   41,
+									Line:   56,
 								},
 								File:   "v1.flux",
 								Source: "tagKeys",
 								Start: ast.Position{
 									Column: 5,
-									Line:   41,
+									Line:   56,
 								},
 							},
 						},
@@ -3140,13 +4564,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 29,
-								Line:   40,
+								Line:   55,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 23,
-								Line:   40,
+								Line:   55,
 							},
 						},
 					},
@@ -3156,13 +4580,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   40,
+									Line:   55,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 23,
-									Line:   40,
+									Line:   55,
 								},
 							},
 						},
@@ -3175,13 +4599,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 42,
-								Line:   40,
+								Line:   55,
 							},
 							File:   "v1.flux",
 							Source: "measurement",
 							Start: ast.Position{
 								Column: 31,
-								Line:   40,
+								Line:   55,
 							},
 						},
 					},
@@ -3191,13 +4615,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 42,
-									Line:   40,
+									Line:   55,
 								},
 								File:   "v1.flux",
 								Source: "measurement",
 								Start: ast.Position{
 									Column: 31,
-									Line:   40,
+									Line:   55,
 								},
 							},
 						},
@@ -3212,13 +4636,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 51,
-						Line:   45,
+						Line:   60,
 					},
 					File:   "v1.flux",
 					Source: "measurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 					Start: ast.Position{
 						Column: 1,
-						Line:   44,
+						Line:   59,
 					},
 				},
 			},
@@ -3228,13 +4652,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 13,
-							Line:   44,
+							Line:   59,
 						},
 						File:   "v1.flux",
 						Source: "measurements",
 						Start: ast.Position{
 							Column: 1,
-							Line:   44,
+							Line:   59,
 						},
 					},
 				},
@@ -3246,13 +4670,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 51,
-							Line:   45,
+							Line:   60,
 						},
 						File:   "v1.flux",
 						Source: "(bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 						Start: ast.Position{
 							Column: 16,
-							Line:   44,
+							Line:   59,
 						},
 					},
 				},
@@ -3263,13 +4687,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 50,
-									Line:   45,
+									Line:   60,
 								},
 								File:   "v1.flux",
 								Source: "bucket: bucket, tag: \"_measurement\"",
 								Start: ast.Position{
 									Column: 15,
-									Line:   45,
+									Line:   60,
 								},
 							},
 						},
@@ -3279,13 +4703,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 29,
-										Line:   45,
+										Line:   60,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 15,
-										Line:   45,
+										Line:   60,
 									},
 								},
 							},
@@ -3295,13 +4719,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   45,
+											Line:   60,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 15,
-											Line:   45,
+											Line:   60,
 										},
 									},
 								},
@@ -3313,13 +4737,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   45,
+											Line:   60,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 23,
-											Line:   45,
+											Line:   60,
 										},
 									},
 								},
@@ -3331,13 +4755,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 50,
-										Line:   45,
+										Line:   60,
 									},
 									File:   "v1.flux",
 									Source: "tag: \"_measurement\"",
 									Start: ast.Position{
 										Column: 31,
-										Line:   45,
+										Line:   60,
 									},
 								},
 							},
@@ -3347,13 +4771,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 34,
-											Line:   45,
+											Line:   60,
 										},
 										File:   "v1.flux",
 										Source: "tag",
 										Start: ast.Position{
 											Column: 31,
-											Line:   45,
+											Line:   60,
 										},
 									},
 								},
@@ -3365,13 +4789,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 50,
-											Line:   45,
+											Line:   60,
 										},
 										File:   "v1.flux",
 										Source: "\"_measurement\"",
 										Start: ast.Position{
 											Column: 36,
-											Line:   45,
+											Line:   60,
 										},
 									},
 								},
@@ -3385,13 +4809,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 51,
-								Line:   45,
+								Line:   60,
 							},
 							File:   "v1.flux",
 							Source: "tagValues(bucket: bucket, tag: \"_measurement\")",
 							Start: ast.Position{
 								Column: 5,
-								Line:   45,
+								Line:   60,
 							},
 						},
 					},
@@ -3401,13 +4825,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   45,
+									Line:   60,
 								},
 								File:   "v1.flux",
 								Source: "tagValues",
 								Start: ast.Position{
 									Column: 5,
-									Line:   45,
+									Line:   60,
 								},
 							},
 						},
@@ -3420,13 +4844,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 23,
-								Line:   44,
+								Line:   59,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 17,
-								Line:   44,
+								Line:   59,
 							},
 						},
 					},
@@ -3436,13 +4860,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 23,
-									Line:   44,
+									Line:   59,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 17,
-									Line:   44,
+									Line:   59,
 								},
 							},
 						},

--- a/stdlib/influxdata/influxdb/v1/flux_gen.go
+++ b/stdlib/influxdata/influxdb/v1/flux_gen.go
@@ -22,10 +22,10 @@ var pkgAST = &ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 51,
-					Line:   60,
+					Line:   55,
 				},
 				File:   "v1.flux",
-				Source: "package v1\n\n// Json parses an InfluxDB 1.x json result into a table stream.\nbuiltin json\n\n// Databases returns the list of available databases, it has no parameters.\nbuiltin databases\n\n// fieldsAsCols is a special application of pivot that will automatically align fields within each measurement that have the same timestamp.\nfieldsAsCols = (tables=<-) =>\n    tables\n        |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\n// FieldKeys returns the list of field keys in a given bucket.\n// The return value is always a single table with a single column, \"_value\".\nfieldKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")\n\n// MeasurementFieldKeys returns field keys in a given measurement.\n// The return value is always a single table with a single column, \"_value\".\nmeasurementFieldKeys = (bucket, measurement, start) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)\n\n// TagValues returns the unique values for a given tag.\n// The return value is always a single table with a single column \"_value\".\ntagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)\n\n// MeasurementTagValues returns a single table with a single column \"_value\" that contains the\n// The return value is always a single table with a single column \"_value\".\nmeasurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)\n\n// TagKeys returns the list of tag keys for all series that match the predicate.\n// The return value is always a single table with a single column \"_value\".\ntagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()\n\n// MeasurementTagKeys returns the list of tag keys for a specific measurement.\nmeasurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)\n\n// Measurements returns the list of measurements in a specific bucket.\nmeasurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+				Source: "package v1\n\n// Json parses an InfluxDB 1.x json result into a table stream.\nbuiltin json\n\n// Databases returns the list of available databases, it has no parameters.\nbuiltin databases\n\n// fieldsAsCols is a special application of pivot that will automatically align fields within each measurement that have the same timestamp.\nfieldsAsCols = (tables=<-) =>\n    tables\n        |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")\n\n// TagValues returns the unique values for a given tag.\n// The return value is always a single table with a single column \"_value\".\ntagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)\n\n// MeasurementTagValues returns a single table with a single column \"_value\" that contains the\n// The return value is always a single table with a single column \"_value\".\nmeasurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)\n\n// TagKeys returns the list of tag keys for all series that match the predicate.\n// The return value is always a single table with a single column \"_value\".\ntagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()\n\n// MeasurementTagKeys returns the list of tag keys for a specific measurement.\nmeasurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)\n\n// FieldKeys is a special application of tagValues that returns field keys in a given bucket.\n// The return value is always a single table with a single column, \"_value\".\nfieldKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    tagValues(bucket: bucket, tag: \"_field\", predicate: predicate, start: start)\n\n// MeasurementFieldKeys returns field keys in a given measurement.\n// The return value is always a single table with a single column, \"_value\".\nmeasurementFieldKeys = (bucket, measurement, start=-30d) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)\n\n// Measurements returns the list of measurements in a specific bucket.\nmeasurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -485,11 +485,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 36,
+						Column: 31,
 						Line:   22,
 					},
 					File:   "v1.flux",
-					Source: "fieldKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")",
+					Source: "tagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   16,
@@ -505,25 +505,25 @@ var pkgAST = &ast.Package{
 							Line:   16,
 						},
 						File:   "v1.flux",
-						Source: "fieldKeys",
+						Source: "tagValues",
 						Start: ast.Position{
 							Column: 1,
 							Line:   16,
 						},
 					},
 				},
-				Name: "fieldKeys",
+				Name: "tagValues",
 			},
 			Init: &ast.FunctionExpression{
 				BaseNode: ast.BaseNode{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 36,
+							Column: 31,
 							Line:   22,
 						},
 						File:   "v1.flux",
-						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")",
+						Source: "(bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
 						Start: ast.Position{
 							Column: 13,
 							Line:   16,
@@ -889,11 +889,11 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 35,
+										Column: 30,
 										Line:   20,
 									},
 									File:   "v1.flux",
-									Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])",
+									Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])",
 									Start: ast.Position{
 										Column: 5,
 										Line:   17,
@@ -906,11 +906,11 @@ var pkgAST = &ast.Package{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 34,
+												Column: 29,
 												Line:   20,
 											},
 											File:   "v1.flux",
-											Source: "columns: [\"_field\"]",
+											Source: "columns: [tag]",
 											Start: ast.Position{
 												Column: 15,
 												Line:   20,
@@ -922,11 +922,11 @@ var pkgAST = &ast.Package{
 											Errors: nil,
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
-													Column: 34,
+													Column: 29,
 													Line:   20,
 												},
 												File:   "v1.flux",
-												Source: "columns: [\"_field\"]",
+												Source: "columns: [tag]",
 												Start: ast.Position{
 													Column: 15,
 													Line:   20,
@@ -956,34 +956,34 @@ var pkgAST = &ast.Package{
 												Errors: nil,
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
-														Column: 34,
+														Column: 29,
 														Line:   20,
 													},
 													File:   "v1.flux",
-													Source: "[\"_field\"]",
+													Source: "[tag]",
 													Start: ast.Position{
 														Column: 24,
 														Line:   20,
 													},
 												},
 											},
-											Elements: []ast.Expression{&ast.StringLiteral{
+											Elements: []ast.Expression{&ast.Identifier{
 												BaseNode: ast.BaseNode{
 													Errors: nil,
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
-															Column: 33,
+															Column: 28,
 															Line:   20,
 														},
 														File:   "v1.flux",
-														Source: "\"_field\"",
+														Source: "tag",
 														Start: ast.Position{
 															Column: 25,
 															Line:   20,
 														},
 													},
 												},
-												Value: "_field",
+												Name: "tag",
 											}},
 										},
 									}},
@@ -993,11 +993,11 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 35,
+											Column: 30,
 											Line:   20,
 										},
 										File:   "v1.flux",
-										Source: "keep(columns: [\"_field\"])",
+										Source: "keep(columns: [tag])",
 										Start: ast.Position{
 											Column: 10,
 											Line:   20,
@@ -1032,7 +1032,7 @@ var pkgAST = &ast.Package{
 									Line:   21,
 								},
 								File:   "v1.flux",
-								Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()",
+								Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()",
 								Start: ast.Position{
 									Column: 5,
 									Line:   17,
@@ -1080,11 +1080,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 36,
+								Column: 31,
 								Line:   22,
 							},
 							File:   "v1.flux",
-							Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [\"_field\"])\n      |> group()\n      |> distinct(column: \"_field\")",
+							Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
 							Start: ast.Position{
 								Column: 5,
 								Line:   17,
@@ -1097,11 +1097,11 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 35,
+										Column: 30,
 										Line:   22,
 									},
 									File:   "v1.flux",
-									Source: "column: \"_field\"",
+									Source: "column: tag",
 									Start: ast.Position{
 										Column: 19,
 										Line:   22,
@@ -1113,11 +1113,11 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 35,
+											Column: 30,
 											Line:   22,
 										},
 										File:   "v1.flux",
-										Source: "column: \"_field\"",
+										Source: "column: tag",
 										Start: ast.Position{
 											Column: 19,
 											Line:   22,
@@ -1142,23 +1142,23 @@ var pkgAST = &ast.Package{
 									},
 									Name: "column",
 								},
-								Value: &ast.StringLiteral{
+								Value: &ast.Identifier{
 									BaseNode: ast.BaseNode{
 										Errors: nil,
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
-												Column: 35,
+												Column: 30,
 												Line:   22,
 											},
 											File:   "v1.flux",
-											Source: "\"_field\"",
+											Source: "tag",
 											Start: ast.Position{
 												Column: 27,
 												Line:   22,
 											},
 										},
 									},
-									Value: "_field",
+									Name: "tag",
 								},
 							}},
 							With: nil,
@@ -1167,11 +1167,11 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 36,
+									Column: 31,
 									Line:   22,
 								},
 								File:   "v1.flux",
-								Source: "distinct(column: \"_field\")",
+								Source: "distinct(column: tag)",
 								Start: ast.Position{
 									Column: 10,
 									Line:   22,
@@ -1238,11 +1238,11 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 43,
+								Column: 25,
 								Line:   16,
 							},
 							File:   "v1.flux",
-							Source: "predicate=(r) => true",
+							Source: "tag",
 							Start: ast.Position{
 								Column: 22,
 								Line:   16,
@@ -1254,13 +1254,48 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 31,
+									Column: 25,
+									Line:   16,
+								},
+								File:   "v1.flux",
+								Source: "tag",
+								Start: ast.Position{
+									Column: 22,
+									Line:   16,
+								},
+							},
+						},
+						Name: "tag",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 48,
+								Line:   16,
+							},
+							File:   "v1.flux",
+							Source: "predicate=(r) => true",
+							Start: ast.Position{
+								Column: 27,
+								Line:   16,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "predicate",
 								Start: ast.Position{
-									Column: 22,
+									Column: 27,
 									Line:   16,
 								},
 							},
@@ -1272,13 +1307,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 43,
+									Column: 48,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "(r) => true",
 								Start: ast.Position{
-									Column: 32,
+									Column: 37,
 									Line:   16,
 								},
 							},
@@ -1288,13 +1323,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 43,
+										Column: 48,
 										Line:   16,
 									},
 									File:   "v1.flux",
 									Source: "true",
 									Start: ast.Position{
-										Column: 39,
+										Column: 44,
 										Line:   16,
 									},
 								},
@@ -1306,13 +1341,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 34,
+										Column: 39,
 										Line:   16,
 									},
 									File:   "v1.flux",
 									Source: "r",
 									Start: ast.Position{
-										Column: 33,
+										Column: 38,
 										Line:   16,
 									},
 								},
@@ -1322,13 +1357,13 @@ var pkgAST = &ast.Package{
 									Errors: nil,
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
-											Column: 34,
+											Column: 39,
 											Line:   16,
 										},
 										File:   "v1.flux",
 										Source: "r",
 										Start: ast.Position{
-											Column: 33,
+											Column: 38,
 											Line:   16,
 										},
 									},
@@ -1343,13 +1378,13 @@ var pkgAST = &ast.Package{
 						Errors: nil,
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
-								Column: 55,
+								Column: 60,
 								Line:   16,
 							},
 							File:   "v1.flux",
 							Source: "start=-30d",
 							Start: ast.Position{
-								Column: 45,
+								Column: 50,
 								Line:   16,
 							},
 						},
@@ -1359,13 +1394,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 50,
+									Column: 55,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "start",
 								Start: ast.Position{
-									Column: 45,
+									Column: 50,
 									Line:   16,
 								},
 							},
@@ -1378,13 +1413,13 @@ var pkgAST = &ast.Package{
 								Errors: nil,
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
-										Column: 55,
+										Column: 60,
 										Line:   16,
 									},
 									File:   "v1.flux",
 									Source: "30d",
 									Start: ast.Position{
-										Column: 52,
+										Column: 57,
 										Line:   16,
 									},
 								},
@@ -1398,13 +1433,13 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 55,
+									Column: 60,
 									Line:   16,
 								},
 								File:   "v1.flux",
 								Source: "-30d",
 								Start: ast.Position{
-									Column: 51,
+									Column: 56,
 									Line:   16,
 								},
 							},
@@ -1418,11 +1453,11 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 93,
+						Column: 89,
 						Line:   27,
 					},
 					File:   "v1.flux",
-					Source: "measurementFieldKeys = (bucket, measurement, start) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
+					Source: "measurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
 					Start: ast.Position{
 						Column: 1,
 						Line:   26,
@@ -1438,1469 +1473,10 @@ var pkgAST = &ast.Package{
 							Line:   26,
 						},
 						File:   "v1.flux",
-						Source: "measurementFieldKeys",
-						Start: ast.Position{
-							Column: 1,
-							Line:   26,
-						},
-					},
-				},
-				Name: "measurementFieldKeys",
-			},
-			Init: &ast.FunctionExpression{
-				BaseNode: ast.BaseNode{
-					Errors: nil,
-					Loc: &ast.SourceLocation{
-						End: ast.Position{
-							Column: 93,
-							Line:   27,
-						},
-						File:   "v1.flux",
-						Source: "(bucket, measurement, start) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
-						Start: ast.Position{
-							Column: 24,
-							Line:   26,
-						},
-					},
-				},
-				Body: &ast.CallExpression{
-					Arguments: []ast.Expression{&ast.ObjectExpression{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 92,
-									Line:   27,
-								},
-								File:   "v1.flux",
-								Source: "bucket: bucket, predicate: (r) => r._measurement == measurement, start: start",
-								Start: ast.Position{
-									Column: 15,
-									Line:   27,
-								},
-							},
-						},
-						Properties: []*ast.Property{&ast.Property{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 29,
-										Line:   27,
-									},
-									File:   "v1.flux",
-									Source: "bucket: bucket",
-									Start: ast.Position{
-										Column: 15,
-										Line:   27,
-									},
-								},
-							},
-							Key: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 21,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "bucket",
-										Start: ast.Position{
-											Column: 15,
-											Line:   27,
-										},
-									},
-								},
-								Name: "bucket",
-							},
-							Value: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 29,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "bucket",
-										Start: ast.Position{
-											Column: 23,
-											Line:   27,
-										},
-									},
-								},
-								Name: "bucket",
-							},
-						}, &ast.Property{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 78,
-										Line:   27,
-									},
-									File:   "v1.flux",
-									Source: "predicate: (r) => r._measurement == measurement",
-									Start: ast.Position{
-										Column: 31,
-										Line:   27,
-									},
-								},
-							},
-							Key: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 40,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "predicate",
-										Start: ast.Position{
-											Column: 31,
-											Line:   27,
-										},
-									},
-								},
-								Name: "predicate",
-							},
-							Value: &ast.FunctionExpression{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 78,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "(r) => r._measurement == measurement",
-										Start: ast.Position{
-											Column: 42,
-											Line:   27,
-										},
-									},
-								},
-								Body: &ast.BinaryExpression{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 78,
-												Line:   27,
-											},
-											File:   "v1.flux",
-											Source: "r._measurement == measurement",
-											Start: ast.Position{
-												Column: 49,
-												Line:   27,
-											},
-										},
-									},
-									Left: &ast.MemberExpression{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 63,
-													Line:   27,
-												},
-												File:   "v1.flux",
-												Source: "r._measurement",
-												Start: ast.Position{
-													Column: 49,
-													Line:   27,
-												},
-											},
-										},
-										Object: &ast.Identifier{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 50,
-														Line:   27,
-													},
-													File:   "v1.flux",
-													Source: "r",
-													Start: ast.Position{
-														Column: 49,
-														Line:   27,
-													},
-												},
-											},
-											Name: "r",
-										},
-										Property: &ast.Identifier{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 63,
-														Line:   27,
-													},
-													File:   "v1.flux",
-													Source: "_measurement",
-													Start: ast.Position{
-														Column: 51,
-														Line:   27,
-													},
-												},
-											},
-											Name: "_measurement",
-										},
-									},
-									Operator: 17,
-									Right: &ast.Identifier{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 78,
-													Line:   27,
-												},
-												File:   "v1.flux",
-												Source: "measurement",
-												Start: ast.Position{
-													Column: 67,
-													Line:   27,
-												},
-											},
-										},
-										Name: "measurement",
-									},
-								},
-								Params: []*ast.Property{&ast.Property{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 44,
-												Line:   27,
-											},
-											File:   "v1.flux",
-											Source: "r",
-											Start: ast.Position{
-												Column: 43,
-												Line:   27,
-											},
-										},
-									},
-									Key: &ast.Identifier{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 44,
-													Line:   27,
-												},
-												File:   "v1.flux",
-												Source: "r",
-												Start: ast.Position{
-													Column: 43,
-													Line:   27,
-												},
-											},
-										},
-										Name: "r",
-									},
-									Value: nil,
-								}},
-							},
-						}, &ast.Property{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 92,
-										Line:   27,
-									},
-									File:   "v1.flux",
-									Source: "start: start",
-									Start: ast.Position{
-										Column: 80,
-										Line:   27,
-									},
-								},
-							},
-							Key: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 85,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "start",
-										Start: ast.Position{
-											Column: 80,
-											Line:   27,
-										},
-									},
-								},
-								Name: "start",
-							},
-							Value: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 92,
-											Line:   27,
-										},
-										File:   "v1.flux",
-										Source: "start",
-										Start: ast.Position{
-											Column: 87,
-											Line:   27,
-										},
-									},
-								},
-								Name: "start",
-							},
-						}},
-						With: nil,
-					}},
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 93,
-								Line:   27,
-							},
-							File:   "v1.flux",
-							Source: "fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
-							Start: ast.Position{
-								Column: 5,
-								Line:   27,
-							},
-						},
-					},
-					Callee: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 14,
-									Line:   27,
-								},
-								File:   "v1.flux",
-								Source: "fieldKeys",
-								Start: ast.Position{
-									Column: 5,
-									Line:   27,
-								},
-							},
-						},
-						Name: "fieldKeys",
-					},
-				},
-				Params: []*ast.Property{&ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 31,
-								Line:   26,
-							},
-							File:   "v1.flux",
-							Source: "bucket",
-							Start: ast.Position{
-								Column: 25,
-								Line:   26,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 31,
-									Line:   26,
-								},
-								File:   "v1.flux",
-								Source: "bucket",
-								Start: ast.Position{
-									Column: 25,
-									Line:   26,
-								},
-							},
-						},
-						Name: "bucket",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 44,
-								Line:   26,
-							},
-							File:   "v1.flux",
-							Source: "measurement",
-							Start: ast.Position{
-								Column: 33,
-								Line:   26,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 44,
-									Line:   26,
-								},
-								File:   "v1.flux",
-								Source: "measurement",
-								Start: ast.Position{
-									Column: 33,
-									Line:   26,
-								},
-							},
-						},
-						Name: "measurement",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 51,
-								Line:   26,
-							},
-							File:   "v1.flux",
-							Source: "start",
-							Start: ast.Position{
-								Column: 46,
-								Line:   26,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 51,
-									Line:   26,
-								},
-								File:   "v1.flux",
-								Source: "start",
-								Start: ast.Position{
-									Column: 46,
-									Line:   26,
-								},
-							},
-						},
-						Name: "start",
-					},
-					Value: nil,
-				}},
-			},
-		}, &ast.VariableAssignment{
-			BaseNode: ast.BaseNode{
-				Errors: nil,
-				Loc: &ast.SourceLocation{
-					End: ast.Position{
-						Column: 31,
-						Line:   37,
-					},
-					File:   "v1.flux",
-					Source: "tagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
-					Start: ast.Position{
-						Column: 1,
-						Line:   31,
-					},
-				},
-			},
-			ID: &ast.Identifier{
-				BaseNode: ast.BaseNode{
-					Errors: nil,
-					Loc: &ast.SourceLocation{
-						End: ast.Position{
-							Column: 10,
-							Line:   31,
-						},
-						File:   "v1.flux",
-						Source: "tagValues",
-						Start: ast.Position{
-							Column: 1,
-							Line:   31,
-						},
-					},
-				},
-				Name: "tagValues",
-			},
-			Init: &ast.FunctionExpression{
-				BaseNode: ast.BaseNode{
-					Errors: nil,
-					Loc: &ast.SourceLocation{
-						End: ast.Position{
-							Column: 31,
-							Line:   37,
-						},
-						File:   "v1.flux",
-						Source: "(bucket, tag, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
-						Start: ast.Position{
-							Column: 13,
-							Line:   31,
-						},
-					},
-				},
-				Body: &ast.PipeExpression{
-					Argument: &ast.PipeExpression{
-						Argument: &ast.PipeExpression{
-							Argument: &ast.PipeExpression{
-								Argument: &ast.PipeExpression{
-									Argument: &ast.CallExpression{
-										Arguments: []ast.Expression{&ast.ObjectExpression{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 24,
-														Line:   32,
-													},
-													File:   "v1.flux",
-													Source: "bucket: bucket",
-													Start: ast.Position{
-														Column: 10,
-														Line:   32,
-													},
-												},
-											},
-											Properties: []*ast.Property{&ast.Property{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 24,
-															Line:   32,
-														},
-														File:   "v1.flux",
-														Source: "bucket: bucket",
-														Start: ast.Position{
-															Column: 10,
-															Line:   32,
-														},
-													},
-												},
-												Key: &ast.Identifier{
-													BaseNode: ast.BaseNode{
-														Errors: nil,
-														Loc: &ast.SourceLocation{
-															End: ast.Position{
-																Column: 16,
-																Line:   32,
-															},
-															File:   "v1.flux",
-															Source: "bucket",
-															Start: ast.Position{
-																Column: 10,
-																Line:   32,
-															},
-														},
-													},
-													Name: "bucket",
-												},
-												Value: &ast.Identifier{
-													BaseNode: ast.BaseNode{
-														Errors: nil,
-														Loc: &ast.SourceLocation{
-															End: ast.Position{
-																Column: 24,
-																Line:   32,
-															},
-															File:   "v1.flux",
-															Source: "bucket",
-															Start: ast.Position{
-																Column: 18,
-																Line:   32,
-															},
-														},
-													},
-													Name: "bucket",
-												},
-											}},
-											With: nil,
-										}},
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 25,
-													Line:   32,
-												},
-												File:   "v1.flux",
-												Source: "from(bucket: bucket)",
-												Start: ast.Position{
-													Column: 5,
-													Line:   32,
-												},
-											},
-										},
-										Callee: &ast.Identifier{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 9,
-														Line:   32,
-													},
-													File:   "v1.flux",
-													Source: "from",
-													Start: ast.Position{
-														Column: 5,
-														Line:   32,
-													},
-												},
-											},
-											Name: "from",
-										},
-									},
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 29,
-												Line:   33,
-											},
-											File:   "v1.flux",
-											Source: "from(bucket: bucket)\n      |> range(start: start)",
-											Start: ast.Position{
-												Column: 5,
-												Line:   32,
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Arguments: []ast.Expression{&ast.ObjectExpression{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 28,
-														Line:   33,
-													},
-													File:   "v1.flux",
-													Source: "start: start",
-													Start: ast.Position{
-														Column: 16,
-														Line:   33,
-													},
-												},
-											},
-											Properties: []*ast.Property{&ast.Property{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 28,
-															Line:   33,
-														},
-														File:   "v1.flux",
-														Source: "start: start",
-														Start: ast.Position{
-															Column: 16,
-															Line:   33,
-														},
-													},
-												},
-												Key: &ast.Identifier{
-													BaseNode: ast.BaseNode{
-														Errors: nil,
-														Loc: &ast.SourceLocation{
-															End: ast.Position{
-																Column: 21,
-																Line:   33,
-															},
-															File:   "v1.flux",
-															Source: "start",
-															Start: ast.Position{
-																Column: 16,
-																Line:   33,
-															},
-														},
-													},
-													Name: "start",
-												},
-												Value: &ast.Identifier{
-													BaseNode: ast.BaseNode{
-														Errors: nil,
-														Loc: &ast.SourceLocation{
-															End: ast.Position{
-																Column: 28,
-																Line:   33,
-															},
-															File:   "v1.flux",
-															Source: "start",
-															Start: ast.Position{
-																Column: 23,
-																Line:   33,
-															},
-														},
-													},
-													Name: "start",
-												},
-											}},
-											With: nil,
-										}},
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 29,
-													Line:   33,
-												},
-												File:   "v1.flux",
-												Source: "range(start: start)",
-												Start: ast.Position{
-													Column: 10,
-													Line:   33,
-												},
-											},
-										},
-										Callee: &ast.Identifier{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 15,
-														Line:   33,
-													},
-													File:   "v1.flux",
-													Source: "range",
-													Start: ast.Position{
-														Column: 10,
-														Line:   33,
-													},
-												},
-											},
-											Name: "range",
-										},
-									},
-								},
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 31,
-											Line:   34,
-										},
-										File:   "v1.flux",
-										Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)",
-										Start: ast.Position{
-											Column: 5,
-											Line:   32,
-										},
-									},
-								},
-								Call: &ast.CallExpression{
-									Arguments: []ast.Expression{&ast.ObjectExpression{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 30,
-													Line:   34,
-												},
-												File:   "v1.flux",
-												Source: "fn: predicate",
-												Start: ast.Position{
-													Column: 17,
-													Line:   34,
-												},
-											},
-										},
-										Properties: []*ast.Property{&ast.Property{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 30,
-														Line:   34,
-													},
-													File:   "v1.flux",
-													Source: "fn: predicate",
-													Start: ast.Position{
-														Column: 17,
-														Line:   34,
-													},
-												},
-											},
-											Key: &ast.Identifier{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 19,
-															Line:   34,
-														},
-														File:   "v1.flux",
-														Source: "fn",
-														Start: ast.Position{
-															Column: 17,
-															Line:   34,
-														},
-													},
-												},
-												Name: "fn",
-											},
-											Value: &ast.Identifier{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 30,
-															Line:   34,
-														},
-														File:   "v1.flux",
-														Source: "predicate",
-														Start: ast.Position{
-															Column: 21,
-															Line:   34,
-														},
-													},
-												},
-												Name: "predicate",
-											},
-										}},
-										With: nil,
-									}},
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 31,
-												Line:   34,
-											},
-											File:   "v1.flux",
-											Source: "filter(fn: predicate)",
-											Start: ast.Position{
-												Column: 10,
-												Line:   34,
-											},
-										},
-									},
-									Callee: &ast.Identifier{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 16,
-													Line:   34,
-												},
-												File:   "v1.flux",
-												Source: "filter",
-												Start: ast.Position{
-													Column: 10,
-													Line:   34,
-												},
-											},
-										},
-										Name: "filter",
-									},
-								},
-							},
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 30,
-										Line:   35,
-									},
-									File:   "v1.flux",
-									Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])",
-									Start: ast.Position{
-										Column: 5,
-										Line:   32,
-									},
-								},
-							},
-							Call: &ast.CallExpression{
-								Arguments: []ast.Expression{&ast.ObjectExpression{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 29,
-												Line:   35,
-											},
-											File:   "v1.flux",
-											Source: "columns: [tag]",
-											Start: ast.Position{
-												Column: 15,
-												Line:   35,
-											},
-										},
-									},
-									Properties: []*ast.Property{&ast.Property{
-										BaseNode: ast.BaseNode{
-											Errors: nil,
-											Loc: &ast.SourceLocation{
-												End: ast.Position{
-													Column: 29,
-													Line:   35,
-												},
-												File:   "v1.flux",
-												Source: "columns: [tag]",
-												Start: ast.Position{
-													Column: 15,
-													Line:   35,
-												},
-											},
-										},
-										Key: &ast.Identifier{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 22,
-														Line:   35,
-													},
-													File:   "v1.flux",
-													Source: "columns",
-													Start: ast.Position{
-														Column: 15,
-														Line:   35,
-													},
-												},
-											},
-											Name: "columns",
-										},
-										Value: &ast.ArrayExpression{
-											BaseNode: ast.BaseNode{
-												Errors: nil,
-												Loc: &ast.SourceLocation{
-													End: ast.Position{
-														Column: 29,
-														Line:   35,
-													},
-													File:   "v1.flux",
-													Source: "[tag]",
-													Start: ast.Position{
-														Column: 24,
-														Line:   35,
-													},
-												},
-											},
-											Elements: []ast.Expression{&ast.Identifier{
-												BaseNode: ast.BaseNode{
-													Errors: nil,
-													Loc: &ast.SourceLocation{
-														End: ast.Position{
-															Column: 28,
-															Line:   35,
-														},
-														File:   "v1.flux",
-														Source: "tag",
-														Start: ast.Position{
-															Column: 25,
-															Line:   35,
-														},
-													},
-												},
-												Name: "tag",
-											}},
-										},
-									}},
-									With: nil,
-								}},
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 30,
-											Line:   35,
-										},
-										File:   "v1.flux",
-										Source: "keep(columns: [tag])",
-										Start: ast.Position{
-											Column: 10,
-											Line:   35,
-										},
-									},
-								},
-								Callee: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 14,
-												Line:   35,
-											},
-											File:   "v1.flux",
-											Source: "keep",
-											Start: ast.Position{
-												Column: 10,
-												Line:   35,
-											},
-										},
-									},
-									Name: "keep",
-								},
-							},
-						},
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 17,
-									Line:   36,
-								},
-								File:   "v1.flux",
-								Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()",
-								Start: ast.Position{
-									Column: 5,
-									Line:   32,
-								},
-							},
-						},
-						Call: &ast.CallExpression{
-							Arguments: nil,
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 17,
-										Line:   36,
-									},
-									File:   "v1.flux",
-									Source: "group()",
-									Start: ast.Position{
-										Column: 10,
-										Line:   36,
-									},
-								},
-							},
-							Callee: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 15,
-											Line:   36,
-										},
-										File:   "v1.flux",
-										Source: "group",
-										Start: ast.Position{
-											Column: 10,
-											Line:   36,
-										},
-									},
-								},
-								Name: "group",
-							},
-						},
-					},
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 31,
-								Line:   37,
-							},
-							File:   "v1.flux",
-							Source: "from(bucket: bucket)\n      |> range(start: start)\n      |> filter(fn: predicate)\n      |> keep(columns: [tag])\n      |> group()\n      |> distinct(column: tag)",
-							Start: ast.Position{
-								Column: 5,
-								Line:   32,
-							},
-						},
-					},
-					Call: &ast.CallExpression{
-						Arguments: []ast.Expression{&ast.ObjectExpression{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 30,
-										Line:   37,
-									},
-									File:   "v1.flux",
-									Source: "column: tag",
-									Start: ast.Position{
-										Column: 19,
-										Line:   37,
-									},
-								},
-							},
-							Properties: []*ast.Property{&ast.Property{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 30,
-											Line:   37,
-										},
-										File:   "v1.flux",
-										Source: "column: tag",
-										Start: ast.Position{
-											Column: 19,
-											Line:   37,
-										},
-									},
-								},
-								Key: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 25,
-												Line:   37,
-											},
-											File:   "v1.flux",
-											Source: "column",
-											Start: ast.Position{
-												Column: 19,
-												Line:   37,
-											},
-										},
-									},
-									Name: "column",
-								},
-								Value: &ast.Identifier{
-									BaseNode: ast.BaseNode{
-										Errors: nil,
-										Loc: &ast.SourceLocation{
-											End: ast.Position{
-												Column: 30,
-												Line:   37,
-											},
-											File:   "v1.flux",
-											Source: "tag",
-											Start: ast.Position{
-												Column: 27,
-												Line:   37,
-											},
-										},
-									},
-									Name: "tag",
-								},
-							}},
-							With: nil,
-						}},
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 31,
-									Line:   37,
-								},
-								File:   "v1.flux",
-								Source: "distinct(column: tag)",
-								Start: ast.Position{
-									Column: 10,
-									Line:   37,
-								},
-							},
-						},
-						Callee: &ast.Identifier{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 18,
-										Line:   37,
-									},
-									File:   "v1.flux",
-									Source: "distinct",
-									Start: ast.Position{
-										Column: 10,
-										Line:   37,
-									},
-								},
-							},
-							Name: "distinct",
-						},
-					},
-				},
-				Params: []*ast.Property{&ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 20,
-								Line:   31,
-							},
-							File:   "v1.flux",
-							Source: "bucket",
-							Start: ast.Position{
-								Column: 14,
-								Line:   31,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 20,
-									Line:   31,
-								},
-								File:   "v1.flux",
-								Source: "bucket",
-								Start: ast.Position{
-									Column: 14,
-									Line:   31,
-								},
-							},
-						},
-						Name: "bucket",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 25,
-								Line:   31,
-							},
-							File:   "v1.flux",
-							Source: "tag",
-							Start: ast.Position{
-								Column: 22,
-								Line:   31,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 25,
-									Line:   31,
-								},
-								File:   "v1.flux",
-								Source: "tag",
-								Start: ast.Position{
-									Column: 22,
-									Line:   31,
-								},
-							},
-						},
-						Name: "tag",
-					},
-					Value: nil,
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 48,
-								Line:   31,
-							},
-							File:   "v1.flux",
-							Source: "predicate=(r) => true",
-							Start: ast.Position{
-								Column: 27,
-								Line:   31,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 36,
-									Line:   31,
-								},
-								File:   "v1.flux",
-								Source: "predicate",
-								Start: ast.Position{
-									Column: 27,
-									Line:   31,
-								},
-							},
-						},
-						Name: "predicate",
-					},
-					Value: &ast.FunctionExpression{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 48,
-									Line:   31,
-								},
-								File:   "v1.flux",
-								Source: "(r) => true",
-								Start: ast.Position{
-									Column: 37,
-									Line:   31,
-								},
-							},
-						},
-						Body: &ast.Identifier{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 48,
-										Line:   31,
-									},
-									File:   "v1.flux",
-									Source: "true",
-									Start: ast.Position{
-										Column: 44,
-										Line:   31,
-									},
-								},
-							},
-							Name: "true",
-						},
-						Params: []*ast.Property{&ast.Property{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 39,
-										Line:   31,
-									},
-									File:   "v1.flux",
-									Source: "r",
-									Start: ast.Position{
-										Column: 38,
-										Line:   31,
-									},
-								},
-							},
-							Key: &ast.Identifier{
-								BaseNode: ast.BaseNode{
-									Errors: nil,
-									Loc: &ast.SourceLocation{
-										End: ast.Position{
-											Column: 39,
-											Line:   31,
-										},
-										File:   "v1.flux",
-										Source: "r",
-										Start: ast.Position{
-											Column: 38,
-											Line:   31,
-										},
-									},
-								},
-								Name: "r",
-							},
-							Value: nil,
-						}},
-					},
-				}, &ast.Property{
-					BaseNode: ast.BaseNode{
-						Errors: nil,
-						Loc: &ast.SourceLocation{
-							End: ast.Position{
-								Column: 60,
-								Line:   31,
-							},
-							File:   "v1.flux",
-							Source: "start=-30d",
-							Start: ast.Position{
-								Column: 50,
-								Line:   31,
-							},
-						},
-					},
-					Key: &ast.Identifier{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 55,
-									Line:   31,
-								},
-								File:   "v1.flux",
-								Source: "start",
-								Start: ast.Position{
-									Column: 50,
-									Line:   31,
-								},
-							},
-						},
-						Name: "start",
-					},
-					Value: &ast.UnaryExpression{
-						Argument: &ast.DurationLiteral{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 60,
-										Line:   31,
-									},
-									File:   "v1.flux",
-									Source: "30d",
-									Start: ast.Position{
-										Column: 57,
-										Line:   31,
-									},
-								},
-							},
-							Values: []ast.Duration{ast.Duration{
-								Magnitude: int64(30),
-								Unit:      "d",
-							}},
-						},
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 60,
-									Line:   31,
-								},
-								File:   "v1.flux",
-								Source: "-30d",
-								Start: ast.Position{
-									Column: 56,
-									Line:   31,
-								},
-							},
-						},
-						Operator: 6,
-					},
-				}},
-			},
-		}, &ast.VariableAssignment{
-			BaseNode: ast.BaseNode{
-				Errors: nil,
-				Loc: &ast.SourceLocation{
-					End: ast.Position{
-						Column: 89,
-						Line:   42,
-					},
-					File:   "v1.flux",
-					Source: "measurementTagValues = (bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
-					Start: ast.Position{
-						Column: 1,
-						Line:   41,
-					},
-				},
-			},
-			ID: &ast.Identifier{
-				BaseNode: ast.BaseNode{
-					Errors: nil,
-					Loc: &ast.SourceLocation{
-						End: ast.Position{
-							Column: 21,
-							Line:   41,
-						},
-						File:   "v1.flux",
 						Source: "measurementTagValues",
 						Start: ast.Position{
 							Column: 1,
-							Line:   41,
+							Line:   26,
 						},
 					},
 				},
@@ -2912,13 +1488,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 89,
-							Line:   42,
+							Line:   27,
 						},
 						File:   "v1.flux",
 						Source: "(bucket, measurement, tag) =>\n    tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
 						Start: ast.Position{
 							Column: 24,
-							Line:   41,
+							Line:   26,
 						},
 					},
 				},
@@ -2929,13 +1505,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 88,
-									Line:   42,
+									Line:   27,
 								},
 								File:   "v1.flux",
 								Source: "bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement",
 								Start: ast.Position{
 									Column: 15,
-									Line:   42,
+									Line:   27,
 								},
 							},
 						},
@@ -2945,13 +1521,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 29,
-										Line:   42,
+										Line:   27,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 15,
-										Line:   42,
+										Line:   27,
 									},
 								},
 							},
@@ -2961,13 +1537,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   42,
+											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 15,
-											Line:   42,
+											Line:   27,
 										},
 									},
 								},
@@ -2979,13 +1555,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   42,
+											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 23,
-											Line:   42,
+											Line:   27,
 										},
 									},
 								},
@@ -2997,13 +1573,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 39,
-										Line:   42,
+										Line:   27,
 									},
 									File:   "v1.flux",
 									Source: "tag: tag",
 									Start: ast.Position{
 										Column: 31,
-										Line:   42,
+										Line:   27,
 									},
 								},
 							},
@@ -3013,13 +1589,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 34,
-											Line:   42,
+											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "tag",
 										Start: ast.Position{
 											Column: 31,
-											Line:   42,
+											Line:   27,
 										},
 									},
 								},
@@ -3031,13 +1607,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 39,
-											Line:   42,
+											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "tag",
 										Start: ast.Position{
 											Column: 36,
-											Line:   42,
+											Line:   27,
 										},
 									},
 								},
@@ -3049,13 +1625,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 88,
-										Line:   42,
+										Line:   27,
 									},
 									File:   "v1.flux",
 									Source: "predicate: (r) => r._measurement == measurement",
 									Start: ast.Position{
 										Column: 41,
-										Line:   42,
+										Line:   27,
 									},
 								},
 							},
@@ -3065,13 +1641,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 50,
-											Line:   42,
+											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "predicate",
 										Start: ast.Position{
 											Column: 41,
-											Line:   42,
+											Line:   27,
 										},
 									},
 								},
@@ -3083,13 +1659,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 88,
-											Line:   42,
+											Line:   27,
 										},
 										File:   "v1.flux",
 										Source: "(r) => r._measurement == measurement",
 										Start: ast.Position{
 											Column: 52,
-											Line:   42,
+											Line:   27,
 										},
 									},
 								},
@@ -3099,13 +1675,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 88,
-												Line:   42,
+												Line:   27,
 											},
 											File:   "v1.flux",
 											Source: "r._measurement == measurement",
 											Start: ast.Position{
 												Column: 59,
-												Line:   42,
+												Line:   27,
 											},
 										},
 									},
@@ -3115,13 +1691,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 73,
-													Line:   42,
+													Line:   27,
 												},
 												File:   "v1.flux",
 												Source: "r._measurement",
 												Start: ast.Position{
 													Column: 59,
-													Line:   42,
+													Line:   27,
 												},
 											},
 										},
@@ -3131,13 +1707,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 60,
-														Line:   42,
+														Line:   27,
 													},
 													File:   "v1.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 59,
-														Line:   42,
+														Line:   27,
 													},
 												},
 											},
@@ -3149,13 +1725,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 73,
-														Line:   42,
+														Line:   27,
 													},
 													File:   "v1.flux",
 													Source: "_measurement",
 													Start: ast.Position{
 														Column: 61,
-														Line:   42,
+														Line:   27,
 													},
 												},
 											},
@@ -3169,13 +1745,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 88,
-													Line:   42,
+													Line:   27,
 												},
 												File:   "v1.flux",
 												Source: "measurement",
 												Start: ast.Position{
 													Column: 77,
-													Line:   42,
+													Line:   27,
 												},
 											},
 										},
@@ -3188,13 +1764,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 54,
-												Line:   42,
+												Line:   27,
 											},
 											File:   "v1.flux",
 											Source: "r",
 											Start: ast.Position{
 												Column: 53,
-												Line:   42,
+												Line:   27,
 											},
 										},
 									},
@@ -3204,13 +1780,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 54,
-													Line:   42,
+													Line:   27,
 												},
 												File:   "v1.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 53,
-													Line:   42,
+													Line:   27,
 												},
 											},
 										},
@@ -3227,13 +1803,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 89,
-								Line:   42,
+								Line:   27,
 							},
 							File:   "v1.flux",
 							Source: "tagValues(bucket: bucket, tag: tag, predicate: (r) => r._measurement == measurement)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   42,
+								Line:   27,
 							},
 						},
 					},
@@ -3243,13 +1819,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   42,
+									Line:   27,
 								},
 								File:   "v1.flux",
 								Source: "tagValues",
 								Start: ast.Position{
 									Column: 5,
-									Line:   42,
+									Line:   27,
 								},
 							},
 						},
@@ -3262,13 +1838,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 31,
-								Line:   41,
+								Line:   26,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 25,
-								Line:   41,
+								Line:   26,
 							},
 						},
 					},
@@ -3278,13 +1854,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 31,
-									Line:   41,
+									Line:   26,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 25,
-									Line:   41,
+									Line:   26,
 								},
 							},
 						},
@@ -3297,13 +1873,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 44,
-								Line:   41,
+								Line:   26,
 							},
 							File:   "v1.flux",
 							Source: "measurement",
 							Start: ast.Position{
 								Column: 33,
-								Line:   41,
+								Line:   26,
 							},
 						},
 					},
@@ -3313,13 +1889,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 44,
-									Line:   41,
+									Line:   26,
 								},
 								File:   "v1.flux",
 								Source: "measurement",
 								Start: ast.Position{
 									Column: 33,
-									Line:   41,
+									Line:   26,
 								},
 							},
 						},
@@ -3332,13 +1908,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 49,
-								Line:   41,
+								Line:   26,
 							},
 							File:   "v1.flux",
 							Source: "tag",
 							Start: ast.Position{
 								Column: 46,
-								Line:   41,
+								Line:   26,
 							},
 						},
 					},
@@ -3348,13 +1924,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 49,
-									Line:   41,
+									Line:   26,
 								},
 								File:   "v1.flux",
 								Source: "tag",
 								Start: ast.Position{
 									Column: 46,
-									Line:   41,
+									Line:   26,
 								},
 							},
 						},
@@ -3369,13 +1945,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 22,
-						Line:   52,
+						Line:   37,
 					},
 					File:   "v1.flux",
 					Source: "tagKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
 					Start: ast.Position{
 						Column: 1,
-						Line:   46,
+						Line:   31,
 					},
 				},
 			},
@@ -3385,13 +1961,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 8,
-							Line:   46,
+							Line:   31,
 						},
 						File:   "v1.flux",
 						Source: "tagKeys",
 						Start: ast.Position{
 							Column: 1,
-							Line:   46,
+							Line:   31,
 						},
 					},
 				},
@@ -3403,13 +1979,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 22,
-							Line:   52,
+							Line:   37,
 						},
 						File:   "v1.flux",
 						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
 						Start: ast.Position{
 							Column: 11,
-							Line:   46,
+							Line:   31,
 						},
 					},
 				},
@@ -3425,13 +2001,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 24,
-														Line:   47,
+														Line:   32,
 													},
 													File:   "v1.flux",
 													Source: "bucket: bucket",
 													Start: ast.Position{
 														Column: 10,
-														Line:   47,
+														Line:   32,
 													},
 												},
 											},
@@ -3441,13 +2017,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 24,
-															Line:   47,
+															Line:   32,
 														},
 														File:   "v1.flux",
 														Source: "bucket: bucket",
 														Start: ast.Position{
 															Column: 10,
-															Line:   47,
+															Line:   32,
 														},
 													},
 												},
@@ -3457,13 +2033,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 16,
-																Line:   47,
+																Line:   32,
 															},
 															File:   "v1.flux",
 															Source: "bucket",
 															Start: ast.Position{
 																Column: 10,
-																Line:   47,
+																Line:   32,
 															},
 														},
 													},
@@ -3475,13 +2051,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 24,
-																Line:   47,
+																Line:   32,
 															},
 															File:   "v1.flux",
 															Source: "bucket",
 															Start: ast.Position{
 																Column: 18,
-																Line:   47,
+																Line:   32,
 															},
 														},
 													},
@@ -3495,13 +2071,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 25,
-													Line:   47,
+													Line:   32,
 												},
 												File:   "v1.flux",
 												Source: "from(bucket: bucket)",
 												Start: ast.Position{
 													Column: 5,
-													Line:   47,
+													Line:   32,
 												},
 											},
 										},
@@ -3511,13 +2087,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 9,
-														Line:   47,
+														Line:   32,
 													},
 													File:   "v1.flux",
 													Source: "from",
 													Start: ast.Position{
 														Column: 5,
-														Line:   47,
+														Line:   32,
 													},
 												},
 											},
@@ -3529,13 +2105,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 31,
-												Line:   48,
+												Line:   33,
 											},
 											File:   "v1.flux",
 											Source: "from(bucket: bucket)\n        |> range(start: start)",
 											Start: ast.Position{
 												Column: 5,
-												Line:   47,
+												Line:   32,
 											},
 										},
 									},
@@ -3546,13 +2122,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 30,
-														Line:   48,
+														Line:   33,
 													},
 													File:   "v1.flux",
 													Source: "start: start",
 													Start: ast.Position{
 														Column: 18,
-														Line:   48,
+														Line:   33,
 													},
 												},
 											},
@@ -3562,13 +2138,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 30,
-															Line:   48,
+															Line:   33,
 														},
 														File:   "v1.flux",
 														Source: "start: start",
 														Start: ast.Position{
 															Column: 18,
-															Line:   48,
+															Line:   33,
 														},
 													},
 												},
@@ -3578,13 +2154,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 23,
-																Line:   48,
+																Line:   33,
 															},
 															File:   "v1.flux",
 															Source: "start",
 															Start: ast.Position{
 																Column: 18,
-																Line:   48,
+																Line:   33,
 															},
 														},
 													},
@@ -3596,13 +2172,13 @@ var pkgAST = &ast.Package{
 														Loc: &ast.SourceLocation{
 															End: ast.Position{
 																Column: 30,
-																Line:   48,
+																Line:   33,
 															},
 															File:   "v1.flux",
 															Source: "start",
 															Start: ast.Position{
 																Column: 25,
-																Line:   48,
+																Line:   33,
 															},
 														},
 													},
@@ -3616,13 +2192,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 31,
-													Line:   48,
+													Line:   33,
 												},
 												File:   "v1.flux",
 												Source: "range(start: start)",
 												Start: ast.Position{
 													Column: 12,
-													Line:   48,
+													Line:   33,
 												},
 											},
 										},
@@ -3632,13 +2208,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 17,
-														Line:   48,
+														Line:   33,
 													},
 													File:   "v1.flux",
 													Source: "range",
 													Start: ast.Position{
 														Column: 12,
-														Line:   48,
+														Line:   33,
 													},
 												},
 											},
@@ -3651,13 +2227,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 33,
-											Line:   49,
+											Line:   34,
 										},
 										File:   "v1.flux",
 										Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)",
 										Start: ast.Position{
 											Column: 5,
-											Line:   47,
+											Line:   32,
 										},
 									},
 								},
@@ -3668,13 +2244,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 32,
-													Line:   49,
+													Line:   34,
 												},
 												File:   "v1.flux",
 												Source: "fn: predicate",
 												Start: ast.Position{
 													Column: 19,
-													Line:   49,
+													Line:   34,
 												},
 											},
 										},
@@ -3684,13 +2260,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 32,
-														Line:   49,
+														Line:   34,
 													},
 													File:   "v1.flux",
 													Source: "fn: predicate",
 													Start: ast.Position{
 														Column: 19,
-														Line:   49,
+														Line:   34,
 													},
 												},
 											},
@@ -3700,13 +2276,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 21,
-															Line:   49,
+															Line:   34,
 														},
 														File:   "v1.flux",
 														Source: "fn",
 														Start: ast.Position{
 															Column: 19,
-															Line:   49,
+															Line:   34,
 														},
 													},
 												},
@@ -3718,13 +2294,13 @@ var pkgAST = &ast.Package{
 													Loc: &ast.SourceLocation{
 														End: ast.Position{
 															Column: 32,
-															Line:   49,
+															Line:   34,
 														},
 														File:   "v1.flux",
 														Source: "predicate",
 														Start: ast.Position{
 															Column: 23,
-															Line:   49,
+															Line:   34,
 														},
 													},
 												},
@@ -3738,13 +2314,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 33,
-												Line:   49,
+												Line:   34,
 											},
 											File:   "v1.flux",
 											Source: "filter(fn: predicate)",
 											Start: ast.Position{
 												Column: 12,
-												Line:   49,
+												Line:   34,
 											},
 										},
 									},
@@ -3754,13 +2330,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 18,
-													Line:   49,
+													Line:   34,
 												},
 												File:   "v1.flux",
 												Source: "filter",
 												Start: ast.Position{
 													Column: 12,
-													Line:   49,
+													Line:   34,
 												},
 											},
 										},
@@ -3773,13 +2349,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 18,
-										Line:   50,
+										Line:   35,
 									},
 									File:   "v1.flux",
 									Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()",
 									Start: ast.Position{
 										Column: 5,
-										Line:   47,
+										Line:   32,
 									},
 								},
 							},
@@ -3790,13 +2366,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 18,
-											Line:   50,
+											Line:   35,
 										},
 										File:   "v1.flux",
 										Source: "keys()",
 										Start: ast.Position{
 											Column: 12,
-											Line:   50,
+											Line:   35,
 										},
 									},
 								},
@@ -3806,13 +2382,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 16,
-												Line:   50,
+												Line:   35,
 											},
 											File:   "v1.flux",
 											Source: "keys",
 											Start: ast.Position{
 												Column: 12,
-												Line:   50,
+												Line:   35,
 											},
 										},
 									},
@@ -3825,13 +2401,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 37,
-									Line:   51,
+									Line:   36,
 								},
 								File:   "v1.flux",
 								Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])",
 								Start: ast.Position{
 									Column: 5,
-									Line:   47,
+									Line:   32,
 								},
 							},
 						},
@@ -3842,13 +2418,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 36,
-											Line:   51,
+											Line:   36,
 										},
 										File:   "v1.flux",
 										Source: "columns: [\"_value\"]",
 										Start: ast.Position{
 											Column: 17,
-											Line:   51,
+											Line:   36,
 										},
 									},
 								},
@@ -3858,13 +2434,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 36,
-												Line:   51,
+												Line:   36,
 											},
 											File:   "v1.flux",
 											Source: "columns: [\"_value\"]",
 											Start: ast.Position{
 												Column: 17,
-												Line:   51,
+												Line:   36,
 											},
 										},
 									},
@@ -3874,13 +2450,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 24,
-													Line:   51,
+													Line:   36,
 												},
 												File:   "v1.flux",
 												Source: "columns",
 												Start: ast.Position{
 													Column: 17,
-													Line:   51,
+													Line:   36,
 												},
 											},
 										},
@@ -3892,13 +2468,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 36,
-													Line:   51,
+													Line:   36,
 												},
 												File:   "v1.flux",
 												Source: "[\"_value\"]",
 												Start: ast.Position{
 													Column: 26,
-													Line:   51,
+													Line:   36,
 												},
 											},
 										},
@@ -3908,13 +2484,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 35,
-														Line:   51,
+														Line:   36,
 													},
 													File:   "v1.flux",
 													Source: "\"_value\"",
 													Start: ast.Position{
 														Column: 27,
-														Line:   51,
+														Line:   36,
 													},
 												},
 											},
@@ -3929,13 +2505,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 37,
-										Line:   51,
+										Line:   36,
 									},
 									File:   "v1.flux",
 									Source: "keep(columns: [\"_value\"])",
 									Start: ast.Position{
 										Column: 12,
-										Line:   51,
+										Line:   36,
 									},
 								},
 							},
@@ -3945,13 +2521,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 16,
-											Line:   51,
+											Line:   36,
 										},
 										File:   "v1.flux",
 										Source: "keep",
 										Start: ast.Position{
 											Column: 12,
-											Line:   51,
+											Line:   36,
 										},
 									},
 								},
@@ -3964,13 +2540,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 22,
-								Line:   52,
+								Line:   37,
 							},
 							File:   "v1.flux",
 							Source: "from(bucket: bucket)\n        |> range(start: start)\n        |> filter(fn: predicate)\n        |> keys()\n        |> keep(columns: [\"_value\"])\n        |> distinct()",
 							Start: ast.Position{
 								Column: 5,
-								Line:   47,
+								Line:   32,
 							},
 						},
 					},
@@ -3981,13 +2557,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 22,
-									Line:   52,
+									Line:   37,
 								},
 								File:   "v1.flux",
 								Source: "distinct()",
 								Start: ast.Position{
 									Column: 12,
-									Line:   52,
+									Line:   37,
 								},
 							},
 						},
@@ -3997,13 +2573,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 20,
-										Line:   52,
+										Line:   37,
 									},
 									File:   "v1.flux",
 									Source: "distinct",
 									Start: ast.Position{
 										Column: 12,
-										Line:   52,
+										Line:   37,
 									},
 								},
 							},
@@ -4017,13 +2593,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 18,
-								Line:   46,
+								Line:   31,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 12,
-								Line:   46,
+								Line:   31,
 							},
 						},
 					},
@@ -4033,13 +2609,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 18,
-									Line:   46,
+									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 12,
-									Line:   46,
+									Line:   31,
 								},
 							},
 						},
@@ -4052,13 +2628,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 41,
-								Line:   46,
+								Line:   31,
 							},
 							File:   "v1.flux",
 							Source: "predicate=(r) => true",
 							Start: ast.Position{
 								Column: 20,
-								Line:   46,
+								Line:   31,
 							},
 						},
 					},
@@ -4068,13 +2644,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   46,
+									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "predicate",
 								Start: ast.Position{
 									Column: 20,
-									Line:   46,
+									Line:   31,
 								},
 							},
 						},
@@ -4086,13 +2662,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 41,
-									Line:   46,
+									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "(r) => true",
 								Start: ast.Position{
 									Column: 30,
-									Line:   46,
+									Line:   31,
 								},
 							},
 						},
@@ -4102,13 +2678,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 41,
-										Line:   46,
+										Line:   31,
 									},
 									File:   "v1.flux",
 									Source: "true",
 									Start: ast.Position{
 										Column: 37,
-										Line:   46,
+										Line:   31,
 									},
 								},
 							},
@@ -4120,13 +2696,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 32,
-										Line:   46,
+										Line:   31,
 									},
 									File:   "v1.flux",
 									Source: "r",
 									Start: ast.Position{
 										Column: 31,
-										Line:   46,
+										Line:   31,
 									},
 								},
 							},
@@ -4136,13 +2712,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 32,
-											Line:   46,
+											Line:   31,
 										},
 										File:   "v1.flux",
 										Source: "r",
 										Start: ast.Position{
 											Column: 31,
-											Line:   46,
+											Line:   31,
 										},
 									},
 								},
@@ -4157,13 +2733,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 53,
-								Line:   46,
+								Line:   31,
 							},
 							File:   "v1.flux",
 							Source: "start=-30d",
 							Start: ast.Position{
 								Column: 43,
-								Line:   46,
+								Line:   31,
 							},
 						},
 					},
@@ -4173,13 +2749,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 48,
-									Line:   46,
+									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "start",
 								Start: ast.Position{
 									Column: 43,
-									Line:   46,
+									Line:   31,
 								},
 							},
 						},
@@ -4192,13 +2768,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 53,
-										Line:   46,
+										Line:   31,
 									},
 									File:   "v1.flux",
 									Source: "30d",
 									Start: ast.Position{
 										Column: 50,
-										Line:   46,
+										Line:   31,
 									},
 								},
 							},
@@ -4212,13 +2788,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 53,
-									Line:   46,
+									Line:   31,
 								},
 								File:   "v1.flux",
 								Source: "-30d",
 								Start: ast.Position{
 									Column: 49,
-									Line:   46,
+									Line:   31,
 								},
 							},
 						},
@@ -4232,13 +2808,13 @@ var pkgAST = &ast.Package{
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
 						Column: 77,
-						Line:   56,
+						Line:   41,
 					},
 					File:   "v1.flux",
 					Source: "measurementTagKeys = (bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   55,
+						Line:   40,
 					},
 				},
 			},
@@ -4248,13 +2824,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 19,
-							Line:   55,
+							Line:   40,
 						},
 						File:   "v1.flux",
 						Source: "measurementTagKeys",
 						Start: ast.Position{
 							Column: 1,
-							Line:   55,
+							Line:   40,
 						},
 					},
 				},
@@ -4266,13 +2842,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 77,
-							Line:   56,
+							Line:   41,
 						},
 						File:   "v1.flux",
 						Source: "(bucket, measurement) =>\n    tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 						Start: ast.Position{
 							Column: 22,
-							Line:   55,
+							Line:   40,
 						},
 					},
 				},
@@ -4283,13 +2859,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 76,
-									Line:   56,
+									Line:   41,
 								},
 								File:   "v1.flux",
 								Source: "bucket: bucket, predicate: (r) => r._measurement == measurement",
 								Start: ast.Position{
 									Column: 13,
-									Line:   56,
+									Line:   41,
 								},
 							},
 						},
@@ -4299,13 +2875,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 27,
-										Line:   56,
+										Line:   41,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 13,
-										Line:   56,
+										Line:   41,
 									},
 								},
 							},
@@ -4315,13 +2891,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 19,
-											Line:   56,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 13,
-											Line:   56,
+											Line:   41,
 										},
 									},
 								},
@@ -4333,13 +2909,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 27,
-											Line:   56,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 21,
-											Line:   56,
+											Line:   41,
 										},
 									},
 								},
@@ -4351,13 +2927,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 76,
-										Line:   56,
+										Line:   41,
 									},
 									File:   "v1.flux",
 									Source: "predicate: (r) => r._measurement == measurement",
 									Start: ast.Position{
 										Column: 29,
-										Line:   56,
+										Line:   41,
 									},
 								},
 							},
@@ -4367,13 +2943,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 38,
-											Line:   56,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "predicate",
 										Start: ast.Position{
 											Column: 29,
-											Line:   56,
+											Line:   41,
 										},
 									},
 								},
@@ -4385,13 +2961,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 76,
-											Line:   56,
+											Line:   41,
 										},
 										File:   "v1.flux",
 										Source: "(r) => r._measurement == measurement",
 										Start: ast.Position{
 											Column: 40,
-											Line:   56,
+											Line:   41,
 										},
 									},
 								},
@@ -4401,13 +2977,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 76,
-												Line:   56,
+												Line:   41,
 											},
 											File:   "v1.flux",
 											Source: "r._measurement == measurement",
 											Start: ast.Position{
 												Column: 47,
-												Line:   56,
+												Line:   41,
 											},
 										},
 									},
@@ -4417,13 +2993,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 61,
-													Line:   56,
+													Line:   41,
 												},
 												File:   "v1.flux",
 												Source: "r._measurement",
 												Start: ast.Position{
 													Column: 47,
-													Line:   56,
+													Line:   41,
 												},
 											},
 										},
@@ -4433,13 +3009,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 48,
-														Line:   56,
+														Line:   41,
 													},
 													File:   "v1.flux",
 													Source: "r",
 													Start: ast.Position{
 														Column: 47,
-														Line:   56,
+														Line:   41,
 													},
 												},
 											},
@@ -4451,13 +3027,13 @@ var pkgAST = &ast.Package{
 												Loc: &ast.SourceLocation{
 													End: ast.Position{
 														Column: 61,
-														Line:   56,
+														Line:   41,
 													},
 													File:   "v1.flux",
 													Source: "_measurement",
 													Start: ast.Position{
 														Column: 49,
-														Line:   56,
+														Line:   41,
 													},
 												},
 											},
@@ -4471,13 +3047,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 76,
-													Line:   56,
+													Line:   41,
 												},
 												File:   "v1.flux",
 												Source: "measurement",
 												Start: ast.Position{
 													Column: 65,
-													Line:   56,
+													Line:   41,
 												},
 											},
 										},
@@ -4490,13 +3066,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 42,
-												Line:   56,
+												Line:   41,
 											},
 											File:   "v1.flux",
 											Source: "r",
 											Start: ast.Position{
 												Column: 41,
-												Line:   56,
+												Line:   41,
 											},
 										},
 									},
@@ -4506,13 +3082,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 42,
-													Line:   56,
+													Line:   41,
 												},
 												File:   "v1.flux",
 												Source: "r",
 												Start: ast.Position{
 													Column: 41,
-													Line:   56,
+													Line:   41,
 												},
 											},
 										},
@@ -4529,13 +3105,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 77,
-								Line:   56,
+								Line:   41,
 							},
 							File:   "v1.flux",
 							Source: "tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)",
 							Start: ast.Position{
 								Column: 5,
-								Line:   56,
+								Line:   41,
 							},
 						},
 					},
@@ -4545,13 +3121,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 12,
-									Line:   56,
+									Line:   41,
 								},
 								File:   "v1.flux",
 								Source: "tagKeys",
 								Start: ast.Position{
 									Column: 5,
-									Line:   56,
+									Line:   41,
 								},
 							},
 						},
@@ -4564,13 +3140,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 29,
-								Line:   55,
+								Line:   40,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 23,
-								Line:   55,
+								Line:   40,
 							},
 						},
 					},
@@ -4580,13 +3156,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 29,
-									Line:   55,
+									Line:   40,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 23,
-									Line:   55,
+									Line:   40,
 								},
 							},
 						},
@@ -4599,13 +3175,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 42,
-								Line:   55,
+								Line:   40,
 							},
 							File:   "v1.flux",
 							Source: "measurement",
 							Start: ast.Position{
 								Column: 31,
-								Line:   55,
+								Line:   40,
 							},
 						},
 					},
@@ -4615,13 +3191,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 42,
-									Line:   55,
+									Line:   40,
 								},
 								File:   "v1.flux",
 								Source: "measurement",
 								Start: ast.Position{
 									Column: 31,
-									Line:   55,
+									Line:   40,
 								},
 							},
 						},
@@ -4635,14 +3211,14 @@ var pkgAST = &ast.Package{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
 					End: ast.Position{
-						Column: 51,
-						Line:   60,
+						Column: 81,
+						Line:   46,
 					},
 					File:   "v1.flux",
-					Source: "measurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+					Source: "fieldKeys = (bucket, predicate=(r) => true, start=-30d) =>\n    tagValues(bucket: bucket, tag: \"_field\", predicate: predicate, start: start)",
 					Start: ast.Position{
 						Column: 1,
-						Line:   59,
+						Line:   45,
 					},
 				},
 			},
@@ -4651,32 +3227,32 @@ var pkgAST = &ast.Package{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 13,
-							Line:   59,
+							Column: 10,
+							Line:   45,
 						},
 						File:   "v1.flux",
-						Source: "measurements",
+						Source: "fieldKeys",
 						Start: ast.Position{
 							Column: 1,
-							Line:   59,
+							Line:   45,
 						},
 					},
 				},
-				Name: "measurements",
+				Name: "fieldKeys",
 			},
 			Init: &ast.FunctionExpression{
 				BaseNode: ast.BaseNode{
 					Errors: nil,
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
-							Column: 51,
-							Line:   60,
+							Column: 81,
+							Line:   46,
 						},
 						File:   "v1.flux",
-						Source: "(bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+						Source: "(bucket, predicate=(r) => true, start=-30d) =>\n    tagValues(bucket: bucket, tag: \"_field\", predicate: predicate, start: start)",
 						Start: ast.Position{
-							Column: 16,
-							Line:   59,
+							Column: 13,
+							Line:   45,
 						},
 					},
 				},
@@ -4686,14 +3262,14 @@ var pkgAST = &ast.Package{
 							Errors: nil,
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
-									Column: 50,
-									Line:   60,
+									Column: 80,
+									Line:   46,
 								},
 								File:   "v1.flux",
-								Source: "bucket: bucket, tag: \"_measurement\"",
+								Source: "bucket: bucket, tag: \"_field\", predicate: predicate, start: start",
 								Start: ast.Position{
 									Column: 15,
-									Line:   60,
+									Line:   46,
 								},
 							},
 						},
@@ -4703,13 +3279,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 29,
-										Line:   60,
+										Line:   46,
 									},
 									File:   "v1.flux",
 									Source: "bucket: bucket",
 									Start: ast.Position{
 										Column: 15,
-										Line:   60,
+										Line:   46,
 									},
 								},
 							},
@@ -4719,13 +3295,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 21,
-											Line:   60,
+											Line:   46,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 15,
-											Line:   60,
+											Line:   46,
 										},
 									},
 								},
@@ -4737,13 +3313,1069 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   60,
+											Line:   46,
 										},
 										File:   "v1.flux",
 										Source: "bucket",
 										Start: ast.Position{
 											Column: 23,
-											Line:   60,
+											Line:   46,
+										},
+									},
+								},
+								Name: "bucket",
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 44,
+										Line:   46,
+									},
+									File:   "v1.flux",
+									Source: "tag: \"_field\"",
+									Start: ast.Position{
+										Column: 31,
+										Line:   46,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 34,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "tag",
+										Start: ast.Position{
+											Column: 31,
+											Line:   46,
+										},
+									},
+								},
+								Name: "tag",
+							},
+							Value: &ast.StringLiteral{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 44,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "\"_field\"",
+										Start: ast.Position{
+											Column: 36,
+											Line:   46,
+										},
+									},
+								},
+								Value: "_field",
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 66,
+										Line:   46,
+									},
+									File:   "v1.flux",
+									Source: "predicate: predicate",
+									Start: ast.Position{
+										Column: 46,
+										Line:   46,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 55,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "predicate",
+										Start: ast.Position{
+											Column: 46,
+											Line:   46,
+										},
+									},
+								},
+								Name: "predicate",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 66,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "predicate",
+										Start: ast.Position{
+											Column: 57,
+											Line:   46,
+										},
+									},
+								},
+								Name: "predicate",
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 80,
+										Line:   46,
+									},
+									File:   "v1.flux",
+									Source: "start: start",
+									Start: ast.Position{
+										Column: 68,
+										Line:   46,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 73,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "start",
+										Start: ast.Position{
+											Column: 68,
+											Line:   46,
+										},
+									},
+								},
+								Name: "start",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 80,
+											Line:   46,
+										},
+										File:   "v1.flux",
+										Source: "start",
+										Start: ast.Position{
+											Column: 75,
+											Line:   46,
+										},
+									},
+								},
+								Name: "start",
+							},
+						}},
+						With: nil,
+					}},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 81,
+								Line:   46,
+							},
+							File:   "v1.flux",
+							Source: "tagValues(bucket: bucket, tag: \"_field\", predicate: predicate, start: start)",
+							Start: ast.Position{
+								Column: 5,
+								Line:   46,
+							},
+						},
+					},
+					Callee: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 14,
+									Line:   46,
+								},
+								File:   "v1.flux",
+								Source: "tagValues",
+								Start: ast.Position{
+									Column: 5,
+									Line:   46,
+								},
+							},
+						},
+						Name: "tagValues",
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 20,
+								Line:   45,
+							},
+							File:   "v1.flux",
+							Source: "bucket",
+							Start: ast.Position{
+								Column: 14,
+								Line:   45,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 20,
+									Line:   45,
+								},
+								File:   "v1.flux",
+								Source: "bucket",
+								Start: ast.Position{
+									Column: 14,
+									Line:   45,
+								},
+							},
+						},
+						Name: "bucket",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 43,
+								Line:   45,
+							},
+							File:   "v1.flux",
+							Source: "predicate=(r) => true",
+							Start: ast.Position{
+								Column: 22,
+								Line:   45,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 31,
+									Line:   45,
+								},
+								File:   "v1.flux",
+								Source: "predicate",
+								Start: ast.Position{
+									Column: 22,
+									Line:   45,
+								},
+							},
+						},
+						Name: "predicate",
+					},
+					Value: &ast.FunctionExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 43,
+									Line:   45,
+								},
+								File:   "v1.flux",
+								Source: "(r) => true",
+								Start: ast.Position{
+									Column: 32,
+									Line:   45,
+								},
+							},
+						},
+						Body: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 43,
+										Line:   45,
+									},
+									File:   "v1.flux",
+									Source: "true",
+									Start: ast.Position{
+										Column: 39,
+										Line:   45,
+									},
+								},
+							},
+							Name: "true",
+						},
+						Params: []*ast.Property{&ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 34,
+										Line:   45,
+									},
+									File:   "v1.flux",
+									Source: "r",
+									Start: ast.Position{
+										Column: 33,
+										Line:   45,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 34,
+											Line:   45,
+										},
+										File:   "v1.flux",
+										Source: "r",
+										Start: ast.Position{
+											Column: 33,
+											Line:   45,
+										},
+									},
+								},
+								Name: "r",
+							},
+							Value: nil,
+						}},
+					},
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 55,
+								Line:   45,
+							},
+							File:   "v1.flux",
+							Source: "start=-30d",
+							Start: ast.Position{
+								Column: 45,
+								Line:   45,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 50,
+									Line:   45,
+								},
+								File:   "v1.flux",
+								Source: "start",
+								Start: ast.Position{
+									Column: 45,
+									Line:   45,
+								},
+							},
+						},
+						Name: "start",
+					},
+					Value: &ast.UnaryExpression{
+						Argument: &ast.DurationLiteral{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 55,
+										Line:   45,
+									},
+									File:   "v1.flux",
+									Source: "30d",
+									Start: ast.Position{
+										Column: 52,
+										Line:   45,
+									},
+								},
+							},
+							Values: []ast.Duration{ast.Duration{
+								Magnitude: int64(30),
+								Unit:      "d",
+							}},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 55,
+									Line:   45,
+								},
+								File:   "v1.flux",
+								Source: "-30d",
+								Start: ast.Position{
+									Column: 51,
+									Line:   45,
+								},
+							},
+						},
+						Operator: 6,
+					},
+				}},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 93,
+						Line:   51,
+					},
+					File:   "v1.flux",
+					Source: "measurementFieldKeys = (bucket, measurement, start=-30d) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
+					Start: ast.Position{
+						Column: 1,
+						Line:   50,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 21,
+							Line:   50,
+						},
+						File:   "v1.flux",
+						Source: "measurementFieldKeys",
+						Start: ast.Position{
+							Column: 1,
+							Line:   50,
+						},
+					},
+				},
+				Name: "measurementFieldKeys",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 93,
+							Line:   51,
+						},
+						File:   "v1.flux",
+						Source: "(bucket, measurement, start=-30d) =>\n    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
+						Start: ast.Position{
+							Column: 24,
+							Line:   50,
+						},
+					},
+				},
+				Body: &ast.CallExpression{
+					Arguments: []ast.Expression{&ast.ObjectExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 92,
+									Line:   51,
+								},
+								File:   "v1.flux",
+								Source: "bucket: bucket, predicate: (r) => r._measurement == measurement, start: start",
+								Start: ast.Position{
+									Column: 15,
+									Line:   51,
+								},
+							},
+						},
+						Properties: []*ast.Property{&ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 29,
+										Line:   51,
+									},
+									File:   "v1.flux",
+									Source: "bucket: bucket",
+									Start: ast.Position{
+										Column: 15,
+										Line:   51,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 21,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "bucket",
+										Start: ast.Position{
+											Column: 15,
+											Line:   51,
+										},
+									},
+								},
+								Name: "bucket",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 29,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "bucket",
+										Start: ast.Position{
+											Column: 23,
+											Line:   51,
+										},
+									},
+								},
+								Name: "bucket",
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 78,
+										Line:   51,
+									},
+									File:   "v1.flux",
+									Source: "predicate: (r) => r._measurement == measurement",
+									Start: ast.Position{
+										Column: 31,
+										Line:   51,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 40,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "predicate",
+										Start: ast.Position{
+											Column: 31,
+											Line:   51,
+										},
+									},
+								},
+								Name: "predicate",
+							},
+							Value: &ast.FunctionExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 78,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "(r) => r._measurement == measurement",
+										Start: ast.Position{
+											Column: 42,
+											Line:   51,
+										},
+									},
+								},
+								Body: &ast.BinaryExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 78,
+												Line:   51,
+											},
+											File:   "v1.flux",
+											Source: "r._measurement == measurement",
+											Start: ast.Position{
+												Column: 49,
+												Line:   51,
+											},
+										},
+									},
+									Left: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 63,
+													Line:   51,
+												},
+												File:   "v1.flux",
+												Source: "r._measurement",
+												Start: ast.Position{
+													Column: 49,
+													Line:   51,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 50,
+														Line:   51,
+													},
+													File:   "v1.flux",
+													Source: "r",
+													Start: ast.Position{
+														Column: 49,
+														Line:   51,
+													},
+												},
+											},
+											Name: "r",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 63,
+														Line:   51,
+													},
+													File:   "v1.flux",
+													Source: "_measurement",
+													Start: ast.Position{
+														Column: 51,
+														Line:   51,
+													},
+												},
+											},
+											Name: "_measurement",
+										},
+									},
+									Operator: 17,
+									Right: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 78,
+													Line:   51,
+												},
+												File:   "v1.flux",
+												Source: "measurement",
+												Start: ast.Position{
+													Column: 67,
+													Line:   51,
+												},
+											},
+										},
+										Name: "measurement",
+									},
+								},
+								Params: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 44,
+												Line:   51,
+											},
+											File:   "v1.flux",
+											Source: "r",
+											Start: ast.Position{
+												Column: 43,
+												Line:   51,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 44,
+													Line:   51,
+												},
+												File:   "v1.flux",
+												Source: "r",
+												Start: ast.Position{
+													Column: 43,
+													Line:   51,
+												},
+											},
+										},
+										Name: "r",
+									},
+									Value: nil,
+								}},
+							},
+						}, &ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 92,
+										Line:   51,
+									},
+									File:   "v1.flux",
+									Source: "start: start",
+									Start: ast.Position{
+										Column: 80,
+										Line:   51,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 85,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "start",
+										Start: ast.Position{
+											Column: 80,
+											Line:   51,
+										},
+									},
+								},
+								Name: "start",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 92,
+											Line:   51,
+										},
+										File:   "v1.flux",
+										Source: "start",
+										Start: ast.Position{
+											Column: 87,
+											Line:   51,
+										},
+									},
+								},
+								Name: "start",
+							},
+						}},
+						With: nil,
+					}},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 93,
+								Line:   51,
+							},
+							File:   "v1.flux",
+							Source: "fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)",
+							Start: ast.Position{
+								Column: 5,
+								Line:   51,
+							},
+						},
+					},
+					Callee: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 14,
+									Line:   51,
+								},
+								File:   "v1.flux",
+								Source: "fieldKeys",
+								Start: ast.Position{
+									Column: 5,
+									Line:   51,
+								},
+							},
+						},
+						Name: "fieldKeys",
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 31,
+								Line:   50,
+							},
+							File:   "v1.flux",
+							Source: "bucket",
+							Start: ast.Position{
+								Column: 25,
+								Line:   50,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 31,
+									Line:   50,
+								},
+								File:   "v1.flux",
+								Source: "bucket",
+								Start: ast.Position{
+									Column: 25,
+									Line:   50,
+								},
+							},
+						},
+						Name: "bucket",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 44,
+								Line:   50,
+							},
+							File:   "v1.flux",
+							Source: "measurement",
+							Start: ast.Position{
+								Column: 33,
+								Line:   50,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 44,
+									Line:   50,
+								},
+								File:   "v1.flux",
+								Source: "measurement",
+								Start: ast.Position{
+									Column: 33,
+									Line:   50,
+								},
+							},
+						},
+						Name: "measurement",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 56,
+								Line:   50,
+							},
+							File:   "v1.flux",
+							Source: "start=-30d",
+							Start: ast.Position{
+								Column: 46,
+								Line:   50,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 51,
+									Line:   50,
+								},
+								File:   "v1.flux",
+								Source: "start",
+								Start: ast.Position{
+									Column: 46,
+									Line:   50,
+								},
+							},
+						},
+						Name: "start",
+					},
+					Value: &ast.UnaryExpression{
+						Argument: &ast.DurationLiteral{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 56,
+										Line:   50,
+									},
+									File:   "v1.flux",
+									Source: "30d",
+									Start: ast.Position{
+										Column: 53,
+										Line:   50,
+									},
+								},
+							},
+							Values: []ast.Duration{ast.Duration{
+								Magnitude: int64(30),
+								Unit:      "d",
+							}},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 56,
+									Line:   50,
+								},
+								File:   "v1.flux",
+								Source: "-30d",
+								Start: ast.Position{
+									Column: 52,
+									Line:   50,
+								},
+							},
+						},
+						Operator: 6,
+					},
+				}},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 51,
+						Line:   55,
+					},
+					File:   "v1.flux",
+					Source: "measurements = (bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+					Start: ast.Position{
+						Column: 1,
+						Line:   54,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 13,
+							Line:   54,
+						},
+						File:   "v1.flux",
+						Source: "measurements",
+						Start: ast.Position{
+							Column: 1,
+							Line:   54,
+						},
+					},
+				},
+				Name: "measurements",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 51,
+							Line:   55,
+						},
+						File:   "v1.flux",
+						Source: "(bucket) =>\n    tagValues(bucket: bucket, tag: \"_measurement\")",
+						Start: ast.Position{
+							Column: 16,
+							Line:   54,
+						},
+					},
+				},
+				Body: &ast.CallExpression{
+					Arguments: []ast.Expression{&ast.ObjectExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 50,
+									Line:   55,
+								},
+								File:   "v1.flux",
+								Source: "bucket: bucket, tag: \"_measurement\"",
+								Start: ast.Position{
+									Column: 15,
+									Line:   55,
+								},
+							},
+						},
+						Properties: []*ast.Property{&ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 29,
+										Line:   55,
+									},
+									File:   "v1.flux",
+									Source: "bucket: bucket",
+									Start: ast.Position{
+										Column: 15,
+										Line:   55,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 21,
+											Line:   55,
+										},
+										File:   "v1.flux",
+										Source: "bucket",
+										Start: ast.Position{
+											Column: 15,
+											Line:   55,
+										},
+									},
+								},
+								Name: "bucket",
+							},
+							Value: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 29,
+											Line:   55,
+										},
+										File:   "v1.flux",
+										Source: "bucket",
+										Start: ast.Position{
+											Column: 23,
+											Line:   55,
 										},
 									},
 								},
@@ -4755,13 +4387,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 50,
-										Line:   60,
+										Line:   55,
 									},
 									File:   "v1.flux",
 									Source: "tag: \"_measurement\"",
 									Start: ast.Position{
 										Column: 31,
-										Line:   60,
+										Line:   55,
 									},
 								},
 							},
@@ -4771,13 +4403,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 34,
-											Line:   60,
+											Line:   55,
 										},
 										File:   "v1.flux",
 										Source: "tag",
 										Start: ast.Position{
 											Column: 31,
-											Line:   60,
+											Line:   55,
 										},
 									},
 								},
@@ -4789,13 +4421,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 50,
-											Line:   60,
+											Line:   55,
 										},
 										File:   "v1.flux",
 										Source: "\"_measurement\"",
 										Start: ast.Position{
 											Column: 36,
-											Line:   60,
+											Line:   55,
 										},
 									},
 								},
@@ -4809,13 +4441,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 51,
-								Line:   60,
+								Line:   55,
 							},
 							File:   "v1.flux",
 							Source: "tagValues(bucket: bucket, tag: \"_measurement\")",
 							Start: ast.Position{
 								Column: 5,
-								Line:   60,
+								Line:   55,
 							},
 						},
 					},
@@ -4825,13 +4457,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 14,
-									Line:   60,
+									Line:   55,
 								},
 								File:   "v1.flux",
 								Source: "tagValues",
 								Start: ast.Position{
 									Column: 5,
-									Line:   60,
+									Line:   55,
 								},
 							},
 						},
@@ -4844,13 +4476,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 23,
-								Line:   59,
+								Line:   54,
 							},
 							File:   "v1.flux",
 							Source: "bucket",
 							Start: ast.Position{
 								Column: 17,
-								Line:   59,
+								Line:   54,
 							},
 						},
 					},
@@ -4860,13 +4492,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 23,
-									Line:   59,
+									Line:   54,
 								},
 								File:   "v1.flux",
 								Source: "bucket",
 								Start: ast.Position{
 									Column: 17,
-									Line:   59,
+									Line:   54,
 								},
 							},
 						},

--- a/stdlib/influxdata/influxdb/v1/flux_test_gen.go
+++ b/stdlib/influxdata/influxdb/v1/flux_test_gen.go
@@ -4194,6 +4194,1864 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 					Column: 114,
 					Line:   90,
 				},
+				File:   "measurement_field_keys_test.flux",
+				Source: "package v1_test\n\nimport \"testing\"\n\ninput = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,long\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,sys,host.global,load7,183\n,,0,2018-05-22T19:53:36Z,sys,host.global,load7,172\n,,0,2018-05-22T19:53:46Z,sys,host.global,load7,174\n,,0,2018-05-22T19:53:56Z,sys,host.global,load7,163\n,,0,2018-05-22T19:54:06Z,sys,host.global,load7,191\n,,0,2018-05-22T19:54:16Z,sys,host.global,load7,184\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load8,198\n,,1,2018-05-22T19:53:36Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:46Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:56Z,sys,host.local,load8,196\n,,1,2018-05-22T19:54:06Z,sys,host.local,load8,198\n,,1,2018-05-22T19:54:16Z,sys,host.local,load8,197\n\n,,2,2018-05-22T19:53:26Z,sys,host.global,load9,195\n,,2,2018-05-22T19:53:36Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:46Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:56Z,sys,host.global,load9,189\n,,2,2018-05-22T19:54:06Z,sys,host.global,load9,194\n,,2,2018-05-22T19:54:16Z,sys,host.global,load9,193\n\n,,3,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298\n,,3,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264\n\"\n\noutput = \"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load3\n,,0,load8\n\"\n\nmeasurement_field_keys_fn = (tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()\n\ntest measurement_field_keys = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn})",
+				Start: ast.Position{
+					Column: 1,
+					Line:   1,
+				},
+			},
+		},
+		Body: []ast.Statement{&ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   69,
+					},
+					File:   "measurement_field_keys_test.flux",
+					Source: "input = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,long\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,sys,host.global,load7,183\n,,0,2018-05-22T19:53:36Z,sys,host.global,load7,172\n,,0,2018-05-22T19:53:46Z,sys,host.global,load7,174\n,,0,2018-05-22T19:53:56Z,sys,host.global,load7,163\n,,0,2018-05-22T19:54:06Z,sys,host.global,load7,191\n,,0,2018-05-22T19:54:16Z,sys,host.global,load7,184\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load8,198\n,,1,2018-05-22T19:53:36Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:46Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:56Z,sys,host.local,load8,196\n,,1,2018-05-22T19:54:06Z,sys,host.local,load8,198\n,,1,2018-05-22T19:54:16Z,sys,host.local,load8,197\n\n,,2,2018-05-22T19:53:26Z,sys,host.global,load9,195\n,,2,2018-05-22T19:53:36Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:46Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:56Z,sys,host.global,load9,189\n,,2,2018-05-22T19:54:06Z,sys,host.global,load9,194\n,,2,2018-05-22T19:54:16Z,sys,host.global,load9,193\n\n,,3,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298\n,,3,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   5,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 6,
+							Line:   5,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "input",
+						Start: ast.Position{
+							Column: 1,
+							Line:   5,
+						},
+					},
+				},
+				Name: "input",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   69,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,long\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,sys,host.global,load7,183\n,,0,2018-05-22T19:53:36Z,sys,host.global,load7,172\n,,0,2018-05-22T19:53:46Z,sys,host.global,load7,174\n,,0,2018-05-22T19:53:56Z,sys,host.global,load7,163\n,,0,2018-05-22T19:54:06Z,sys,host.global,load7,191\n,,0,2018-05-22T19:54:16Z,sys,host.global,load7,184\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load8,198\n,,1,2018-05-22T19:53:36Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:46Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:56Z,sys,host.local,load8,196\n,,1,2018-05-22T19:54:06Z,sys,host.local,load8,198\n,,1,2018-05-22T19:54:16Z,sys,host.local,load8,197\n\n,,2,2018-05-22T19:53:26Z,sys,host.global,load9,195\n,,2,2018-05-22T19:53:36Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:46Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:56Z,sys,host.global,load9,189\n,,2,2018-05-22T19:54:06Z,sys,host.global,load9,194\n,,2,2018-05-22T19:54:16Z,sys,host.global,load9,193\n\n,,3,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298\n,,3,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264\n\"",
+						Start: ast.Position{
+							Column: 9,
+							Line:   5,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,long\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,sys,host.global,load7,183\n,,0,2018-05-22T19:53:36Z,sys,host.global,load7,172\n,,0,2018-05-22T19:53:46Z,sys,host.global,load7,174\n,,0,2018-05-22T19:53:56Z,sys,host.global,load7,163\n,,0,2018-05-22T19:54:06Z,sys,host.global,load7,191\n,,0,2018-05-22T19:54:16Z,sys,host.global,load7,184\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load8,198\n,,1,2018-05-22T19:53:36Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:46Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:56Z,sys,host.local,load8,196\n,,1,2018-05-22T19:54:06Z,sys,host.local,load8,198\n,,1,2018-05-22T19:54:16Z,sys,host.local,load8,197\n\n,,2,2018-05-22T19:53:26Z,sys,host.global,load9,195\n,,2,2018-05-22T19:53:36Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:46Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:56Z,sys,host.global,load9,189\n,,2,2018-05-22T19:54:06Z,sys,host.global,load9,194\n,,2,2018-05-22T19:54:16Z,sys,host.global,load9,193\n\n,,3,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298\n,,3,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   78,
+					},
+					File:   "measurement_field_keys_test.flux",
+					Source: "output = \"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load3\n,,0,load8\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   71,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 7,
+							Line:   71,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "output",
+						Start: ast.Position{
+							Column: 1,
+							Line:   71,
+						},
+					},
+				},
+				Name: "output",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   78,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "\"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load3\n,,0,load8\n\"",
+						Start: ast.Position{
+							Column: 10,
+							Line:   71,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load3\n,,0,load8\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 14,
+						Line:   87,
+					},
+					File:   "measurement_field_keys_test.flux",
+					Source: "measurement_field_keys_fn = (tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()",
+					Start: ast.Position{
+						Column: 1,
+						Line:   80,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 26,
+							Line:   80,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "measurement_field_keys_fn",
+						Start: ast.Position{
+							Column: 1,
+							Line:   80,
+						},
+					},
+				},
+				Name: "measurement_field_keys_fn",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 14,
+							Line:   87,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "(tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()",
+						Start: ast.Position{
+							Column: 29,
+							Line:   80,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.PipeExpression{
+							Argument: &ast.PipeExpression{
+								Argument: &ast.PipeExpression{
+									Argument: &ast.PipeExpression{
+										Argument: &ast.PipeExpression{
+											Argument: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 50,
+															Line:   80,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "tables",
+														Start: ast.Position{
+															Column: 44,
+															Line:   80,
+														},
+													},
+												},
+												Name: "tables",
+											},
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 70,
+														Line:   81,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)",
+													Start: ast.Position{
+														Column: 44,
+														Line:   80,
+													},
+												},
+											},
+											Call: &ast.CallExpression{
+												Arguments: []ast.Expression{&ast.ObjectExpression{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 69,
+																Line:   81,
+															},
+															File:   "measurement_field_keys_test.flux",
+															Source: "start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z",
+															Start: ast.Position{
+																Column: 14,
+																Line:   81,
+															},
+														},
+													},
+													Properties: []*ast.Property{&ast.Property{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 41,
+																	Line:   81,
+																},
+																File:   "measurement_field_keys_test.flux",
+																Source: "start: 2018-01-01T00:00:00Z",
+																Start: ast.Position{
+																	Column: 14,
+																	Line:   81,
+																},
+															},
+														},
+														Key: &ast.Identifier{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 19,
+																		Line:   81,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "start",
+																	Start: ast.Position{
+																		Column: 14,
+																		Line:   81,
+																	},
+																},
+															},
+															Name: "start",
+														},
+														Value: &ast.DateTimeLiteral{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 41,
+																		Line:   81,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "2018-01-01T00:00:00Z",
+																	Start: ast.Position{
+																		Column: 21,
+																		Line:   81,
+																	},
+																},
+															},
+															Value: parser.MustParseTime("2018-01-01T00:00:00Z"),
+														},
+													}, &ast.Property{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 69,
+																	Line:   81,
+																},
+																File:   "measurement_field_keys_test.flux",
+																Source: "stop: 2019-01-01T00:00:00Z",
+																Start: ast.Position{
+																	Column: 43,
+																	Line:   81,
+																},
+															},
+														},
+														Key: &ast.Identifier{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 47,
+																		Line:   81,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "stop",
+																	Start: ast.Position{
+																		Column: 43,
+																		Line:   81,
+																	},
+																},
+															},
+															Name: "stop",
+														},
+														Value: &ast.DateTimeLiteral{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 69,
+																		Line:   81,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "2019-01-01T00:00:00Z",
+																	Start: ast.Position{
+																		Column: 49,
+																		Line:   81,
+																	},
+																},
+															},
+															Value: parser.MustParseTime("2019-01-01T00:00:00Z"),
+														},
+													}},
+													With: nil,
+												}},
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 70,
+															Line:   81,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)",
+														Start: ast.Position{
+															Column: 8,
+															Line:   81,
+														},
+													},
+												},
+												Callee: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 13,
+																Line:   81,
+															},
+															File:   "measurement_field_keys_test.flux",
+															Source: "range",
+															Start: ast.Position{
+																Column: 8,
+																Line:   81,
+															},
+														},
+													},
+													Name: "range",
+												},
+											},
+										},
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 50,
+													Line:   82,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")",
+												Start: ast.Position{
+													Column: 44,
+													Line:   80,
+												},
+											},
+										},
+										Call: &ast.CallExpression{
+											Arguments: []ast.Expression{&ast.ObjectExpression{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 49,
+															Line:   82,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "fn: (r) => r._measurement == \"sys\"",
+														Start: ast.Position{
+															Column: 15,
+															Line:   82,
+														},
+													},
+												},
+												Properties: []*ast.Property{&ast.Property{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 49,
+																Line:   82,
+															},
+															File:   "measurement_field_keys_test.flux",
+															Source: "fn: (r) => r._measurement == \"sys\"",
+															Start: ast.Position{
+																Column: 15,
+																Line:   82,
+															},
+														},
+													},
+													Key: &ast.Identifier{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 17,
+																	Line:   82,
+																},
+																File:   "measurement_field_keys_test.flux",
+																Source: "fn",
+																Start: ast.Position{
+																	Column: 15,
+																	Line:   82,
+																},
+															},
+														},
+														Name: "fn",
+													},
+													Value: &ast.FunctionExpression{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 49,
+																	Line:   82,
+																},
+																File:   "measurement_field_keys_test.flux",
+																Source: "(r) => r._measurement == \"sys\"",
+																Start: ast.Position{
+																	Column: 19,
+																	Line:   82,
+																},
+															},
+														},
+														Body: &ast.BinaryExpression{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 49,
+																		Line:   82,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "r._measurement == \"sys\"",
+																	Start: ast.Position{
+																		Column: 26,
+																		Line:   82,
+																	},
+																},
+															},
+															Left: &ast.MemberExpression{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 40,
+																			Line:   82,
+																		},
+																		File:   "measurement_field_keys_test.flux",
+																		Source: "r._measurement",
+																		Start: ast.Position{
+																			Column: 26,
+																			Line:   82,
+																		},
+																	},
+																},
+																Object: &ast.Identifier{
+																	BaseNode: ast.BaseNode{
+																		Errors: nil,
+																		Loc: &ast.SourceLocation{
+																			End: ast.Position{
+																				Column: 27,
+																				Line:   82,
+																			},
+																			File:   "measurement_field_keys_test.flux",
+																			Source: "r",
+																			Start: ast.Position{
+																				Column: 26,
+																				Line:   82,
+																			},
+																		},
+																	},
+																	Name: "r",
+																},
+																Property: &ast.Identifier{
+																	BaseNode: ast.BaseNode{
+																		Errors: nil,
+																		Loc: &ast.SourceLocation{
+																			End: ast.Position{
+																				Column: 40,
+																				Line:   82,
+																			},
+																			File:   "measurement_field_keys_test.flux",
+																			Source: "_measurement",
+																			Start: ast.Position{
+																				Column: 28,
+																				Line:   82,
+																			},
+																		},
+																	},
+																	Name: "_measurement",
+																},
+															},
+															Operator: 17,
+															Right: &ast.StringLiteral{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 49,
+																			Line:   82,
+																		},
+																		File:   "measurement_field_keys_test.flux",
+																		Source: "\"sys\"",
+																		Start: ast.Position{
+																			Column: 44,
+																			Line:   82,
+																		},
+																	},
+																},
+																Value: "sys",
+															},
+														},
+														Params: []*ast.Property{&ast.Property{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 21,
+																		Line:   82,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "r",
+																	Start: ast.Position{
+																		Column: 20,
+																		Line:   82,
+																	},
+																},
+															},
+															Key: &ast.Identifier{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 21,
+																			Line:   82,
+																		},
+																		File:   "measurement_field_keys_test.flux",
+																		Source: "r",
+																		Start: ast.Position{
+																			Column: 20,
+																			Line:   82,
+																		},
+																	},
+																},
+																Name: "r",
+															},
+															Value: nil,
+														}},
+													},
+												}},
+												With: nil,
+											}},
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 50,
+														Line:   82,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "filter(fn: (r) => r._measurement == \"sys\")",
+													Start: ast.Position{
+														Column: 8,
+														Line:   82,
+													},
+												},
+											},
+											Callee: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 14,
+															Line:   82,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "filter",
+														Start: ast.Position{
+															Column: 8,
+															Line:   82,
+														},
+													},
+												},
+												Name: "filter",
+											},
+										},
+									},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 49,
+												Line:   83,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")",
+											Start: ast.Position{
+												Column: 44,
+												Line:   80,
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Arguments: []ast.Expression{&ast.ObjectExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 48,
+														Line:   83,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "fn: (r) => r.host == \"host.local\"",
+													Start: ast.Position{
+														Column: 15,
+														Line:   83,
+													},
+												},
+											},
+											Properties: []*ast.Property{&ast.Property{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 48,
+															Line:   83,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "fn: (r) => r.host == \"host.local\"",
+														Start: ast.Position{
+															Column: 15,
+															Line:   83,
+														},
+													},
+												},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 17,
+																Line:   83,
+															},
+															File:   "measurement_field_keys_test.flux",
+															Source: "fn",
+															Start: ast.Position{
+																Column: 15,
+																Line:   83,
+															},
+														},
+													},
+													Name: "fn",
+												},
+												Value: &ast.FunctionExpression{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 48,
+																Line:   83,
+															},
+															File:   "measurement_field_keys_test.flux",
+															Source: "(r) => r.host == \"host.local\"",
+															Start: ast.Position{
+																Column: 19,
+																Line:   83,
+															},
+														},
+													},
+													Body: &ast.BinaryExpression{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 48,
+																	Line:   83,
+																},
+																File:   "measurement_field_keys_test.flux",
+																Source: "r.host == \"host.local\"",
+																Start: ast.Position{
+																	Column: 26,
+																	Line:   83,
+																},
+															},
+														},
+														Left: &ast.MemberExpression{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 32,
+																		Line:   83,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "r.host",
+																	Start: ast.Position{
+																		Column: 26,
+																		Line:   83,
+																	},
+																},
+															},
+															Object: &ast.Identifier{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 27,
+																			Line:   83,
+																		},
+																		File:   "measurement_field_keys_test.flux",
+																		Source: "r",
+																		Start: ast.Position{
+																			Column: 26,
+																			Line:   83,
+																		},
+																	},
+																},
+																Name: "r",
+															},
+															Property: &ast.Identifier{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 32,
+																			Line:   83,
+																		},
+																		File:   "measurement_field_keys_test.flux",
+																		Source: "host",
+																		Start: ast.Position{
+																			Column: 28,
+																			Line:   83,
+																		},
+																	},
+																},
+																Name: "host",
+															},
+														},
+														Operator: 17,
+														Right: &ast.StringLiteral{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 48,
+																		Line:   83,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "\"host.local\"",
+																	Start: ast.Position{
+																		Column: 36,
+																		Line:   83,
+																	},
+																},
+															},
+															Value: "host.local",
+														},
+													},
+													Params: []*ast.Property{&ast.Property{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 21,
+																	Line:   83,
+																},
+																File:   "measurement_field_keys_test.flux",
+																Source: "r",
+																Start: ast.Position{
+																	Column: 20,
+																	Line:   83,
+																},
+															},
+														},
+														Key: &ast.Identifier{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 21,
+																		Line:   83,
+																	},
+																	File:   "measurement_field_keys_test.flux",
+																	Source: "r",
+																	Start: ast.Position{
+																		Column: 20,
+																		Line:   83,
+																	},
+																},
+															},
+															Name: "r",
+														},
+														Value: nil,
+													}},
+												},
+											}},
+											With: nil,
+										}},
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 49,
+													Line:   83,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "filter(fn: (r) => r.host == \"host.local\")",
+												Start: ast.Position{
+													Column: 8,
+													Line:   83,
+												},
+											},
+										},
+										Callee: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 14,
+														Line:   83,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "filter",
+													Start: ast.Position{
+														Column: 8,
+														Line:   83,
+													},
+												},
+											},
+											Name: "filter",
+										},
+									},
+								},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   84,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])",
+										Start: ast.Position{
+											Column: 44,
+											Line:   80,
+										},
+									},
+								},
+								Call: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 32,
+													Line:   84,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "columns: [\"_field\"]",
+												Start: ast.Position{
+													Column: 13,
+													Line:   84,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 32,
+														Line:   84,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "columns: [\"_field\"]",
+													Start: ast.Position{
+														Column: 13,
+														Line:   84,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 20,
+															Line:   84,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "columns",
+														Start: ast.Position{
+															Column: 13,
+															Line:   84,
+														},
+													},
+												},
+												Name: "columns",
+											},
+											Value: &ast.ArrayExpression{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 32,
+															Line:   84,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "[\"_field\"]",
+														Start: ast.Position{
+															Column: 22,
+															Line:   84,
+														},
+													},
+												},
+												Elements: []ast.Expression{&ast.StringLiteral{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 31,
+																Line:   84,
+															},
+															File:   "measurement_field_keys_test.flux",
+															Source: "\"_field\"",
+															Start: ast.Position{
+																Column: 23,
+																Line:   84,
+															},
+														},
+													},
+													Value: "_field",
+												}},
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 33,
+												Line:   84,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "keep(columns: [\"_field\"])",
+											Start: ast.Position{
+												Column: 8,
+												Line:   84,
+											},
+										},
+									},
+									Callee: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 12,
+													Line:   84,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "keep",
+												Start: ast.Position{
+													Column: 8,
+													Line:   84,
+												},
+											},
+										},
+										Name: "keep",
+									},
+								},
+							},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 15,
+										Line:   85,
+									},
+									File:   "measurement_field_keys_test.flux",
+									Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()",
+									Start: ast.Position{
+										Column: 44,
+										Line:   80,
+									},
+								},
+							},
+							Call: &ast.CallExpression{
+								Arguments: nil,
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 15,
+											Line:   85,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "group()",
+										Start: ast.Position{
+											Column: 8,
+											Line:   85,
+										},
+									},
+								},
+								Callee: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 13,
+												Line:   85,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "group",
+											Start: ast.Position{
+												Column: 8,
+												Line:   85,
+											},
+										},
+									},
+									Name: "group",
+								},
+							},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 34,
+									Line:   86,
+								},
+								File:   "measurement_field_keys_test.flux",
+								Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")",
+								Start: ast.Position{
+									Column: 44,
+									Line:   80,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   86,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "column: \"_field\"",
+										Start: ast.Position{
+											Column: 17,
+											Line:   86,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 33,
+												Line:   86,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "column: \"_field\"",
+											Start: ast.Position{
+												Column: 17,
+												Line:   86,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 23,
+													Line:   86,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "column",
+												Start: ast.Position{
+													Column: 17,
+													Line:   86,
+												},
+											},
+										},
+										Name: "column",
+									},
+									Value: &ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   86,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "\"_field\"",
+												Start: ast.Position{
+													Column: 25,
+													Line:   86,
+												},
+											},
+										},
+										Value: "_field",
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 34,
+										Line:   86,
+									},
+									File:   "measurement_field_keys_test.flux",
+									Source: "distinct(column: \"_field\")",
+									Start: ast.Position{
+										Column: 8,
+										Line:   86,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 16,
+											Line:   86,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "distinct",
+										Start: ast.Position{
+											Column: 8,
+											Line:   86,
+										},
+									},
+								},
+								Name: "distinct",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 14,
+								Line:   87,
+							},
+							File:   "measurement_field_keys_test.flux",
+							Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()",
+							Start: ast.Position{
+								Column: 44,
+								Line:   80,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: nil,
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 14,
+									Line:   87,
+								},
+								File:   "measurement_field_keys_test.flux",
+								Source: "sort()",
+								Start: ast.Position{
+									Column: 8,
+									Line:   87,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 12,
+										Line:   87,
+									},
+									File:   "measurement_field_keys_test.flux",
+									Source: "sort",
+									Start: ast.Position{
+										Column: 8,
+										Line:   87,
+									},
+								},
+							},
+							Name: "sort",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 39,
+								Line:   80,
+							},
+							File:   "measurement_field_keys_test.flux",
+							Source: "tables=<-",
+							Start: ast.Position{
+								Column: 30,
+								Line:   80,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   80,
+								},
+								File:   "measurement_field_keys_test.flux",
+								Source: "tables",
+								Start: ast.Position{
+									Column: 30,
+									Line:   80,
+								},
+							},
+						},
+						Name: "tables",
+					},
+					Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 39,
+								Line:   80,
+							},
+							File:   "measurement_field_keys_test.flux",
+							Source: "<-",
+							Start: ast.Position{
+								Column: 37,
+								Line:   80,
+							},
+						},
+					}},
+				}},
+			},
+		}, &ast.TestStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 114,
+							Line:   90,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "measurement_field_keys = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn})",
+						Start: ast.Position{
+							Column: 6,
+							Line:   89,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 28,
+								Line:   89,
+							},
+							File:   "measurement_field_keys_test.flux",
+							Source: "measurement_field_keys",
+							Start: ast.Position{
+								Column: 6,
+								Line:   89,
+							},
+						},
+					},
+					Name: "measurement_field_keys",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 114,
+								Line:   90,
+							},
+							File:   "measurement_field_keys_test.flux",
+							Source: "() =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn})",
+							Start: ast.Position{
+								Column: 31,
+								Line:   89,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 114,
+									Line:   90,
+								},
+								File:   "measurement_field_keys_test.flux",
+								Source: "({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn})",
+								Start: ast.Position{
+									Column: 5,
+									Line:   90,
+								},
+							},
+						},
+						Expression: &ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 113,
+										Line:   90,
+									},
+									File:   "measurement_field_keys_test.flux",
+									Source: "{input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn}",
+									Start: ast.Position{
+										Column: 6,
+										Line:   90,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 45,
+											Line:   90,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "input: testing.loadStorage(csv: input)",
+										Start: ast.Position{
+											Column: 7,
+											Line:   90,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 12,
+												Line:   90,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "input",
+											Start: ast.Position{
+												Column: 7,
+												Line:   90,
+											},
+										},
+									},
+									Name: "input",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 44,
+													Line:   90,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "csv: input",
+												Start: ast.Position{
+													Column: 34,
+													Line:   90,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 44,
+														Line:   90,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "csv: input",
+													Start: ast.Position{
+														Column: 34,
+														Line:   90,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 37,
+															Line:   90,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 34,
+															Line:   90,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 44,
+															Line:   90,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "input",
+														Start: ast.Position{
+															Column: 39,
+															Line:   90,
+														},
+													},
+												},
+												Name: "input",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 45,
+												Line:   90,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "testing.loadStorage(csv: input)",
+											Start: ast.Position{
+												Column: 14,
+												Line:   90,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   90,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "testing.loadStorage",
+												Start: ast.Position{
+													Column: 14,
+													Line:   90,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 21,
+														Line:   90,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 14,
+														Line:   90,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 33,
+														Line:   90,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "loadStorage",
+													Start: ast.Position{
+														Column: 22,
+														Line:   90,
+													},
+												},
+											},
+											Name: "loadStorage",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 81,
+											Line:   90,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "want: testing.loadMem(csv: output)",
+										Start: ast.Position{
+											Column: 47,
+											Line:   90,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 51,
+												Line:   90,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "want",
+											Start: ast.Position{
+												Column: 47,
+												Line:   90,
+											},
+										},
+									},
+									Name: "want",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 80,
+													Line:   90,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "csv: output",
+												Start: ast.Position{
+													Column: 69,
+													Line:   90,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 80,
+														Line:   90,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "csv: output",
+													Start: ast.Position{
+														Column: 69,
+														Line:   90,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 72,
+															Line:   90,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 69,
+															Line:   90,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 80,
+															Line:   90,
+														},
+														File:   "measurement_field_keys_test.flux",
+														Source: "output",
+														Start: ast.Position{
+															Column: 74,
+															Line:   90,
+														},
+													},
+												},
+												Name: "output",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 81,
+												Line:   90,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "testing.loadMem(csv: output)",
+											Start: ast.Position{
+												Column: 53,
+												Line:   90,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 68,
+													Line:   90,
+												},
+												File:   "measurement_field_keys_test.flux",
+												Source: "testing.loadMem",
+												Start: ast.Position{
+													Column: 53,
+													Line:   90,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 60,
+														Line:   90,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 53,
+														Line:   90,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 68,
+														Line:   90,
+													},
+													File:   "measurement_field_keys_test.flux",
+													Source: "loadMem",
+													Start: ast.Position{
+														Column: 61,
+														Line:   90,
+													},
+												},
+											},
+											Name: "loadMem",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 112,
+											Line:   90,
+										},
+										File:   "measurement_field_keys_test.flux",
+										Source: "fn: measurement_field_keys_fn",
+										Start: ast.Position{
+											Column: 83,
+											Line:   90,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 85,
+												Line:   90,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "fn",
+											Start: ast.Position{
+												Column: 83,
+												Line:   90,
+											},
+										},
+									},
+									Name: "fn",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 112,
+												Line:   90,
+											},
+											File:   "measurement_field_keys_test.flux",
+											Source: "measurement_field_keys_fn",
+											Start: ast.Position{
+												Column: 87,
+												Line:   90,
+											},
+										},
+									},
+									Name: "measurement_field_keys_fn",
+								},
+							}},
+							With: nil,
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 114,
+						Line:   90,
+					},
+					File:   "measurement_field_keys_test.flux",
+					Source: "test measurement_field_keys = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn})",
+					Start: ast.Position{
+						Column: 1,
+						Line:   89,
+					},
+				},
+			},
+		}},
+		Imports: []*ast.ImportDeclaration{&ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   3,
+					},
+					File:   "measurement_field_keys_test.flux",
+					Source: "import \"testing\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   3,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   3,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "\"testing\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   3,
+						},
+					},
+				},
+				Value: "testing",
+			},
+		}},
+		Metadata: "parser-type=rust",
+		Name:     "measurement_field_keys_test.flux",
+		Package: &ast.PackageClause{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 16,
+						Line:   1,
+					},
+					File:   "measurement_field_keys_test.flux",
+					Source: "package v1_test",
+					Start: ast.Position{
+						Column: 1,
+						Line:   1,
+					},
+				},
+			},
+			Name: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 16,
+							Line:   1,
+						},
+						File:   "measurement_field_keys_test.flux",
+						Source: "v1_test",
+						Start: ast.Position{
+							Column: 9,
+							Line:   1,
+						},
+					},
+				},
+				Name: "v1_test",
+			},
+		},
+	}, &ast.File{
+		BaseNode: ast.BaseNode{
+			Errors: nil,
+			Loc: &ast.SourceLocation{
+				End: ast.Position{
+					Column: 114,
+					Line:   90,
+				},
 				File:   "measurement_tag_values_test.flux",
 				Source: "package v1_test\n\nimport \"testing\"\n\ninput = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,long\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,sys,host.global,load7,183\n,,0,2018-05-22T19:53:36Z,sys,host.global,load7,172\n,,0,2018-05-22T19:53:46Z,sys,host.global,load7,174\n,,0,2018-05-22T19:53:56Z,sys,host.global,load7,163\n,,0,2018-05-22T19:54:06Z,sys,host.global,load7,191\n,,0,2018-05-22T19:54:16Z,sys,host.global,load7,184\n\n,,1,2018-05-22T19:53:26Z,sys,host.local,load8,198\n,,1,2018-05-22T19:53:36Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:46Z,sys,host.local,load8,197\n,,1,2018-05-22T19:53:56Z,sys,host.local,load8,196\n,,1,2018-05-22T19:54:06Z,sys,host.local,load8,198\n,,1,2018-05-22T19:54:16Z,sys,host.local,load8,197\n\n,,2,2018-05-22T19:53:26Z,sys,host.global,load9,195\n,,2,2018-05-22T19:53:36Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:46Z,sys,host.global,load9,192\n,,2,2018-05-22T19:53:56Z,sys,host.global,load9,189\n,,2,2018-05-22T19:54:06Z,sys,host.global,load9,194\n,,2,2018-05-22T19:54:16Z,sys,host.global,load9,193\n\n,,3,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298\n,,3,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259\n,,3,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264\n\"\n\noutput = \"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load3\n,,0,load8\n\"\n\nmeasurement_tag_values_fn = (tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => r._measurement == \"sys\")\n    |> filter(fn: (r) => r.host == \"host.local\")\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()\n\ntest measurement_tag_values = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_tag_values_fn})",
 				Start: ast.Position{
@@ -6034,6 +7892,1546 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 							Line:   1,
 						},
 						File:   "measurement_tag_values_test.flux",
+						Source: "v1_test",
+						Start: ast.Position{
+							Column: 9,
+							Line:   1,
+						},
+					},
+				},
+				Name: "v1_test",
+			},
+		},
+	}, &ast.File{
+		BaseNode: ast.BaseNode{
+			Errors: nil,
+			Loc: &ast.SourceLocation{
+				End: ast.Position{
+					Column: 107,
+					Line:   59,
+				},
+				File:   "show_field_keys_test.flux",
+				Source: "package v1_test\n\nimport \"testing\"\n\ninput = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.local,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.local,used_percent,82.64\n\"\n\noutput = \"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load1\n,,0,load3\n,,0,load5\n,,0,used_percent\n\"\n\nshow_field_keys_fn = (tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()\n\ntest show_field_keys = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn})",
+				Start: ast.Position{
+					Column: 1,
+					Line:   1,
+				},
+			},
+		},
+		Body: []ast.Statement{&ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   37,
+					},
+					File:   "show_field_keys_test.flux",
+					Source: "input = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.local,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.local,used_percent,82.64\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   5,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 6,
+							Line:   5,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "input",
+						Start: ast.Position{
+							Column: 1,
+							Line:   5,
+						},
+					},
+				},
+				Name: "input",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   37,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.local,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.local,used_percent,82.64\n\"",
+						Start: ast.Position{
+							Column: 9,
+							Line:   5,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\n,,3,2018-05-22T19:53:26Z,swap,host.local,used_percent,82.98\n,,3,2018-05-22T19:53:36Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:46Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:53:56Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:06Z,swap,host.local,used_percent,82.59\n,,3,2018-05-22T19:54:16Z,swap,host.local,used_percent,82.64\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   48,
+					},
+					File:   "show_field_keys_test.flux",
+					Source: "output = \"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load1\n,,0,load3\n,,0,load5\n,,0,used_percent\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   39,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 7,
+							Line:   39,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "output",
+						Start: ast.Position{
+							Column: 1,
+							Line:   39,
+						},
+					},
+				},
+				Name: "output",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   48,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "\"\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load1\n,,0,load3\n,,0,load5\n,,0,used_percent\n\"",
+						Start: ast.Position{
+							Column: 10,
+							Line:   39,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,string\n#group,false,false,false\n#default,0,,\n,result,table,_value\n,,0,load1\n,,0,load3\n,,0,load5\n,,0,used_percent\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 14,
+						Line:   56,
+					},
+					File:   "show_field_keys_test.flux",
+					Source: "show_field_keys_fn = (tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()",
+					Start: ast.Position{
+						Column: 1,
+						Line:   50,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 19,
+							Line:   50,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "show_field_keys_fn",
+						Start: ast.Position{
+							Column: 1,
+							Line:   50,
+						},
+					},
+				},
+				Name: "show_field_keys_fn",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 14,
+							Line:   56,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "(tables=<-) => tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()",
+						Start: ast.Position{
+							Column: 22,
+							Line:   50,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.PipeExpression{
+							Argument: &ast.PipeExpression{
+								Argument: &ast.PipeExpression{
+									Argument: &ast.PipeExpression{
+										Argument: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 43,
+														Line:   50,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "tables",
+													Start: ast.Position{
+														Column: 37,
+														Line:   50,
+													},
+												},
+											},
+											Name: "tables",
+										},
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 70,
+													Line:   51,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)",
+												Start: ast.Position{
+													Column: 37,
+													Line:   50,
+												},
+											},
+										},
+										Call: &ast.CallExpression{
+											Arguments: []ast.Expression{&ast.ObjectExpression{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 69,
+															Line:   51,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z",
+														Start: ast.Position{
+															Column: 14,
+															Line:   51,
+														},
+													},
+												},
+												Properties: []*ast.Property{&ast.Property{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 41,
+																Line:   51,
+															},
+															File:   "show_field_keys_test.flux",
+															Source: "start: 2018-01-01T00:00:00Z",
+															Start: ast.Position{
+																Column: 14,
+																Line:   51,
+															},
+														},
+													},
+													Key: &ast.Identifier{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 19,
+																	Line:   51,
+																},
+																File:   "show_field_keys_test.flux",
+																Source: "start",
+																Start: ast.Position{
+																	Column: 14,
+																	Line:   51,
+																},
+															},
+														},
+														Name: "start",
+													},
+													Value: &ast.DateTimeLiteral{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 41,
+																	Line:   51,
+																},
+																File:   "show_field_keys_test.flux",
+																Source: "2018-01-01T00:00:00Z",
+																Start: ast.Position{
+																	Column: 21,
+																	Line:   51,
+																},
+															},
+														},
+														Value: parser.MustParseTime("2018-01-01T00:00:00Z"),
+													},
+												}, &ast.Property{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 69,
+																Line:   51,
+															},
+															File:   "show_field_keys_test.flux",
+															Source: "stop: 2019-01-01T00:00:00Z",
+															Start: ast.Position{
+																Column: 43,
+																Line:   51,
+															},
+														},
+													},
+													Key: &ast.Identifier{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 47,
+																	Line:   51,
+																},
+																File:   "show_field_keys_test.flux",
+																Source: "stop",
+																Start: ast.Position{
+																	Column: 43,
+																	Line:   51,
+																},
+															},
+														},
+														Name: "stop",
+													},
+													Value: &ast.DateTimeLiteral{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 69,
+																	Line:   51,
+																},
+																File:   "show_field_keys_test.flux",
+																Source: "2019-01-01T00:00:00Z",
+																Start: ast.Position{
+																	Column: 49,
+																	Line:   51,
+																},
+															},
+														},
+														Value: parser.MustParseTime("2019-01-01T00:00:00Z"),
+													},
+												}},
+												With: nil,
+											}},
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 70,
+														Line:   51,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)",
+													Start: ast.Position{
+														Column: 8,
+														Line:   51,
+													},
+												},
+											},
+											Callee: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 13,
+															Line:   51,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "range",
+														Start: ast.Position{
+															Column: 8,
+															Line:   51,
+														},
+													},
+												},
+												Name: "range",
+											},
+										},
+									},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 31,
+												Line:   52,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)",
+											Start: ast.Position{
+												Column: 37,
+												Line:   50,
+											},
+										},
+									},
+									Call: &ast.CallExpression{
+										Arguments: []ast.Expression{&ast.ObjectExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 30,
+														Line:   52,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "fn: (r) => true",
+													Start: ast.Position{
+														Column: 15,
+														Line:   52,
+													},
+												},
+											},
+											Properties: []*ast.Property{&ast.Property{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 30,
+															Line:   52,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "fn: (r) => true",
+														Start: ast.Position{
+															Column: 15,
+															Line:   52,
+														},
+													},
+												},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 17,
+																Line:   52,
+															},
+															File:   "show_field_keys_test.flux",
+															Source: "fn",
+															Start: ast.Position{
+																Column: 15,
+																Line:   52,
+															},
+														},
+													},
+													Name: "fn",
+												},
+												Value: &ast.FunctionExpression{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 30,
+																Line:   52,
+															},
+															File:   "show_field_keys_test.flux",
+															Source: "(r) => true",
+															Start: ast.Position{
+																Column: 19,
+																Line:   52,
+															},
+														},
+													},
+													Body: &ast.Identifier{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 30,
+																	Line:   52,
+																},
+																File:   "show_field_keys_test.flux",
+																Source: "true",
+																Start: ast.Position{
+																	Column: 26,
+																	Line:   52,
+																},
+															},
+														},
+														Name: "true",
+													},
+													Params: []*ast.Property{&ast.Property{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 21,
+																	Line:   52,
+																},
+																File:   "show_field_keys_test.flux",
+																Source: "r",
+																Start: ast.Position{
+																	Column: 20,
+																	Line:   52,
+																},
+															},
+														},
+														Key: &ast.Identifier{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 21,
+																		Line:   52,
+																	},
+																	File:   "show_field_keys_test.flux",
+																	Source: "r",
+																	Start: ast.Position{
+																		Column: 20,
+																		Line:   52,
+																	},
+																},
+															},
+															Name: "r",
+														},
+														Value: nil,
+													}},
+												},
+											}},
+											With: nil,
+										}},
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 31,
+													Line:   52,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "filter(fn: (r) => true)",
+												Start: ast.Position{
+													Column: 8,
+													Line:   52,
+												},
+											},
+										},
+										Callee: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 14,
+														Line:   52,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "filter",
+													Start: ast.Position{
+														Column: 8,
+														Line:   52,
+													},
+												},
+											},
+											Name: "filter",
+										},
+									},
+								},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   53,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])",
+										Start: ast.Position{
+											Column: 37,
+											Line:   50,
+										},
+									},
+								},
+								Call: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 32,
+													Line:   53,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "columns: [\"_field\"]",
+												Start: ast.Position{
+													Column: 13,
+													Line:   53,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 32,
+														Line:   53,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "columns: [\"_field\"]",
+													Start: ast.Position{
+														Column: 13,
+														Line:   53,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 20,
+															Line:   53,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "columns",
+														Start: ast.Position{
+															Column: 13,
+															Line:   53,
+														},
+													},
+												},
+												Name: "columns",
+											},
+											Value: &ast.ArrayExpression{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 32,
+															Line:   53,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "[\"_field\"]",
+														Start: ast.Position{
+															Column: 22,
+															Line:   53,
+														},
+													},
+												},
+												Elements: []ast.Expression{&ast.StringLiteral{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 31,
+																Line:   53,
+															},
+															File:   "show_field_keys_test.flux",
+															Source: "\"_field\"",
+															Start: ast.Position{
+																Column: 23,
+																Line:   53,
+															},
+														},
+													},
+													Value: "_field",
+												}},
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 33,
+												Line:   53,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "keep(columns: [\"_field\"])",
+											Start: ast.Position{
+												Column: 8,
+												Line:   53,
+											},
+										},
+									},
+									Callee: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 12,
+													Line:   53,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "keep",
+												Start: ast.Position{
+													Column: 8,
+													Line:   53,
+												},
+											},
+										},
+										Name: "keep",
+									},
+								},
+							},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 15,
+										Line:   54,
+									},
+									File:   "show_field_keys_test.flux",
+									Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])\n    |> group()",
+									Start: ast.Position{
+										Column: 37,
+										Line:   50,
+									},
+								},
+							},
+							Call: &ast.CallExpression{
+								Arguments: nil,
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 15,
+											Line:   54,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "group()",
+										Start: ast.Position{
+											Column: 8,
+											Line:   54,
+										},
+									},
+								},
+								Callee: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 13,
+												Line:   54,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "group",
+											Start: ast.Position{
+												Column: 8,
+												Line:   54,
+											},
+										},
+									},
+									Name: "group",
+								},
+							},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 34,
+									Line:   55,
+								},
+								File:   "show_field_keys_test.flux",
+								Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")",
+								Start: ast.Position{
+									Column: 37,
+									Line:   50,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   55,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "column: \"_field\"",
+										Start: ast.Position{
+											Column: 17,
+											Line:   55,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 33,
+												Line:   55,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "column: \"_field\"",
+											Start: ast.Position{
+												Column: 17,
+												Line:   55,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 23,
+													Line:   55,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "column",
+												Start: ast.Position{
+													Column: 17,
+													Line:   55,
+												},
+											},
+										},
+										Name: "column",
+									},
+									Value: &ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   55,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "\"_field\"",
+												Start: ast.Position{
+													Column: 25,
+													Line:   55,
+												},
+											},
+										},
+										Value: "_field",
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 34,
+										Line:   55,
+									},
+									File:   "show_field_keys_test.flux",
+									Source: "distinct(column: \"_field\")",
+									Start: ast.Position{
+										Column: 8,
+										Line:   55,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 16,
+											Line:   55,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "distinct",
+										Start: ast.Position{
+											Column: 8,
+											Line:   55,
+										},
+									},
+								},
+								Name: "distinct",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 14,
+								Line:   56,
+							},
+							File:   "show_field_keys_test.flux",
+							Source: "tables\n    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)\n    |> filter(fn: (r) => true)\n    |> keep(columns: [\"_field\"])\n    |> group()\n    |> distinct(column: \"_field\")\n    |> sort()",
+							Start: ast.Position{
+								Column: 37,
+								Line:   50,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: nil,
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 14,
+									Line:   56,
+								},
+								File:   "show_field_keys_test.flux",
+								Source: "sort()",
+								Start: ast.Position{
+									Column: 8,
+									Line:   56,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 12,
+										Line:   56,
+									},
+									File:   "show_field_keys_test.flux",
+									Source: "sort",
+									Start: ast.Position{
+										Column: 8,
+										Line:   56,
+									},
+								},
+							},
+							Name: "sort",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 32,
+								Line:   50,
+							},
+							File:   "show_field_keys_test.flux",
+							Source: "tables=<-",
+							Start: ast.Position{
+								Column: 23,
+								Line:   50,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 29,
+									Line:   50,
+								},
+								File:   "show_field_keys_test.flux",
+								Source: "tables",
+								Start: ast.Position{
+									Column: 23,
+									Line:   50,
+								},
+							},
+						},
+						Name: "tables",
+					},
+					Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 32,
+								Line:   50,
+							},
+							File:   "show_field_keys_test.flux",
+							Source: "<-",
+							Start: ast.Position{
+								Column: 30,
+								Line:   50,
+							},
+						},
+					}},
+				}},
+			},
+		}, &ast.TestStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 107,
+							Line:   59,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "show_field_keys = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn})",
+						Start: ast.Position{
+							Column: 6,
+							Line:   58,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 21,
+								Line:   58,
+							},
+							File:   "show_field_keys_test.flux",
+							Source: "show_field_keys",
+							Start: ast.Position{
+								Column: 6,
+								Line:   58,
+							},
+						},
+					},
+					Name: "show_field_keys",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 107,
+								Line:   59,
+							},
+							File:   "show_field_keys_test.flux",
+							Source: "() =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn})",
+							Start: ast.Position{
+								Column: 24,
+								Line:   58,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 107,
+									Line:   59,
+								},
+								File:   "show_field_keys_test.flux",
+								Source: "({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn})",
+								Start: ast.Position{
+									Column: 5,
+									Line:   59,
+								},
+							},
+						},
+						Expression: &ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 106,
+										Line:   59,
+									},
+									File:   "show_field_keys_test.flux",
+									Source: "{input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn}",
+									Start: ast.Position{
+										Column: 6,
+										Line:   59,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 45,
+											Line:   59,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "input: testing.loadStorage(csv: input)",
+										Start: ast.Position{
+											Column: 7,
+											Line:   59,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 12,
+												Line:   59,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "input",
+											Start: ast.Position{
+												Column: 7,
+												Line:   59,
+											},
+										},
+									},
+									Name: "input",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 44,
+													Line:   59,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "csv: input",
+												Start: ast.Position{
+													Column: 34,
+													Line:   59,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 44,
+														Line:   59,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "csv: input",
+													Start: ast.Position{
+														Column: 34,
+														Line:   59,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 37,
+															Line:   59,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 34,
+															Line:   59,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 44,
+															Line:   59,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "input",
+														Start: ast.Position{
+															Column: 39,
+															Line:   59,
+														},
+													},
+												},
+												Name: "input",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 45,
+												Line:   59,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "testing.loadStorage(csv: input)",
+											Start: ast.Position{
+												Column: 14,
+												Line:   59,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   59,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "testing.loadStorage",
+												Start: ast.Position{
+													Column: 14,
+													Line:   59,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 21,
+														Line:   59,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 14,
+														Line:   59,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 33,
+														Line:   59,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "loadStorage",
+													Start: ast.Position{
+														Column: 22,
+														Line:   59,
+													},
+												},
+											},
+											Name: "loadStorage",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 81,
+											Line:   59,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "want: testing.loadMem(csv: output)",
+										Start: ast.Position{
+											Column: 47,
+											Line:   59,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 51,
+												Line:   59,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "want",
+											Start: ast.Position{
+												Column: 47,
+												Line:   59,
+											},
+										},
+									},
+									Name: "want",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 80,
+													Line:   59,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "csv: output",
+												Start: ast.Position{
+													Column: 69,
+													Line:   59,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 80,
+														Line:   59,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "csv: output",
+													Start: ast.Position{
+														Column: 69,
+														Line:   59,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 72,
+															Line:   59,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 69,
+															Line:   59,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 80,
+															Line:   59,
+														},
+														File:   "show_field_keys_test.flux",
+														Source: "output",
+														Start: ast.Position{
+															Column: 74,
+															Line:   59,
+														},
+													},
+												},
+												Name: "output",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 81,
+												Line:   59,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "testing.loadMem(csv: output)",
+											Start: ast.Position{
+												Column: 53,
+												Line:   59,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 68,
+													Line:   59,
+												},
+												File:   "show_field_keys_test.flux",
+												Source: "testing.loadMem",
+												Start: ast.Position{
+													Column: 53,
+													Line:   59,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 60,
+														Line:   59,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 53,
+														Line:   59,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 68,
+														Line:   59,
+													},
+													File:   "show_field_keys_test.flux",
+													Source: "loadMem",
+													Start: ast.Position{
+														Column: 61,
+														Line:   59,
+													},
+												},
+											},
+											Name: "loadMem",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 105,
+											Line:   59,
+										},
+										File:   "show_field_keys_test.flux",
+										Source: "fn: show_field_keys_fn",
+										Start: ast.Position{
+											Column: 83,
+											Line:   59,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 85,
+												Line:   59,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "fn",
+											Start: ast.Position{
+												Column: 83,
+												Line:   59,
+											},
+										},
+									},
+									Name: "fn",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 105,
+												Line:   59,
+											},
+											File:   "show_field_keys_test.flux",
+											Source: "show_field_keys_fn",
+											Start: ast.Position{
+												Column: 87,
+												Line:   59,
+											},
+										},
+									},
+									Name: "show_field_keys_fn",
+								},
+							}},
+							With: nil,
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 107,
+						Line:   59,
+					},
+					File:   "show_field_keys_test.flux",
+					Source: "test show_field_keys = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn})",
+					Start: ast.Position{
+						Column: 1,
+						Line:   58,
+					},
+				},
+			},
+		}},
+		Imports: []*ast.ImportDeclaration{&ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   3,
+					},
+					File:   "show_field_keys_test.flux",
+					Source: "import \"testing\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   3,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   3,
+						},
+						File:   "show_field_keys_test.flux",
+						Source: "\"testing\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   3,
+						},
+					},
+				},
+				Value: "testing",
+			},
+		}},
+		Metadata: "parser-type=rust",
+		Name:     "show_field_keys_test.flux",
+		Package: &ast.PackageClause{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 16,
+						Line:   1,
+					},
+					File:   "show_field_keys_test.flux",
+					Source: "package v1_test",
+					Start: ast.Position{
+						Column: 1,
+						Line:   1,
+					},
+				},
+			},
+			Name: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 16,
+							Line:   1,
+						},
+						File:   "show_field_keys_test.flux",
 						Source: "v1_test",
 						Start: ast.Position{
 							Column: 9,

--- a/stdlib/influxdata/influxdb/v1/measurement_field_keys_test.flux
+++ b/stdlib/influxdata/influxdb/v1/measurement_field_keys_test.flux
@@ -1,0 +1,90 @@
+package v1_test
+
+import "testing"
+
+input = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72
+,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74
+,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,sys,host.local,load3,1.98
+,,1,2018-05-22T19:53:36Z,sys,host.local,load3,1.97
+,,1,2018-05-22T19:53:46Z,sys,host.local,load3,1.97
+,,1,2018-05-22T19:53:56Z,sys,host.local,load3,1.96
+,,1,2018-05-22T19:54:06Z,sys,host.local,load3,1.98
+,,1,2018-05-22T19:54:16Z,sys,host.local,load3,1.97
+
+,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89
+,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94
+,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93
+
+,,3,2018-05-22T19:53:26Z,swap,host.global,used_percent,82.98
+,,3,2018-05-22T19:53:36Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:53:46Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:53:56Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:54:06Z,swap,host.global,used_percent,82.59
+,,3,2018-05-22T19:54:16Z,swap,host.global,used_percent,82.64
+
+#datatype,string,long,dateTime:RFC3339,string,string,string,long
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,sys,host.global,load7,183
+,,0,2018-05-22T19:53:36Z,sys,host.global,load7,172
+,,0,2018-05-22T19:53:46Z,sys,host.global,load7,174
+,,0,2018-05-22T19:53:56Z,sys,host.global,load7,163
+,,0,2018-05-22T19:54:06Z,sys,host.global,load7,191
+,,0,2018-05-22T19:54:16Z,sys,host.global,load7,184
+
+,,1,2018-05-22T19:53:26Z,sys,host.local,load8,198
+,,1,2018-05-22T19:53:36Z,sys,host.local,load8,197
+,,1,2018-05-22T19:53:46Z,sys,host.local,load8,197
+,,1,2018-05-22T19:53:56Z,sys,host.local,load8,196
+,,1,2018-05-22T19:54:06Z,sys,host.local,load8,198
+,,1,2018-05-22T19:54:16Z,sys,host.local,load8,197
+
+,,2,2018-05-22T19:53:26Z,sys,host.global,load9,195
+,,2,2018-05-22T19:53:36Z,sys,host.global,load9,192
+,,2,2018-05-22T19:53:46Z,sys,host.global,load9,192
+,,2,2018-05-22T19:53:56Z,sys,host.global,load9,189
+,,2,2018-05-22T19:54:06Z,sys,host.global,load9,194
+,,2,2018-05-22T19:54:16Z,sys,host.global,load9,193
+
+,,3,2018-05-22T19:53:26Z,swp,host.global,used_percent,8298
+,,3,2018-05-22T19:53:36Z,swp,host.global,used_percent,8259
+,,3,2018-05-22T19:53:46Z,swp,host.global,used_percent,8259
+,,3,2018-05-22T19:53:56Z,swp,host.global,used_percent,8259
+,,3,2018-05-22T19:54:06Z,swp,host.global,used_percent,8259
+,,3,2018-05-22T19:54:16Z,swp,host.global,used_percent,8264
+"
+
+output = "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,load3
+,,0,load8
+"
+
+measurement_field_keys_fn = (tables=<-) => tables
+    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)
+    |> filter(fn: (r) => r._measurement == "sys")
+    |> filter(fn: (r) => r.host == "host.local")
+    |> keep(columns: ["_field"])
+    |> group()
+    |> distinct(column: "_field")
+    |> sort()
+
+test measurement_field_keys = () =>
+    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: measurement_field_keys_fn})

--- a/stdlib/influxdata/influxdb/v1/show_field_keys_test.flux
+++ b/stdlib/influxdata/influxdb/v1/show_field_keys_test.flux
@@ -1,0 +1,59 @@
+package v1_test
+
+import "testing"
+
+input = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72
+,,0,2018-05-22T19:53:46Z,system,host.local,load1,1.74
+,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96
+,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97
+
+,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89
+,,2,2018-05-22T19:54:06Z,system,host.local,load5,1.94
+,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93
+
+,,3,2018-05-22T19:53:26Z,swap,host.local,used_percent,82.98
+,,3,2018-05-22T19:53:36Z,swap,host.local,used_percent,82.59
+,,3,2018-05-22T19:53:46Z,swap,host.local,used_percent,82.59
+,,3,2018-05-22T19:53:56Z,swap,host.local,used_percent,82.59
+,,3,2018-05-22T19:54:06Z,swap,host.local,used_percent,82.59
+,,3,2018-05-22T19:54:16Z,swap,host.local,used_percent,82.64
+"
+
+output = "
+#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,load1
+,,0,load3
+,,0,load5
+,,0,used_percent
+"
+
+show_field_keys_fn = (tables=<-) => tables
+    |> range(start: 2018-01-01T00:00:00Z, stop: 2019-01-01T00:00:00Z)
+    |> filter(fn: (r) => true)
+    |> keep(columns: ["_field"])
+    |> group()
+    |> distinct(column: "_field")
+    |> sort()
+
+test show_field_keys = () =>
+    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: show_field_keys_fn})

--- a/stdlib/influxdata/influxdb/v1/v1.flux
+++ b/stdlib/influxdata/influxdb/v1/v1.flux
@@ -11,21 +11,6 @@ fieldsAsCols = (tables=<-) =>
     tables
         |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
 
-// FieldKeys returns the list of field keys in a given bucket.
-// The return value is always a single table with a single column, "_value".
-fieldKeys = (bucket, predicate=(r) => true, start=-30d) =>
-    from(bucket: bucket)
-      |> range(start: start)
-      |> filter(fn: predicate)
-      |> keep(columns: ["_field"])
-      |> group()
-      |> distinct(column: "_field")
-
-// MeasurementFieldKeys returns field keys in a given measurement.
-// The return value is always a single table with a single column, "_value".
-measurementFieldKeys = (bucket, measurement, start) =>
-    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)
-
 // TagValues returns the unique values for a given tag.
 // The return value is always a single table with a single column "_value".
 tagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>
@@ -54,6 +39,16 @@ tagKeys = (bucket, predicate=(r) => true, start=-30d) =>
 // MeasurementTagKeys returns the list of tag keys for a specific measurement.
 measurementTagKeys = (bucket, measurement) =>
     tagKeys(bucket: bucket, predicate: (r) => r._measurement == measurement)
+
+// FieldKeys is a special application of tagValues that returns field keys in a given bucket.
+// The return value is always a single table with a single column, "_value".
+fieldKeys = (bucket, predicate=(r) => true, start=-30d) =>
+    tagValues(bucket: bucket, tag: "_field", predicate: predicate, start: start)
+
+// MeasurementFieldKeys returns field keys in a given measurement.
+// The return value is always a single table with a single column, "_value".
+measurementFieldKeys = (bucket, measurement, start=-30d) =>
+    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)
 
 // Measurements returns the list of measurements in a specific bucket.
 measurements = (bucket) =>

--- a/stdlib/influxdata/influxdb/v1/v1.flux
+++ b/stdlib/influxdata/influxdb/v1/v1.flux
@@ -11,6 +11,21 @@ fieldsAsCols = (tables=<-) =>
     tables
         |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
 
+// FieldKeys returns the list of field keys in a given bucket.
+// The return value is always a single table with a single column, "_value".
+fieldKeys = (bucket, predicate=(r) => true, start=-30d) =>
+    from(bucket: bucket)
+      |> range(start: start)
+      |> filter(fn: predicate)
+      |> keep(columns: ["_field"])
+      |> group()
+      |> distinct(column: "_field")
+
+// MeasurementFieldKeys returns field keys in a given measurement.
+// The return value is always a single table with a single column, "_value".
+measurementFieldKeys = (bucket, measurement, start) =>
+    fieldKeys(bucket: bucket, predicate: (r) => r._measurement == measurement, start: start)
+
 // TagValues returns the unique values for a given tag.
 // The return value is always a single table with a single column "_value".
 tagValues = (bucket, tag, predicate=(r) => true, start=-30d) =>
@@ -43,4 +58,3 @@ measurementTagKeys = (bucket, measurement) =>
 // Measurements returns the list of measurements in a specific bucket.
 measurements = (bucket) =>
     tagValues(bucket: bucket, tag: "_measurement")
-


### PR DESCRIPTION
Introduces `fieldKeys()` and `measurementFieldKeys()` into the v1 package for querying lists of fields in a bucket/measurement. These provide graceful equivalents to `SHOW FIELD KEYS` in InfluxQL.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
