### PR TITLE
feat: add query plan to query metadata

### DIFF
--- a/execute/source.go
+++ b/execute/source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/metadata"
 	"github.com/influxdata/flux/plan"
 )
 
@@ -17,7 +17,7 @@ type Node interface {
 // processed.
 type MetadataNode interface {
 	Node
-	Metadata() flux.Metadata
+	Metadata() metadata.Metadata
 }
 
 type Source interface {

--- a/lang/execdeps/dependencies.go
+++ b/lang/execdeps/dependencies.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/metadata"
 	"go.uber.org/zap"
 )
 
@@ -21,6 +22,10 @@ type ExecutionDependencies struct {
 
 	// Allowed to be nil
 	Logger *zap.Logger
+
+	// Metadata is passed up from any invocations of execution up to the parent
+	// execution, and out through the statistics.
+	Metadata metadata.Metadata
 }
 
 func (d ExecutionDependencies) Inject(ctx context.Context) context.Context {
@@ -50,6 +55,7 @@ func NewExecutionDependencies(allocator *memory.Allocator, now *time.Time, logge
 		Allocator: allocator,
 		Now:       now,
 		Logger:    logger,
+		Metadata:  make(metadata.Metadata),
 	}
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,32 @@
+package metadata
+
+// Metadata is made as a standalone package to avoid import cycle:
+// influxd -> flux -> flux/interpreter -> flux/lang/execdeps -> flux
+type Metadata map[string][]interface{}
+
+func (md Metadata) Add(key string, value interface{}) {
+	md[key] = append(md[key], value)
+}
+
+func (md Metadata) AddAll(other Metadata) {
+	for key, values := range other {
+		md[key] = append(md[key], values...)
+	}
+}
+
+// Range will iterate over the Metadata. It will invoke the function for each
+// key/value pair. If there are multiple values for a single key, then this will
+// be called with the same key once for each value.
+func (md Metadata) Range(fn func(key string, value interface{}) bool) {
+	for key, values := range md {
+		for _, value := range values {
+			if ok := fn(key, value); !ok {
+				return
+			}
+		}
+	}
+}
+
+func (md Metadata) Del(key string) {
+	delete(md, key)
+}

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -6,33 +6,34 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/metadata"
 	"github.com/influxdata/flux/plan"
 )
 
 var _ execute.Executor = (*Executor)(nil)
 
-var NoMetadata <-chan flux.Metadata
+var NoMetadata <-chan metadata.Metadata
 
 // Executor is a mock implementation of an execute.Executor.
 type Executor struct {
-	ExecuteFn func(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error)
+	ExecuteFn func(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error)
 }
 
 // NewExecutor returns a mock Executor where its methods will return zero values.
 func NewExecutor() *Executor {
 	return &Executor{
-		ExecuteFn: func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+		ExecuteFn: func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
 			return nil, NoMetadata, nil
 		},
 	}
 }
 
-func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan flux.Metadata, error) {
+func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
 	return e.ExecuteFn(ctx, p, a)
 }
 
 func init() {
-	noMetaCh := make(chan flux.Metadata)
+	noMetaCh := make(chan metadata.Metadata)
 	close(noMetaCh)
 	NoMetadata = noMetaCh
 }

--- a/stdlib/experimental/chain.go
+++ b/stdlib/experimental/chain.go
@@ -66,5 +66,7 @@ func chainCall(ctx context.Context, args values.Object) (values.Value, error) {
 		}
 	}
 
+	deps.Metadata.AddAll(query.Statistics().Metadata)
+
 	return second, nil
 }

--- a/stdlib/universe/dual_impl_spec.go
+++ b/stdlib/universe/dual_impl_spec.go
@@ -1,6 +1,8 @@
 package universe
 
 import (
+	"fmt"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/plan"
@@ -10,6 +12,10 @@ type DualImplProcedureSpec struct {
 	plan.ProcedureSpec
 	plan.DefaultCost
 	UseDeprecated bool
+}
+
+func (s *DualImplProcedureSpec) PlanDetails() string {
+	return fmt.Sprintf("DualImplProcedureSpec, UseDeprecated = %v", s.UseDeprecated)
 }
 
 func (s *DualImplProcedureSpec) Kind() plan.ProcedureKind {

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -136,6 +136,9 @@ func tableFind(ctx context.Context, to *flux.TableObject, fn *execute.TablePredi
 			return nil, err
 		}
 	}
+
+	deps.Metadata.AddAll(q.Statistics().Metadata)
+
 	if !found {
 		return nil, nil
 	}


### PR DESCRIPTION
`Metadata` is a key-value map stored with the query statistics.
It currently contains data for the sources, for example, "influxdb/scanned-bytes" and "influxdb/scanned-values".
The goal here is to add the query plan to query metadata, which is later accessed to generate the `query_log` entry.

Queries with functions like `tableFind()` and `experimental.chain()` will call into the execution engine more than once. The statistics of those additional calls won't be preserved so their query plans are lost.
The solution for it is temporarily caching their metadata in the execution dependency, and we will extract them at the time when the main query is executed. 

In this PR, `flux.Metadata` is moved to a standalone package to address a dependency cycle issue: `influxd -> flux -> flux/interpreter -> flux/lang/execdeps -> flux` 

This PR also adds `Detailer` implementations to several procedure specs. The `Detailer` interface is used to add additional details to the formatted query plan output. For example, the aggregate function that is being pushed down with the `ReadGroup` or the `ReadWindowAggregate` call, the real implementation that is being used for transformations that have dual implementations.