### PR TITLE
fix(compiler): handle pipe arguments inside of compiler

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -593,6 +593,22 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 		if err != nil {
 			return nil, err
 		}
+		if n.Pipe != nil {
+			pipeArg, err := n.Callee.TypeOf().PipeArgument()
+			if err != nil {
+				return nil, err
+
+			}
+			if pipeArg == nil {
+				// This should be caught during type inference
+				return nil, errors.Newf(codes.Internal, "callee lacks a pipe argument, but one was provided")
+			}
+			pipe, err := compile(n.Pipe, subst, scope)
+			if err != nil {
+				return nil, err
+			}
+			args.(*objEvaluator).properties[string(pipeArg.Name())] = pipe
+		}
 		callee, err := compile(n.Callee, subst, scope)
 		if err != nil {
 			return nil, err

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -146,6 +146,20 @@ func TestCompileAndEval(t *testing.T) {
 			want: values.NewBool(true),
 		},
 		{
+			name: "call with pipe argument",
+			fn: `(n) => {
+				f = (v=<-) => v + n
+				return 5 |> f()
+			}`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("n"), Value: semantic.BasicInt},
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"n": values.NewInt(6),
+			}),
+			want: values.NewInt(11),
+		},
+		{
 			name: "conditional",
 			fn:   `(t, c, a) => if t then c else a`,
 			inType: semantic.NewObjectType([]semantic.PropertyType{

--- a/semantic/monotype.go
+++ b/semantic/monotype.go
@@ -194,6 +194,27 @@ func (mt MonoType) Argument(i int) (*Argument, error) {
 	return newArgument(a)
 }
 
+// PipeArgument will return the pipe argument if this monotype
+// is a function and it has a pipe argument. If this monotype
+// is a function with no pipe argument, nil will be returned.
+// If this monotype is not a function, an error will be returned.
+func (mt MonoType) PipeArgument() (*Argument, error) {
+	nargs, err := mt.NumArguments()
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < nargs; i++ {
+		arg, err := mt.Argument(i)
+		if err != nil {
+			return nil, err
+		}
+		if arg.Pipe() {
+			return arg, nil
+		}
+	}
+	return nil, nil
+}
+
 // SortedArguments returns a slice of function arguments,
 // sorted by argument name, if this monotype is a function.
 func (mt MonoType) SortedArguments() ([]*Argument, error) {


### PR DESCRIPTION
This fixes a bug in the compiler for an example like this:
```
csv.from(csv: inData)
  |> range(start: 2020-08-10T00:00:00Z)
  |> filter(fn: (r) => r._measurement == "events" and r._field == "times")
  |> map(fn: (r) => {
    start = time(v: r._value)
    stop = experimental.addDuration(to: start, d: 1h)
    city = r.city
    agg = csv.from(csv: inData)
      |> range(start, stop)
      |> filter(fn: (r) => r._measurement == "city_data" and r._field == "temp" and r.city == city)
      |> mean()
      |> findRecord(fn: (key) => true, idx: 0)
    return {_time: stop, _value: agg._value, _field: "event_temp_mean"}
  })
```
The issue was that if one uses the `|>` operator from inside a call to `map` (here we use the `compiler` to evaluate Flux, rather than the interpreter), it would not properly propagate the pipe argument for call expressions. As a result, I got `missing required keyword argument "tables"` errors.

I needed to fix this in order create the test case for #3057.