### PR TITLE
fix: inject the url validator into NewDefaultClient

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -87,13 +87,14 @@ func GetDependencies(ctx context.Context) Dependencies {
 // NewDefaultDependencies produces a set of dependencies.
 // Not all dependencies have valid defaults and will not be set.
 func NewDefaultDependencies() Deps {
+	validator := url.PassValidator{}
 	return Deps{
 		Deps: WrappedDeps{
-			HTTPClient: http.NewLimitedDefaultClient(),
+			HTTPClient: http.NewLimitedDefaultClient(validator),
 			// Default to having no filesystem, no secrets, and no url validation (always pass).
 			FilesystemService: nil,
 			SecretService:     secret.EmptySecretService{},
-			URLValidator:      url.PassValidator{},
+			URLValidator:      validator,
 		},
 	}
 }

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/dependencies/url"
 )
 
 func TestNewDefaultClient(t *testing.T) {
-	c := NewDefaultClient()
+	c := NewDefaultClient(url.PassValidator{})
 	if c == nil {
 		t.Fail()
 	}
@@ -21,7 +22,7 @@ func TestNewDefaultClient(t *testing.T) {
 func TestLimitedDefaultClient(t *testing.T) {
 	t.Run("response larger than given size", func(t *testing.T) {
 		var size int64 = 1
-		c := LimitHTTPBody(*NewDefaultClient(), size)
+		c := LimitHTTPBody(*NewDefaultClient(url.PassValidator{}), size)
 		body := "hello"
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
@@ -52,7 +53,7 @@ func TestLimitedDefaultClient(t *testing.T) {
 
 func TestInvalidRedirects(t *testing.T) {
 	t.Run("redirects to localhost are rejected", func(t *testing.T) {
-		client := NewDefaultClient()
+		client := NewDefaultClient(url.PrivateIPValidator{})
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 			http.Redirect(w, request, "http://localhost", http.StatusMovedPermanently)


### PR DESCRIPTION
This patch uses dependency injection to add the url validator to the
http client.

Fixes #2841
