### PR TITLE
fix: remove bad_sqlite_path1 test

### DIFF
--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -197,14 +197,6 @@ func TestFromSqliteUrlValidation(t *testing.T) {
 			},
 			ErrMsg: "sql driver sqlite4 not supported",
 		}, {
-			Name: "bad sqlite path1",
-			Spec: &FromSQLProcedureSpec{
-				DriverName:     "sqlite3",
-				DataSourceName: ":cool_pragma",
-				Query:          "",
-			},
-			ErrMsg: "invalid data source url: parse :cool_pragma: missing protocol scheme",
-		}, {
 			Name: "bad sqlite path2",
 			Spec: &FromSQLProcedureSpec{
 				DriverName:     "sqlite3",


### PR DESCRIPTION
This test breaks on go 1.14 as the error message sqlite generates is
different. It was removed in this patch because it doesn't seem to
actually test any flux code, but asserts on code from the stdlib.
Asserting on code we don't own should be a thing that is done often, and
when it is done, should have well understood reasoning for, rather than
just defaulting.

Closes #2931