### PR TITLE
feat(contrib/discord): add discord.endpoint fn

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -67,7 +67,7 @@ var sourceHashes = map[string]string{
 	"libflux/src/flux/benches/builtins.rs":                                          "c60908c65ea51c225fccec19c44343af9103c950a91b23071ddb80292da708c8",
 	"libflux/src/flux/build.rs":                                                     "31a4f825297f9b79d1c8692a5fa3ff9211cb87d01650d147128d061588f75abd",
 	"libflux/src/flux/lib.rs":                                                       "ad1fc4c3b4809f1c76eb7752404699089143ecf5a34c9c14b333acc156c1b3dd",
-	"stdlib/contrib/chobbs/discord/discord.flux":                                    "8fd42ce1b459969ec3254dc0215a21b3669e01960a203e93c05284384f3eb49a",
+	"stdlib/contrib/chobbs/discord/discord.flux":                                    "b9f9b1a60fc92f47930fa4252a77bfc1def5ba98084880eddb4ebbab4078a697",
 	"stdlib/contrib/sranka/teams/teams.flux":                                        "57d5656dcb2db79f173e84d551efdbeefb643d028eaaecfff8ee7d2a033f9f50",
 	"stdlib/contrib/sranka/telegram/telegram.flux":                                  "37d1614a215c6ca523e4efa5642ec9104936755a403e5bc4481d82a602f7719b",
 	"stdlib/csv/csv.flux":                                                           "1951875e6e55fb63d0df75937f38b5051fc7bff5ab0a1bdaf8793bd70329c9a2",

--- a/stdlib/contrib/chobbs/discord/README.md
+++ b/stdlib/contrib/chobbs/discord/README.md
@@ -1,11 +1,11 @@
 # Discord Package
 
 
-Use this Flux Package to send a single message to a Discord channel using a webhook.
+Use this Flux Package to send messages to a Discord channel using a webhook.
 
-## Parameters
+## discord.send
 
-`discord.send` has the following properties:
+`discord.send` sends a single message to a Discord channel using a webhook. It has the following arguments:
 
 | Name     | Type   | Description                                                       |
 | ----     | ----   | -----------                                                       |
@@ -15,8 +15,6 @@ Use this Flux Package to send a single message to a Discord channel using a webh
 | content  | string | simple message, the message contains. (up to 2000 characters)     |
 | avatar_url  | string | override the default avatar of the webhook. (_optional_)       |
 
-
-## Basic Example
 
 Here's an example definition for the `discord.send()` function.
 
@@ -42,6 +40,43 @@ Here's an example definition for the `discord.send()` function.
       avatar_url:"https://staff-photos.net/pic.jpg"
       )
 
+## discord.endpoint
+
+`discord.endpoint` creates a factory function that creates a target function for pipeline `|>` to send messages 
+to discord for each table row. The returned factory function accepts a `mapFn` parameter.
+The `mapFn` accepts a row and returns an object with message `content`. Arguments:
+
+| Name     | Type   | Description                                                       |
+| ----     | ----   | -----------                                                       |
+| webhookToken | string | secure token of the webhook. (Auto-gen from the WebhookURL)   |
+| webhookID  | string | ID of the webhook. (Auto-gen from the WebhookURL)               |
+| username | string | overrides the current username of the webhook.                    |
+| avatar_url  | string | override the default avatar of the webhook. (_optional_)       |
+
+Here's an example definition for the `discord.endpoint()` function
+
+    import "contrib/chobbs/discord"
+    import "influxdata/influxdb/secrets"
+
+    //this value can be stored in the secret-store()
+    token = secrets.get(key: "DISCORD_TOKEN")
+
+    endpoint = discord.endpoint(
+      webhookToken:token,
+      webhookID:"1234567890",
+      username:"chobbs",
+      avatar_url:"https://staff-photos.net/pic.jpg"
+      )
+    
+    from(bucket: "example-bucket")
+      |> range(start: -1m)
+      |> filter(fn: (r) => r._measurement == "statuses")
+      |> last()
+      |> tableFind(fn: (key) => true)
+      |> endpoint(mapFn: (r) => ({
+              content: "Great Scott!- Disk usage is: \"${r.status}\".",
+            })
+         )
 
 ## Contact
 

--- a/stdlib/contrib/chobbs/discord/discord.flux
+++ b/stdlib/contrib/chobbs/discord/discord.flux
@@ -3,12 +3,13 @@ package discord
 import "http"
 import "json"
 
+option discordURL = "https://discordapp.com/api/webhooks/"
+ 
 // `webhookToken` - string - the secure token of the webhook.
 // `webhookID` - string - the ID of the webhook.
 // `username` - string - username posting the message.
 // `content` - string - the text to display in discord.
 // `avatar_url` -  override the default avatar of the webhook.
-
 send = (webhookToken, webhookID, username, content, avatar_url="") => {
   data = {
       username: username,
@@ -21,6 +22,26 @@ send = (webhookToken, webhookID, username, content, avatar_url="") => {
     }
   encode = json.encode(v:data)
 
-  discordURL = "https://discordapp.com/api/webhooks/"
   return http.post(headers: headers, url: discordURL + webhookID + "/" + webhookToken, data: encode)
 }
+
+// `endpoint` creates a factory function that creates a target function for pipeline `|>` to send messages to discord for each table row.
+// `webhookToken` - string - the secure token of the webhook.
+// `webhookID` - string - the ID of the webhook.
+// `username` - string - username posting the message.
+// `avatar_url` -  override the default avatar of the webhook.
+// The returned factory function accepts a `mapFn` parameter.
+// The `mapFn` must return an object with `content`, as defined in the `send` function arguments.
+endpoint = (webhookToken, webhookID, username, avatar_url="") =>
+    (mapFn) =>
+        (tables=<-) => tables
+            |> map(fn: (r) => {
+                obj = mapFn(r: r)
+                return {r with _sent: string(v: 2 == send(
+                    webhookToken: webhookToken,
+                    webhookID: webhookID,
+                    username: username,
+                    avatar_url: avatar_url,
+                    content: obj.content,
+                ) / 100)}
+            })

--- a/stdlib/contrib/chobbs/discord/discord_test.go
+++ b/stdlib/contrib/chobbs/discord/discord_test.go
@@ -2,10 +2,18 @@ package discord_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/lang"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/runtime"
 )
 
@@ -21,4 +29,177 @@ send == 204
 		t.Error("evaluation of discord.send failed: ", err)
 	}
 	_ = scope
