### PR TITLE
feat(ast/edit): Add function to indicate duplicate option assignments

### DIFF
--- a/ast/edit/task_editor.go
+++ b/ast/edit/task_editor.go
@@ -107,3 +107,22 @@ func DeleteProperty(obj *ast.ObjectExpression, key string) {
 		}
 	}
 }
+
+// HasDuplicateOptions determines whether or not there are multiple assignments
+// to the same option variable.
+func HasDuplicateOptions(file *ast.File, name string) bool {
+	var n int
+	for _, st := range file.Body {
+		if val, ok := st.(*ast.OptionStatement); ok {
+			assign := val.Assignment
+			if va, ok := assign.(*ast.VariableAssignment); ok {
+				if va.ID.Name == name {
+					if ok {
+						n++
+					}
+				}
+			}
+		}
+	}
+	return n > 1
+}

--- a/ast/edit/task_editor_test.go
+++ b/ast/edit/task_editor_test.go
@@ -524,3 +524,82 @@ func TestSetDeleteProperty(t *testing.T) {
 		})
 	}
 }
+
+func TestHasDuplicateOptions(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		optionID       string
+		file           *ast.File
+		wantDuplicates bool
+	}{
+		{
+			testName: "duplicate options",
+			optionID: "task",
+			file: &ast.File{
+				Name: "foo.flux",
+				Body: []ast.Statement{
+					&ast.OptionStatement{
+						Assignment: &ast.VariableAssignment{
+							ID:   &ast.Identifier{Name: "task"},
+							Init: &ast.BooleanLiteral{Value: true},
+						},
+					},
+					&ast.OptionStatement{
+						Assignment: &ast.VariableAssignment{
+							ID:   &ast.Identifier{Name: "task"},
+							Init: &ast.BooleanLiteral{Value: false},
+						},
+					},
+				},
+			},
+			wantDuplicates: true,
+		},
+		{
+			testName: "multiple, non-duplicate option",
+			optionID: "task",
+			file: &ast.File{
+				Name: "foo.flux",
+				Body: []ast.Statement{
+					&ast.OptionStatement{
+						Assignment: &ast.VariableAssignment{
+							ID:   &ast.Identifier{Name: "task"},
+							Init: &ast.BooleanLiteral{Value: true},
+						},
+					},
+					&ast.OptionStatement{
+						Assignment: &ast.VariableAssignment{
+							ID:   &ast.Identifier{Name: "another"},
+							Init: &ast.BooleanLiteral{Value: true},
+						},
+					},
+				},
+			},
+			wantDuplicates: false,
+		},
+		{
+			testName: "single task option",
+			optionID: "task",
+			file: &ast.File{
+				Name: "foo.flux",
+				Body: []ast.Statement{
+					&ast.OptionStatement{
+						Assignment: &ast.VariableAssignment{
+							ID:   &ast.Identifier{Name: "task"},
+							Init: &ast.BooleanLiteral{Value: true},
+						},
+					},
+				},
+			},
+			wantDuplicates: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			hasDuplicates := edit.HasDuplicateOptions(tc.file, tc.optionID)
+
+			if tc.wantDuplicates != hasDuplicates {
+				t.Errorf("Mismatch in duplicate expectation want=%t got=%t", tc.wantDuplicates, hasDuplicates)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a new helper function to the `ast/edit` package that indicates whether or not an `ast.File` has duplicate `option` assignments for the same variable. The current evaluation behavior of Flux produces a runtime error when it sees multiple assignments to the same `option` variable. This will allow us to maintain parity with that behavior as we migrate to AST-based `option` extraction/updating for Task options.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
