### PR TITLE
feat(execute/table): add stringify method for a table and a diff utility

### DIFF
--- a/internal/execute/table/buffered_builder_test.go
+++ b/internal/execute/table/buffered_builder_test.go
@@ -158,7 +158,7 @@ func TestBufferedBuilder_AppendTable(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			if diff := table.Diff(t, tt.want, out); diff != "" {
+			if diff := table.Diff(tt.want, out); diff != "" {
 				t.Fatalf("unexpected diff -want/+got:\n%s", diff)
 			}
 		})

--- a/internal/execute/table/buffered_test.go
+++ b/internal/execute/table/buffered_test.go
@@ -112,9 +112,7 @@ func TestBufferedTable(t *testing.T) {
 						Columns:  cols,
 					}
 				}()
-				return TableIterator(
-					[]flux.Table{tbl1, tbl2, tbl3},
-				)
+				return table.Iterator{tbl1, tbl2, tbl3}
 			},
 			IsDone: func(tbl flux.Table) bool {
 				return tbl.(interface{ IsDone() bool }).IsDone()

--- a/internal/execute/table/diff.go
+++ b/internal/execute/table/diff.go
@@ -1,0 +1,140 @@
+package table
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/andreyvit/diff"
+	"github.com/influxdata/flux"
+)
+
+// Diff will perform a diff between two tables.
+// If the tables are the same, the output will be an empty string.
+// This will produce a fatal error if there was any problem reading
+// either table.
+func Diff(want, got flux.Table, opts ...DiffOption) string {
+	wantS, gotS := Stringify(want), Stringify(got)
+	differ := newDiffer(opts...)
+	return differ.diff(wantS, gotS)
+}
+
+// DiffIterator will perform a diff between two table iterators.
+// This will sort the tables within the table iterators and produce
+// a diff of the full output.
+func DiffIterator(want, got flux.TableIterator, opts ...DiffOption) string {
+	var wantS string
+	if wantT, err := Sort(want); err != nil {
+		wantS = fmt.Sprintf("table error: %s\n", err)
+	} else {
+		var sb strings.Builder
+		if err := wantT.Do(func(table flux.Table) error {
+			sb.WriteString(Stringify(table))
+			return nil
+		}); err != nil {
+			_, _ = fmt.Fprintf(&sb, "table error: %s\n", err)
+		}
+		wantS = sb.String()
+	}
+
+	var gotS string
+	if gotT, err := Sort(got); err != nil {
+		gotS = fmt.Sprintf("table error: %s\n", err)
+	} else {
+		var sb strings.Builder
+		if err := gotT.Do(func(table flux.Table) error {
+			sb.WriteString(Stringify(table))
+			return nil
+		}); err != nil {
+			_, _ = fmt.Fprintf(&sb, "table error: %s\n", err)
+		}
+		gotS = sb.String()
+	}
+
+	differ := newDiffer(opts...)
+	return differ.diff(wantS, gotS)
+}
+
+type differ struct {
+	ctx *[2]int
+}
+
+func newDiffer(opts ...DiffOption) (d differ) {
+	for _, opt := range diffDefaultOptions {
+		opt.apply(&d)
+	}
+	for _, opt := range opts {
+		opt.apply(&d)
+	}
+	return d
+}
+
+func (d differ) diff(want, got string) string {
+	lines := diff.LineDiffAsLines(want, got)
+	if d.ctx == nil {
+		return strings.Join(lines, "\n")
+	}
+
+	difflines := make([]string, 0, len(lines))
+OUTER:
+	for {
+		for i := 0; i < len(lines); i++ {
+			if lines[i][0] == ' ' {
+				continue
+			}
+
+			// This is the start of a diff section. Store this location.
+			start := i - (*d.ctx)[0]
+			if start < 0 {
+				start = 0
+			}
+
+			// Find the end of this section.
+			for ; i < len(lines); i++ {
+				if lines[i][0] == ' ' {
+					break
+				}
+			}
+
+			// Look n points in the future and, if they are
+			// not part of a diff or don't overrun the number
+			// of lines, include them.
+			stop := i
+
+			for n := (*d.ctx)[1]; n > 0; n-- {
+				if stop+1 >= len(lines) || lines[stop+1][0] != ' ' {
+					break
+				}
+				stop++
+			}
+
+			difflines = append(difflines, lines[start:stop]...)
+			lines = lines[stop:]
+			continue OUTER
+		}
+		return strings.Join(difflines, "\n")
+	}
+}
+
+type DiffOption interface {
+	apply(*differ)
+}
+
+type diffOptionFn func(d *differ)
+
+func (opt diffOptionFn) apply(d *differ) {
+	opt(d)
+}
+
+var diffDefaultOptions = []DiffOption{
+	DiffContext(3),
+}
+
+func DiffContext(n int) DiffOption {
+	return diffOptionFn(func(d *differ) {
+		if n < 0 {
+			d.ctx = nil
+		}
+		ctx := [2]int{n, n}
+		d.ctx = &ctx
+	})
+}

