### PR TITLE
fix(deps): make socket/sql url test robust

### DIFF
--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -179,8 +179,7 @@ func (testCases *SourceUrlValidationTestCases) Run(t *testing.T, fn execute.Crea
 					t.Errorf("Expect an error with message \"%s\", but did not get one.", tc.ErrMsg)
 				} else {
 					if !strings.Contains(err.Error(), tc.ErrMsg) {
-						t.Fatalf("unexpected result -want/+got:\n%s",
-							cmp.Diff(err.Error(), tc.ErrMsg))
+						t.Fatalf("unexpected result got %q expected error to contain %q", err.Error(), tc.ErrMsg)
 					}
 				}
 			} else {

--- a/stdlib/socket/from_private_test.go
+++ b/stdlib/socket/from_private_test.go
@@ -34,11 +34,13 @@ func TestFromSocketUrlValidation(t *testing.T) {
 		}, {
 			Name: "no such host",
 			Spec: &FromSocketProcedureSpec{
-				URL:     "unix://notfound:12345/abc",
+				// Using 'invalid.' for DNS name as its guaranteed not to exist
+				// https://tools.ietf.org/html/rfc6761#section-6.4
+				URL:     "unix://notfound.invalid.:12345/abc",
 				Decoder: "csv",
 			},
 			V:      url.PrivateIPValidator{},
-			ErrMsg: "no such host",
+			ErrMsg: "url did not pass validation",
 		},
 	}
 	testCases.Run(t, createFromSocketSource)

--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -119,12 +119,14 @@ func TestFromSqlUrlValidation(t *testing.T) {
 		}, {
 			Name: "no such host",
 			Spec: &FromSQLProcedureSpec{
-				DriverName:     "sqlmock",
-				DataSourceName: "sqlmock://test:password@notfound/pqgotest?sslmode=verify-full",
+				DriverName: "sqlmock",
+				// Using 'invalid.' for DNS name as its guaranteed not to exist
+				// https://tools.ietf.org/html/rfc6761#section-6.4
+				DataSourceName: "sqlmock://test:password@notfound.invalid./pqgotest?sslmode=verify-full",
 				Query:          "",
 			},
 			V:      url.PrivateIPValidator{},
-			ErrMsg: "no such host",
+			ErrMsg: "data source did not pass url validation",
 		},
 	}
 	testCases.Run(t, createFromSQLSource)


### PR DESCRIPTION
The socket and sql url validator tests would fail on linux systems
because the message returned from Go depended on the specific DNS
resolver being used. The test case now validates that the error comes
form the correct call to the validation path but does not otherwise care
about the specific wording used to indicate a DNS resolution failure.

Additionally the hostname used is guaranteed to not exist based on RFC
6761.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
