### PR TITLE
fix(libflux/src): reenable clippy linter rule match single binding

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -321,18 +321,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
 dependencies = [
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn",
 ]
 
 [[package]]
 name = "derivative"
-version = "1.0.4"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6d883546668a3e2011b6a716a7330b82eabb0151b138217f632c8243e17135"
+checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn",
 ]
 
 [[package]]
@@ -798,17 +798,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
 
 [[package]]
 name = "syn"
@@ -933,7 +922,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -955,7 +944,7 @@ checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
- "syn 1.0.17",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/libflux/src/core/Cargo.toml
+++ b/libflux/src/core/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 maplit = "1.0.2"
 flatbuffers = "0.6.1"
-derivative = "1.0.3"
+derivative = "2.1.1"
 walkdir = "2.2.9"
 
 [dev-dependencies]

--- a/libflux/src/core/ast/mod.rs
+++ b/libflux/src/core/ast/mod.rs
@@ -10,7 +10,6 @@ use std::fmt;
 use std::str::FromStr;
 use std::vec::Vec;
 
-use chrono;
 use chrono::FixedOffset;
 
 use serde::de::{Deserialize, Deserializer, Error, Visitor};

--- a/libflux/src/core/lib.rs
+++ b/libflux/src/core/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
-#![allow(clippy::unknown_clippy_lints)]
+
 //! The flux crate handles the parsing and semantic analysis of flux source
 //! code.
 extern crate chrono;

--- a/libflux/src/core/semantic/flatbuffers/types.rs
+++ b/libflux/src/core/semantic/flatbuffers/types.rs
@@ -4,8 +4,6 @@
 use crate::semantic::env::Environment;
 use crate::semantic::flatbuffers::semantic_generated::fbsemantic as fb;
 
-use flatbuffers;
-
 use crate::semantic::fresh::Fresher;
 
 #[rustfmt::skip]

--- a/libflux/src/flux/build.rs
+++ b/libflux/src/flux/build.rs
@@ -5,8 +5,6 @@ use core::semantic::env::Environment;
 use core::semantic::flatbuffers::types as fb;
 use core::semantic::sub::Substitutable;
 
-use flatbuffers;
-
 #[derive(Debug)]
 struct Error {
     msg: String,

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -10,7 +10,6 @@ use core::semantic::flatbuffers::types::build_env;
 use core::semantic::fresh::Fresher;
 use core::semantic::nodes::{infer_pkg_types, inject_pkg_types};
 use core::semantic::Importer;
-use flatbuffers;
 
 pub use core::ast;
 pub use core::formatter;


### PR DESCRIPTION
Just needed an update of the `derivative` crate. Also removed a few redundant imports as required by clippy. 

Undoes this blanket `allow`: https://github.com/influxdata/flux/pull/2868/files#diff-206e3b6ebbc29523ed43fdcacc3d52e7

Closes #2870. 