--- a/internal/execute/table/diff_test.go
+++ b/internal/execute/table/diff_test.go
@@ -1,0 +1,42 @@
+package table_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/internal/execute/table"
+	"github.com/influxdata/flux/internal/execute/table/static"
+)
+
+func TestDiffIterator(t *testing.T) {
+	wantI := table.Iterator{
+		static.Table{
+			"_measurement": static.StringKey("m0"),
+			"_field":       static.StringKey("f0"),
+			"t0":           static.StringKey("a"),
+			"_time":        static.Times("2020-01-01T00:00:00Z", 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110),
+			"_value":       static.Ints(6, 7, 4, 12, 3, 9, 5, 6, 5, 1, 8, 4),
+		},
+	}
+	gotI := table.Iterator{
+		static.Table{
+			"_measurement": static.StringKey("m0"),
+			"_field":       static.StringKey("f0"),
+			"t0":           static.StringKey("a"),
+			"_time":        static.Times("2020-01-01T00:00:00Z", 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110),
+			"_value":       static.Ints(6, 7, 3, 12, 3, 9, 5, 6, 5, 1, 8, 4),
+		},
+	}
+	got := table.DiffIterator(wantI, gotI)
+
+	want := ` # _field=f0,_measurement=m0,t0=a _time=time,_value=int
+ _field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:00Z,_value=6i
+ _field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:10Z,_value=7i
+-_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:20Z,_value=4i
++_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:20Z,_value=3i
+ _field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:30Z,_value=12i
+ _field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:40Z,_value=3i
+ _field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:50Z,_value=9i`
+	if got != want {
+		t.Errorf("unexpected diff output -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}

--- a/internal/execute/table/iterator.go
+++ b/internal/execute/table/iterator.go
@@ -1,10 +1,10 @@
-package table_test
+package table
 
 import "github.com/influxdata/flux"
 
-type TableIterator []flux.Table
+type Iterator []flux.Table
 
-func (t TableIterator) Do(f func(flux.Table) error) error {
+func (t Iterator) Do(f func(flux.Table) error) error {
 	for _, tbl := range t {
 		if err := f(tbl); err != nil {
 			return err

--- a/internal/execute/table/sort.go
+++ b/internal/execute/table/sort.go
@@ -1,0 +1,32 @@
+package table
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+)
+
+// Sort will read a TableIterator and produce another TableIterator
+// where the keys are sorted.
+//
+// This method will buffer all of the data since it needs to ensure
+// all of the tables are read to avoid any deadlocks. Be careful
+// using this method in performance sensitive areas.
+func Sort(tables flux.TableIterator) (flux.TableIterator, error) {
+	groups := execute.NewGroupLookup()
+	if err := tables.Do(func(table flux.Table) error {
+		buffered, err := execute.CopyTable(table)
+		if err != nil {
+			return err
+		}
+		groups.Set(buffered.Key(), buffered)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	var buffered []flux.Table
+	groups.Range(func(_ flux.GroupKey, value interface{}) {
+		buffered = append(buffered, value.(flux.Table))
+	})
+	return Iterator(buffered), nil
+}

--- a/internal/execute/table/stream_test.go
+++ b/internal/execute/table/stream_test.go
@@ -95,9 +95,7 @@ func TestStream(t *testing.T) {
 					}
 					return w.Write(vs)
 				})
-				return TableIterator(
-					[]flux.Table{tbl1, tbl2, tbl3},
-				)
+				return table.Iterator{tbl1, tbl2, tbl3}
 			},
 			IsDone: func(tbl flux.Table) bool {
 				return tbl.(interface{ IsDone() bool }).IsDone()

--- a/internal/execute/table/stringify.go
+++ b/internal/execute/table/stringify.go
@@ -1,0 +1,151 @@
+package table
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// Stringify will read a table and turn it into a human-readable string.
+func Stringify(table flux.Table) string {
+	var sb strings.Builder
+	stringifyKey(&sb, table)
+	if err := table.Do(func(cr flux.ColReader) error {
+		stringifyRows(&sb, cr)
+		return nil
+	}); err != nil {
+		_, _ = fmt.Fprintf(&sb, "table error: %s\n", err)
+	}
+	return sb.String()
+}
+
+func getSortedIndices(key flux.GroupKey, cols []flux.ColMeta) ([]flux.ColMeta, []int) {
+	indices := make([]int, len(cols))
+	for i := range indices {
+		indices[i] = i
+	}
+	sort.Slice(indices, func(i, j int) bool {
+		ci, cj := cols[indices[i]], cols[indices[j]]
+		if key.HasCol(ci.Label) && !key.HasCol(cj.Label) {
+			return true
+		} else if !key.HasCol(ci.Label) && key.HasCol(cj.Label) {
+			return false
+		}
+		return ci.Label < cj.Label
+	})
+	return cols, indices
+}
+
+func stringifyKey(sb *strings.Builder, table flux.Table) {
+	key := table.Key()
+	cols, indices := getSortedIndices(table.Key(), table.Cols())
+
+	sb.WriteString("# ")
+	if len(cols) == 0 {
+		sb.WriteString("(none)")
+	} else {
+		nkeys := 0
+		for _, idx := range indices {
+			c := cols[idx]
+			kidx := execute.ColIdx(c.Label, key.Cols())
+			if kidx < 0 {
+				continue
+			}
+
+			if nkeys > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString(cols[idx].Label)
+			sb.WriteString("=")
+
+			v := key.Value(kidx)
+			stringifyValue(sb, v)
+			nkeys++
+		}
+	}
+	sb.WriteString(" ")
+
+	ncols := 0
+	for _, idx := range indices {
+		c := cols[idx]
+		if key.HasCol(c.Label) {
+			continue
+		}
+
+		if ncols > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(cols[idx].Label)
+		sb.WriteString("=")
+		sb.WriteString(cols[idx].Type.String())
+		ncols++
+	}
+	sb.WriteString("\n")
+}
+
+func stringifyRows(sb *strings.Builder, cr flux.ColReader) {
+	key := cr.Key()
+	cols, indices := getSortedIndices(cr.Key(), cr.Cols())
+
+	for i, sz := 0, cr.Len(); i < sz; i++ {
+		inKey := true
+		for j, idx := range indices {
+			c := cols[idx]
+			if j > 0 {
+				if inKey && !key.HasCol(c.Label) {
+					sb.WriteString(" ")
+					inKey = false
+				} else {
+					sb.WriteString(",")
+				}
+			} else if !key.HasCol(c.Label) {
+				inKey = false
+			}
+			sb.WriteString(cols[idx].Label)
+			sb.WriteString("=")
+
+			v := execute.ValueForRow(cr, i, idx)
+			stringifyValue(sb, v)
+		}
+		sb.WriteString("\n")
+	}
+}
+
+func stringifyValue(sb *strings.Builder, v values.Value) {
+	if v.IsNull() {
+		sb.WriteString("!(nil)")
+		return
+	}
+
+	switch v.Type().Nature() {
+	case semantic.Int:
+		_, _ = fmt.Fprintf(sb, "%di", v.Int())
+	case semantic.UInt:
+		_, _ = fmt.Fprintf(sb, "%du", v.UInt())
+	case semantic.Float:
+		_, _ = fmt.Fprintf(sb, "%.3f", v.Float())
+	case semantic.String:
+		sb.WriteString(v.Str())
+	case semantic.Bool:
+		if v.Bool() {
+			sb.WriteString("true")
+		} else {
+			sb.WriteString("false")
+		}
+	case semantic.Time:
+		ts := v.Time().Time()
+		if ts.Nanosecond() > 0 {
+			sb.WriteString(ts.Format(time.RFC3339Nano))
+		} else {
+			sb.WriteString(ts.Format(time.RFC3339))
+		}
+	default:
+		sb.WriteString("!(invalid)")
+	}
+}

--- a/internal/execute/table/stringify_test.go
+++ b/internal/execute/table/stringify_test.go
@@ -1,0 +1,48 @@
+package table_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/internal/execute/table"
+	"github.com/influxdata/flux/internal/execute/table/static"
+)
+
+func TestStringify(t *testing.T) {
+	in := static.Table{
+		"_measurement": static.StringKey("m0"),
+		"_field":       static.StringKey("f0"),
+		"t0":           static.StringKey("a"),
+		"_time":        static.Times("2020-01-01T00:00:00Z", 10, 20, 30, 40, 50),
+		"_value":       static.Ints(6, 7, 4, 12, 3, 9),
+	}
+	got := table.Stringify(in)
+
+	want := `# _field=f0,_measurement=m0,t0=a _time=time,_value=int
+_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:00Z,_value=6i
+_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:10Z,_value=7i
+_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:20Z,_value=4i
+_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:30Z,_value=12i
+_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:40Z,_value=3i
+_field=f0,_measurement=m0,t0=a _time=2020-01-01T00:00:50Z,_value=9i
+`
+	if got != want {
+		t.Errorf("unexpected string output -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
+func TestStringify_Empty(t *testing.T) {
+	in := static.Table{
+		"_measurement": static.StringKey("m0"),
+		"_field":       static.StringKey("f0"),
+		"t0":           static.StringKey("a"),
+		"_time":        static.Times(),
+		"_value":       static.Ints(),
+	}
+	got := table.Stringify(in)
+
+	want := `# _field=f0,_measurement=m0,t0=a _time=time,_value=int
+`
+	if got != want {
+		t.Errorf("unexpected string output -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}

--- a/internal/execute/table/utils.go
+++ b/internal/execute/table/utils.go
@@ -1,13 +1,9 @@
 package table
 
 import (
-	"testing"
-
 	"github.com/apache/arrow/go/arrow/array"
-	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/errors"
 )
 
@@ -29,25 +25,4 @@ func Values(cr flux.ColReader, j int) array.Interface {
 	default:
 		panic(errors.Newf(codes.Internal, "unimplemented column type: %s", typ))
 	}
-}
-
-// Diff will perform a diff between two tables.
-// If the tables are the same, the output will be an empty string.
-// This will produce a fatal error if there was any problem reading
-// either table.
-func Diff(tb testing.TB, want, got flux.Table) string {
-	tb.Helper()
-
-	wantT, err := executetest.ConvertTable(want)
-	if err != nil {
-		tb.Fatalf("unexpected error reading want table: %s", err)
-	}
-	gotT, err := executetest.ConvertTable(got)
-	if err != nil {
-		tb.Fatalf("unexpected error reading got table: %s", err)
-	}
-
-	wantT.Normalize()
-	gotT.Normalize()
-	return cmp.Diff(wantT, gotT)
 }


### PR DESCRIPTION
This adds a `Stringify` method to the `internal/execute/table` package
to convert a table into a string that is easily diffable. It also
contains a `DiffIterator` method that will sort and then stringify each
table and then pass it through a line diff instead of `cmp.Diff`.

This should produce more readable results than `cmp.Diff`.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written