### PR TITLE
test(stdlib): add flux end-to-end test for bare agg push down

### DIFF
--- a/stdlib/planner/bare_agg_eval_test.flux
+++ b/stdlib/planner/bare_agg_eval_test.flux
@@ -1,0 +1,51 @@
+package planner_test
+
+import "testing"
+import "planner"
+
+option now = () => (2030-01-01T00:00:00Z)
+option planner.disablePhysicalRules = ["PushDownBareAggregateRule"]
+
+input = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72
+,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77
+,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96
+,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97
+
+,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91
+,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89
+,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93
+"
+
+output = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long
+#group,false,false,true,true,true,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_measurement,host,_field,_value
+,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6
+,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6
+,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6
+"
+
+bare_count_fn = (tables=<-) => tables
+    |> range(start: 2018-05-01T00:00:00Z)
+    |> count()
+
+test bare_count_evaluate = () =>
+    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})

--- a/stdlib/planner/bare_agg_push_test.flux
+++ b/stdlib/planner/bare_agg_push_test.flux
@@ -1,0 +1,49 @@
+package planner_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+input = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72
+,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77
+,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97
+,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96
+,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98
+,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97
+
+,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91
+,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92
+,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89
+,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93
+"
+
+output = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long
+#group,false,false,true,true,true,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_measurement,host,_field,_value
+,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6
+,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6
+,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6
+"
+
+bare_count_fn = (tables=<-) => tables
+    |> range(start: 2018-05-01T00:00:00Z)
+    |> count()
+
+test bare_count_pushdown = () =>
+    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})

