### PR TITLE
fix: reorder go generate call to libflux in stdlib

### DIFF
--- a/stdlib/gen.go
+++ b/stdlib/gen.go
@@ -1,4 +1,4 @@
 package stdlib
 
-//go:generate go run github.com/influxdata/flux/internal/cmd/builtin generate --go-pkg github.com/influxdata/flux/stdlib --import-file packages.go
 //go:generate go generate ../libflux/go/libflux
+//go:generate go run github.com/influxdata/flux/internal/cmd/builtin generate --go-pkg github.com/influxdata/flux/stdlib --import-file packages.go


### PR DESCRIPTION
The `go generate` call compiles and runs a program that uses libflux so
this switches the go generate call that forces libflux to rebuild to be
before the call to generating the builtins. Without this, the
`go generate ./stdlib` will sometimes fail because it will be using an
old version of the rust library and embedded stdlib instead of the new
one so it can't parse the files and generate the builtins. Since
generating the builtins fails, the `go generate` command never touches
the libflux package and never triggers a rebuild. This sticks you in a
circular loop of running `go generate ./stdlib` and it will never fix
itself without knowing ahead of time that you have to call `go generate
./libflux/go/libflux` first which defeats the purpose of adding that
generate call to `stdlib` anyway.



### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written