### PR TITLE
fix(values): fix bug in object equal method

### DIFF
--- a/values/object.go
+++ b/values/object.go
@@ -255,7 +255,7 @@ func (o *object) Equal(rhs Value) bool {
 	}
 	for i, l := range o.labels {
 		val, ok := r.Get(l)
-		if ok && !o.values[i].Equal(val) {
+		if !ok || !o.values[i].Equal(val) {
 			return false
 		}
 	}

--- a/values/object_test.go
+++ b/values/object_test.go
@@ -41,6 +41,19 @@ func TestObjectEqual(t *testing.T) {
 	}
 }
 
+func TestObjectEqualMismatchedKeys(t *testing.T) {
+	r := values.NewObjectWithValues(map[string]values.Value{
+		"a": values.NewInt(1),
+	})
+	l := values.NewObjectWithValues(map[string]values.Value{
+		"b": values.NewInt(1),
+	})
+
+	if l.Equal(r) {
+		t.Fatal("expected objects to be unequal")
+	}
+}
+
 func TestBuildObject(t *testing.T) {
 	object, err := values.BuildObject(func(set values.ObjectSetter) error {
 		set("b", values.NewInt(2))


### PR DESCRIPTION
The previous implementation ignored differences in the field names of objects


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