--- a/stdlib/planner/flux_test_gen.go
+++ b/stdlib/planner/flux_test_gen.go
@@ -17,6 +17,2362 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 			Errors: nil,
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
+					Column: 102,
+					Line:   51,
+				},
+				File:   "bare_agg_eval_test.flux",
+				Source: "package planner_test\n\nimport \"testing\"\nimport \"planner\"\n\noption now = () => (2030-01-01T00:00:00Z)\noption planner.disablePhysicalRules = [\"PushDownBareAggregateRule\"]\n\ninput = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\"\n\noutput = \"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n\"\n\nbare_count_fn = (tables=<-) => tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()\n\ntest bare_count_evaluate = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+				Start: ast.Position{
+					Column: 1,
+					Line:   1,
+				},
+			},
+		},
+		Body: []ast.Statement{&ast.OptionStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 42,
+							Line:   6,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "now = () => (2030-01-01T00:00:00Z)",
+						Start: ast.Position{
+							Column: 8,
+							Line:   6,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 11,
+								Line:   6,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "now",
+							Start: ast.Position{
+								Column: 8,
+								Line:   6,
+							},
+						},
+					},
+					Name: "now",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 42,
+								Line:   6,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "() => (2030-01-01T00:00:00Z)",
+							Start: ast.Position{
+								Column: 14,
+								Line:   6,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 42,
+									Line:   6,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "(2030-01-01T00:00:00Z)",
+								Start: ast.Position{
+									Column: 20,
+									Line:   6,
+								},
+							},
+						},
+						Expression: &ast.DateTimeLiteral{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 41,
+										Line:   6,
+									},
+									File:   "bare_agg_eval_test.flux",
+									Source: "2030-01-01T00:00:00Z",
+									Start: ast.Position{
+										Column: 21,
+										Line:   6,
+									},
+								},
+							},
+							Value: parser.MustParseTime("2030-01-01T00:00:00Z"),
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 42,
+						Line:   6,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "option now = () => (2030-01-01T00:00:00Z)",
+					Start: ast.Position{
+						Column: 1,
+						Line:   6,
+					},
+				},
+			},
+		}, &ast.OptionStatement{
+			Assignment: &ast.MemberAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 68,
+							Line:   7,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "planner.disablePhysicalRules = [\"PushDownBareAggregateRule\"]",
+						Start: ast.Position{
+							Column: 8,
+							Line:   7,
+						},
+					},
+				},
+				Init: &ast.ArrayExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 68,
+								Line:   7,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "[\"PushDownBareAggregateRule\"]",
+							Start: ast.Position{
+								Column: 39,
+								Line:   7,
+							},
+						},
+					},
+					Elements: []ast.Expression{&ast.StringLiteral{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 67,
+									Line:   7,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "\"PushDownBareAggregateRule\"",
+								Start: ast.Position{
+									Column: 40,
+									Line:   7,
+								},
+							},
+						},
+						Value: "PushDownBareAggregateRule",
+					}},
+				},
+				Member: &ast.MemberExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 36,
+								Line:   7,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "planner.disablePhysicalRules",
+							Start: ast.Position{
+								Column: 8,
+								Line:   7,
+							},
+						},
+					},
+					Object: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   7,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "planner",
+								Start: ast.Position{
+									Column: 8,
+									Line:   7,
+								},
+							},
+						},
+						Name: "planner",
+					},
+					Property: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   7,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "disablePhysicalRules",
+								Start: ast.Position{
+									Column: 16,
+									Line:   7,
+								},
+							},
+						},
+						Name: "disablePhysicalRules",
+					},
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 68,
+						Line:   7,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "option planner.disablePhysicalRules = [\"PushDownBareAggregateRule\"]",
+					Start: ast.Position{
+						Column: 1,
+						Line:   7,
+					},
+				},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   34,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "input = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   9,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 6,
+							Line:   9,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "input",
+						Start: ast.Position{
+							Column: 1,
+							Line:   9,
+						},
+					},
+				},
+				Name: "input",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   34,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\"",
+						Start: ast.Position{
+							Column: 9,
+							Line:   9,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   44,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "output = \"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   36,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 7,
+							Line:   36,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "output",
+						Start: ast.Position{
+							Column: 1,
+							Line:   36,
+						},
+					},
+				},
+				Name: "output",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   44,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n\"",
+						Start: ast.Position{
+							Column: 10,
+							Line:   36,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 15,
+						Line:   48,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "bare_count_fn = (tables=<-) => tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()",
+					Start: ast.Position{
+						Column: 1,
+						Line:   46,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 14,
+							Line:   46,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "bare_count_fn",
+						Start: ast.Position{
+							Column: 1,
+							Line:   46,
+						},
+					},
+				},
+				Name: "bare_count_fn",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 15,
+							Line:   48,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "(tables=<-) => tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()",
+						Start: ast.Position{
+							Column: 17,
+							Line:   46,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 38,
+										Line:   46,
+									},
+									File:   "bare_agg_eval_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 32,
+										Line:   46,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 42,
+									Line:   47,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "tables\n    |> range(start: 2018-05-01T00:00:00Z)",
+								Start: ast.Position{
+									Column: 32,
+									Line:   46,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 41,
+											Line:   47,
+										},
+										File:   "bare_agg_eval_test.flux",
+										Source: "start: 2018-05-01T00:00:00Z",
+										Start: ast.Position{
+											Column: 14,
+											Line:   47,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 41,
+												Line:   47,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "start: 2018-05-01T00:00:00Z",
+											Start: ast.Position{
+												Column: 14,
+												Line:   47,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 19,
+													Line:   47,
+												},
+												File:   "bare_agg_eval_test.flux",
+												Source: "start",
+												Start: ast.Position{
+													Column: 14,
+													Line:   47,
+												},
+											},
+										},
+										Name: "start",
+									},
+									Value: &ast.DateTimeLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 41,
+													Line:   47,
+												},
+												File:   "bare_agg_eval_test.flux",
+												Source: "2018-05-01T00:00:00Z",
+												Start: ast.Position{
+													Column: 21,
+													Line:   47,
+												},
+											},
+										},
+										Value: parser.MustParseTime("2018-05-01T00:00:00Z"),
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 42,
+										Line:   47,
+									},
+									File:   "bare_agg_eval_test.flux",
+									Source: "range(start: 2018-05-01T00:00:00Z)",
+									Start: ast.Position{
+										Column: 8,
+										Line:   47,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 13,
+											Line:   47,
+										},
+										File:   "bare_agg_eval_test.flux",
+										Source: "range",
+										Start: ast.Position{
+											Column: 8,
+											Line:   47,
+										},
+									},
+								},
+								Name: "range",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 15,
+								Line:   48,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()",
+							Start: ast.Position{
+								Column: 32,
+								Line:   46,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: nil,
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   48,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "count()",
+								Start: ast.Position{
+									Column: 8,
+									Line:   48,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 13,
+										Line:   48,
+									},
+									File:   "bare_agg_eval_test.flux",
+									Source: "count",
+									Start: ast.Position{
+										Column: 8,
+										Line:   48,
+									},
+								},
+							},
+							Name: "count",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 27,
+								Line:   46,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "tables=<-",
+							Start: ast.Position{
+								Column: 18,
+								Line:   46,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 24,
+									Line:   46,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "tables",
+								Start: ast.Position{
+									Column: 18,
+									Line:   46,
+								},
+							},
+						},
+						Name: "tables",
+					},
+					Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 27,
+								Line:   46,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "<-",
+							Start: ast.Position{
+								Column: 25,
+								Line:   46,
+							},
+						},
+					}},
+				}},
+			},
+		}, &ast.TestStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 102,
+							Line:   51,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "bare_count_evaluate = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+						Start: ast.Position{
+							Column: 6,
+							Line:   50,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 25,
+								Line:   50,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "bare_count_evaluate",
+							Start: ast.Position{
+								Column: 6,
+								Line:   50,
+							},
+						},
+					},
+					Name: "bare_count_evaluate",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 102,
+								Line:   51,
+							},
+							File:   "bare_agg_eval_test.flux",
+							Source: "() =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+							Start: ast.Position{
+								Column: 28,
+								Line:   50,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 102,
+									Line:   51,
+								},
+								File:   "bare_agg_eval_test.flux",
+								Source: "({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+								Start: ast.Position{
+									Column: 5,
+									Line:   51,
+								},
+							},
+						},
+						Expression: &ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 101,
+										Line:   51,
+									},
+									File:   "bare_agg_eval_test.flux",
+									Source: "{input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn}",
+									Start: ast.Position{
+										Column: 6,
+										Line:   51,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 45,
+											Line:   51,
+										},
+										File:   "bare_agg_eval_test.flux",
+										Source: "input: testing.loadStorage(csv: input)",
+										Start: ast.Position{
+											Column: 7,
+											Line:   51,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 12,
+												Line:   51,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "input",
+											Start: ast.Position{
+												Column: 7,
+												Line:   51,
+											},
+										},
+									},
+									Name: "input",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 44,
+													Line:   51,
+												},
+												File:   "bare_agg_eval_test.flux",
+												Source: "csv: input",
+												Start: ast.Position{
+													Column: 34,
+													Line:   51,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 44,
+														Line:   51,
+													},
+													File:   "bare_agg_eval_test.flux",
+													Source: "csv: input",
+													Start: ast.Position{
+														Column: 34,
+														Line:   51,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 37,
+															Line:   51,
+														},
+														File:   "bare_agg_eval_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 34,
+															Line:   51,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 44,
+															Line:   51,
+														},
+														File:   "bare_agg_eval_test.flux",
+														Source: "input",
+														Start: ast.Position{
+															Column: 39,
+															Line:   51,
+														},
+													},
+												},
+												Name: "input",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 45,
+												Line:   51,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "testing.loadStorage(csv: input)",
+											Start: ast.Position{
+												Column: 14,
+												Line:   51,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   51,
+												},
+												File:   "bare_agg_eval_test.flux",
+												Source: "testing.loadStorage",
+												Start: ast.Position{
+													Column: 14,
+													Line:   51,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 21,
+														Line:   51,
+													},
+													File:   "bare_agg_eval_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 14,
+														Line:   51,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 33,
+														Line:   51,
+													},
+													File:   "bare_agg_eval_test.flux",
+													Source: "loadStorage",
+													Start: ast.Position{
+														Column: 22,
+														Line:   51,
+													},
+												},
+											},
+											Name: "loadStorage",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 81,
+											Line:   51,
+										},
+										File:   "bare_agg_eval_test.flux",
+										Source: "want: testing.loadMem(csv: output)",
+										Start: ast.Position{
+											Column: 47,
+											Line:   51,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 51,
+												Line:   51,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "want",
+											Start: ast.Position{
+												Column: 47,
+												Line:   51,
+											},
+										},
+									},
+									Name: "want",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 80,
+													Line:   51,
+												},
+												File:   "bare_agg_eval_test.flux",
+												Source: "csv: output",
+												Start: ast.Position{
+													Column: 69,
+													Line:   51,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 80,
+														Line:   51,
+													},
+													File:   "bare_agg_eval_test.flux",
+													Source: "csv: output",
+													Start: ast.Position{
+														Column: 69,
+														Line:   51,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 72,
+															Line:   51,
+														},
+														File:   "bare_agg_eval_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 69,
+															Line:   51,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 80,
+															Line:   51,
+														},
+														File:   "bare_agg_eval_test.flux",
+														Source: "output",
+														Start: ast.Position{
+															Column: 74,
+															Line:   51,
+														},
+													},
+												},
+												Name: "output",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 81,
+												Line:   51,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "testing.loadMem(csv: output)",
+											Start: ast.Position{
+												Column: 53,
+												Line:   51,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 68,
+													Line:   51,
+												},
+												File:   "bare_agg_eval_test.flux",
+												Source: "testing.loadMem",
+												Start: ast.Position{
+													Column: 53,
+													Line:   51,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 60,
+														Line:   51,
+													},
+													File:   "bare_agg_eval_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 53,
+														Line:   51,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 68,
+														Line:   51,
+													},
+													File:   "bare_agg_eval_test.flux",
+													Source: "loadMem",
+													Start: ast.Position{
+														Column: 61,
+														Line:   51,
+													},
+												},
+											},
+											Name: "loadMem",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 100,
+											Line:   51,
+										},
+										File:   "bare_agg_eval_test.flux",
+										Source: "fn: bare_count_fn",
+										Start: ast.Position{
+											Column: 83,
+											Line:   51,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 85,
+												Line:   51,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "fn",
+											Start: ast.Position{
+												Column: 83,
+												Line:   51,
+											},
+										},
+									},
+									Name: "fn",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 100,
+												Line:   51,
+											},
+											File:   "bare_agg_eval_test.flux",
+											Source: "bare_count_fn",
+											Start: ast.Position{
+												Column: 87,
+												Line:   51,
+											},
+										},
+									},
+									Name: "bare_count_fn",
+								},
+							}},
+							With: nil,
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 102,
+						Line:   51,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "test bare_count_evaluate = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+					Start: ast.Position{
+						Column: 1,
+						Line:   50,
+					},
+				},
+			},
+		}},
+		Imports: []*ast.ImportDeclaration{&ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   3,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "import \"testing\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   3,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   3,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "\"testing\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   3,
+						},
+					},
+				},
+				Value: "testing",
+			},
+		}, &ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   4,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "import \"planner\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   4,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   4,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "\"planner\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   4,
+						},
+					},
+				},
+				Value: "planner",
+			},
+		}},
+		Metadata: "parser-type=rust",
+		Name:     "bare_agg_eval_test.flux",
+		Package: &ast.PackageClause{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 21,
+						Line:   1,
+					},
+					File:   "bare_agg_eval_test.flux",
+					Source: "package planner_test",
+					Start: ast.Position{
+						Column: 1,
+						Line:   1,
+					},
+				},
+			},
+			Name: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 21,
+							Line:   1,
+						},
+						File:   "bare_agg_eval_test.flux",
+						Source: "planner_test",
+						Start: ast.Position{
+							Column: 9,
+							Line:   1,
+						},
+					},
+				},
+				Name: "planner_test",
+			},
+		},
+	}, &ast.File{
+		BaseNode: ast.BaseNode{
+			Errors: nil,
+			Loc: &ast.SourceLocation{
+				End: ast.Position{
+					Column: 102,
+					Line:   49,
+				},
+				File:   "bare_agg_push_test.flux",
+				Source: "package planner_test\n\nimport \"testing\"\n\noption now = () => (2030-01-01T00:00:00Z)\n\ninput = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\"\n\noutput = \"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n\"\n\nbare_count_fn = (tables=<-) => tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()\n\ntest bare_count_pushdown = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+				Start: ast.Position{
+					Column: 1,
+					Line:   1,
+				},
+			},
+		},
+		Body: []ast.Statement{&ast.OptionStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 42,
+							Line:   5,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "now = () => (2030-01-01T00:00:00Z)",
+						Start: ast.Position{
+							Column: 8,
+							Line:   5,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 11,
+								Line:   5,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "now",
+							Start: ast.Position{
+								Column: 8,
+								Line:   5,
+							},
+						},
+					},
+					Name: "now",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 42,
+								Line:   5,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "() => (2030-01-01T00:00:00Z)",
+							Start: ast.Position{
+								Column: 14,
+								Line:   5,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 42,
+									Line:   5,
+								},
+								File:   "bare_agg_push_test.flux",
+								Source: "(2030-01-01T00:00:00Z)",
+								Start: ast.Position{
+									Column: 20,
+									Line:   5,
+								},
+							},
+						},
+						Expression: &ast.DateTimeLiteral{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 41,
+										Line:   5,
+									},
+									File:   "bare_agg_push_test.flux",
+									Source: "2030-01-01T00:00:00Z",
+									Start: ast.Position{
+										Column: 21,
+										Line:   5,
+									},
+								},
+							},
+							Value: parser.MustParseTime("2030-01-01T00:00:00Z"),
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 42,
+						Line:   5,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "option now = () => (2030-01-01T00:00:00Z)",
+					Start: ast.Position{
+						Column: 1,
+						Line:   5,
+					},
+				},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   32,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "input = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   7,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 6,
+							Line:   7,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "input",
+						Start: ast.Position{
+							Column: 1,
+							Line:   7,
+						},
+					},
+				},
+				Name: "input",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   32,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n\"",
+						Start: ast.Position{
+							Column: 9,
+							Line:   7,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,host.local,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,host.local,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,host.local,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,host.local,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,host.local,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,host.local,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,host.local,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,host.local,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,host.local,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,host.local,load3,1.97\n\n,,2,2018-05-22T19:53:26Z,system,host.local,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,host.local,load5,1.91\n,,2,2018-05-22T19:53:46Z,system,host.local,load5,1.92\n,,2,2018-05-22T19:53:56Z,system,host.local,load5,1.89\n,,2,2018-05-22T19:54:16Z,system,host.local,load5,1.93\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   42,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "output = \"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   34,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 7,
+							Line:   34,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "output",
+						Start: ast.Position{
+							Column: 1,
+							Line:   34,
+						},
+					},
+				},
+				Name: "output",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   42,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n\"",
+						Start: ast.Position{
+							Column: 10,
+							Line:   34,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,long\n#group,false,false,true,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,_measurement,host,_field,_value\n,,0,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load1,6\n,,1,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load3,6\n,,2,2018-05-01T00:00:00Z,2030-01-01T00:00:00Z,system,host.local,load5,6\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 15,
+						Line:   46,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "bare_count_fn = (tables=<-) => tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()",
+					Start: ast.Position{
+						Column: 1,
+						Line:   44,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 14,
+							Line:   44,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "bare_count_fn",
+						Start: ast.Position{
+							Column: 1,
+							Line:   44,
+						},
+					},
+				},
+				Name: "bare_count_fn",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 15,
+							Line:   46,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "(tables=<-) => tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()",
+						Start: ast.Position{
+							Column: 17,
+							Line:   44,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 38,
+										Line:   44,
+									},
+									File:   "bare_agg_push_test.flux",
+									Source: "tables",
+									Start: ast.Position{
+										Column: 32,
+										Line:   44,
+									},
+								},
+							},
+							Name: "tables",
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 42,
+									Line:   45,
+								},
+								File:   "bare_agg_push_test.flux",
+								Source: "tables\n    |> range(start: 2018-05-01T00:00:00Z)",
+								Start: ast.Position{
+									Column: 32,
+									Line:   44,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: []ast.Expression{&ast.ObjectExpression{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 41,
+											Line:   45,
+										},
+										File:   "bare_agg_push_test.flux",
+										Source: "start: 2018-05-01T00:00:00Z",
+										Start: ast.Position{
+											Column: 14,
+											Line:   45,
+										},
+									},
+								},
+								Properties: []*ast.Property{&ast.Property{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 41,
+												Line:   45,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "start: 2018-05-01T00:00:00Z",
+											Start: ast.Position{
+												Column: 14,
+												Line:   45,
+											},
+										},
+									},
+									Key: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 19,
+													Line:   45,
+												},
+												File:   "bare_agg_push_test.flux",
+												Source: "start",
+												Start: ast.Position{
+													Column: 14,
+													Line:   45,
+												},
+											},
+										},
+										Name: "start",
+									},
+									Value: &ast.DateTimeLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 41,
+													Line:   45,
+												},
+												File:   "bare_agg_push_test.flux",
+												Source: "2018-05-01T00:00:00Z",
+												Start: ast.Position{
+													Column: 21,
+													Line:   45,
+												},
+											},
+										},
+										Value: parser.MustParseTime("2018-05-01T00:00:00Z"),
+									},
+								}},
+								With: nil,
+							}},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 42,
+										Line:   45,
+									},
+									File:   "bare_agg_push_test.flux",
+									Source: "range(start: 2018-05-01T00:00:00Z)",
+									Start: ast.Position{
+										Column: 8,
+										Line:   45,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 13,
+											Line:   45,
+										},
+										File:   "bare_agg_push_test.flux",
+										Source: "range",
+										Start: ast.Position{
+											Column: 8,
+											Line:   45,
+										},
+									},
+								},
+								Name: "range",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 15,
+								Line:   46,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "tables\n    |> range(start: 2018-05-01T00:00:00Z)\n    |> count()",
+							Start: ast.Position{
+								Column: 32,
+								Line:   44,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: nil,
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   46,
+								},
+								File:   "bare_agg_push_test.flux",
+								Source: "count()",
+								Start: ast.Position{
+									Column: 8,
+									Line:   46,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 13,
+										Line:   46,
+									},
+									File:   "bare_agg_push_test.flux",
+									Source: "count",
+									Start: ast.Position{
+										Column: 8,
+										Line:   46,
+									},
+								},
+							},
+							Name: "count",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 27,
+								Line:   44,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "tables=<-",
+							Start: ast.Position{
+								Column: 18,
+								Line:   44,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 24,
+									Line:   44,
+								},
+								File:   "bare_agg_push_test.flux",
+								Source: "tables",
+								Start: ast.Position{
+									Column: 18,
+									Line:   44,
+								},
+							},
+						},
+						Name: "tables",
+					},
+					Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 27,
+								Line:   44,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "<-",
+							Start: ast.Position{
+								Column: 25,
+								Line:   44,
+							},
+						},
+					}},
+				}},
+			},
+		}, &ast.TestStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 102,
+							Line:   49,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "bare_count_pushdown = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+						Start: ast.Position{
+							Column: 6,
+							Line:   48,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 25,
+								Line:   48,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "bare_count_pushdown",
+							Start: ast.Position{
+								Column: 6,
+								Line:   48,
+							},
+						},
+					},
+					Name: "bare_count_pushdown",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 102,
+								Line:   49,
+							},
+							File:   "bare_agg_push_test.flux",
+							Source: "() =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+							Start: ast.Position{
+								Column: 28,
+								Line:   48,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 102,
+									Line:   49,
+								},
+								File:   "bare_agg_push_test.flux",
+								Source: "({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+								Start: ast.Position{
+									Column: 5,
+									Line:   49,
+								},
+							},
+						},
+						Expression: &ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 101,
+										Line:   49,
+									},
+									File:   "bare_agg_push_test.flux",
+									Source: "{input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn}",
+									Start: ast.Position{
+										Column: 6,
+										Line:   49,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 45,
+											Line:   49,
+										},
+										File:   "bare_agg_push_test.flux",
+										Source: "input: testing.loadStorage(csv: input)",
+										Start: ast.Position{
+											Column: 7,
+											Line:   49,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 12,
+												Line:   49,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "input",
+											Start: ast.Position{
+												Column: 7,
+												Line:   49,
+											},
+										},
+									},
+									Name: "input",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 44,
+													Line:   49,
+												},
+												File:   "bare_agg_push_test.flux",
+												Source: "csv: input",
+												Start: ast.Position{
+													Column: 34,
+													Line:   49,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 44,
+														Line:   49,
+													},
+													File:   "bare_agg_push_test.flux",
+													Source: "csv: input",
+													Start: ast.Position{
+														Column: 34,
+														Line:   49,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 37,
+															Line:   49,
+														},
+														File:   "bare_agg_push_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 34,
+															Line:   49,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 44,
+															Line:   49,
+														},
+														File:   "bare_agg_push_test.flux",
+														Source: "input",
+														Start: ast.Position{
+															Column: 39,
+															Line:   49,
+														},
+													},
+												},
+												Name: "input",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 45,
+												Line:   49,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "testing.loadStorage(csv: input)",
+											Start: ast.Position{
+												Column: 14,
+												Line:   49,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   49,
+												},
+												File:   "bare_agg_push_test.flux",
+												Source: "testing.loadStorage",
+												Start: ast.Position{
+													Column: 14,
+													Line:   49,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 21,
+														Line:   49,
+													},
+													File:   "bare_agg_push_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 14,
+														Line:   49,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 33,
+														Line:   49,
+													},
+													File:   "bare_agg_push_test.flux",
+													Source: "loadStorage",
+													Start: ast.Position{
+														Column: 22,
+														Line:   49,
+													},
+												},
+											},
+											Name: "loadStorage",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 81,
+											Line:   49,
+										},
+										File:   "bare_agg_push_test.flux",
+										Source: "want: testing.loadMem(csv: output)",
+										Start: ast.Position{
+											Column: 47,
+											Line:   49,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 51,
+												Line:   49,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "want",
+											Start: ast.Position{
+												Column: 47,
+												Line:   49,
+											},
+										},
+									},
+									Name: "want",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 80,
+													Line:   49,
+												},
+												File:   "bare_agg_push_test.flux",
+												Source: "csv: output",
+												Start: ast.Position{
+													Column: 69,
+													Line:   49,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 80,
+														Line:   49,
+													},
+													File:   "bare_agg_push_test.flux",
+													Source: "csv: output",
+													Start: ast.Position{
+														Column: 69,
+														Line:   49,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 72,
+															Line:   49,
+														},
+														File:   "bare_agg_push_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 69,
+															Line:   49,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 80,
+															Line:   49,
+														},
+														File:   "bare_agg_push_test.flux",
+														Source: "output",
+														Start: ast.Position{
+															Column: 74,
+															Line:   49,
+														},
+													},
+												},
+												Name: "output",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 81,
+												Line:   49,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "testing.loadMem(csv: output)",
+											Start: ast.Position{
+												Column: 53,
+												Line:   49,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 68,
+													Line:   49,
+												},
+												File:   "bare_agg_push_test.flux",
+												Source: "testing.loadMem",
+												Start: ast.Position{
+													Column: 53,
+													Line:   49,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 60,
+														Line:   49,
+													},
+													File:   "bare_agg_push_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 53,
+														Line:   49,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 68,
+														Line:   49,
+													},
+													File:   "bare_agg_push_test.flux",
+													Source: "loadMem",
+													Start: ast.Position{
+														Column: 61,
+														Line:   49,
+													},
+												},
+											},
+											Name: "loadMem",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 100,
+											Line:   49,
+										},
+										File:   "bare_agg_push_test.flux",
+										Source: "fn: bare_count_fn",
+										Start: ast.Position{
+											Column: 83,
+											Line:   49,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 85,
+												Line:   49,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "fn",
+											Start: ast.Position{
+												Column: 83,
+												Line:   49,
+											},
+										},
+									},
+									Name: "fn",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 100,
+												Line:   49,
+											},
+											File:   "bare_agg_push_test.flux",
+											Source: "bare_count_fn",
+											Start: ast.Position{
+												Column: 87,
+												Line:   49,
+											},
+										},
+									},
+									Name: "bare_count_fn",
+								},
+							}},
+							With: nil,
+						},
+					},
+					Params: nil,
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 102,
+						Line:   49,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "test bare_count_pushdown = () =>\n    ({input: testing.loadStorage(csv: input), want: testing.loadMem(csv: output), fn: bare_count_fn})",
+					Start: ast.Position{
+						Column: 1,
+						Line:   48,
+					},
+				},
+			},
+		}},
+		Imports: []*ast.ImportDeclaration{&ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   3,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "import \"testing\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   3,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   3,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "\"testing\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   3,
+						},
+					},
+				},
+				Value: "testing",
+			},
+		}},
+		Metadata: "parser-type=rust",
+		Name:     "bare_agg_push_test.flux",
+		Package: &ast.PackageClause{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 21,
+						Line:   1,
+					},
+					File:   "bare_agg_push_test.flux",
+					Source: "package planner_test",
+					Start: ast.Position{
+						Column: 1,
+						Line:   1,
+					},
+				},
+			},
+			Name: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 21,
+							Line:   1,
+						},
+						File:   "bare_agg_push_test.flux",
+						Source: "planner_test",
+						Start: ast.Position{
+							Column: 9,
+							Line:   1,
+						},
+					},
+				},
+				Name: "planner_test",
+			},
+		},
+	}, &ast.File{
+		BaseNode: ast.BaseNode{
+			Errors: nil,
+			Loc: &ast.SourceLocation{
+				End: ast.Position{
 					Column: 4,
 					Line:   58,
 				},


### PR DESCRIPTION
This adds a Flux end-to-end test that ensures that the rule for pushing down bare aggregates gets the right answer.

Related to https://github.com/influxdata/influxdb/issues/17994