### PR TITLE
test: add test for join and usePrevious

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -357,6 +357,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/join_agg_test.flux":                                            "8ab6a33469a50645e41deaaa1f87c1e4c4180b5d79dd87b03d6b4b1012f8ade9",
 	"stdlib/universe/join_missing_on_col_test.flux":                                 "98f4ca3999b1379d3a35f836449232e3b664fe312e5485179be57e4cc64e6ef4",
 	"stdlib/universe/join_test.flux":                                                "325c73591182914215b7856cf287d5fd283106f620fbead49fb09885ac83c261",
+	"stdlib/universe/join_use_previous_test.flux":                                   "e9c8daae528f43311c6ce8189df8c0a4c8c708a4bc9f6bee68e2de42e15e0c76",
 	"stdlib/universe/kama_test.flux":                                                "c84bfe6689f42f8bba75b9e06a4b1cb8e441615266ad0d12201d9fff27e34994",
 	"stdlib/universe/kama_v2_test.flux":                                             "f9d073089fdfd51c2260167d5e30b05de67ee3e4d91bc5e4261ed1ca722dfbc6",
 	"stdlib/universe/keep_fn_test.flux":                                             "75c51163c14700eb46d8ae8d4aef328ddeffe886c7b9a73f74c6204adb7571a6",

--- a/stdlib/universe/join_use_previous_test.flux
+++ b/stdlib/universe/join_use_previous_test.flux
@@ -1,0 +1,76 @@
+package universe_test
+
+import "csv"
+import "testing"
+
+option now = () => (2020-05-15T00:00:00Z)
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,double
+#group,false,true,true,true
+#default,,,,
+,result,table,_time,value
+,_result,0,2020-05-14T17:23:00Z,1
+,_result,0,2020-05-14T17:40:00Z,2
+,_result,0,2020-05-14T17:41:00Z,3
+,_result,0,2020-05-14T17:42:00Z,4
+,_result,0,2020-05-14T17:43:00Z,5
+,_result,0,2020-05-14T17:44:00Z,6
+,_result,0,2020-05-14T17:45:00Z,
+,_result,0,2020-05-14T17:46:00Z,7
+,_result,0,2020-05-14T17:47:00Z,
+,_result,0,2020-05-14T17:48:00Z,8
+,_result,0,2020-05-14T17:49:00Z,9
+,_result,0,2020-05-14T17:50:00Z,10
+
+#datatype,string,long,dateTime:RFC3339,boolean
+#group,false,true,true,true
+#default,,,,
+,result,table,_time,flag
+,_result,0,2020-05-14T17:23:00Z,false
+,_result,0,2020-05-14T17:40:00Z,
+,_result,0,2020-05-14T17:41:00Z,
+,_result,0,2020-05-14T17:42:00Z,
+,_result,0,2020-05-14T17:43:00Z,
+,_result,0,2020-05-14T17:44:00Z,
+,_result,0,2020-05-14T17:45:00Z,true
+,_result,0,2020-05-14T17:46:00Z,false
+,_result,0,2020-05-14T17:47:00Z,true
+,_result,0,2020-05-14T17:48:00Z,false
+,_result,0,2020-05-14T17:49:00Z,
+,_result,0,2020-05-14T17:50:00Z,
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,double,boolean
+#group,false,false,false,false,false
+#default,_result,,,,
+,result,table,_time,value,flag
+,_result,0,2020-05-14T17:23:00Z,1,false
+,_result,0,2020-05-14T17:40:00Z,2,false
+,_result,0,2020-05-14T17:41:00Z,3,false
+,_result,0,2020-05-14T17:42:00Z,4,false
+,_result,0,2020-05-14T17:43:00Z,5,false
+,_result,0,2020-05-14T17:44:00Z,6,false
+,_result,0,2020-05-14T17:45:00Z,,true
+,_result,0,2020-05-14T17:46:00Z,7,false
+,_result,0,2020-05-14T17:47:00Z,,true
+,_result,0,2020-05-14T17:48:00Z,8,false
+,_result,0,2020-05-14T17:49:00Z,9,false
+,_result,0,2020-05-14T17:50:00Z,10,false
+"
+
+t_join_use_previous_test = (tables=<-) => {
+    lhs = tables
+        |> range(start: 2020-05-01T00:00:00Z)
+        |> filter(fn: (r) => exists r.value)
+        |> drop(columns: ["_start", "_stop"])
+    rhs = tables
+        |> range(start: 2020-05-01T00:00:00Z)
+        |> filter(fn: (r) => exists r.flag)
+        |> drop(columns: ["_start", "_stop"])
+    return join(tables: {left: lhs, right: rhs}, on: ["_time"], method: "inner") |> group(columns: []) |> fill(column: "flag", usePrevious: true)
+}
+
+test _join_use_previous_test = () =>
+    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_join_use_previous_test})


### PR DESCRIPTION
This patch adds a test for a coincidental fix that was added previously.
There was a correctness error when using boolean values when joining
that was made worse when using `usePrevious`.

Closes #2864