### PR TITLE
fix(lang): pass the context to the planner when using the table object compiler

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -131,7 +131,7 @@ func CompileTableObject(ctx context.Context, to *flux.TableObject, now time.Time
 	if o.verbose {
 		log.Println("Query Spec: ", flux.Formatted(s, flux.FmtJSON))
 	}
-	ps, err := buildPlan(context.Background(), s, o)
+	ps, err := buildPlan(ctx, s, o)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written