### PR TITLE
chore: update .gitignore file flux binary pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,8 @@ target
 /libflux/.cache
 /libflux/go/libflux/hack.gen.go
 /release-notes.txt
-/flux
+
+# exclude any files with the name flux but
+# include any directories that share the same name.
+**/flux
+!**/flux/


### PR DESCRIPTION
Updating the flux binary pattern to model it off of this similar commit:
https://github.com/influxdata/influxdb/commit/bdf35172493177edbbeb643415c53469ef46e91c

This change allows us to have a directory named `flux` inside of the
structure while preventing an accidental commit of a `flux` file (the
binary) anywhere in the directory tree.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written