### PR TITLE
feat(execute/function): create an alternative for constructing new transformations

### DIFF
--- a/internal/execute/function/args.go
+++ b/internal/execute/function/args.go
@@ -1,0 +1,283 @@
+package function
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// Arguments defines the interface for reading an Argument.
+type Arguments interface {
+	// Get will retrieve the Value associated with
+	// the name. If the argument was not provided,
+	// false will be returned.
+	Get(name string) (values.Value, bool)
+}
+
+// ReadArgs will read Arguments into a spec.
+// The spec must be a pointer to a struct value.
+//
+// Each field is set from a value with the corresponding name.
+// The default name for a field is to convert the exported
+// field name to lowerCamelCase.
+//
+// The basic types of int, uint, float, and string are converted
+// directly from the corresponding value type. All of the different
+// sizes for the numeric types are supported.
+//
+// Array types are converted into slice types. Go array types
+// are not supported.
+//
+// Object types are converted into maps or structs. If a map,
+// the key must be a string and the value can be anything normally
+// supported. If a struct type, the same process is used as
+// reading a spec.
+//
+// If a type implements the Argument interface, the ReadArg
+// function will be used instead of the normal assignments.
+//
+// For all other types, it will attempt to assign the
+// values.Value type. If this isn't possible, an error will
+// be returned.
+//
+// To customize the behavior, the `flux` struct tag can be used.
+//
+// 		type CustomSpec struct {
+//			Tables       *function.TableObject `flux:"tables,required"`
+//			Column       string                `flux:",required"`
+//			DefaultValue values.Value          `flux:"default"`
+//			Ignored      string                `flux:"-"`
+//		}
+//
+// An alternate name can be used with the `flux` struct tag.
+// The `-` string can be used to tell the argument reader to
+// ignore that value. Non-exported values are always ignored.
+//
+// A comma can be used to separate options or no name can be given
+// and a comma can be used to use the default name with options.
+// The `required` option marks a field as required.
+func ReadArgs(spec interface{}, args Arguments, a *flux.Administration) error {
+	if a == nil {
+		a = &flux.Administration{}
+	}
+
+	v := reflect.ValueOf(spec)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return errors.New(codes.Internal, "spec must be a pointer to a struct")
+	}
+
+	elem := v.Elem()
+	elemType := elem.Type()
+	for i, n := 0, elemType.NumField(); i < n; i++ {
+		ftype := elemType.Field(i)
+		name, required, ok := getArgInfo(ftype)
+		if !ok {
+			continue
+		}
+
+		fval := elem.Field(i)
+		if err := readArg(fval, args, name, required, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getArgInfo(field reflect.StructField) (name string, required, ok bool) {
+	name = field.Tag.Get("flux")
+	if name == "-" {
+		return
+	}
+
+	options := strings.Split(name, ",")
+	for _, opt := range options[1:] {
+		if opt == "required" {
+			required = true
+		}
+	}
+	name = options[0]
+
+	if name == "" {
+		argN := []rune(field.Name)
+		if len(argN) > 0 {
+			argN[0] = unicode.ToLower(argN[0])
+		}
+		name = string(argN)
+	}
+	ok = true
+	return
+}
+
+func readArg(fv reflect.Value, args Arguments, name string, required bool, a *flux.Administration) error {
+	arg, ok := args.Get(name)
+	if !ok && required {
+		return errors.Newf(codes.Invalid, "missing required keyword argument %q", name)
+	} else if !ok {
+		return nil
+	}
+
+	if fv.Kind() == reflect.Ptr {
+		if fv.IsNil() {
+			v := reflect.New(fv.Type().Elem())
+			fv.Set(v)
+		}
+		fv = fv.Elem()
+	}
+	return readArgValue(fv, arg, name, a)
+}
+
+func readArgValue(fv reflect.Value, arg values.Value, name string, a *flux.Administration) error {
+	// If the field is implements the Argument interface,
+	// always use that.
+	if fv.CanAddr() {
+		iv := fv.Addr().Interface()
+		if argV, ok := iv.(Argument); ok {
+			return argV.ReadArg(name, arg, a)
+		}
+	}
+
+	switch fv.Kind() {
+	case reflect.String:
+		return readStrArg(fv, arg, name)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return readIntArg(fv, arg, name)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return readUintArg(fv, arg, name)
+	case reflect.Float64, reflect.Float32:
+		return readFloatArg(fv, arg, name)
+	case reflect.Slice:
+		return readArrayArg(fv, arg, name, a)
+	case reflect.Map:
+		return readObjectArg(fv, arg, name, a)
+	case reflect.Struct:
+		return readStructArg(fv, arg, name, a)
+	default:
+		argV := reflect.ValueOf(arg)
+		if argV.Type().AssignableTo(fv.Type()) {
+			fv.Set(argV)
+			return nil
+		}
+		return errors.Newf(codes.Internal, "invalid argument type: %T", fv.Interface())
+	}
+}
+
+func readStrArg(fv reflect.Value, arg values.Value, name string) error {
+	if arg.Type().Nature() != semantic.String {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.String, arg.Type().Nature())
+	}
+	fv.SetString(arg.Str())
+	return nil
+}
+
+func readIntArg(fv reflect.Value, arg values.Value, name string) error {
+	if arg.Type().Nature() != semantic.Int {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.Int, arg.Type().Nature())
+	}
+	// TODO(jsternberg): Check for integer size.
+	fv.SetInt(arg.Int())
+	return nil
+}
+
+func readUintArg(fv reflect.Value, arg values.Value, name string) error {
+	if arg.Type().Nature() != semantic.UInt {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.UInt, arg.Type().Nature())
+	}
+	// TODO(jsternberg): Check for float size.
+	fv.SetUint(arg.UInt())
+	return nil
+}
+
+func readFloatArg(fv reflect.Value, arg values.Value, name string) error {
+	if arg.Type().Nature() != semantic.Float {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.Float, arg.Type().Nature())
+	}
+	// TODO(jsternberg): Check for float size.
+	fv.SetFloat(arg.Float())
+	return nil
+}
+
+func readArrayArg(fv reflect.Value, arg values.Value, name string, a *flux.Administration) error {
+	if arg.Type().Nature() != semantic.Array {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.Array, arg.Type().Nature())
+	}
+	arr := arg.Array()
+
+	arrv := reflect.MakeSlice(fv.Type(), arr.Len(), arr.Len())
+	for i, sz := 0, arr.Len(); i < sz; i++ {
+		name := fmt.Sprintf("%s[%d]", name, i)
+		if err := readArgValue(arrv.Index(i), arr.Get(i), name, a); err != nil {
+			return err
+		}
+	}
+	fv.Set(arrv)
+	return nil
+}
+
+func readObjectArg(fv reflect.Value, arg values.Value, name string, a *flux.Administration) (err error) {
+	if fv.Type().Key().Kind() != reflect.String {
+		return errors.Newf(codes.Internal, "only string keys are supported for map types")
+	} else if arg.Type().Nature() != semantic.Object {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.Object, arg.Type().Nature())
+	}
+	obj := arg.Object()
+
+	objv := reflect.MakeMapWithSize(fv.Type(), obj.Len())
+	obj.Range(func(key string, v values.Value) {
+		if err != nil {
+			return
+		}
+		name := fmt.Sprintf("%s[%s]", name, key)
+		keyV := reflect.ValueOf(key)
+
+		var elem reflect.Value
+		if elemT := fv.Type().Elem(); elemT.Kind() == reflect.Ptr {
+			elem = reflect.New(elemT.Elem())
+		} else {
+			elem = reflect.New(elemT).Elem()
+		}
+
+		if err = readArgValue(elem, v, name, a); err != nil {
+			return
+		}
+		objv.SetMapIndex(keyV, elem)
+	})
+	fv.Set(objv)
+	return err
+}
+
+func readStructArg(fv reflect.Value, arg values.Value, name string, a *flux.Administration) error {
+	if arg.Type().Nature() != semantic.Object {
+		return errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, semantic.Object, arg.Type().Nature())
+	}
+	args := interpreter.NewArguments(arg.Object())
+	return ReadArgs(fv.Addr().Interface(), args, a)
+}
+
+// Argument defines the interface for reading an argument
+// into a value.
+type Argument interface {
+	ReadArg(name string, arg values.Value, a *flux.Administration) error
+}
+
+// TableObject is a flux.TableObject that implements the Argument interface.
+type TableObject struct {
+	*flux.TableObject
+}
+
+func (t *TableObject) ReadArg(name string, arg values.Value, a *flux.Administration) error {
+	o, ok := arg.(*flux.TableObject)
+	if !ok {
+		return errors.Newf(codes.Invalid, "argument is not a table object: got %T", arg)
+	}
+	t.TableObject = o
+	a.AddParent(o)
+	return nil
+}

