### PR TITLE
fix(release): add diff output to release script on error

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -21,6 +21,7 @@ git_local_tags () { git show-ref --tags | grep -v '{}' | grep -v 'origin'| grep 
 # check if local tags are different from remote tags
 if ! diff -q <(git_remote_tags) <(git_local_tags) &>/dev/null; then
     echo "Error: local tags do not match remote. Exiting release script."
+    diff -u <(git_remote_tags) <(git_local_tags)
     exit 1
 fi
 


### PR DESCRIPTION
This change makes it so that if local and remote tags do not match you can see the difference.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
