### PR TITLE
fix(stdlib): use query strings instead of ast for remote influxdb queries

### DIFF
--- a/stdlib/influxdata/influxdb/buckets_test.go
+++ b/stdlib/influxdata/influxdb/buckets_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
@@ -118,22 +117,10 @@ func TestBuckets_Run(t *testing.T) {
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.CallExpression{
-									Callee: &ast.Identifier{Name: "buckets"},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+buckets()`,
 				Tables: defaultTablesFn,
 			},
 		},

--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -206,9 +206,7 @@ func (s *FromRemoteProcedureSpec) Copy() plan.ProcedureSpec {
 }
 
 func (s *FromRemoteProcedureSpec) PostPhysicalValidate(id plan.NodeID) error {
-	if s.Org == nil {
-		return errors.New(codes.Invalid, "reading from a remote host requires an organization to be set")
-	} else if s.Range == nil {
+	if s.Range == nil {
 		var bucket string
 		if s.Bucket.Name != "" {
 			bucket = s.Bucket.Name

--- a/stdlib/influxdata/influxdb/from_test.go
+++ b/stdlib/influxdata/influxdb/from_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -179,52 +178,11 @@ func TestFrom_Run(t *testing.T) {
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.PipeExpression{
-									Argument: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "from"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key:   &ast.Identifier{Name: "bucket"},
-														Value: &ast.StringLiteral{Value: "telegraf"},
-													},
-												},
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "range"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key: &ast.Identifier{Name: "start"},
-														Value: &ast.UnaryExpression{
-															Operator: ast.SubtractionOperator,
-															Argument: &ast.DurationLiteral{Values: []ast.Duration{
-																{Magnitude: 1, Unit: "m"},
-															}},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+from(bucket: "telegraf")
+	|> range(start: -1m)`,
 				Tables: defaultTablesFn,
 			},
 		},
