### PR TITLE
fix: do not disclose dns info in http

### DIFF
--- a/stdlib/experimental/http/get_test.go
+++ b/stdlib/experimental/http/get_test.go
@@ -68,7 +68,27 @@ http.get(url:"http://127.1.1.1/path/a/b/c", headers: {x:"a",y:"b",z:"c"})
 	if err == nil {
 		t.Fatal("expected failure")
 	}
-	if !strings.Contains(err.Error(), "url is not valid") {
+	if !strings.Contains(err.Error(), "no such host") {
+		t.Errorf("unexpected cause of failure, got err: %v", err)
+	}
+}
+
+func TestGet_DNSFail(t *testing.T) {
+	script := `
+import "experimental/http"
+
+http.get(url:"http://notarealaddressatall/path/a/b/c", headers: {x:"a",y:"b",z:"c"})
+`
+
+	deps := flux.NewDefaultDependencies()
+	deps.Deps.HTTPClient = http.DefaultClient
+	deps.Deps.URLValidator = url.PrivateIPValidator{}
+	ctx := deps.Inject(context.Background())
+	_, _, err := runtime.Eval(ctx, script)
+	if err == nil {
+		t.Fatal("expected failure")
+	}
+	if !strings.Contains(err.Error(), "no such host") {
 		t.Errorf("unexpected cause of failure, got err: %v", err)
 	}
 }


### PR DESCRIPTION
This patch ensures that DNS information is not disclosed via DNS
validation failures or raw lookups (where the DNS server address is
added to the error message).