+}
+
+type Server struct {
+	mu       sync.Mutex
+	ts       *httptest.Server
+	URL      string
+	requests []Request
+	closed   bool
+}
+
+func NewServer(t *testing.T) *Server {
+	s := new(Server)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sr := Request{
+			URL: r.URL.String(), // r.URL.String(),
+		}
+		dec := json.NewDecoder(r.Body)
+		err := dec.Decode(&sr.PostData)
+		if err != nil {
+			t.Error(err)
+		}
+		s.mu.Lock()
+		s.requests = append(s.requests, sr)
+		s.mu.Unlock()
+	}))
+	s.ts = ts
+	s.URL = ts.URL + "/"
+	return s
+}
+func (s *Server) Requests() []Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests
+}
+func (s *Server) Close() {
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.ts.Close()
+}
+
+type Request struct {
+	URL      string
+	PostData PostData
+}
+
+type PostData struct {
+	Username  string `json:"username"`
+	Content   string `json:"content"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+func TestDiscordEndpoint(t *testing.T) {
+
+	s := NewServer(t)
+	defer s.Close()
+
+	testCases := []struct {
+		webhookID    string
+		webhookToken string
+		username     string
+		content      string
+		avatar_url   string
+		extraArgs    string
+	}{
+		{
+			webhookID:    "simple",
+			webhookToken: "fakeToken",
+			username:     "influxdb",
+			content:      "whatever",
+		},
+		{
+			webhookID:    "withAvatarUrl",
+			webhookToken: "fakeToken",
+			username:     "influxdb",
+			content:      "whatever",
+			avatar_url:   "myavaurl",
+			extraArgs:    `,avatar_url:"myavaurl"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.webhookID, func(t *testing.T) {
+
+			fluxString := `import "csv"
+import "contrib/chobbs/discord"
+option discord.discordURL = "` + s.URL + `"
+
+endpoint = discord.endpoint(webhookToken:webhookToken, webhookID:webhookID, username:username ` + tc.extraArgs + `)(mapFn: (r) => {
+ return {content:r.qtext}
+})
+
+csv.from(csv:data) |> endpoint() `
+			extern := `
+webhookToken = "` + tc.webhookToken + `"
+webhookID = "` + tc.webhookID + `"
+username = "` + tc.username + `"
+avatar_url = "` + tc.avatar_url + `"
+data = "
+#datatype,string,string,string
+#group,false,false,false
+#default,_result,,
+,result,,qtext
+,,,` + tc.content + `"`
+
+			extHdl, err := runtime.Default.Parse(extern)
+			if err != nil {
+				t.Fatal(err)
+			}
+			prog, err := lang.Compile(fluxString, runtime.Default, time.Now(), lang.WithExtern(extHdl))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := flux.NewDefaultDependencies().Inject(context.Background())
+			query, err := prog.Start(ctx, &memory.Allocator{})
+
+			if err != nil {
+				t.Fatal(err)
+			}
+			res := <-query.Results()
+			_ = res
+			var HasSent bool
+			err = res.Tables().Do(func(table flux.Table) error {
+				return table.Do(func(reader flux.ColReader) error {
+					if reader == nil {
+						return nil
+					}
+					for i, meta := range reader.Cols() {
+						if meta.Label == "_sent" {
+							HasSent = true
+							if v := reader.Strings(i).Value(0); string(v) != "true" {
+								t.Fatalf("expecting _sent=true but got _sent=%v", string(v))
+							}
+						}
+					}
+					return nil
+				})
+			})
+			if !HasSent {
+				t.Fatal("expected a _sent column but didn't get one")
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			query.Done()
+			if err := query.Err(); err != nil {
+				t.Error(err)
+			}
+			reqs := s.Requests()
+
+			if len(reqs) < 1 {
+				t.Fatal("received no requests")
+			}
+			req := reqs[len(reqs)-1]
+
+			if req.URL != "/"+tc.webhookID+"/"+tc.webhookToken {
+				t.Errorf("got URL: %s, expected %s", req.URL, "/"+tc.webhookID+"/"+tc.webhookToken)
+			}
+			if req.PostData.Content != tc.content {
+				t.Errorf("got content: %s, expected %s", req.PostData.Content, tc.content)
+			}
+			if req.PostData.Username != tc.username {
+				t.Errorf("got username: %s, expected %s", req.PostData.Username, tc.username)
+			}
+			if req.PostData.AvatarURL != tc.avatar_url {
+				t.Errorf("got avatar_url: %s, expected %s", req.PostData.AvatarURL, tc.avatar_url)
+			}
+		})
+	}
+
 }

--- a/stdlib/contrib/chobbs/discord/flux_gen.go
+++ b/stdlib/contrib/chobbs/discord/flux_gen.go
@@ -21,18 +21,87 @@ var pkgAST = &ast.Package{
 			Errors: nil,
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
-					Column: 2,
-					Line:   26,
+					Column: 15,
+					Line:   47,
 				},
 				File:   "discord.flux",
-				Source: "package discord\n\nimport \"http\"\nimport \"json\"\n\n// `webhookToken` - string - the secure token of the webhook.\n// `webhookID` - string - the ID of the webhook.\n// `username` - string - username posting the message.\n// `content` - string - the text to display in discord.\n// `avatar_url` -  override the default avatar of the webhook.\n\nsend = (webhookToken, webhookID, username, content, avatar_url=\"\") => {\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  discordURL = \"https://discordapp.com/api/webhooks/\"\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
+				Source: "package discord\n\nimport \"http\"\nimport \"json\"\n\noption discordURL = \"https://discordapp.com/api/webhooks/\"\n \n// `webhookToken` - string - the secure token of the webhook.\n// `webhookID` - string - the ID of the webhook.\n// `username` - string - username posting the message.\n// `content` - string - the text to display in discord.\n// `avatar_url` -  override the default avatar of the webhook.\nsend = (webhookToken, webhookID, username, content, avatar_url=\"\") => {\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}\n\n// `endpoint` creates a factory function that creates a target function for pipeline `|>` to send messages to discord for each table row.\n// `webhookToken` - string - the secure token of the webhook.\n// `webhookID` - string - the ID of the webhook.\n// `username` - string - username posting the message.\n// `avatar_url` -  override the default avatar of the webhook.\n// The returned factory function accepts a `mapFn` parameter.\n// The `mapFn` must return an object with `content`, as defined in the `send` function arguments.\nendpoint = (webhookToken, webhookID, username, avatar_url=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
 				},
 			},
 		},
