### PR TITLE
refactor(interpreter): expose interpreter's resolver to compiler

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -570,6 +571,23 @@ type functionValue struct {
 	fn     *semantic.FunctionExpression
 	params []functionParam
 	scope  Scope
+}
+
+// functionValue implements the interpreter.Resolver interface.
+var _ interpreter.Resolver = (*functionValue)(nil)
+
+func (f *functionValue) Resolve() (semantic.Node, error) {
+	n := f.fn.Copy()
+	localIdentifiers := make([]string, 0, 10)
+	node, err := interpreter.ResolveIdsInFunction(f.scope, f.fn, n, &localIdentifiers)
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+func (f functionValue) Scope() values.Scope {
+	return f.scope
 }
 
 type functionParam struct {

--- a/compiler/runtime_test.go
+++ b/compiler/runtime_test.go
@@ -1,0 +1,85 @@
+package compiler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/libflux/go/libflux"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/semantic/semantictest"
+	"github.com/influxdata/flux/values"
+)
+
+type mockImporter struct {
+}
+
+func (m mockImporter) ImportPackageObject(_ string) (*interpreter.Package, error) {
+	panic("unimplemented")
+}
+
+// TestFunctionValue_Resolve just demonstrates that
+// functionValue implements the values.Resolver interface
+func TestFunctionValue_Resolve(t *testing.T) {
+	src1 := `x = 42 y = 100`
+	src2 := `() => x + y`
+
+	// we want to show that a functionValue like the above
+	// will be transformed to () => 42 + 100
+
+	// First create a scope with definitions of x and y
+	scope := values.NewScope()
+	{
+		semPkg, err := runtime.AnalyzeSource(src1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		itrp := interpreter.NewInterpreter(nil)
+		_, err = itrp.Eval(context.Background(), semPkg, scope, mockImporter{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create a functionValue from that uses the scope we just created
+	var fnVal functionValue
+	{
+		pkg := libflux.ParseString(src1)
+		fn := libflux.ParseString(src2)
+		if err := libflux.MergePackages(pkg, fn); err != nil {
+			t.Fatal(err)
+		}
+
+		semPkg, err := runtime.AnalyzePackage(pkg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stmt := semPkg.Files[1].Body[0]
+		fnExpr := stmt.(*semantic.ExpressionStatement).Expression.(*semantic.FunctionExpression)
+		fnVal = functionValue{
+			t:     fnExpr.TypeOf(),
+			fn:    fnExpr,
+			scope: runtimeScope{Scope: scope},
+		}
+	}
+
+	var want *semantic.FunctionExpression
+	{
+		pkg, err := runtime.AnalyzeSource(`() => 42 + 100`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want = pkg.Files[0].Body[0].(*semantic.ExpressionStatement).Expression.(*semantic.FunctionExpression)
+	}
+
+	got, err := fnVal.Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(want, got, semantictest.CmpOptions...) {
+		t.Errorf("unexpected resolved function: -want/+got\n%s", cmp.Diff(want, got, semantictest.CmpOptions...))
+	}
+}


### PR DESCRIPTION
This is a refactor that exposes code that implements the `interpreter.Resolver` interface so that it can be accessed via the `compiler` package. This code allows the `compiler.functionValue` struct also implement the interface.

This will let use handle queries like this one:
```
csv.from(csv: inData)
  |> range(start: 2020-08-10T00:00:00Z)
  |> filter(fn: (r) => r._measurement == "events" and r._field == "times")
  |> map(fn: (r) => {
    start = time(v: r._value)
    stop = experimental.addDuration(to: start, d: 1h)
    city = r.city
    agg = csv.from(csv: inData)
      |> range(start, stop)
      |> filter(fn: (r) => r._measurement == "city_data" and r._field == "temp" and r.city == city)
      |> mean()
      |> findRecord(fn: (key) => true, idx: 0)
    return {_time: stop, _value: agg._value, _field: "event_temp_mean"}
  })
```
This query would previously fail because we attempt to resolve the lambda passed to filter here:
https://github.com/influxdata/flux/blob/b7d8af7dfbbc59844be41538d2aa0ad0255ca78e/stdlib/universe/filter.go#L67
This didn't work because in this example we are evaluating the lambda passed to `map` with the compiler rather than the interpreter, and compiled functions did not implement `Resolver`. With these changes, the above query can succeed.

This fix is needed to create the test case requested by this issue: #3057