### PR TITLE
fix(execute): check stream equality

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -288,7 +288,7 @@ func (sfe *serializedFluxError) Error() string {
 }
 
 // readMetadata reads the table annotations and header.
-// If there is no more data, returns (tablMetadata{}, io.EOF).
+// If there is no more data, returns (tableMetadata{}, io.EOF).
 // In case of an actual error:
 //   - if it's error that was serialized to CSV, it will be wrapped in serializedFluxError.
 //   - otherwise, it's a serialization error, it will be returned as-is.

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -30,198 +30,21 @@ type TestCase struct {
 	encoderConfig csv.ResultEncoderConfig
 }
 
-var symmetricalTestCases = []TestCase{
-	{
-		name:          "single table",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+func TestResultDecoder(t *testing.T) {
+	testCases := []TestCase{
+		{
+			name:          "single table",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #group,false,false,true,true,false,true,true,false
 #default,_result,,,,,,,
 ,result,table,_start,_stop,_time,_measurement,host,_value
 ,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
 ,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
 `),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{{
-				KeyCols: []string{"_start", "_stop", "_measurement", "host"},
-				ColMeta: []flux.ColMeta{
-					{Label: "_start", Type: flux.TTime},
-					{Label: "_stop", Type: flux.TTime},
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_measurement", Type: flux.TString},
-					{Label: "host", Type: flux.TString},
-					{Label: "_value", Type: flux.TFloat},
-				},
-				Data: [][]interface{}{
-					{
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						"cpu",
-						"A",
-						42.0,
-					},
-					{
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
-						"cpu",
-						"A",
-						43.0,
-					},
-				},
-			}},
-		},
-	},
-	{
-		name:          "single table with null",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
-#group,false,false,true,true,false,true,true,false
-#default,_result,,,,,,,
-,result,table,_start,_stop,_time,_measurement,host,_value
-,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
-,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,
-`),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{{
-				KeyCols: []string{"_start", "_stop", "_measurement", "host"},
-				ColMeta: []flux.ColMeta{
-					{Label: "_start", Type: flux.TTime},
-					{Label: "_stop", Type: flux.TTime},
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_measurement", Type: flux.TString},
-					{Label: "host", Type: flux.TString},
-					{Label: "_value", Type: flux.TFloat},
-				},
-				Data: [][]interface{}{
-					{
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						"cpu",
-						"A",
-						42.0,
-					},
-					{
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
-						"cpu",
-						"A",
-						nil,
-					},
-				},
-			}},
-		},
-	},
-	{
-		name:          "single table with null in group key column",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
-#group,false,false,true,true,false,true,true,false
-#default,_result,,,,,,,
-,result,table,_start,_stop,_time,_measurement,host,_value
-,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,,42
-,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,,43
-`),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{{
-				KeyCols: []string{"_start", "_stop", "_measurement", "host"},
-				ColMeta: []flux.ColMeta{
-					{Label: "_start", Type: flux.TTime},
-					{Label: "_stop", Type: flux.TTime},
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_measurement", Type: flux.TString},
-					{Label: "host", Type: flux.TString},
-					{Label: "_value", Type: flux.TFloat},
-				},
-				Data: [][]interface{}{
-					{
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						"cpu",
-						nil,
-						42.0,
-					},
-					{
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
-						"cpu",
-						nil,
-						43.0,
-					},
-				},
-			}},
-		},
-	},
-	{
-		name:          "single empty table",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
-#group,false,false,true,true,false,true,true,false
-#default,_result,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
-,result,table,_start,_stop,_time,_measurement,host,_value
-`),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{{
-				KeyCols: []string{"_start", "_stop", "_measurement", "host"},
-				KeyValues: []interface{}{
-					values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-					values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-					"cpu",
-					"A",
-				},
-				ColMeta: []flux.ColMeta{
-					{Label: "_start", Type: flux.TTime},
-					{Label: "_stop", Type: flux.TTime},
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_measurement", Type: flux.TString},
-					{Label: "host", Type: flux.TString},
-					{Label: "_value", Type: flux.TFloat},
-				},
-			}},
-		},
-	},
-	{
-		name:          "single empty table with no columns",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long
-#group,false,false
-#default,_result,0
-,result,table
-`),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{{
-				KeyCols:   []string(nil),
-				KeyValues: []interface{}(nil),
-				ColMeta:   []flux.ColMeta(nil),
-			}},
-		},
-	},
-	{
-		name:          "multiple tables",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
-#group,false,false,true,true,false,true,true,false
-#default,_result,,,,,,,
-,result,table,_start,_stop,_time,_measurement,host,_value
-,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
-,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
-,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,mem,A,52
-,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,mem,A,53
-`),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{
-				{
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
 					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
 					ColMeta: []flux.ColMeta{
 						{Label: "_start", Type: flux.TTime},
@@ -249,8 +72,22 @@ var symmetricalTestCases = []TestCase{
 							43.0,
 						},
 					},
-				},
-				{
+				}},
+			},
+		},
+		{
+			name:          "single table with null",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
 					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
 					ColMeta: []flux.ColMeta{
 						{Label: "_start", Type: flux.TTime},
@@ -262,30 +99,194 @@ var symmetricalTestCases = []TestCase{
 					},
 					Data: [][]interface{}{
 						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
 							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
-							"mem",
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							"cpu",
 							"A",
-							52.0,
+							42.0,
 						},
 						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
 							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
-							"mem",
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+							"cpu",
 							"A",
-							53.0,
+							nil,
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:          "single table with null in group key column",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,,43
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							"cpu",
+							nil,
+							42.0,
+						},
+						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+							"cpu",
+							nil,
+							43.0,
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:          "single empty table",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+,result,table,_start,_stop,_time,_measurement,host,_value
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					KeyValues: []interface{}{
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+						values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+						"cpu",
+						"A",
+					},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+				}},
+			},
+		},
+		{
+			name:          "single empty table with no columns",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long
+#group,false,false
+#default,_result,0
+,result,table
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols:   []string(nil),
+					KeyValues: []interface{}(nil),
+					ColMeta:   []flux.ColMeta(nil),
+				}},
+			},
+		},
+		{
+			name:          "multiple tables",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,mem,A,52
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,mem,A,53
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"cpu",
+								"A",
+								42.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"cpu",
+								"A",
+								43.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"mem",
+								"A",
+								52.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"mem",
+								"A",
+								53.0,
+							},
 						},
 					},
 				},
 			},
 		},