-		Body: []ast.Statement{&ast.VariableAssignment{
+		Body: []ast.Statement{&ast.OptionStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 59,
+							Line:   6,
+						},
+						File:   "discord.flux",
+						Source: "discordURL = \"https://discordapp.com/api/webhooks/\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   6,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 18,
+								Line:   6,
+							},
+							File:   "discord.flux",
+							Source: "discordURL",
+							Start: ast.Position{
+								Column: 8,
+								Line:   6,
+							},
+						},
+					},
+					Name: "discordURL",
+				},
+				Init: &ast.StringLiteral{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 59,
+								Line:   6,
+							},
+							File:   "discord.flux",
+							Source: "\"https://discordapp.com/api/webhooks/\"",
+							Start: ast.Position{
+								Column: 21,
+								Line:   6,
+							},
+						},
+					},
+					Value: "https://discordapp.com/api/webhooks/",
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 59,
+						Line:   6,
+					},
+					File:   "discord.flux",
+					Source: "option discordURL = \"https://discordapp.com/api/webhooks/\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   6,
+					},
+				},
+			},
+		}, &ast.VariableAssignment{
 			BaseNode: ast.BaseNode{
 				Errors: nil,
 				Loc: &ast.SourceLocation{
@@ -41,10 +110,10 @@ var pkgAST = &ast.Package{
 						Line:   26,
 					},
 					File:   "discord.flux",
-					Source: "send = (webhookToken, webhookID, username, content, avatar_url=\"\") => {\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  discordURL = \"https://discordapp.com/api/webhooks/\"\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
+					Source: "send = (webhookToken, webhookID, username, content, avatar_url=\"\") => {\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
 					Start: ast.Position{
 						Column: 1,
-						Line:   12,
+						Line:   13,
 					},
 				},
 			},
@@ -54,13 +123,13 @@ var pkgAST = &ast.Package{
 					Loc: &ast.SourceLocation{
 						End: ast.Position{
 							Column: 5,
-							Line:   12,
+							Line:   13,
 						},
 						File:   "discord.flux",
 						Source: "send",
 						Start: ast.Position{
 							Column: 1,
-							Line:   12,
+							Line:   13,
 						},
 					},
 				},
@@ -75,10 +144,10 @@ var pkgAST = &ast.Package{
 							Line:   26,
 						},
 						File:   "discord.flux",
-						Source: "(webhookToken, webhookID, username, content, avatar_url=\"\") => {\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  discordURL = \"https://discordapp.com/api/webhooks/\"\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
+						Source: "(webhookToken, webhookID, username, content, avatar_url=\"\") => {\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
 						Start: ast.Position{
 							Column: 8,
-							Line:   12,
+							Line:   13,
 						},
 					},
 				},
@@ -91,10 +160,10 @@ var pkgAST = &ast.Package{
 								Line:   26,
 							},
 							File:   "discord.flux",
-							Source: "{\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  discordURL = \"https://discordapp.com/api/webhooks/\"\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
+							Source: "{\n  data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }\n\n  headers = {\n      \"Content-Type\": \"application/json\"\n    }\n  encode = json.encode(v:data)\n\n  return http.post(headers: headers, url: discordURL + webhookID + \"/\" + webhookToken, data: encode)\n}",
 							Start: ast.Position{
 								Column: 71,
-								Line:   12,
+								Line:   13,
 							},
 						},
 					},
@@ -104,13 +173,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   17,
+									Line:   18,
 								},
 								File:   "discord.flux",
 								Source: "data = {\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }",
 								Start: ast.Position{
 									Column: 3,
-									Line:   13,
+									Line:   14,
 								},
 							},
 						},
@@ -120,13 +189,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 7,
-										Line:   13,
+										Line:   14,
 									},
 									File:   "discord.flux",
 									Source: "data",
 									Start: ast.Position{
 										Column: 3,
-										Line:   13,
+										Line:   14,
 									},
 								},
 							},
@@ -138,13 +207,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 6,
-										Line:   17,
+										Line:   18,
 									},
 									File:   "discord.flux",
 									Source: "{\n      username: username,\n      content: content,\n      avatar_url: avatar_url\n    }",
 									Start: ast.Position{
 										Column: 10,
-										Line:   13,
+										Line:   14,
 									},
 								},
 							},
@@ -154,13 +223,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 25,
-											Line:   14,
+											Line:   15,
 										},
 										File:   "discord.flux",
 										Source: "username: username",
 										Start: ast.Position{
 											Column: 7,
-											Line:   14,
+											Line:   15,
 										},
 									},
 								},
@@ -170,13 +239,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 15,
-												Line:   14,
+												Line:   15,
 											},
 											File:   "discord.flux",
 											Source: "username",
 											Start: ast.Position{
 												Column: 7,
-												Line:   14,
+												Line:   15,
 											},
 										},
 									},
@@ -188,13 +257,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 25,
-												Line:   14,
+												Line:   15,
 											},
 											File:   "discord.flux",
 											Source: "username",
 											Start: ast.Position{
 												Column: 17,
-												Line:   14,
+												Line:   15,
 											},
 										},
 									},
@@ -206,13 +275,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 23,
-											Line:   15,
+											Line:   16,
 										},
 										File:   "discord.flux",
 										Source: "content: content",
 										Start: ast.Position{
 											Column: 7,
-											Line:   15,
+											Line:   16,
 										},
 									},
 								},
@@ -222,13 +291,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 14,
-												Line:   15,
+												Line:   16,
 											},
 											File:   "discord.flux",
 											Source: "content",
 											Start: ast.Position{
 												Column: 7,
-												Line:   15,
+												Line:   16,
 											},
 										},
 									},
@@ -240,13 +309,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   15,
+												Line:   16,
 											},
 											File:   "discord.flux",
 											Source: "content",
 											Start: ast.Position{
 												Column: 16,
-												Line:   15,
+												Line:   16,
 											},
 										},
 									},
@@ -258,13 +327,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 29,
-											Line:   16,
+											Line:   17,
 										},
 										File:   "discord.flux",
 										Source: "avatar_url: avatar_url",
 										Start: ast.Position{
 											Column: 7,
-											Line:   16,
+											Line:   17,
 										},
 									},
 								},
@@ -274,13 +343,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 17,
-												Line:   16,
+												Line:   17,
 											},
 											File:   "discord.flux",
 											Source: "avatar_url",
 											Start: ast.Position{
 												Column: 7,
-												Line:   16,
+												Line:   17,
 											},
 										},
 									},
@@ -292,13 +361,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 29,
-												Line:   16,
+												Line:   17,
 											},
 											File:   "discord.flux",
 											Source: "avatar_url",
 											Start: ast.Position{
 												Column: 19,
-												Line:   16,
+												Line:   17,
 											},
 										},
 									},
@@ -313,13 +382,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 6,
-									Line:   21,
+									Line:   22,
 								},
 								File:   "discord.flux",
 								Source: "headers = {\n      \"Content-Type\": \"application/json\"\n    }",
 								Start: ast.Position{
 									Column: 3,
-									Line:   19,
+									Line:   20,
 								},
 							},
 						},
@@ -329,13 +398,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 10,
-										Line:   19,
+										Line:   20,
 									},
 									File:   "discord.flux",
 									Source: "headers",
 									Start: ast.Position{
 										Column: 3,
-										Line:   19,
+										Line:   20,
 									},
 								},
 							},
