### PR TITLE
fix(execute): appending an array of booleans with null values functions correctly

### DIFF
--- a/execute/table.go
+++ b/execute/table.go
@@ -801,13 +801,12 @@ func (b *ColListTableBuilder) AppendBools(j int, vs *array.Boolean) error {
 	}
 
 	for i := 0; i < vs.Len(); i++ {
-		if err := b.AppendValue(j, values.NewBool(vs.Value(i))); err != nil {
-			return err
-		}
 		if vs.IsNull(i) {
-			if err := b.SetNil(b.nrows, j); err != nil {
+			if err := b.AppendNil(j); err != nil {
 				return err
 			}
+		} else if err := b.AppendBool(j, vs.Value(i)); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
When appending an array of boolean values, it was marking the wrong
indices as boolean by marking one after the value that was appended
rather than the one just appended. This resulted in other sections of
the code being wrong because the copied column was not copied correctly.

Related to influxdata/influxdb#18433.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written