--- a/internal/execute/function/args_internal_test.go
+++ b/internal/execute/function/args_internal_test.go
@@ -1,0 +1,5 @@
+package function
+
+func (t *TableObject) Equal(other *TableObject) bool {
+	return t.Kind == other.Kind
+}

--- a/internal/execute/function/args_test.go
+++ b/internal/execute/function/args_test.go
@@ -1,0 +1,290 @@
+package function_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/internal/execute/function"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func TestReadArgs(t *testing.T) {
+	readArgs := func(spec interface{}, args map[string]values.Value) error {
+		fargs := interpreter.NewArguments(values.NewObjectWithValues(args))
+		return function.ReadArgs(spec, fargs, nil)
+	}
+	for _, tt := range []struct {
+		name    string
+		args    map[string]values.Value
+		want    interface{}
+		wantErr string
+	}{
+		{
+			name: "Any",
+			args: map[string]values.Value{
+				"a": values.NewString("t0"),
+				"b": values.NewInt(4),
+			},
+			want: &struct {
+				A values.Value
+				B values.Value
+			}{
+				A: values.NewString("t0"),
+				B: values.NewInt(4),
+			},
+		},
+		{
+			name: "Float64",
+			args: map[string]values.Value{
+				"a": values.NewFloat(2.0),
+			},
+			want: &struct{ A float64 }{A: 2.0},
+		},
+		{
+			name: "Int64",
+			args: map[string]values.Value{
+				"a": values.NewInt(5),
+			},
+			want: &struct{ A int64 }{A: 5},
+		},
+		{
+			name: "Uint64",
+			args: map[string]values.Value{
+				"a": values.NewUInt(8),
+			},
+			want: &struct{ A uint64 }{A: 8},
+		},
+		{
+			name: "Pointer",
+			args: map[string]values.Value{
+				"a": values.NewFloat(2.0),
+			},
+			want: &struct {
+				A *float64
+				B *int64
+			}{
+				A: func(v float64) *float64 { return &v }(2.0),
+				B: nil,
+			},
+		},
+		{
+			name: "Strings",
+			args: map[string]values.Value{
+				"values": values.NewArrayWithBacking(
+					semantic.NewArrayType(semantic.BasicString),
+					[]values.Value{
+						values.NewString("a"),
+						values.NewString("b"),
+						values.NewString("c"),
+					},
+				),
+			},
+			want: &struct {
+				Values []string
+			}{
+				Values: []string{"a", "b", "c"},
+			},
+		},
+		{
+			name: "Object",
+			args: map[string]values.Value{
+				"columns": values.NewObjectWithValues(map[string]values.Value{
+					"name":  values.NewString("foo"),
+					"value": values.NewInt(4),
+				}),
+			},
+			want: &struct {
+				Columns map[string]values.Value
+			}{
+				Columns: map[string]values.Value{
+					"name":  values.NewString("foo"),
+					"value": values.NewInt(4),
+				},
+			},
+		},
+		{
+			name: "ObjectNativeType",
+			args: map[string]values.Value{
+				"columns": values.NewObjectWithValues(map[string]values.Value{
+					"name":  values.NewString("foo"),
+					"value": values.NewString("bar"),
+				}),
+			},
+			want: &struct {
+				Columns map[string]string
+			}{
+				Columns: map[string]string{
+					"name":  "foo",
+					"value": "bar",
+				},
+			},
+		},
+		{
+			name: "Struct",
+			args: map[string]values.Value{
+				"o": values.NewObjectWithValues(map[string]values.Value{
+					"a": values.NewInt(4),
+					"b": values.NewFloat(7.0),
+				}),
+			},
+			want: &struct {
+				O struct {
+					A int64
+					B float64
+				}
+			}{
+				O: struct {
+					A int64
+					B float64
+				}{A: 4, B: 7.0},
+			},
+		},
+		{
+			name: "TableObject",
+			args: map[string]values.Value{
+				"tables": &flux.TableObject{Kind: "from"},
+				"column": values.NewString("_value"),
+			},
+			want: &struct {
+				Tables *function.TableObject
+				Column string
+			}{
+				Tables: &function.TableObject{
+					TableObject: &flux.TableObject{
+						Kind: "from",
+					},
+				},
+				Column: "_value",
+			},
+		},
+		{
+			name: "TagName",
+			args: map[string]values.Value{
+				"a": values.NewInt(5),
+			},
+			want: &struct {
+				B int `flux:"a"`
+			}{B: 5},
+		},
+		{
+			name: "Ignored",
+			args: map[string]values.Value{
+				"a": values.NewInt(5),
+				"b": values.NewString("foo"),
+			},
+			want: &struct {
+				A int
+				B string `flux:"-"`
+			}{
+				A: 5,
+			},
+		},
+		{
+			name: "MissingRequired",
+			args: map[string]values.Value{
+				"a": values.NewInt(5),
+			},
+			want: &struct {
+				A int
+				B string `flux:",required"`
+			}{
+				A: 5,
+			},
+			wantErr: "missing required keyword argument \"b\"",
+		},
+		{
+			name: "BadString",
+			args: map[string]values.Value{
+				"a": values.NewInt(4),
+			},
+			want:    &struct{ A string }{},
+			wantErr: "keyword argument \"a\" should be of kind string, but got int",
+		},
+		{
+			name: "BadInt",
+			args: map[string]values.Value{
+				"a": values.NewFloat(4),
+			},
+			want:    &struct{ A int }{},
+			wantErr: "keyword argument \"a\" should be of kind int, but got float",
+		},
+		{
+			name: "BadUInt",
+			args: map[string]values.Value{
+				"a": values.NewFloat(4),
+			},
+			want:    &struct{ A uint }{},
+			wantErr: "keyword argument \"a\" should be of kind uint, but got float",
+		},
+		{
+			name: "BadFloat",
+			args: map[string]values.Value{
+				"a": values.NewInt(4),
+			},
+			want:    &struct{ A float64 }{},
+			wantErr: "keyword argument \"a\" should be of kind float, but got int",
+		},
+		{
+			name: "BadArray",
+			args: map[string]values.Value{
+				"a": values.NewInt(4),
+			},
+			want:    &struct{ A []int }{},
+			wantErr: "keyword argument \"a\" should be of kind array, but got int",
+		},
+		{
+			name: "BadObject",
+			args: map[string]values.Value{
+				"a": values.NewInt(4),
+			},
+			want:    &struct{ A map[string]int }{},
+			wantErr: "keyword argument \"a\" should be of kind object, but got int",
+		},
+		{
+			name: "BadObjectKey",
+			args: map[string]values.Value{
+				"a": values.NewObjectWithValues(map[string]values.Value{
+					"b": values.NewInt(4),
+				}),
+			},
+			want:    &struct{ A map[int]int }{},
+			wantErr: "only string keys are supported for map types",
+		},
+		{
+			name: "BadStruct",
+			args: map[string]values.Value{
+				"o": values.NewInt(4),
+			},
+			want: &struct {
+				O struct {
+					A int64
+					B float64
+				}
+			}{},
+			wantErr: "keyword argument \"o\" should be of kind object, but got int",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			typ := reflect.TypeOf(tt.want).Elem()
+			got := reflect.New(typ).Interface()
+			if err := readArgs(got, tt.args); err != nil {
+				if want, got := tt.wantErr, err.Error(); want != got {
+					t.Fatalf("unexpected error -want/+got:\n\t- %q\n\t+ %q", want, got)
+				}
+				return
+			}
+
+			if tt.wantErr != "" {
+				t.Fatal("expected error")
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/internal/execute/function/doc.go
+++ b/internal/execute/function/doc.go
@@ -1,0 +1,14 @@
+// Package function implements a utility for defining
+// transformations using reflection on structs.
+//
+// This package is experimental and important features
+// have not yet been implemented. Be cautioned to test
+// well any code that uses this package to build procedure
+// specs. If the struct itself is invalid, the program can
+// panic.
+//
+// The heart of this package is in the ReadArgs function
+// and the associated RegisterTransformation. Look at the
+// documentation to those functions to get a better idea
+// of how to use this package.
+package function

--- a/internal/execute/function/transformation.go
+++ b/internal/execute/function/transformation.go
@@ -1,0 +1,96 @@
+package function
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/semantic"
+)
+
+// TransformationSpec defines a spec for creating a transformation.
+type TransformationSpec interface {
+	// CreateTransformation will construct a transformation
+	// and dataset using the given dataset and administration object.
+	CreateTransformation(id execute.DatasetID, a execute.Administration) (execute.Transformation, execute.Dataset, error)
+}
+
+type specFactory struct {
+	t    reflect.Type
+	kind plan.ProcedureKind
+}
+
+func (f *specFactory) createOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	ptr := reflect.New(f.t)
+	if err := ReadArgs(ptr.Interface(), args, a); err != nil {
+		return nil, err
+	}
+	return &operationSpec{
+		spec: &procedureSpec{
+			kind: f.kind,
+			spec: ptr.Interface().(TransformationSpec),
+		},
+	}, nil
+}
+
+type operationSpec struct {
+	spec *procedureSpec
+}
+
+func (o *operationSpec) Kind() flux.OperationKind {
+	return flux.OperationKind(o.spec.Kind())
+}
+
+type procedureSpec struct {
+	plan.DefaultCost
+	kind plan.ProcedureKind
+	spec TransformationSpec
+}
+
+func newProcedureSpec(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*operationSpec)
+	if !ok {
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
+	}
+	return spec.spec, nil
+}
+
+func (p *procedureSpec) Kind() plan.ProcedureKind {
+	return p.kind
+}
+
+func (p *procedureSpec) Copy() plan.ProcedureSpec {
+	return p
+}
+
+func createTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*procedureSpec)
+	if !ok {
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
+	}
+	return s.spec.CreateTransformation(id, a)
+}
+
+// RegisterTransformation will register a TransformationSpec
+// in the pkgpath with name. The TransformationSpec is read from
+// arguments using ReadArgs.
+//
+// The operation spec and procedure spec will be automatically generated
+// for this transformation and the kind will be a concatenation of
+// the pkgpath and name separated by a dot.
+func RegisterTransformation(pkgpath, name string, spec TransformationSpec, signature semantic.MonoType) {
+	kind := plan.ProcedureKind(fmt.Sprintf("%s.%s", pkgpath, name))
+	factory := &specFactory{
+		t:    reflect.TypeOf(spec).Elem(),
+		kind: kind,
+	}
+	fn := flux.MustValue(flux.FunctionValue(name, factory.createOpSpec, signature))
+	runtime.RegisterPackageValue(pkgpath, name, fn)
+	plan.RegisterProcedureSpec(kind, newProcedureSpec, flux.OperationKind(kind))
+	execute.RegisterTransformation(kind, createTransformation)
+}


### PR DESCRIPTION
This code tries to simplify creating new transformations by using
reflection to read arguments rather than custom code that looks very
similar. This method should work for a majority of transformations where
creating the operation spec is a simple mapping of types to their Go
equivalents and potentially a bit more.

The idea is that you create a single struct called the
`TransformationSpec`. This is a `ProcedureSpec` that knows how to create
a transformation from itself. The `TransformationSpec` can define and
customize its parameters using struct tags labeled as `flux` or it can
use the defaults as described in the `ReadArgs` documentation. That can
make implementing some transformations more simple. As an example,
`max()` could be implemented by doing:

    type MaxProcedureSpec struct {
        Tables *functions.TableObject `flux:"<-"`
        Column string
    }

    func (s *MaxProcedureSpec) CreateTransformation(id execute.DatasetID, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
        // construct the transformation using the arguments
    }

This work is experimental and incomplete. Please be sure to thoroughly
test the transformation with different arguments when testing. The
intention is to create a foundation that makes creating transformations
easier, less code intense, and easier to document and teach.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written