### PR TITLE
fix(runtime): move semantic analysis to the finalize step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
   test-race:
     docker:
       - image: quay.io/influxdb/flux-build:latest
+    resource_class: large
     environment:
       GOPATH: /tmp/go
       GOFLAGS: -p=8


### PR DESCRIPTION
This moves the semantic analysis to the finalize step like it was
previously. For applications that avoid finalizing unless they are using
the interpreter, this should restore the quicker startup time because
package registration will store the AST and move on.

In the longer term, we probably want to stop using `init()` so much and
switch to a system where the application explicitly pulls packages into
the runtime. For now, this is more simple and doesn't involve any
changes to existing applications and restores the previous speed for
commands that do not use flux but import the flux runtime.

influxdata/influxdb#18292

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written