### PR TITLE
fix(compiler): substitute array element types correctly

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -127,7 +127,7 @@ func substituteTypes(subst map[uint64]semantic.MonoType, inType, in semantic.Mon
 			return err
 		}
 
-		rt, err := inType.ElemType()
+		rt, err := in.ElemType()
 		if err != nil {
 			return err
 		}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -273,6 +273,25 @@ func TestCompileAndEval(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "array access",
+			fn:   `(values) => values[0]`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("values"), Value: semantic.NewArrayType(semantic.BasicFloat)},
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"values": values.NewArrayWithBacking(
+					semantic.NewArrayType(semantic.BasicFloat),
+					[]values.Value{
+						values.NewFloat(1),
+						values.NewFloat(2),
+						values.NewFloat(3),
+					},
+				),
+			}),
+			want:    values.NewFloat(1),
+			wantErr: false,
+		},
+		{
 			name: "logical expression",
 			fn:   `(a, b) => a or b`,
 			inType: semantic.NewObjectType([]semantic.PropertyType{
@@ -441,6 +460,14 @@ func TestCompiler_ReturnType(t *testing.T) {
 				})},
 			}),
 			want: `{_time: time | _value: float | _value: float}`,
+		},
+		{
+			name: "array access",
+			fn:   `(values) => values[0]`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("values"), Value: semantic.NewArrayType(semantic.BasicFloat)},
+			}),
+			want: `float`,
 		},
 	}
 


### PR DESCRIPTION
The array element type wouldn't substitute correctly because it compared
only one of the types with itself instead of comparing the two different
types.

The compiler has also been modified to catch when a required argument is
omitted within the go runtime compiler.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written