@@ -347,13 +416,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 6,
-										Line:   21,
+										Line:   22,
 									},
 									File:   "discord.flux",
 									Source: "{\n      \"Content-Type\": \"application/json\"\n    }",
 									Start: ast.Position{
 										Column: 13,
-										Line:   19,
+										Line:   20,
 									},
 								},
 							},
@@ -363,13 +432,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 41,
-											Line:   20,
+											Line:   21,
 										},
 										File:   "discord.flux",
 										Source: "\"Content-Type\": \"application/json\"",
 										Start: ast.Position{
 											Column: 7,
-											Line:   20,
+											Line:   21,
 										},
 									},
 								},
@@ -379,13 +448,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 21,
-												Line:   20,
+												Line:   21,
 											},
 											File:   "discord.flux",
 											Source: "\"Content-Type\"",
 											Start: ast.Position{
 												Column: 7,
-												Line:   20,
+												Line:   21,
 											},
 										},
 									},
@@ -397,13 +466,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 41,
-												Line:   20,
+												Line:   21,
 											},
 											File:   "discord.flux",
 											Source: "\"application/json\"",
 											Start: ast.Position{
 												Column: 23,
-												Line:   20,
+												Line:   21,
 											},
 										},
 									},
@@ -418,13 +487,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 31,
-									Line:   22,
+									Line:   23,
 								},
 								File:   "discord.flux",
 								Source: "encode = json.encode(v:data)",
 								Start: ast.Position{
 									Column: 3,
-									Line:   22,
+									Line:   23,
 								},
 							},
 						},
@@ -434,13 +503,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 9,
-										Line:   22,
+										Line:   23,
 									},
 									File:   "discord.flux",
 									Source: "encode",
 									Start: ast.Position{
 										Column: 3,
-										Line:   22,
+										Line:   23,
 									},
 								},
 							},
@@ -453,13 +522,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 30,
-											Line:   22,
+											Line:   23,
 										},
 										File:   "discord.flux",
 										Source: "v:data",
 										Start: ast.Position{
 											Column: 24,
-											Line:   22,
+											Line:   23,
 										},
 									},
 								},
@@ -469,13 +538,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 30,
-												Line:   22,
+												Line:   23,
 											},
 											File:   "discord.flux",
 											Source: "v:data",
 											Start: ast.Position{
 												Column: 24,
-												Line:   22,
+												Line:   23,
 											},
 										},
 									},
@@ -485,13 +554,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 25,
-													Line:   22,
+													Line:   23,
 												},
 												File:   "discord.flux",
 												Source: "v",
 												Start: ast.Position{
 													Column: 24,
-													Line:   22,
+													Line:   23,
 												},
 											},
 										},
@@ -503,13 +572,13 @@ var pkgAST = &ast.Package{
 											Loc: &ast.SourceLocation{
 												End: ast.Position{
 													Column: 30,
-													Line:   22,
+													Line:   23,
 												},
 												File:   "discord.flux",
 												Source: "data",
 												Start: ast.Position{
 													Column: 26,
-													Line:   22,
+													Line:   23,
 												},
 											},
 										},
@@ -523,13 +592,13 @@ var pkgAST = &ast.Package{
 								Loc: &ast.SourceLocation{
 									End: ast.Position{
 										Column: 31,
-										Line:   22,
+										Line:   23,
 									},
 									File:   "discord.flux",
 									Source: "json.encode(v:data)",
 									Start: ast.Position{
 										Column: 12,
-										Line:   22,
+										Line:   23,
 									},
 								},
 							},
@@ -539,13 +608,13 @@ var pkgAST = &ast.Package{
 									Loc: &ast.SourceLocation{
 										End: ast.Position{
 											Column: 23,
-											Line:   22,
+											Line:   23,
 										},
 										File:   "discord.flux",
 										Source: "json.encode",
 										Start: ast.Position{
 											Column: 12,
-											Line:   22,
+											Line:   23,
 										},
 									},
 								},
@@ -555,13 +624,13 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 16,
-												Line:   22,
+												Line:   23,
 											},
 											File:   "discord.flux",
 											Source: "json",
 											Start: ast.Position{
 												Column: 12,
-												Line:   22,
+												Line:   23,
 											},
 										},
 									},
@@ -573,71 +642,19 @@ var pkgAST = &ast.Package{
 										Loc: &ast.SourceLocation{
 											End: ast.Position{
 												Column: 23,
-												Line:   22,
+												Line:   23,
 											},
 											File:   "discord.flux",
 											Source: "encode",
 											Start: ast.Position{
 												Column: 17,
-												Line:   22,
+												Line:   23,
 											},
 										},
 									},
 									Name: "encode",
 								},
 							},
-						},
-					}, &ast.VariableAssignment{
-						BaseNode: ast.BaseNode{
-							Errors: nil,
-							Loc: &ast.SourceLocation{
-								End: ast.Position{
-									Column: 54,
-									Line:   24,
-								},
-								File:   "discord.flux",
-								Source: "discordURL = \"https://discordapp.com/api/webhooks/\"",
-								Start: ast.Position{
-									Column: 3,
-									Line:   24,
-								},
-							},
-						},
-						ID: &ast.Identifier{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 13,
-										Line:   24,
-									},
-									File:   "discord.flux",
-									Source: "discordURL",
-									Start: ast.Position{
-										Column: 3,
-										Line:   24,
-									},
-								},
-							},
-							Name: "discordURL",
-						},
-						Init: &ast.StringLiteral{
-							BaseNode: ast.BaseNode{
-								Errors: nil,
-								Loc: &ast.SourceLocation{
-									End: ast.Position{
-										Column: 54,
-										Line:   24,
-									},
-									File:   "discord.flux",
-									Source: "\"https://discordapp.com/api/webhooks/\"",
-									Start: ast.Position{
-										Column: 16,
-										Line:   24,
-									},
-								},
-							},
-							Value: "https://discordapp.com/api/webhooks/",
 						},
 					}, &ast.ReturnStatement{
 						Argument: &ast.CallExpression{
@@ -1016,13 +1033,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 21,
-								Line:   12,
+								Line:   13,
 							},
 							File:   "discord.flux",
 							Source: "webhookToken",
 							Start: ast.Position{
 								Column: 9,
-								Line:   12,
+								Line:   13,
 							},
 						},
 					},
@@ -1032,13 +1049,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 21,
-									Line:   12,
+									Line:   13,
 								},
 								File:   "discord.flux",
 								Source: "webhookToken",
 								Start: ast.Position{
 									Column: 9,
-									Line:   12,
+									Line:   13,
 								},
 							},
 						},
@@ -1051,13 +1068,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 32,
-								Line:   12,
+								Line:   13,
 							},
 							File:   "discord.flux",
 							Source: "webhookID",
 							Start: ast.Position{
 								Column: 23,
-								Line:   12,
+								Line:   13,
 							},
 						},
 					},