-	},
-	{
-		name:          "multiple tables with differing schemas",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+		{
+			name:          "multiple tables with differing schemas",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #group,false,false,true,true,false,true,true,false
 #default,_result,,,,,,,
 ,result,table,_start,_stop,_time,_measurement,host,_value
@@ -303,138 +304,138 @@ var symmetricalTestCases = []TestCase{
 ,,3,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,Europe,4623,52,89.3
 ,,3,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,Europe,3163,53,55.6
 `),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{
-				{
-					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
-					ColMeta: []flux.ColMeta{
-						{Label: "_start", Type: flux.TTime},
-						{Label: "_stop", Type: flux.TTime},
-						{Label: "_time", Type: flux.TTime},
-						{Label: "_measurement", Type: flux.TString},
-						{Label: "host", Type: flux.TString},
-						{Label: "_value", Type: flux.TFloat},
-					},
-					Data: [][]interface{}{
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-							"cpu",
-							"A",
-							42.0,
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
 						},
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
-							"cpu",
-							"A",
-							43.0,
-						},
-					},
-				},
-				{
-					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
-					ColMeta: []flux.ColMeta{
-						{Label: "_start", Type: flux.TTime},
-						{Label: "_stop", Type: flux.TTime},
-						{Label: "_time", Type: flux.TTime},
-						{Label: "_measurement", Type: flux.TString},
-						{Label: "host", Type: flux.TString},
-						{Label: "_value", Type: flux.TFloat},
-					},
-					Data: [][]interface{}{
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
-							"mem",
-							"A",
-							52.0,
-						},
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
-							"mem",
-							"A",
-							53.0,
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"cpu",
+								"A",
+								42.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"cpu",
+								"A",
+								43.0,
+							},
 						},
 					},
-				},
-				{
-					KeyCols: []string{"_start", "_stop", "location"},
-					ColMeta: []flux.ColMeta{
-						{Label: "_start", Type: flux.TTime},
-						{Label: "_stop", Type: flux.TTime},
-						{Label: "_time", Type: flux.TTime},
-						{Label: "location", Type: flux.TString},
-						{Label: "device", Type: flux.TString},
-						{Label: "min", Type: flux.TFloat},
-						{Label: "max", Type: flux.TFloat},
-					},
-					Data: [][]interface{}{
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-							"USA",
-							"1563",
-							42.0,
-							67.9,
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
 						},
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
-							"USA",
-							"1414",
-							43.0,
-							44.7,
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"mem",
+								"A",
+								52.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"mem",
+								"A",
+								53.0,
+							},
 						},
 					},
-				},
-				{
-					KeyCols: []string{"_start", "_stop", "location"},
-					ColMeta: []flux.ColMeta{
-						{Label: "_start", Type: flux.TTime},
-						{Label: "_stop", Type: flux.TTime},
-						{Label: "_time", Type: flux.TTime},
-						{Label: "location", Type: flux.TString},
-						{Label: "device", Type: flux.TString},
-						{Label: "min", Type: flux.TFloat},
-						{Label: "max", Type: flux.TFloat},
-					},
-					Data: [][]interface{}{
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
-							"Europe",
-							"4623",
-							52.0,
-							89.3,
+					{
+						KeyCols: []string{"_start", "_stop", "location"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "location", Type: flux.TString},
+							{Label: "device", Type: flux.TString},
+							{Label: "min", Type: flux.TFloat},
+							{Label: "max", Type: flux.TFloat},
 						},
-						{
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
-							"Europe",
-							"3163",
-							53.0,
-							55.6,
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"USA",
+								"1563",
+								42.0,
+								67.9,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"USA",
+								"1414",
+								43.0,
+								44.7,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "location"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "location", Type: flux.TString},
+							{Label: "device", Type: flux.TString},
+							{Label: "min", Type: flux.TFloat},
+							{Label: "max", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"Europe",
+								"4623",
+								52.0,
+								89.3,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"Europe",
+								"3163",
+								53.0,
+								55.6,
+							},
 						},
 					},
 				},
 			},
 		},
-	},
-	{
-		name:          "multiple tables with one empty",
-		encoderConfig: csv.DefaultEncoderConfig(),
-		encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+		{
+			name:          "multiple tables with one empty",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #group,false,false,true,true,false,true,true,false
 #default,_result,,,,,,,
 ,result,table,_start,_stop,_time,_measurement,host,_value
@@ -448,10 +449,100 @@ var symmetricalTestCases = []TestCase{
 #default,_result,2,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
 ,result,table,_start,_stop,_time,_measurement,host,_value
 `),
-		result: &executetest.Result{
-			Nm: "_result",
-			Tbls: []*executetest.Table{
-				{
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"cpu",
+								"A",
+								42.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"cpu",
+								"A",
+								43.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"mem",
+								"A",
+								52.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"mem",
+								"A",
+								53.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						KeyValues: []interface{}{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							"cpu",
+							"A",
+						},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "single table",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
 					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
 					ColMeta: []flux.ColMeta{
 						{Label: "_start", Type: flux.TTime},
@@ -479,8 +570,22 @@ var symmetricalTestCases = []TestCase{
 							43.0,
 						},
 					},
-				},
-				{
+				}},
+			},
+		},
+		{
+			name:          "single table with null",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
 					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
 					ColMeta: []flux.ColMeta{
 						{Label: "_start", Type: flux.TTime},
@@ -492,24 +597,79 @@ var symmetricalTestCases = []TestCase{
 					},
 					Data: [][]interface{}{
 						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
 							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
-							"mem",
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							"cpu",
 							"A",
-							52.0,
+							42.0,
 						},
 						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
 							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
-							values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
-							"mem",
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+							"cpu",
 							"A",
-							53.0,
+							nil,
 						},
 					},
-				},
-				{
+				}},
+			},
+		},
+		{
+			name:          "single table with null in group key column",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,,43
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_start", Type: flux.TTime},
+						{Label: "_stop", Type: flux.TTime},
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_measurement", Type: flux.TString},
+						{Label: "host", Type: flux.TString},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					Data: [][]interface{}{
+						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							"cpu",
+							nil,
+							42.0,
+						},
+						{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+							"cpu",
+							nil,
+							43.0,
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:          "single empty table",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+,result,table,_start,_stop,_time,_measurement,host,_value
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
 					KeyCols: []string{"_start", "_stop", "_measurement", "host"},
 					KeyValues: []interface{}{
 						values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
@@ -525,14 +685,349 @@ var symmetricalTestCases = []TestCase{
 						{Label: "host", Type: flux.TString},
 						{Label: "_value", Type: flux.TFloat},
 					},
+				}},
+			},
+		},
+		{
+			name:          "single empty table with no columns",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long
+#group,false,false
+#default,_result,0
+,result,table
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{{
+					KeyCols:   []string(nil),
+					KeyValues: []interface{}(nil),
+					ColMeta:   []flux.ColMeta(nil),
+				}},
+			},
+		},
+		{
+			name:          "multiple tables",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,mem,A,52
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,mem,A,53
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"cpu",
+								"A",
+								42.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"cpu",
+								"A",
+								43.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"mem",
+								"A",
+								52.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"mem",
+								"A",
+								53.0,
+							},
+						},
+					},
 				},
 			},
 		},
