### PR TITLE
fix(libflux): repair find_var_type tests

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "criterion",
  "flatbuffers",
  "maplit",
+ "regex",
  "serde",
  "serde-aux",
  "serde_derive",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,7 +12,7 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                            "b0745b5aa727c26b41acf768f7def2b918720f1057c608631710da556a5ac7ac",
+	"libflux/Cargo.lock":                                                            "8e598b35e4f65efb4286856e109cbc3ece1b42dd9635d9c85714eef9870d07fa",
 	"libflux/Cargo.toml":                                                            "9ef291bc6fcfbdcd7a71946dd306fa2599d17c20be2ca15d59d93cec0a564f77",
 	"libflux/include/influxdata/flux.h":                                             "8a534237a7f7a36cea9c2ed24f10d436217e043b78de2129a820d72fb043ea4d",
 	"libflux/scanner.c":                                                             "0cad3d3ee8963a2ed7627efaaffe6111fd1a6563e5bc74113e62c11db438dfb0",
@@ -63,10 +63,10 @@ var sourceHashes = map[string]string{
 	"libflux/src/core/semantic/walk/test_utils.rs":                                  "317606227b28f607273e4ff6ac431e148f753cc20ea1812fa7b97ecb262b3f90",
 	"libflux/src/core/semantic/walk/walk_mut.rs":                                    "d3870f38cb8269acf637d6f6338a52e751dd984c1cb4442f341bada11e8b84de",
 	"libflux/src/core/tests/analyze_test.rs":                                        "c49d81bdaa2275681990cdf8e18eb13adcbb54895ba0c2c49ab1a727d529a820",
-	"libflux/src/flux/Cargo.toml":                                                   "ede8860c53d1fd5cc7bc730a090e615b5668b0c340ccc8b1b9dbed426b5c8f76",
+	"libflux/src/flux/Cargo.toml":                                                   "e3f3624f2f6a32c0f1f9a1a464d464a4370a2cfcfe64f17afc94e7928e5c9740",
 	"libflux/src/flux/benches/builtins.rs":                                          "c60908c65ea51c225fccec19c44343af9103c950a91b23071ddb80292da708c8",
 	"libflux/src/flux/build.rs":                                                     "31a4f825297f9b79d1c8692a5fa3ff9211cb87d01650d147128d061588f75abd",
-	"libflux/src/flux/lib.rs":                                                       "76c8b6c69a296e718e8bcf600c0b44b7eb571fb63c5d8562c7c1c85589191d51",
+	"libflux/src/flux/lib.rs":                                                       "3272ee913ca33f0e5f4fead9a4a2f7a3fac4f2658424d6812f7b2d7ebfd10b4b",
 	"stdlib/contrib/chobbs/discord/discord.flux":                                    "8fd42ce1b459969ec3254dc0215a21b3669e01960a203e93c05284384f3eb49a",
 	"stdlib/contrib/sranka/teams/teams.flux":                                        "57d5656dcb2db79f173e84d551efdbeefb643d028eaaecfff8ee7d2a033f9f50",
 	"stdlib/contrib/sranka/telegram/telegram.flux":                                  "37d1614a215c6ca523e4efa5642ec9104936755a403e5bc4481d82a602f7719b",

--- a/libflux/src/flux/Cargo.toml
+++ b/libflux/src/flux/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 [dependencies]
 core = { path = "../core" }
 flatbuffers = "0.6.0"
+regex = "1"
 serde = "^1.0.59"
 serde_derive = "^1.0.59"
 serde_json = "1.0"

--- a/libflux/src/flux/lib.rs
+++ b/libflux/src/flux/lib.rs
@@ -606,6 +606,7 @@ mod tests {
     use core::semantic::nodes::infer_file;
     use core::semantic::types::MonoType;
     use core::{ast, semantic};
+    use regex::Regex;
 
     #[test]
     fn find_var_ref() {
@@ -619,13 +620,17 @@ vstr = v.str + "hello"
         let mut p = Parser::new(&source);
         let pkg: ast::Package = p.parse_file("".to_string()).into();
         let t = find_var_type(pkg, "v".into()).expect("Should be able to get a MonoType.");
+        // the following asserts use regexp to replace names of generated types
         assert_eq!(
-            format!("{}", t),
-            "{int:int | sweet:t4955 | str:string | t4966}"
+            Regex::new(r"\d+")
+                .unwrap()
+                .replace_all(&format!("{}", t), ""),
+            "{int:int | sweet:t | str:string | t}"
         );
-
         assert_eq!(
-            serde_json::to_string_pretty(&t).unwrap(),
+            Regex::new(r"\d+")
+                .unwrap()
+                .replace_all(&serde_json::to_string_pretty(&t).unwrap(), "1"),
             r#"{
   "Row": {
     "type": "Extension",
@@ -639,7 +644,7 @@ vstr = v.str + "hello"
         "head": {
           "k": "sweet",
           "v": {
-            "Var": 4955
+            "Var": 1
           }
         },
         "tail": {
@@ -650,7 +655,7 @@ vstr = v.str + "hello"
               "v": "String"
             },
             "tail": {
-              "Var": 4966
+              "Var": 1
             }
           }
         }
@@ -684,10 +689,17 @@ p = o.ethan
         let mut p = Parser::new(&source);
         let pkg: ast::Package = p.parse_file("".to_string()).into();
         let t = find_var_type(pkg, "v".into()).expect("Should be able to get a MonoType.");
-        assert_eq!(format!("{}", t), "{int:int | ethan:t4951 | t4955}");
-
+        // the following asserts use regexp to replace names of generated types
         assert_eq!(
-            serde_json::to_string_pretty(&t).unwrap(),
+            Regex::new(r"\d+")
+                .unwrap()
+                .replace_all(&format!("{}", t), ""),
+            "{int:int | ethan:t | t}"
+        );
+        assert_eq!(
+            Regex::new(r"\d+")
+                .unwrap()
+                .replace_all(&serde_json::to_string_pretty(&t).unwrap(), "1"),
             r#"{
   "Row": {
     "type": "Extension",
@@ -701,11 +713,11 @@ p = o.ethan
         "head": {
           "k": "ethan",
           "v": {
-            "Var": 4951
+            "Var": 1
           }
         },
         "tail": {
-          "Var": 4955
+          "Var": 1
         }
       }
     }
@@ -727,7 +739,13 @@ from(bucket: v.bucket)
         let mut p = Parser::new(&source);
         let pkg: ast::Package = p.parse_file("".to_string()).into();
         let ty = find_var_type(pkg, "v".to_string()).expect("should be able to find var type");
-        assert_eq!(format!("{}", ty), "{measurement:t4960 | timeRangeStart:t4970 | timeRangeStop:t4972 | bucket:string | t5008}");
+        // use regexp to replace names of generated types
+        assert_eq!(
+            Regex::new(r"\d+")
+                .unwrap()
+                .replace_all(&format!("{}", ty), ""),
+            "{measurement:t | timeRangeStart:t | timeRangeStop:t | bucket:string | t}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes the tests to ignore the generated number during comparison of the formatted output of find_var_type result. The following tests failed on that in #3000

```
---- tests::find_var_ref_obj_with stdout ----
thread 'tests::find_var_ref_obj_with' panicked at 'assertion failed: `(left == right)`
  left: `"{int:int | ethan:t5062 | t5066}"`,
 right: `"{int:int | ethan:t4951 | t4955}"`', src/flux/lib.rs:687:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::find_var_ref stdout ----
thread 'tests::find_var_ref' panicked at 'assertion failed: `(left == right)`
  left: `"{int:int | sweet:t5066 | str:string | t5077}"`,
 right: `"{int:int | sweet:t4955 | str:string | t4966}"`', src/flux/lib.rs:622:9

---- tests::find_var_ref_query stdout ----
thread 'tests::find_var_ref_query' panicked at 'assertion failed: `(left == right)`
  left: `"{measurement:t5071 | timeRangeStart:t5081 | timeRangeStop:t5083 | bucket:string | t5119}"`,
 right: `"{measurement:t4960 | timeRangeStart:t4970 | timeRangeStop:t4972 | bucket:string | t5008}"`', src/flux/lib.rs:730:9
```