@@ -1067,13 +1084,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 32,
-									Line:   12,
+									Line:   13,
 								},
 								File:   "discord.flux",
 								Source: "webhookID",
 								Start: ast.Position{
 									Column: 23,
-									Line:   12,
+									Line:   13,
 								},
 							},
 						},
@@ -1086,13 +1103,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 42,
-								Line:   12,
+								Line:   13,
 							},
 							File:   "discord.flux",
 							Source: "username",
 							Start: ast.Position{
 								Column: 34,
-								Line:   12,
+								Line:   13,
 							},
 						},
 					},
@@ -1102,13 +1119,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 42,
-									Line:   12,
+									Line:   13,
 								},
 								File:   "discord.flux",
 								Source: "username",
 								Start: ast.Position{
 									Column: 34,
-									Line:   12,
+									Line:   13,
 								},
 							},
 						},
@@ -1121,13 +1138,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 51,
-								Line:   12,
+								Line:   13,
 							},
 							File:   "discord.flux",
 							Source: "content",
 							Start: ast.Position{
 								Column: 44,
-								Line:   12,
+								Line:   13,
 							},
 						},
 					},
@@ -1137,13 +1154,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 51,
-									Line:   12,
+									Line:   13,
 								},
 								File:   "discord.flux",
 								Source: "content",
 								Start: ast.Position{
 									Column: 44,
-									Line:   12,
+									Line:   13,
 								},
 							},
 						},
@@ -1156,13 +1173,13 @@ var pkgAST = &ast.Package{
 						Loc: &ast.SourceLocation{
 							End: ast.Position{
 								Column: 66,
-								Line:   12,
+								Line:   13,
 							},
 							File:   "discord.flux",
 							Source: "avatar_url=\"\"",
 							Start: ast.Position{
 								Column: 53,
-								Line:   12,
+								Line:   13,
 							},
 						},
 					},
@@ -1172,13 +1189,13 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 63,
-									Line:   12,
+									Line:   13,
 								},
 								File:   "discord.flux",
 								Source: "avatar_url",
 								Start: ast.Position{
 									Column: 53,
-									Line:   12,
+									Line:   13,
 								},
 							},
 						},