@@ -252,52 +210,11 @@ func TestFrom_Run(t *testing.T) {
 				Params: url.Values{
 					"orgID": []string{"97aa81cc0e247dc4"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.PipeExpression{
-									Argument: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "from"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key:   &ast.Identifier{Name: "bucketID"},
-														Value: &ast.StringLiteral{Value: "1e01ac57da723035"},
-													},
-												},
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "range"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key: &ast.Identifier{Name: "start"},
-														Value: &ast.UnaryExpression{
-															Operator: ast.SubtractionOperator,
-															Argument: &ast.DurationLiteral{Values: []ast.Duration{
-																{Magnitude: 1, Unit: "m"},
-															}},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+from(bucketID: "1e01ac57da723035")
+	|> range(start: -1m)`,
 				Tables: defaultTablesFn,
 			},
 		},
@@ -324,55 +241,11 @@ func TestFrom_Run(t *testing.T) {
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.PipeExpression{
-									Argument: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "from"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key:   &ast.Identifier{Name: "bucket"},
-														Value: &ast.StringLiteral{Value: "telegraf"},
-													},
-												},
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "range"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key: &ast.Identifier{Name: "start"},
-														Value: &ast.DateTimeLiteral{
-															Value: mustParseTime("2018-05-30T09:00:00Z"),
-														},
-													},
-													{
-														Key: &ast.Identifier{Name: "stop"},
-														Value: &ast.DateTimeLiteral{
-															Value: mustParseTime("2018-05-30T10:00:00Z"),
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+from(bucket: "telegraf")
+	|> range(start: 2018-05-30T09:00:00Z, stop: 2018-05-30T10:00:00Z)`,
 				Tables: defaultTablesFn,
 			},
 		},
@@ -408,85 +281,14 @@ func TestFrom_Run(t *testing.T) {
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.PipeExpression{
-									Argument: &ast.PipeExpression{
-										Argument: &ast.CallExpression{
-											Callee: &ast.Identifier{Name: "from"},
-											Arguments: []ast.Expression{
-												&ast.ObjectExpression{
-													Properties: []*ast.Property{
-														{
-															Key:   &ast.Identifier{Name: "bucket"},
-															Value: &ast.StringLiteral{Value: "telegraf"},
-														},
-													},
-												},
-											},
-										},
-										Call: &ast.CallExpression{
-											Callee: &ast.Identifier{Name: "range"},
-											Arguments: []ast.Expression{
-												&ast.ObjectExpression{
-													Properties: []*ast.Property{
-														{
-															Key: &ast.Identifier{Name: "start"},
-															Value: &ast.UnaryExpression{
-																Operator: ast.SubtractionOperator,
-																Argument: &ast.DurationLiteral{Values: []ast.Duration{
-																	{Magnitude: 1, Unit: "m"},
-																}},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "filter"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key: &ast.Identifier{Name: "fn"},
-														Value: &ast.FunctionExpression{
-															Params: []*ast.Property{{
-																Key: &ast.Identifier{Name: "r"},
-															}},
-															Body: &ast.Block{
-																Body: []ast.Statement{
-																	&ast.ReturnStatement{
-																		Argument: &ast.BinaryExpression{
-																			Operator: ast.GreaterThanEqualOperator,
-																			Left: &ast.MemberExpression{
-																				Object:   &ast.Identifier{Name: "r"},
-																				Property: &ast.StringLiteral{Value: "_value"},
-																			},
-																			Right: &ast.FloatLiteral{Value: 0.0},
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+from(bucket: "telegraf")
+	|> range(start: -1m)
+	|> filter(fn: (r) => {
+		return r["_value"] >= 0.0
+	})`,
 				Tables: defaultTablesFn,
 			},
 		},
@@ -523,89 +325,14 @@ func TestFrom_Run(t *testing.T) {
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.PipeExpression{
-									Argument: &ast.PipeExpression{
-										Argument: &ast.CallExpression{
-											Callee: &ast.Identifier{Name: "from"},
-											Arguments: []ast.Expression{
-												&ast.ObjectExpression{
-													Properties: []*ast.Property{
-														{
-															Key:   &ast.Identifier{Name: "bucket"},
-															Value: &ast.StringLiteral{Value: "telegraf"},
-														},
-													},
-												},
-											},
-										},
-										Call: &ast.CallExpression{
-											Callee: &ast.Identifier{Name: "range"},
-											Arguments: []ast.Expression{
-												&ast.ObjectExpression{
-													Properties: []*ast.Property{
-														{
-															Key: &ast.Identifier{Name: "start"},
-															Value: &ast.UnaryExpression{
-																Operator: ast.SubtractionOperator,
-																Argument: &ast.DurationLiteral{Values: []ast.Duration{
-																	{Magnitude: 1, Unit: "m"},
-																}},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "filter"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key: &ast.Identifier{Name: "fn"},
-														Value: &ast.FunctionExpression{
-															Params: []*ast.Property{{
-																Key: &ast.Identifier{Name: "r"},
-															}},
-															Body: &ast.Block{
-																Body: []ast.Statement{
-																	&ast.ReturnStatement{
-																		Argument: &ast.BinaryExpression{
-																			Operator: ast.GreaterThanEqualOperator,
-																			Left: &ast.MemberExpression{
-																				Object:   &ast.Identifier{Name: "r"},
-																				Property: &ast.StringLiteral{Value: "_value"},
-																			},
-																			Right: &ast.FloatLiteral{Value: 0.0},
-																		},
-																	},
-																},
-															},
-														},
-													},
-													{
-														Key:   &ast.Identifier{Name: "onEmpty"},
-														Value: &ast.StringLiteral{Value: "keep"},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+from(bucket: "telegraf")
+	|> range(start: -1m)
+	|> filter(fn: (r) => {
+		return r["_value"] >= 0.0
+	}, onEmpty: "keep")`,
 				Tables: defaultTablesFn,
 			},
 		},
@@ -659,98 +386,16 @@ import "math"
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Imports: []*ast.ImportDeclaration{
-							{
-								Path: &ast.StringLiteral{Value: "math"},
-								As:   &ast.Identifier{Name: "math"},
-							},
-						},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.PipeExpression{
-									Argument: &ast.PipeExpression{
-										Argument: &ast.CallExpression{
-											Callee: &ast.Identifier{Name: "from"},
-											Arguments: []ast.Expression{
-												&ast.ObjectExpression{
-													Properties: []*ast.Property{
-														{
-															Key:   &ast.Identifier{Name: "bucket"},
-															Value: &ast.StringLiteral{Value: "telegraf"},
-														},
-													},
-												},
-											},
-										},
-										Call: &ast.CallExpression{
-											Callee: &ast.Identifier{Name: "range"},
-											Arguments: []ast.Expression{
-												&ast.ObjectExpression{
-													Properties: []*ast.Property{
-														{
-															Key: &ast.Identifier{Name: "start"},
-															Value: &ast.UnaryExpression{
-																Operator: ast.SubtractionOperator,
-																Argument: &ast.DurationLiteral{Values: []ast.Duration{
-																	{Magnitude: 1, Unit: "m"},
-																}},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-									Call: &ast.CallExpression{
-										Callee: &ast.Identifier{Name: "filter"},
-										Arguments: []ast.Expression{
-											&ast.ObjectExpression{
-												Properties: []*ast.Property{
-													{
-														Key: &ast.Identifier{Name: "fn"},
-														Value: &ast.FunctionExpression{
-															Params: []*ast.Property{{
-																Key: &ast.Identifier{Name: "r"},
-															}},
-															Body: &ast.Block{
-																Body: []ast.Statement{
-																	&ast.ReturnStatement{
-																		Argument: &ast.BinaryExpression{
-																			Operator: ast.GreaterThanEqualOperator,
-																			Left: &ast.MemberExpression{
-																				Object:   &ast.Identifier{Name: "r"},
-																				Property: &ast.StringLiteral{Value: "_value"},
-																			},
-																			Right: &ast.MemberExpression{
-																				Object:   &ast.Identifier{Name: "math"},
-																				Property: &ast.StringLiteral{Value: "pi"},
-																			},
-																		},
-																	},
-																},
-															},
-														},
-													},
-													{
-														Key:   &ast.Identifier{Name: "onEmpty"},
-														Value: &ast.StringLiteral{Value: "keep"},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+import math "math"
+
+from(bucket: "telegraf")
+	|> range(start: -1m)
+	|> filter(fn: (r) => {
+		return r["_value"] >= math["pi"]
+	}, onEmpty: "keep")`,
 				Tables: defaultTablesFn,
 			},
 		},

--- a/stdlib/influxdata/influxdb/internal/testutil/testing.go
+++ b/stdlib/influxdata/influxdb/internal/testutil/testing.go
@@ -30,7 +30,7 @@ type (
 
 type Want struct {
 	Params url.Values
-	Ast    *ast.Package
+	Query  string
 	Tables func() []*executetest.Table
 }
 
@@ -50,7 +50,7 @@ func RunSourceTestHelper(t *testing.T, spec SourceProcedureSpec, want Want) {
 		}
 
 		var req struct {
-			AST     *ast.Package `json:"ast"`
+			Query   string `json:"query"`
 			Dialect struct {
 				Header         bool     `json:"header"`
 				DateTimeFormat string   `json:"dateTimeFormat"`
@@ -62,8 +62,8 @@ func RunSourceTestHelper(t *testing.T, spec SourceProcedureSpec, want Want) {
 			return
 		}
 
-		if want, got := want.Ast, req.AST; !cmp.Equal(want, got) {
-			t.Errorf("unexpected ast in request body -want/+got:\n%s", cmp.Diff(want, got))
+		if want, got := want.Query, req.Query; !cmp.Equal(want, got) {
+			t.Errorf("unexpected query in request body -want/+got:\n%s", cmp.Diff(want, got))
 		}
 
 		w.Header().Add("Content-Type", "text/csv")

--- a/stdlib/influxdata/influxdb/rules_test.go
+++ b/stdlib/influxdata/influxdb/rules_test.go
@@ -125,40 +125,6 @@ func TestFromRemoteRule_WithoutHostValidation(t *testing.T) {
 	plantest.PhysicalRuleTestHelper(t, &tc)
 }
 
-func TestFromRemoteRule_WithoutOrgValidation(t *testing.T) {
-	fromSpec := influxdb.FromProcedureSpec{
-		Bucket: influxdb.NameOrID{Name: "telegraf"},
-		Host:   stringPtr("http://localhost:9999"),
-	}
-	rangeSpec := universe.RangeProcedureSpec{
-		Bounds: flux.Bounds{
-			Start: flux.Time{
-				IsRelative: true,
-				Relative:   -time.Minute,
-			},
-			Stop: flux.Time{
-				IsRelative: true,
-			},
-		},
-	}
-
-	tc := plantest.RuleTestCase{
-		Name: "without org validation",
-		Rules: []plan.Rule{
-			influxdb.FromRemoteRule{},
-		},
-		Before: &plantest.PlanSpec{
-			Nodes: []plan.Node{
-				plan.CreateLogicalNode("from", &fromSpec),
-				plan.CreateLogicalNode("range", &rangeSpec),
-			},
-			Edges: [][2]int{{0, 1}},
-		},
-		ValidateError: errors.New(codes.Invalid, "reading from a remote host requires an organization to be set"),
-	}
-	plantest.PhysicalRuleTestHelper(t, &tc)
-}
-
 func TestFromRemoteRule_WithoutRangeValidation(t *testing.T) {
 	fromSpec := influxdb.FromProcedureSpec{
 		Org:    &influxdb.NameOrID{Name: "influxdata"},

--- a/stdlib/influxdata/influxdb/v1/databases_test.go
+++ b/stdlib/influxdata/influxdb/v1/databases_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
@@ -125,28 +124,12 @@ func TestDatabases_Run(t *testing.T) {
 				Params: url.Values{
 					"org": []string{"influxdata"},
 				},
-				Ast: &ast.Package{
-					Package: "main",
-					Files: []*ast.File{{
-						Name: "query.flux",
-						Package: &ast.PackageClause{
-							Name: &ast.Identifier{Name: "main"},
-						},
-						Imports: []*ast.ImportDeclaration{{
-							Path: &ast.StringLiteral{Value: "influxdata/influxdb/v1"},
-						}},
-						Body: []ast.Statement{
-							&ast.ExpressionStatement{
-								Expression: &ast.CallExpression{
-									Callee: &ast.MemberExpression{
-										Object:   &ast.Identifier{Name: "v1"},
-										Property: &ast.Identifier{Name: "databases"},
-									},
-								},
-							},
-						},
-					}},
-				},
+				Query: `package main
+
+
+import "influxdata/influxdb/v1"
+
+v1.databases()`,
 				Tables: defaultTablesFn,
 			},
 		},


### PR DESCRIPTION
The remote influxdb queries are now formatted and issued with query text
instead of raw AST. This is because the query string is better supported
for all of the various different platforms. The influxdb 1.x integration
with flux doesn't support AST and the influxdb v2 official client
doesn't support using AST anyway.

We are still using our own HTTP calls at the moment instead of the
official v2 API because the official API doesn't support both `org` and
`orgID`. Since we are not certain if both of those query parameters will
be supported in the future, I am hesitant to switch to the official
client until that decision has been made and the client is either
updated to support only one of them or support both.

This change also removes the requirement for `org` or `orgID` to be
specified. This parameter is not required for influxdb 1.x so it
shouldn't be required for flux to issue the request. If the individual
API that is being queried needs it, then it will return an error message
which we display.

Fixes #2865.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written