### PR TITLE
fix: verify index expression bounds in evaluation

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -516,7 +516,12 @@ func (e *arrayIndexEvaluator) Eval(ctx context.Context, scope Scope) (values.Val
 	if err != nil {
 		return nil, err
 	}
-	return a.Array().Get(int(i.Int())), nil
+	ix := int(i.Int())
+	l := a.Array().Len()
+	if ix < 0 || ix >= l {
+		return nil, errors.Newf(codes.OutOfRange, "cannot access element %v of array of length %v", ix, l)
+	}
+	return a.Array().Get(ix), nil
 }
 
 type callEvaluator struct {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -273,6 +273,24 @@ func TestEval(t *testing.T) {
 			`,
 		},
 		{
+			name: "array index expression out of bounds low",
+			query: `
+				a = [1, 2, 3]
+				i = -1
+				x = a[i]
+			`,
+			wantErr: true,
+		},
+		{
+			name: "array index expression out of bounds high",
+			query: `
+				a = [1, 2, 3]
+				i = 3 
+				x = a[i]
+			`,
+			wantErr: true,
+		},
+		{
 			name: "array with complex index expression",
 			query: `
 				f = () => ({l: 0, m: 1, n: 2})


### PR DESCRIPTION
This check was present for the interpreter only. Added tests for both
interpreter and evaluation.