@@ -1190,13 +1207,1271 @@ var pkgAST = &ast.Package{
 							Loc: &ast.SourceLocation{
 								End: ast.Position{
 									Column: 66,
-									Line:   12,
+									Line:   13,
 								},
 								File:   "discord.flux",
 								Source: "\"\"",
 								Start: ast.Position{
 									Column: 64,
-									Line:   12,
+									Line:   13,
+								},
+							},
+						},
+						Value: "",
+					},
+				}},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 15,
+						Line:   47,
+					},
+					File:   "discord.flux",
+					Source: "endpoint = (webhookToken, webhookID, username, avatar_url=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
+					Start: ast.Position{
+						Column: 1,
+						Line:   35,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 9,
+							Line:   35,
+						},
+						File:   "discord.flux",
+						Source: "endpoint",
+						Start: ast.Position{
+							Column: 1,
+							Line:   35,
+						},
+					},
+				},
+				Name: "endpoint",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 15,
+							Line:   47,
+						},
+						File:   "discord.flux",
+						Source: "(webhookToken, webhookID, username, avatar_url=\"\") =>\n    (mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
+						Start: ast.Position{
+							Column: 12,
+							Line:   35,
+						},
+					},
+				},
+				Body: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 15,
+								Line:   47,
+							},
+							File:   "discord.flux",
+							Source: "(mapFn) =>\n        (tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
+							Start: ast.Position{
+								Column: 5,
+								Line:   36,
+							},
+						},
+					},
+					Body: &ast.FunctionExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 15,
+									Line:   47,
+								},
+								File:   "discord.flux",
+								Source: "(tables=<-) => tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
+								Start: ast.Position{
+									Column: 9,
+									Line:   37,
+								},
+							},
+						},
+						Body: &ast.PipeExpression{
+							Argument: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 30,
+											Line:   37,
+										},
+										File:   "discord.flux",
+										Source: "tables",
+										Start: ast.Position{
+											Column: 24,
+											Line:   37,
+										},
+									},
+								},
+								Name: "tables",
+							},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 15,
+										Line:   47,
+									},
+									File:   "discord.flux",
+									Source: "tables\n            |> map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
+									Start: ast.Position{
+										Column: 24,
+										Line:   37,
+									},
+								},
+							},
+							Call: &ast.CallExpression{
+								Arguments: []ast.Expression{&ast.ObjectExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 14,
+												Line:   47,
+											},
+											File:   "discord.flux",
+											Source: "fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            }",
+											Start: ast.Position{
+												Column: 20,
+												Line:   38,
+											},
+										},
+									},
+									Properties: []*ast.Property{&ast.Property{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 14,
+													Line:   47,
+												},
+												File:   "discord.flux",
+												Source: "fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            }",
+												Start: ast.Position{
+													Column: 20,
+													Line:   38,
+												},
+											},
+										},
+										Key: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 22,
+														Line:   38,
+													},
+													File:   "discord.flux",
+													Source: "fn",
+													Start: ast.Position{
+														Column: 20,
+														Line:   38,
+													},
+												},
+											},
+											Name: "fn",
+										},
+										Value: &ast.FunctionExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 14,
+														Line:   47,
+													},
+													File:   "discord.flux",
+													Source: "(r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            }",
+													Start: ast.Position{
+														Column: 24,
+														Line:   38,
+													},
+												},
+											},
+											Body: &ast.Block{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 14,
+															Line:   47,
+														},
+														File:   "discord.flux",
+														Source: "{\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            }",
+														Start: ast.Position{
+															Column: 31,
+															Line:   38,
+														},
+													},
+												},
+												Body: []ast.Statement{&ast.VariableAssignment{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 34,
+																Line:   39,
+															},
+															File:   "discord.flux",
+															Source: "obj = mapFn(r: r)",
+															Start: ast.Position{
+																Column: 17,
+																Line:   39,
+															},
+														},
+													},
+													ID: &ast.Identifier{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 20,
+																	Line:   39,
+																},
+																File:   "discord.flux",
+																Source: "obj",
+																Start: ast.Position{
+																	Column: 17,
+																	Line:   39,
+																},
+															},
+														},
+														Name: "obj",
+													},
+													Init: &ast.CallExpression{
+														Arguments: []ast.Expression{&ast.ObjectExpression{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 33,
+																		Line:   39,
+																	},
+																	File:   "discord.flux",
+																	Source: "r: r",
+																	Start: ast.Position{
+																		Column: 29,
+																		Line:   39,
+																	},
+																},
+															},
+															Properties: []*ast.Property{&ast.Property{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 33,
+																			Line:   39,
+																		},
+																		File:   "discord.flux",
+																		Source: "r: r",
+																		Start: ast.Position{
+																			Column: 29,
+																			Line:   39,
+																		},
+																	},
+																},
+																Key: &ast.Identifier{
+																	BaseNode: ast.BaseNode{
+																		Errors: nil,
+																		Loc: &ast.SourceLocation{
+																			End: ast.Position{
+																				Column: 30,
+																				Line:   39,
+																			},
+																			File:   "discord.flux",
+																			Source: "r",
+																			Start: ast.Position{
+																				Column: 29,
+																				Line:   39,
+																			},
+																		},
+																	},
+																	Name: "r",
+																},
+																Value: &ast.Identifier{
+																	BaseNode: ast.BaseNode{
+																		Errors: nil,
+																		Loc: &ast.SourceLocation{
+																			End: ast.Position{
+																				Column: 33,
+																				Line:   39,
+																			},
+																			File:   "discord.flux",
+																			Source: "r",
+																			Start: ast.Position{
+																				Column: 32,
+																				Line:   39,
+																			},
+																		},
+																	},
+																	Name: "r",
+																},
+															}},
+															With: nil,
+														}},
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 34,
+																	Line:   39,
+																},
+																File:   "discord.flux",
+																Source: "mapFn(r: r)",
+																Start: ast.Position{
+																	Column: 23,
+																	Line:   39,
+																},
+															},
+														},
+														Callee: &ast.Identifier{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 28,
+																		Line:   39,
+																	},
+																	File:   "discord.flux",
+																	Source: "mapFn",
+																	Start: ast.Position{
+																		Column: 23,
+																		Line:   39,
+																	},
+																},
+															},
+															Name: "mapFn",
+														},
+													},
+												}, &ast.ReturnStatement{
+													Argument: &ast.ObjectExpression{
+														BaseNode: ast.BaseNode{
+															Errors: nil,
+															Loc: &ast.SourceLocation{
+																End: ast.Position{
+																	Column: 26,
+																	Line:   46,
+																},
+																File:   "discord.flux",
+																Source: "{r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}",
+																Start: ast.Position{
+																	Column: 24,
+																	Line:   40,
+																},
+															},
+														},
+														Properties: []*ast.Property{&ast.Property{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 25,
+																		Line:   46,
+																	},
+																	File:   "discord.flux",
+																	Source: "_sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)",
+																	Start: ast.Position{
+																		Column: 32,
+																		Line:   40,
+																	},
+																},
+															},
+															Key: &ast.Identifier{
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 37,
+																			Line:   40,
+																		},
+																		File:   "discord.flux",
+																		Source: "_sent",
+																		Start: ast.Position{
+																			Column: 32,
+																			Line:   40,
+																		},
+																	},
+																},
+																Name: "_sent",
+															},
+															Value: &ast.CallExpression{
+																Arguments: []ast.Expression{&ast.ObjectExpression{
+																	BaseNode: ast.BaseNode{
+																		Errors: nil,
+																		Loc: &ast.SourceLocation{
+																			End: ast.Position{
+																				Column: 24,
+																				Line:   46,
+																			},
+																			File:   "discord.flux",
+																			Source: "v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100",
+																			Start: ast.Position{
+																				Column: 46,
+																				Line:   40,
+																			},
+																		},
+																	},
+																	Properties: []*ast.Property{&ast.Property{
+																		BaseNode: ast.BaseNode{
+																			Errors: nil,
+																			Loc: &ast.SourceLocation{
+																				End: ast.Position{
+																					Column: 24,
+																					Line:   46,
+																				},
+																				File:   "discord.flux",
+																				Source: "v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100",
+																				Start: ast.Position{
+																					Column: 46,
+																					Line:   40,
+																				},
+																			},
+																		},
+																		Key: &ast.Identifier{
+																			BaseNode: ast.BaseNode{
+																				Errors: nil,
+																				Loc: &ast.SourceLocation{
+																					End: ast.Position{
+																						Column: 47,
+																						Line:   40,
+																					},
+																					File:   "discord.flux",
+																					Source: "v",
+																					Start: ast.Position{
+																						Column: 46,
+																						Line:   40,
+																					},
+																				},
+																			},
+																			Name: "v",
+																		},
+																		Value: &ast.BinaryExpression{
+																			BaseNode: ast.BaseNode{
+																				Errors: nil,
+																				Loc: &ast.SourceLocation{
+																					End: ast.Position{
+																						Column: 24,
+																						Line:   46,
+																					},
+																					File:   "discord.flux",
+																					Source: "2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100",
+																					Start: ast.Position{
+																						Column: 49,
+																						Line:   40,
+																					},
+																				},
+																			},
+																			Left: &ast.IntegerLiteral{
+																				BaseNode: ast.BaseNode{
+																					Errors: nil,
+																					Loc: &ast.SourceLocation{
+																						End: ast.Position{
+																							Column: 50,
+																							Line:   40,
+																						},
+																						File:   "discord.flux",
+																						Source: "2",
+																						Start: ast.Position{
+																							Column: 49,
+																							Line:   40,
+																						},
+																					},
+																				},
+																				Value: int64(2),
+																			},
+																			Operator: 17,
+																			Right: &ast.BinaryExpression{
+																				BaseNode: ast.BaseNode{
+																					Errors: nil,
+																					Loc: &ast.SourceLocation{
+																						End: ast.Position{
+																							Column: 24,
+																							Line:   46,
+																						},
+																						File:   "discord.flux",
+																						Source: "send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100",
+																						Start: ast.Position{
+																							Column: 54,
+																							Line:   40,
+																						},
+																					},
+																				},
+																				Left: &ast.CallExpression{
+																					Arguments: []ast.Expression{&ast.ObjectExpression{
+																						BaseNode: ast.BaseNode{
+																							Errors: nil,
+																							Loc: &ast.SourceLocation{
+																								End: ast.Position{
+																									Column: 41,
+																									Line:   45,
+																								},
+																								File:   "discord.flux",
+																								Source: "webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content",
+																								Start: ast.Position{
+																									Column: 21,
+																									Line:   41,
+																								},
+																							},
+																						},
+																						Properties: []*ast.Property{&ast.Property{
+																							BaseNode: ast.BaseNode{
+																								Errors: nil,
+																								Loc: &ast.SourceLocation{
+																									End: ast.Position{
+																										Column: 47,
+																										Line:   41,
+																									},
+																									File:   "discord.flux",
+																									Source: "webhookToken: webhookToken",
+																									Start: ast.Position{
+																										Column: 21,
+																										Line:   41,
+																									},
+																								},
+																							},
+																							Key: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 33,
+																											Line:   41,
+																										},
+																										File:   "discord.flux",
+																										Source: "webhookToken",
+																										Start: ast.Position{
+																											Column: 21,
+																											Line:   41,
+																										},
+																									},
+																								},
+																								Name: "webhookToken",
+																							},
+																							Value: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 47,
+																											Line:   41,
+																										},
+																										File:   "discord.flux",
+																										Source: "webhookToken",
+																										Start: ast.Position{
+																											Column: 35,
+																											Line:   41,
+																										},
+																									},
+																								},
+																								Name: "webhookToken",
+																							},
+																						}, &ast.Property{
+																							BaseNode: ast.BaseNode{
+																								Errors: nil,
+																								Loc: &ast.SourceLocation{
+																									End: ast.Position{
+																										Column: 41,
+																										Line:   42,
+																									},
+																									File:   "discord.flux",
+																									Source: "webhookID: webhookID",
+																									Start: ast.Position{
+																										Column: 21,
+																										Line:   42,
+																									},
+																								},
+																							},
+																							Key: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 30,
+																											Line:   42,
+																										},
+																										File:   "discord.flux",
+																										Source: "webhookID",
+																										Start: ast.Position{
+																											Column: 21,
+																											Line:   42,
+																										},
+																									},
+																								},
+																								Name: "webhookID",
+																							},
+																							Value: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 41,
+																											Line:   42,
+																										},
+																										File:   "discord.flux",
+																										Source: "webhookID",
+																										Start: ast.Position{
+																											Column: 32,
+																											Line:   42,
+																										},
+																									},
+																								},
+																								Name: "webhookID",
+																							},
+																						}, &ast.Property{
+																							BaseNode: ast.BaseNode{
+																								Errors: nil,
+																								Loc: &ast.SourceLocation{
+																									End: ast.Position{
+																										Column: 39,
+																										Line:   43,
+																									},
+																									File:   "discord.flux",
+																									Source: "username: username",
+																									Start: ast.Position{
+																										Column: 21,
+																										Line:   43,
+																									},
+																								},
+																							},
+																							Key: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 29,
+																											Line:   43,
+																										},
+																										File:   "discord.flux",
+																										Source: "username",
+																										Start: ast.Position{
+																											Column: 21,
+																											Line:   43,
+																										},
+																									},
+																								},
+																								Name: "username",
+																							},
+																							Value: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 39,
+																											Line:   43,
+																										},
+																										File:   "discord.flux",
+																										Source: "username",
+																										Start: ast.Position{
+																											Column: 31,
+																											Line:   43,
+																										},
+																									},
+																								},
+																								Name: "username",
+																							},
+																						}, &ast.Property{
+																							BaseNode: ast.BaseNode{
+																								Errors: nil,
+																								Loc: &ast.SourceLocation{
+																									End: ast.Position{
+																										Column: 43,
+																										Line:   44,
+																									},
+																									File:   "discord.flux",
+																									Source: "avatar_url: avatar_url",
+																									Start: ast.Position{
+																										Column: 21,
+																										Line:   44,
+																									},
+																								},
+																							},
+																							Key: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 31,
+																											Line:   44,
+																										},
+																										File:   "discord.flux",
+																										Source: "avatar_url",
+																										Start: ast.Position{
+																											Column: 21,
+																											Line:   44,
+																										},
+																									},
+																								},
+																								Name: "avatar_url",
+																							},
+																							Value: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 43,
+																											Line:   44,
+																										},
+																										File:   "discord.flux",
+																										Source: "avatar_url",
+																										Start: ast.Position{
+																											Column: 33,
+																											Line:   44,
+																										},
+																									},
+																								},
+																								Name: "avatar_url",
+																							},
+																						}, &ast.Property{
+																							BaseNode: ast.BaseNode{
+																								Errors: nil,
+																								Loc: &ast.SourceLocation{
+																									End: ast.Position{
+																										Column: 41,
+																										Line:   45,
+																									},
+																									File:   "discord.flux",
+																									Source: "content: obj.content",
+																									Start: ast.Position{
+																										Column: 21,
+																										Line:   45,
+																									},
+																								},
+																							},
+																							Key: &ast.Identifier{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 28,
+																											Line:   45,
+																										},
+																										File:   "discord.flux",
+																										Source: "content",
+																										Start: ast.Position{
+																											Column: 21,
+																											Line:   45,
+																										},
+																									},
+																								},
+																								Name: "content",
+																							},
+																							Value: &ast.MemberExpression{
+																								BaseNode: ast.BaseNode{
+																									Errors: nil,
+																									Loc: &ast.SourceLocation{
+																										End: ast.Position{
+																											Column: 41,
+																											Line:   45,
+																										},
+																										File:   "discord.flux",
+																										Source: "obj.content",
+																										Start: ast.Position{
+																											Column: 30,
+																											Line:   45,
+																										},
+																									},
+																								},
+																								Object: &ast.Identifier{
+																									BaseNode: ast.BaseNode{
+																										Errors: nil,
+																										Loc: &ast.SourceLocation{
+																											End: ast.Position{
+																												Column: 33,
+																												Line:   45,
+																											},
+																											File:   "discord.flux",
+																											Source: "obj",
+																											Start: ast.Position{
+																												Column: 30,
+																												Line:   45,
+																											},
+																										},
+																									},
+																									Name: "obj",
+																								},
+																								Property: &ast.Identifier{
+																									BaseNode: ast.BaseNode{
+																										Errors: nil,
+																										Loc: &ast.SourceLocation{
+																											End: ast.Position{
+																												Column: 41,
+																												Line:   45,
+																											},
+																											File:   "discord.flux",
+																											Source: "content",
+																											Start: ast.Position{
+																												Column: 34,
+																												Line:   45,
+																											},
+																										},
+																									},
+																									Name: "content",
+																								},
+																							},
+																						}},
+																						With: nil,
+																					}},
+																					BaseNode: ast.BaseNode{
+																						Errors: nil,
+																						Loc: &ast.SourceLocation{
+																							End: ast.Position{
+																								Column: 18,
+																								Line:   46,
+																							},
+																							File:   "discord.flux",
+																							Source: "send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                )",
+																							Start: ast.Position{
+																								Column: 54,
+																								Line:   40,
+																							},
+																						},
+																					},
+																					Callee: &ast.Identifier{
+																						BaseNode: ast.BaseNode{
+																							Errors: nil,
+																							Loc: &ast.SourceLocation{
+																								End: ast.Position{
+																									Column: 58,
+																									Line:   40,
+																								},
+																								File:   "discord.flux",
+																								Source: "send",
+																								Start: ast.Position{
+																									Column: 54,
+																									Line:   40,
+																								},
+																							},
+																						},
+																						Name: "send",
+																					},
+																				},
+																				Operator: 2,
+																				Right: &ast.IntegerLiteral{
+																					BaseNode: ast.BaseNode{
+																						Errors: nil,
+																						Loc: &ast.SourceLocation{
+																							End: ast.Position{
+																								Column: 24,
+																								Line:   46,
+																							},
+																							File:   "discord.flux",
+																							Source: "100",
+																							Start: ast.Position{
+																								Column: 21,
+																								Line:   46,
+																							},
+																						},
+																					},
+																					Value: int64(100),
+																				},
+																			},
+																		},
+																	}},
+																	With: nil,
+																}},
+																BaseNode: ast.BaseNode{
+																	Errors: nil,
+																	Loc: &ast.SourceLocation{
+																		End: ast.Position{
+																			Column: 25,
+																			Line:   46,
+																		},
+																		File:   "discord.flux",
+																		Source: "string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)",
+																		Start: ast.Position{
+																			Column: 39,
+																			Line:   40,
+																		},
+																	},
+																},
+																Callee: &ast.Identifier{
+																	BaseNode: ast.BaseNode{
+																		Errors: nil,
+																		Loc: &ast.SourceLocation{
+																			End: ast.Position{
+																				Column: 45,
+																				Line:   40,
+																			},
+																			File:   "discord.flux",
+																			Source: "string",
+																			Start: ast.Position{
+																				Column: 39,
+																				Line:   40,
+																			},
+																		},
+																	},
+																	Name: "string",
+																},
+															},
+														}},
+														With: &ast.Identifier{
+															BaseNode: ast.BaseNode{
+																Errors: nil,
+																Loc: &ast.SourceLocation{
+																	End: ast.Position{
+																		Column: 26,
+																		Line:   40,
+																	},
+																	File:   "discord.flux",
+																	Source: "r",
+																	Start: ast.Position{
+																		Column: 25,
+																		Line:   40,
+																	},
+																},
+															},
+															Name: "r",
+														},
+													},
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 26,
+																Line:   46,
+															},
+															File:   "discord.flux",
+															Source: "return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}",
+															Start: ast.Position{
+																Column: 17,
+																Line:   40,
+															},
+														},
+													},
+												}},
+											},
+											Params: []*ast.Property{&ast.Property{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 26,
+															Line:   38,
+														},
+														File:   "discord.flux",
+														Source: "r",
+														Start: ast.Position{
+															Column: 25,
+															Line:   38,
+														},
+													},
+												},
+												Key: &ast.Identifier{
+													BaseNode: ast.BaseNode{
+														Errors: nil,
+														Loc: &ast.SourceLocation{
+															End: ast.Position{
+																Column: 26,
+																Line:   38,
+															},
+															File:   "discord.flux",
+															Source: "r",
+															Start: ast.Position{
+																Column: 25,
+																Line:   38,
+															},
+														},
+													},
+													Name: "r",
+												},
+												Value: nil,
+											}},
+										},
+									}},
+									With: nil,
+								}},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 15,
+											Line:   47,
+										},
+										File:   "discord.flux",
+										Source: "map(fn: (r) => {\n                obj = mapFn(r: r)\n                return {r with _sent: string(v: 2 == send(\n                    webhookToken: webhookToken,\n                    webhookID: webhookID,\n                    username: username,\n                    avatar_url: avatar_url,\n                    content: obj.content,\n                ) / 100)}\n            })",
+										Start: ast.Position{
+											Column: 16,
+											Line:   38,
+										},
+									},
+								},
+								Callee: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 19,
+												Line:   38,
+											},
+											File:   "discord.flux",
+											Source: "map",
+											Start: ast.Position{
+												Column: 16,
+												Line:   38,
+											},
+										},
+									},
+									Name: "map",
+								},
+							},
+						},
+						Params: []*ast.Property{&ast.Property{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 19,
+										Line:   37,
+									},
+									File:   "discord.flux",
+									Source: "tables=<-",
+									Start: ast.Position{
+										Column: 10,
+										Line:   37,
+									},
+								},
+							},
+							Key: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 16,
+											Line:   37,
+										},
+										File:   "discord.flux",
+										Source: "tables",
+										Start: ast.Position{
+											Column: 10,
+											Line:   37,
+										},
+									},
+								},
+								Name: "tables",
+							},
+							Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 19,
+										Line:   37,
+									},
+									File:   "discord.flux",
+									Source: "<-",
+									Start: ast.Position{
+										Column: 17,
+										Line:   37,
+									},
+								},
+							}},
+						}},
+					},
+					Params: []*ast.Property{&ast.Property{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 11,
+									Line:   36,
+								},
+								File:   "discord.flux",
+								Source: "mapFn",
+								Start: ast.Position{
+									Column: 6,
+									Line:   36,
+								},
+							},
+						},
+						Key: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 11,
+										Line:   36,
+									},
+									File:   "discord.flux",
+									Source: "mapFn",
+									Start: ast.Position{
+										Column: 6,
+										Line:   36,
+									},
+								},
+							},
+							Name: "mapFn",
+						},
+						Value: nil,
+					}},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 25,
+								Line:   35,
+							},
+							File:   "discord.flux",
+							Source: "webhookToken",
+							Start: ast.Position{
+								Column: 13,
+								Line:   35,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 25,
+									Line:   35,
+								},
+								File:   "discord.flux",
+								Source: "webhookToken",
+								Start: ast.Position{
+									Column: 13,
+									Line:   35,
+								},
+							},
+						},
+						Name: "webhookToken",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 36,
+								Line:   35,
+							},
+							File:   "discord.flux",
+							Source: "webhookID",
+							Start: ast.Position{
+								Column: 27,
+								Line:   35,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 36,
+									Line:   35,
+								},
+								File:   "discord.flux",
+								Source: "webhookID",
+								Start: ast.Position{
+									Column: 27,
+									Line:   35,
+								},
+							},
+						},
+						Name: "webhookID",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 46,
+								Line:   35,
+							},
+							File:   "discord.flux",
+							Source: "username",
+							Start: ast.Position{
+								Column: 38,
+								Line:   35,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 46,
+									Line:   35,
+								},
+								File:   "discord.flux",
+								Source: "username",
+								Start: ast.Position{
+									Column: 38,
+									Line:   35,
+								},
+							},
+						},
+						Name: "username",
+					},
+					Value: nil,
+				}, &ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 61,
+								Line:   35,
+							},
+							File:   "discord.flux",
+							Source: "avatar_url=\"\"",
+							Start: ast.Position{
+								Column: 48,
+								Line:   35,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 58,
+									Line:   35,
+								},
+								File:   "discord.flux",
+								Source: "avatar_url",
+								Start: ast.Position{
+									Column: 48,
+									Line:   35,
+								},
+							},
+						},
+						Name: "avatar_url",
+					},
+					Value: &ast.StringLiteral{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 61,
+									Line:   35,
+								},
+								File:   "discord.flux",
+								Source: "\"\"",
+								Start: ast.Position{
+									Column: 59,
+									Line:   35,
 								},
 							},
 						},


### PR DESCRIPTION
This PR adds a new endpoint function to flux contrib/chobbs/discord package + updates documentation and improves tests. This function is added in order to have the same capabilities as other notification packages (slack/pagerduty/teams/telegram) that are then used in InfluxDB.
  
### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