-	},
-}
+		{
+			name:          "multiple tables with differing schemas",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,mem,A,52
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,mem,A,53
 
-func TestResultDecoder(t *testing.T) {
-	testCases := []TestCase{
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double
+#group,false,false,true,true,false,true,false,false,false
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,location,device,min,max
+,,2,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,USA,1563,42,67.9
+,,2,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,USA,1414,43,44.7
+,,3,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,Europe,4623,52,89.3
+,,3,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,Europe,3163,53,55.6
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"cpu",
+								"A",
+								42.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"cpu",
+								"A",
+								43.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"mem",
+								"A",
+								52.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"mem",
+								"A",
+								53.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "location"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "location", Type: flux.TString},
+							{Label: "device", Type: flux.TString},
+							{Label: "min", Type: flux.TFloat},
+							{Label: "max", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"USA",
+								"1563",
+								42.0,
+								67.9,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"USA",
+								"1414",
+								43.0,
+								44.7,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "location"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "location", Type: flux.TString},
+							{Label: "device", Type: flux.TString},
+							{Label: "min", Type: flux.TFloat},
+							{Label: "max", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"Europe",
+								"4623",
+								52.0,
+								89.3,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"Europe",
+								"3163",
+								53.0,
+								55.6,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "multiple tables with one empty",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_measurement,host,_value
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:00Z,cpu,A,42
+,,0,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,2018-04-17T00:00:01Z,cpu,A,43
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:06:00Z,mem,A,52
+,,1,2018-04-17T00:05:00Z,2018-04-17T00:10:00Z,2018-04-17T00:07:01Z,mem,A,53
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,2,2018-04-17T00:00:00Z,2018-04-17T00:05:00Z,,cpu,A,
+,result,table,_start,_stop,_time,_measurement,host,_value
+`),
+			result: &executetest.Result{
+				Nm: "_result",
+				Tbls: []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								"cpu",
+								"A",
+								42.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 1, 0, time.UTC)),
+								"cpu",
+								"A",
+								43.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+						Data: [][]interface{}{
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 6, 0, 0, time.UTC)),
+								"mem",
+								"A",
+								52.0,
+							},
+							{
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 10, 0, 0, time.UTC)),
+								values.ConvertTime(time.Date(2018, 4, 17, 0, 7, 1, 0, time.UTC)),
+								"mem",
+								"A",
+								53.0,
+							},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop", "_measurement", "host"},
+						KeyValues: []interface{}{
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 0, 0, 0, time.UTC)),
+							values.ConvertTime(time.Date(2018, 4, 17, 0, 5, 0, 0, time.UTC)),
+							"cpu",
+							"A",
+						},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_measurement", Type: flux.TString},
+							{Label: "host", Type: flux.TString},
+							{Label: "_value", Type: flux.TFloat},
+						},
+					},
+				},
+			},
+		},
 		{
 			name:          "single table with defaults",
 			encoderConfig: csv.DefaultEncoderConfig(),
@@ -746,7 +1241,6 @@ func TestResultDecoder(t *testing.T) {
 			},
 		},
 	}
-	testCases = append(testCases, symmetricalTestCases...)
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -799,7 +1293,6 @@ func TestResultDecoder(t *testing.T) {
 
 func TestResultEncoder(t *testing.T) {
 	testCases := []TestCase{
-		// Add tests cases specific to encoding here
 		{
 			name:          "no annotations",
 			encoderConfig: csv.ResultEncoderConfig{},
@@ -924,7 +1417,6 @@ func TestResultEncoder(t *testing.T) {
 			err: errors.New("test error"),
 		},
 	}
-	testCases = append(testCases, symmetricalTestCases...)
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/execute/executetest/result.go
+++ b/execute/executetest/result.go
@@ -67,7 +67,7 @@ func (ti *TableIterator) Do(f func(flux.Table) error) error {
 	return nil
 }
 
-// EqualResults compares two lists of Flux Results for equlity
+// EqualResults compares two lists of Flux Results for equality
 func EqualResults(want, got []flux.Result) error {
 	if len(want) != len(got) {
 		return fmt.Errorf("unexpected number of results - want %d results, got %d results", len(want), len(got))
@@ -81,7 +81,7 @@ func EqualResults(want, got []flux.Result) error {
 	return nil
 }
 
-// EqualResultIterators compares two ResultIterators for equlity
+// EqualResultIterators compares two ResultIterators for equality
 func EqualResultIterators(want, got flux.ResultIterator) error {
 	for {
 		if w, g := want.More(), got.More(); w != g {

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -3,6 +3,7 @@ package executetest
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -475,11 +476,59 @@ func (b SortedTables) Swap(i int, j int) {
 	b[i], b[j] = b[j], b[i]
 }
 
-// NormalizeTables ensures that each table is normalized
+// NormalizeTables ensures that each table is normalized and that tables and columns are sorted in
+// alphabetical order for consistent testing
 func NormalizeTables(bs []*Table) {
 	for _, b := range bs {
 		b.Key()
 	}
+	sortByGroupKey(bs)
+}
+
+func sortByGroupKey(tables []*Table) {
+	sort.Sort(SortedTables(tables))
+	for _, table := range tables {
+		sortColumns(table)
+	}
+}
+
+func sortColumns(table *Table) {
+	// index reference to make sure that sort is consistent for metadata and data
+	indexes := createReferenceArray(table)
+
+	// the copy function doesn't work well with flux.ColMeta. Doing a manual copy here instead
+	columnsCopy := make([]flux.ColMeta, len(table.ColMeta))
+	for i, value := range indexes {
+		columnsCopy[i] = table.ColMeta[value]
+	}
+	table.ColMeta = columnsCopy
+
+	// don't create a new table.Data if there is no Data
+	if len(table.Data) == 0 {
+		return
+	}
+	valuesCopy := make([][]interface{}, len(table.Data))
+	for j, row := range table.Data {
+		if len(row) > 0 {
+			rowCopy := make([]interface{}, len(row))
+			for i, value := range indexes {
+				rowCopy[i] = row[value]
+			}
+			valuesCopy[j] = rowCopy
+		}
+	}
+	table.Data = valuesCopy
+}
+
+func createReferenceArray(table *Table) []int {
+	indexes := make([]int, len(table.ColMeta))
+	for i := range indexes {
+		indexes[i] = i
+	}
+	sort.Slice(indexes, func(i, j int) bool {
+		return table.ColMeta[indexes[i]].Label < table.ColMeta[indexes[j]].Label
+	})
+	return indexes
 }
 
 func MustCopyTable(tbl flux.Table) flux.Table {

--- a/execute/executetest/table_test.go
+++ b/execute/executetest/table_test.go
@@ -2,8 +2,10 @@ package executetest
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
@@ -72,4 +74,199 @@ func TestTable(t *testing.T) {
 			return tbl.Empty() || tbl.(*Table).IsDone
 		},
 	})
+}
+
+func TestNormalizeTables(t *testing.T) {
+	got := []*Table{
+		{
+			ColMeta: []flux.ColMeta{
+				{
+					Label: "otherMeasurement",
+					Type:  flux.TString,
+				},
+				{
+					Label: "aaaaaafieldtest",
+					Type:  flux.TString,
+				},
+				{
+					Label: "aaaaaameasurement",
+					Type:  flux.TString,
+				},
+				{
+					Label: "anothertest",
+					Type:  flux.TString,
+				},
+				{
+					Label: execute.DefaultTimeColLabel,
+					Type:  flux.TTime,
+				},
+				{
+					Label: execute.DefaultValueColLabel,
+					Type:  flux.TFloat,
+				},
+			},
+			KeyCols: []string{"aaaaaameasurement", "aaaaaafieldtest", "anothertest"},
+			Data: [][]interface{}{
+				{"12", "f0", "m0", "test", execute.Time(0), 2.0},
+				{"13", "f0", "m0", "test", execute.Time(10), 2.5},
+				{"11", "f0", "m0", "test", execute.Time(20), 3.0},
+				{"4", "f0", "m0", "test", execute.Time(30), 3.5},
+			},
+		},
+		{
+			ColMeta: []flux.ColMeta{
+				{
+					Label: "atestcolumn",
+					Type:  flux.TString,
+				},
+				{
+					Label: "anothertest",
+					Type:  flux.TString,
+				},
+				{
+					Label: execute.DefaultTimeColLabel,
+					Type:  flux.TTime,
+				},
+				{
+					Label: execute.DefaultValueColLabel,
+					Type:  flux.TFloat,
+				},
+			},
+			KeyCols:   []string{"atestcolumn", "anothertest"},
+			KeyValues: []interface{}{"f0", "m0"},
+		},
+	}
+
+	want := []*Table{
+		{
+			ColMeta: []flux.ColMeta{
+				{
+					Label: execute.DefaultTimeColLabel,
+					Type:  flux.TTime,
+				},
+				{
+					Label: execute.DefaultValueColLabel,
+					Type:  flux.TFloat,
+				},
+				{
+					Label: "anothertest",
+					Type:  flux.TString,
+				},
+				{
+					Label: "atestcolumn",
+					Type:  flux.TString,
+				},
+			},
+			KeyCols:   []string{"atestcolumn", "anothertest"},
+			KeyValues: []interface{}{"f0", "m0"},
+		},
+		{
+			ColMeta: []flux.ColMeta{
+				{
+					Label: execute.DefaultTimeColLabel,
+					Type:  flux.TTime,
+				},
+				{
+					Label: execute.DefaultValueColLabel,
+					Type:  flux.TFloat,
+				},
+				{
+					Label: "aaaaaafieldtest",
+					Type:  flux.TString,
+				},
+				{
+					Label: "aaaaaameasurement",
+					Type:  flux.TString,
+				},
+				{
+					Label: "anothertest",
+					Type:  flux.TString,
+				},
+				{
+					Label: "otherMeasurement",
+					Type:  flux.TString,
+				},
+			},
+			KeyCols: []string{"aaaaaameasurement", "aaaaaafieldtest", "anothertest"},
+			Data: [][]interface{}{
+				{execute.Time(0), 2.0, "f0", "m0", "test", "12"},
+				{execute.Time(10), 2.5, "f0", "m0", "test", "13"},
+				{execute.Time(20), 3.0, "f0", "m0", "test", "11"},
+				{execute.Time(30), 3.5, "f0", "m0", "test", "4"},
+			},
+		},
+	}
+	sortByGroupKey(got)
+	for i, gotTable := range got {
+		if want[i].Key().String() != gotTable.Key().String() {
+			t.Fatalf("tables were not in expected order: %v", cmp.Diff(want[i].Key().String(), gotTable.Key().String()))
+		}
+	}
+
+	for i, gotTable := range got {
+		if !reflect.DeepEqual(want[i].ColMeta, gotTable.ColMeta) {
+			t.Fatalf("column metadata was not in expected order: %v", cmp.Diff(want[i].ColMeta, gotTable.ColMeta))
+		}
+		if !reflect.DeepEqual(want[i].Data, gotTable.Data) {
+			t.Fatalf("column data was not in expected order: %v", cmp.Diff(want[i].Data, gotTable.Data))
+		}
+	}
+}
+
+func TestSortColumns(t *testing.T) {
+	got := Table{
+		ColMeta: []flux.ColMeta{
+			{
+				Label: "zeeBestColumn",
+				Type:  flux.TString,
+			},
+			{
+				Label: "testColumn",
+				Type:  flux.TString,
+			},
+			{
+				Label: "aTestColumn",
+				Type:  flux.TString,
+			},
+			{
+				Label: execute.DefaultTimeColLabel,
+				Type:  flux.TTime,
+			},
+			{
+				Label: execute.DefaultValueColLabel,
+				Type:  flux.TFloat,
+			},
+		},
+		KeyCols:   []string{"aTestColumn", "zeeBestColumn"},
+		KeyValues: []interface{}{"m0", "f0"},
+	}
+
+	want := []flux.ColMeta{
+		{
+			Label: execute.DefaultTimeColLabel,
+			Type:  flux.TTime,
+		},
+		{
+			Label: execute.DefaultValueColLabel,
+			Type:  flux.TFloat,
+		},
+		{
+			Label: "aTestColumn",
+			Type:  flux.TString,
+		},
+		{
+			Label: "testColumn",
+			Type:  flux.TString,
+		},
+		{
+			Label: "zeeBestColumn",
+			Type:  flux.TString,
+		},
+	}
+	sortColumns(&got)
+	for i, val := range got.ColMeta {
+		if want[i].Label != val.Label {
+			t.Fatalf("columns were not sorted correctly: %v", cmp.Diff(want, got.ColMeta))
+		}
+	}
 }

--- a/influxql/decoder_test.go
+++ b/influxql/decoder_test.go
@@ -82,6 +82,10 @@ func TestDecoder(t *testing.T) {
 		got = append(got, res)
 	}
 
+	for i := range got {
+		got[i].Normalize()
+	}
+
 	if !cmp.Equal(exp, got) {
 		t.Fatalf("unexpected result -want/+got:\n%s", cmp.Diff(exp, got))
 	}

--- a/stdlib/experimental/prometheus/prometheus_test.go
+++ b/stdlib/experimental/prometheus/prometheus_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/influxdata/flux/values"
 )
 
-// TestGague will make sure that gague metrics produce accurate flux Tables.
+// TestGauge will make sure that gauge metrics produce accurate flux Tables.
 func TestGauge(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `


### PR DESCRIPTION
Closes #2893. 

Previously table stream checked with `NormalizeTables()` were only registering as equal when both the tables and columns were in the exact same order. This PR will put tables and columns in a consistent order so that they can be properly checked for equality.
