### PR TITLE
refactor: constraints now have an expected type

### DIFF
--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -629,7 +629,7 @@ option planner.disableLogicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:1-4:52: [string] != string`,
+			wantErr: `type error @4:38-4:52: string != [string]`,
 		},
 		{
 			name: "physical planner option must be an array",
@@ -640,7 +640,7 @@ option planner.disablePhysicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:1-4:53: [string] != string`,
+			wantErr: `type error @4:39-4:53: string != [string]`,
 		},
 		{
 			name: "logical planner option must be an array of strings",
@@ -651,7 +651,7 @@ option planner.disableLogicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:1-4:43: string != float`,
+			wantErr: `type error @4:38-4:43: float != string`,
 		},
 		{
 			name: "physical planner option must be an array of strings",
@@ -662,7 +662,7 @@ option planner.disablePhysicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:1-4:44: string != float`,
+			wantErr: `type error @4:39-4:44: float != string`,
 		},
 		{
 			name: "planner is an object defined by the user",

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -629,7 +629,7 @@ option planner.disableLogicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:38-4:52: string != [string]`,
+			wantErr: `type error @4:38-4:52: expected [string] but found string`,
 		},
 		{
 			name: "physical planner option must be an array",
@@ -640,7 +640,7 @@ option planner.disablePhysicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:39-4:53: string != [string]`,
+			wantErr: `type error @4:39-4:53: expected [string] but found string`,
 		},
 		{
 			name: "logical planner option must be an array of strings",
@@ -651,7 +651,7 @@ option planner.disableLogicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:38-4:43: float != string`,
+			wantErr: `type error @4:38-4:43: expected string but found float`,
 		},
 		{
 			name: "physical planner option must be an array of strings",
@@ -662,7 +662,7 @@ option planner.disablePhysicalRules = [1.0]
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `type error @4:39-4:44: float != string`,
+			wantErr: `type error @4:39-4:44: expected string but found float`,
 		},
 		{
 			name: "planner is an object defined by the user",

--- a/libflux/go/libflux/analyze_test.go
+++ b/libflux/go/libflux/analyze_test.go
@@ -26,7 +26,7 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = "foo" + 10`,
-			err:  errors.New("type error @1:13-1:15: int != string"),
+			err:  errors.New("type error @1:13-1:15: expected string but found int"),
 		},
 	}
 	for _, tc := range tcs {

--- a/libflux/go/libflux/analyze_test.go
+++ b/libflux/go/libflux/analyze_test.go
@@ -26,7 +26,7 @@ func TestAnalyze(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = "foo" + 10`,
-			err:  errors.New("type error @1:13-1:15: string != int"),
+			err:  errors.New("type error @1:13-1:15: int != string"),
 		},
 	}
 	for _, tc := range tcs {

--- a/libflux/src/core/semantic/nodes.rs
+++ b/libflux/src/core/semantic/nodes.rs
@@ -428,15 +428,12 @@ impl OptionStmt {
                 let (env, cons) = stmt.init.infer(env, f)?;
                 let (env, rest) = stmt.member.infer(env, f)?;
 
-                let l = stmt.member.typ.clone();
-                let r = stmt.init.type_of();
-
                 Ok((
                     env,
                     cons + rest
                         + vec![Constraint::Equal {
-                            exp: l,
-                            act: r,
+                            exp: stmt.member.typ.clone(),
+                            act: stmt.init.type_of(),
                             loc: stmt.init.loc().clone(),
                         }]
                         .into(),

--- a/libflux/src/core/semantic/nodes.rs
+++ b/libflux/src/core/semantic/nodes.rs
@@ -33,7 +33,7 @@ use std::vec::Vec;
 // updated type environment and a set of type constraints to be solved.
 pub type Result = std::result::Result<(Environment, Constraints), Error>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     Inference(infer::Error),
     UndefinedBuiltin(String, ast::SourceLocation),
@@ -433,7 +433,13 @@ impl OptionStmt {
 
                 Ok((
                     env,
-                    cons + rest + vec![Constraint::Equal(l, r, self.loc.clone())].into(),
+                    cons + rest
+                        + vec![Constraint::Equal {
+                            exp: l,
+                            act: r,
+                            loc: stmt.init.loc().clone(),
+                        }]
+                        .into(),
                 ))
             }
             Assignment::Variable(stmt) => stmt.infer(env, f),
@@ -629,11 +635,11 @@ impl StringExpr {
             if let StringExprPart::Interpolated(ref mut ip) = p {
                 let (e, cons) = ip.expression.infer(env, f)?;
                 constraints.append(&mut Vec::from(cons));
-                constraints.push(Constraint::Equal(
-                    ip.expression.type_of(),
-                    MonoType::String,
-                    ip.expression.loc().clone(),
-                ));
+                constraints.push(Constraint::Equal {
+                    exp: MonoType::String,
+                    act: ip.expression.type_of(),
+                    loc: ip.expression.loc().clone(),
+                });
                 env = e
             }
         }
@@ -702,15 +708,19 @@ impl ArrayExpr {
         for el in &mut self.elements {
             let (e, c) = el.infer(env, f)?;
             cons.append(&mut c.into());
-            cons.push(Constraint::Equal(
-                el.type_of(),
-                elt.clone(),
-                el.loc().clone(),
-            ));
+            cons.push(Constraint::Equal {
+                exp: elt.clone(),
+                act: el.type_of(),
+                loc: el.loc().clone(),
+            });
             env = e;
         }
         let at = MonoType::Arr(Box::new(Array(elt)));
-        cons.push(Constraint::Equal(at, self.typ.clone(), self.loc.clone()));
+        cons.push(Constraint::Equal {
+            exp: at,
+            act: self.typ.clone(),
+            loc: self.loc.clone(),
+        });
         Ok((env, cons.into()))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
@@ -803,7 +813,11 @@ impl FunctionExpr {
             retn,
         }));
         cons = cons + bcons;
-        cons.add(Constraint::Equal(func, self.typ.clone(), self.loc.clone()));
+        cons.add(Constraint::Equal {
+            exp: self.typ.clone(),
+            act: func,
+            loc: self.loc.clone(),
+        });
         Ok((env, cons))
     }
     pub fn pipe(&self) -> Option<&FunctionParameter> {
@@ -941,195 +955,275 @@ impl BinaryExpr {
         let cons = match self.operator {
             // The following operators require both sides to be equal.
             ast::Operator::AdditionOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.left.type_of(),
-                    self.right.type_of(),
-                    self.right.loc().clone(),
-                ),
-                Constraint::Equal(self.left.type_of(), self.typ.clone(), self.loc.clone()),
-                Constraint::Kind(self.typ.clone(), Kind::Addable, self.loc.clone()),
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.typ.clone(),
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.typ.clone(),
+                    exp: Kind::Addable,
+                    loc: self.loc.clone(),
+                },
             ]),
             ast::Operator::SubtractionOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.left.type_of(),
-                    self.right.type_of(),
-                    self.right.loc().clone(),
-                ),
-                Constraint::Equal(self.left.type_of(), self.typ.clone(), self.loc.clone()),
-                Constraint::Kind(self.typ.clone(), Kind::Subtractable, self.loc.clone()),
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.typ.clone(),
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.typ.clone(),
+                    exp: Kind::Subtractable,
+                    loc: self.loc.clone(),
+                },
             ]),
             ast::Operator::MultiplicationOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.left.type_of(),
-                    self.right.type_of(),
-                    self.right.loc().clone(),
-                ),
-                Constraint::Equal(self.left.type_of(), self.typ.clone(), self.loc.clone()),
-                Constraint::Kind(self.typ.clone(), Kind::Divisible, self.loc.clone()),
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.typ.clone(),
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.typ.clone(),
+                    exp: Kind::Divisible,
+                    loc: self.loc.clone(),
+                },
             ]),
             ast::Operator::DivisionOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.left.type_of(),
-                    self.right.type_of(),
-                    self.right.loc().clone(),
-                ),
-                Constraint::Equal(self.left.type_of(), self.typ.clone(), self.loc.clone()),
-                Constraint::Kind(self.typ.clone(), Kind::Divisible, self.loc.clone()),
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.typ.clone(),
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.typ.clone(),
+                    exp: Kind::Divisible,
+                    loc: self.loc.clone(),
+                },
             ]),
             ast::Operator::PowerOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.left.type_of(),
-                    self.right.type_of(),
-                    self.right.loc().clone(),
-                ),
-                Constraint::Equal(self.left.type_of(), self.typ.clone(), self.loc.clone()),
-                Constraint::Kind(self.typ.clone(), Kind::Divisible, self.loc.clone()),
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.typ.clone(),
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.typ.clone(),
+                    exp: Kind::Divisible,
+                    loc: self.loc.clone(),
+                },
             ]),
             ast::Operator::ModuloOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.left.type_of(),
-                    self.right.type_of(),
-                    self.right.loc().clone(),
-                ),
-                Constraint::Equal(self.left.type_of(), self.typ.clone(), self.loc.clone()),
-                Constraint::Kind(self.typ.clone(), Kind::Divisible, self.loc.clone()),
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.left.type_of(),
+                    act: self.typ.clone(),
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.typ.clone(),
+                    exp: Kind::Divisible,
+                    loc: self.loc.clone(),
+                },
             ]),
             ast::Operator::GreaterThanOperator => Constraints::from(vec![
                 // https://github.com/influxdata/flux/issues/2393
-                // Constraint::Equal(self.left.type_of(), self.right.type_of()),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Comparable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Comparable,
-                    self.right.loc().clone(),
-                ),
+                // Constraint::Equal{self.left.type_of(), self.right.type_of()),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             ast::Operator::LessThanOperator => Constraints::from(vec![
                 // https://github.com/influxdata/flux/issues/2393
-                // Constraint::Equal(self.left.type_of(), self.right.type_of()),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Comparable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Comparable,
-                    self.right.loc().clone(),
-                ),
+                // Constraint::Equal{self.left.type_of(), self.right.type_of()),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             ast::Operator::EqualOperator => Constraints::from(vec![
                 // https://github.com/influxdata/flux/issues/2393
-                // Constraint::Equal(self.left.type_of(), self.right.type_of()),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Equatable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Equatable,
-                    self.right.loc().clone(),
-                ),
+                // Constraint::Equal{self.left.type_of(), self.right.type_of()),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             ast::Operator::NotEqualOperator => Constraints::from(vec![
                 // https://github.com/influxdata/flux/issues/2393
-                // Constraint::Equal(self.left.type_of(), self.right.type_of()),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Equatable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Equatable,
-                    self.right.loc().clone(),
-                ),
+                // Constraint::Equal{self.left.type_of(), self.right.type_of()),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             ast::Operator::GreaterThanEqualOperator => Constraints::from(vec![
                 // https://github.com/influxdata/flux/issues/2393
-                // Constraint::Equal(self.left.type_of(), self.right.type_of()),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Equatable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Comparable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Equatable,
-                    self.right.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Comparable,
-                    self.right.loc().clone(),
-                ),
+                // Constraint::Equal{self.left.type_of(), self.right.type_of()),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             ast::Operator::LessThanEqualOperator => Constraints::from(vec![
                 // https://github.com/influxdata/flux/issues/2393
-                // Constraint::Equal(self.left.type_of(), self.right.type_of()),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Equatable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.left.type_of(),
-                    Kind::Comparable,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Equatable,
-                    self.right.loc().clone(),
-                ),
-                Constraint::Kind(
-                    self.right.type_of(),
-                    Kind::Comparable,
-                    self.right.loc().clone(),
-                ),
+                // Constraint::Equal{self.left.type_of(), self.right.type_of()),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.left.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Equatable,
+                    loc: self.right.loc().clone(),
+                },
+                Constraint::Kind {
+                    act: self.right.type_of(),
+                    exp: Kind::Comparable,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             // Regular expression operators.
             ast::Operator::RegexpMatchOperator => Constraints::from(vec![
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Equal(
-                    self.left.type_of(),
-                    MonoType::String,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Equal(
-                    self.right.type_of(),
-                    MonoType::Regexp,
-                    self.right.loc().clone(),
-                ),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Equal {
+                    act: self.left.type_of(),
+                    exp: MonoType::String,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Equal {
+                    act: self.right.type_of(),
+                    exp: MonoType::Regexp,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             ast::Operator::NotRegexpMatchOperator => Constraints::from(vec![
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
-                Constraint::Equal(
-                    self.left.type_of(),
-                    MonoType::String,
-                    self.left.loc().clone(),
-                ),
-                Constraint::Equal(
-                    self.right.type_of(),
-                    MonoType::Regexp,
-                    self.right.loc().clone(),
-                ),
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
+                Constraint::Equal {
+                    act: self.left.type_of(),
+                    exp: MonoType::String,
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Equal {
+                    act: self.right.type_of(),
+                    exp: MonoType::Regexp,
+                    loc: self.right.loc().clone(),
+                },
             ]),
             _ => return Err(Error::InvalidBinOp(self.operator.clone(), self.loc.clone())),
         };
@@ -1187,8 +1281,9 @@ impl CallExpr {
             });
         }
         // Constrain the callee to be a Function.
-        cons.add(Constraint::Equal(
-            MonoType::Fun(Box::new(Function {
+        cons.add(Constraint::Equal {
+            exp: self.callee.type_of(),
+            act: MonoType::Fun(Box::new(Function {
                 opt: MonoTypeMap::new(),
                 req,
                 pipe,
@@ -1203,9 +1298,8 @@ impl CallExpr {
                 // can infer that, for instance, `f(a: 0) + 1` is legal.
                 retn: self.typ.clone(),
             })),
-            self.callee.type_of(),
-            self.loc.clone(),
-        ));
+            loc: self.loc.clone(),
+        });
         Ok((env, cons))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
@@ -1244,12 +1338,16 @@ impl ConditionalExpr {
             + ccons
             + acons
             + Constraints::from(vec![
-                Constraint::Equal(self.test.type_of(), MonoType::Bool, self.test.loc().clone()),
-                Constraint::Equal(
-                    self.consequent.type_of(),
-                    self.alternate.type_of(),
-                    self.alternate.loc().clone(),
-                ),
+                Constraint::Equal {
+                    exp: MonoType::Bool,
+                    act: self.test.type_of(),
+                    loc: self.test.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: self.consequent.type_of(),
+                    act: self.alternate.type_of(),
+                    loc: self.alternate.loc().clone(),
+                },
             ]);
         Ok((env, cons))
     }
@@ -1277,12 +1375,16 @@ impl LogicalExpr {
         let cons = lcons
             + rcons
             + Constraints::from(vec![
-                Constraint::Equal(self.left.type_of(), MonoType::Bool, self.left.loc().clone()),
-                Constraint::Equal(
-                    self.right.type_of(),
-                    MonoType::Bool,
-                    self.right.loc().clone(),
-                ),
+                Constraint::Equal {
+                    exp: MonoType::Bool,
+                    act: self.left.type_of(),
+                    loc: self.left.loc().clone(),
+                },
+                Constraint::Equal {
+                    exp: MonoType::Bool,
+                    act: self.right.type_of(),
+                    loc: self.right.loc().clone(),
+                },
             ]);
         Ok((env, cons))
     }
@@ -1324,7 +1426,12 @@ impl MemberExpr {
         let (env, cons) = self.object.infer(env, f)?;
         Ok((
             env,
-            cons + vec![Constraint::Equal(t, r, self.object.loc().clone())].into(),
+            cons + vec![Constraint::Equal {
+                exp: r,
+                act: t,
+                loc: self.object.loc().clone(),
+            }]
+            .into(),
         ))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
@@ -1352,16 +1459,16 @@ impl IndexExpr {
         let cons = acons
             + icons
             + Constraints::from(vec![
-                Constraint::Equal(
-                    self.index.type_of(),
-                    MonoType::Int,
-                    self.index.loc().clone(),
-                ),
-                Constraint::Equal(
-                    self.array.type_of(),
-                    MonoType::Arr(Box::new(Array(self.typ.clone()))),
-                    self.loc.clone(),
-                ),
+                Constraint::Equal {
+                    act: self.index.type_of(),
+                    exp: MonoType::Int,
+                    loc: self.index.loc().clone(),
+                },
+                Constraint::Equal {
+                    act: self.array.type_of(),
+                    exp: MonoType::Arr(Box::new(Array(self.typ.clone()))),
+                    loc: self.array.loc().clone(),
+                },
             ]);
         Ok((env, cons))
     }
@@ -1413,7 +1520,12 @@ impl ObjectExpr {
         }
         Ok((
             env,
-            cons + vec![Constraint::Equal(self.typ.to_owned(), r, self.loc.clone())].into(),
+            cons + vec![Constraint::Equal {
+                exp: self.typ.to_owned(),
+                act: r,
+                loc: self.loc.clone(),
+            }]
+            .into(),
         ))
     }
     fn apply(mut self, sub: &Substitution) -> Self {
@@ -1446,26 +1558,34 @@ impl UnaryExpr {
         let (env, acons) = self.argument.infer(env, f)?;
         let cons = match self.operator {
             ast::Operator::NotOperator => Constraints::from(vec![
-                Constraint::Equal(
-                    self.argument.type_of(),
-                    MonoType::Bool,
-                    self.argument.loc().clone(),
-                ),
-                Constraint::Equal(self.typ.clone(), MonoType::Bool, self.loc.clone()),
+                Constraint::Equal {
+                    act: self.argument.type_of(),
+                    exp: MonoType::Bool,
+                    loc: self.argument.loc().clone(),
+                },
+                Constraint::Equal {
+                    act: self.typ.clone(),
+                    exp: MonoType::Bool,
+                    loc: self.loc.clone(),
+                },
             ]),
-            ast::Operator::ExistsOperator => Constraints::from(Constraint::Equal(
-                self.typ.clone(),
-                MonoType::Bool,
-                self.loc.clone(),
-            )),
+            ast::Operator::ExistsOperator => Constraints::from(Constraint::Equal {
+                act: self.typ.clone(),
+                exp: MonoType::Bool,
+                loc: self.loc.clone(),
+            }),
             ast::Operator::AdditionOperator | ast::Operator::SubtractionOperator => {
                 Constraints::from(vec![
-                    Constraint::Equal(self.argument.type_of(), self.typ.clone(), self.loc.clone()),
-                    Constraint::Kind(
-                        self.argument.type_of(),
-                        Kind::Negatable,
-                        self.argument.loc().clone(),
-                    ),
+                    Constraint::Equal {
+                        act: self.argument.type_of(),
+                        exp: self.typ.clone(),
+                        loc: self.loc.clone(),
+                    },
+                    Constraint::Kind {
+                        act: self.argument.type_of(),
+                        exp: Kind::Negatable,
+                        loc: self.argument.loc().clone(),
+                    },
                 ])
             }
             _ => {
@@ -1516,11 +1636,11 @@ impl IdentifierExpr {
                 let (t, cons) = infer::instantiate(poly.clone(), f, self.loc.clone());
                 Ok((
                     env,
-                    cons + Constraints::from(vec![Constraint::Equal(
-                        t,
-                        self.typ.clone(),
-                        self.loc.clone(),
-                    )]),
+                    cons + Constraints::from(vec![Constraint::Equal {
+                        act: t,
+                        exp: self.typ.clone(),
+                        loc: self.loc.clone(),
+                    }]),
                 ))
             }
             None => Err(Error::UndefinedIdentifier(

--- a/libflux/src/core/semantic/tests.rs
+++ b/libflux/src/core/semantic/tests.rs
@@ -3254,7 +3254,7 @@ fn test_error_messages() {
             1 + "1"
         "#,
         // Location points to right expression expression
-        err: "type error @2:17-2:20: int != string",
+        err: "type error @2:17-2:20: string != int",
     }
     test_error_msg! {
         src: r#"
@@ -3291,7 +3291,7 @@ fn test_error_messages() {
             if exists 0 then 0 else "b"
         "#,
         // Location points to else expression
-        err: "type error @2:37-2:40: int != string",
+        err: "type error @2:37-2:40: string != int",
     }
     test_error_msg! {
         src: r#"
@@ -3314,7 +3314,15 @@ fn test_error_messages() {
             a[1] + 1.1
         "#,
         // Location points to right expression
-        err: "type error @3:20-3:23: int != float",
+        err: "type error @3:20-3:23: float != int",
+    }
+    test_error_msg! {
+        src: r#"
+            a = 1
+            a[1]
+        "#,
+        // Location points to the identifier a
+        err: "type error @3:13-3:14: int != [t2]",
     }
     test_error_msg! {
         src: r#"
@@ -3354,6 +3362,22 @@ fn test_error_messages() {
             fn = (r) => match(r)
         "#,
         // Location points to call expression `match(r)`
-        err: "type error @3:25-3:33: missing required argument o",
+        err: "type error @3:25-3:33: found unexpected argument r",
+    }
+    test_error_msg! {
+        src: r#"
+            f = (a, b) => a + b
+            f(a: 0, c: 1)
+        "#,
+        // Location points to call expression `f(a: 0, c: 1)`
+        err: "type error @3:13-3:26: found unexpected argument c",
+    }
+    test_error_msg! {
+        src: r#"
+            f = (a, b) => a + b
+            f(a: 0)
+        "#,
+        // Location points to call expression `f(a: 0)`
+        err: "type error @3:13-3:20: missing required argument b",
     }
 }

--- a/libflux/src/core/semantic/tests.rs
+++ b/libflux/src/core/semantic/tests.rs
@@ -3254,7 +3254,7 @@ fn test_error_messages() {
             1 + "1"
         "#,
         // Location points to right expression expression
-        err: "type error @2:17-2:20: string != int",
+        err: "type error @2:17-2:20: expected int but found string",
     }
     test_error_msg! {
         src: r#"
@@ -3277,28 +3277,28 @@ fn test_error_messages() {
             "Hey ${bob} it's me ${joe}!"
         "#,
         // Location points to second interpolated expression
-        err: "type error @4:35-4:38: int != string",
+        err: "type error @4:35-4:38: expected string but found int",
     }
     test_error_msg! {
         src: r#"
             if 0 then "a" else "b"
         "#,
         // Location points to if expression
-        err: "type error @2:16-2:17: int != bool",
+        err: "type error @2:16-2:17: expected bool but found int",
     }
     test_error_msg! {
         src: r#"
             if exists 0 then 0 else "b"
         "#,
         // Location points to else expression
-        err: "type error @2:37-2:40: string != int",
+        err: "type error @2:37-2:40: expected int but found string",
     }
     test_error_msg! {
         src: r#"
             [1, "2"]
         "#,
         // Location points to second element of array
-        err: "type error @2:17-2:20: string != int",
+        err: "type error @2:17-2:20: expected int but found string",
     }
     test_error_msg! {
         src: r#"
@@ -3306,7 +3306,7 @@ fn test_error_messages() {
             a[1.1]
         "#,
         // Location points to expression representing the index
-        err: "type error @3:15-3:18: float != int",
+        err: "type error @3:15-3:18: expected int but found float",
     }
     test_error_msg! {
         src: r#"
@@ -3314,7 +3314,7 @@ fn test_error_messages() {
             a[1] + 1.1
         "#,
         // Location points to right expression
-        err: "type error @3:20-3:23: float != int",
+        err: "type error @3:20-3:23: expected int but found float",
     }
     test_error_msg! {
         src: r#"
@@ -3322,7 +3322,7 @@ fn test_error_messages() {
             a[1]
         "#,
         // Location points to the identifier a
-        err: "type error @3:13-3:14: int != [t2]",
+        err: "type error @3:13-3:14: expected [t2] but found int",
     }
     test_error_msg! {
         src: r#"
@@ -3330,7 +3330,7 @@ fn test_error_messages() {
             a.x
         "#,
         // Location points to the identifier a
-        err: "type error @3:13-3:14: [int] != {x:t3 | t5}",
+        err: "type error @3:13-3:14: expected {x:t3 | t5} but found [int]",
     }
     test_error_msg! {
         src: r#"

--- a/libflux/src/core/semantic/types.rs
+++ b/libflux/src/core/semantic/types.rs
@@ -1842,7 +1842,7 @@ mod tests {
                 &mut Fresher::default(),
             )
             .unwrap_err();
-        assert_eq!(err.to_string(), String::from("int != string"),);
+        assert_eq!(err.to_string(), String::from("string != int"),);
     }
     #[test]
     fn unify_tvars() {

--- a/runtime/analyze_libflux_test.go
+++ b/runtime/analyze_libflux_test.go
@@ -20,7 +20,7 @@ func TestAnalyzeSource(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = 10 + "foo"`,
-			err:  errors.New("type error @1:10-1:15: int != string"),
+			err:  errors.New("type error @1:10-1:15: string != int"),
 		},
 	}
 	for _, tc := range tcs {

--- a/runtime/analyze_libflux_test.go
+++ b/runtime/analyze_libflux_test.go
@@ -20,7 +20,7 @@ func TestAnalyzeSource(t *testing.T) {
 		{
 			name: "failure",
 			flx:  `x = 10 + "foo"`,
-			err:  errors.New("type error @1:10-1:15: string != int"),
+			err:  errors.New("type error @1:10-1:15: expected int but found string"),
 		},
 	}
 	for _, tc := range tcs {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -64,7 +64,7 @@ func TestEval_error(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
-	if want, got := "type error @1:11-1:16: string != float", err.Error(); want != got {
+	if want, got := "type error @1:11-1:16: expected float but found string", err.Error(); want != got {
 		t.Errorf("wanted error %q, got %q", want, got)
 	}
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -64,7 +64,7 @@ func TestEval_error(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
-	if want, got := "type error @1:11-1:16: float != string", err.Error(); want != got {
+	if want, got := "type error @1:11-1:16: string != float", err.Error(); want != got {
 		t.Errorf("wanted error %q, got %q", want, got)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/influxdata/flux/issues/2808.

Previously if a function was not passed the required arguments it was expecting an error would be presented of the form:
```
missing required argument ...
```

Constraints now have an expected and an actual type which means we can now distinguish between a function that was passed too few arguments vs too many.
