### PR TITLE
feat(errors): add a doc url field to flux errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -15,3 +15,12 @@ type Error = errors.Error
 func ErrorCode(err error) codes.Code {
 	return errors.Code(err)
 }
+
+// ErrorDocURL returns the DocURL associated with this error
+// if one exists. This will return the outermost DocURL
+// associated with this error unless the code is Inherit.
+// If the code for an error is Inherit, this will return
+// the DocURL for the nested error if it exists.
+func ErrorDocURL(err error) string {
+	return errors.DocURL(err)
+}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -169,6 +169,88 @@ func TestErrorCode(t *testing.T) {
 	}
 }
 
+func TestErrorDocURL(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "basic error",
+			err: &errors.Error{
+				Code:   codes.Invalid,
+				DocURL: "https://expected.url",
+			},
+			want: "https://expected.url",
+		},
+		{
+			name: "basic error without docs url",
+			err: &errors.Error{
+				Code: codes.Invalid,
+			},
+			want: "",
+		},
+		{
+			name: "wrapped error",
+			err: &errors.Error{
+				Code:   codes.Invalid,
+				DocURL: "https://expected.url",
+				Err: &errors.Error{
+					Code:   codes.Invalid,
+					DocURL: "https://unexpected.url",
+				},
+			},
+			want: "https://expected.url",
+		},
+		{
+			name: "wrapper error with docs url",
+			err: &errors.Error{
+				Code: codes.Invalid,
+				Err: &errors.Error{
+					Code:   codes.Invalid,
+					DocURL: "https://expected.url",
+				},
+			},
+			want: "https://expected.url",
+		},
+		{
+			name: "inherited error",
+			err: &errors.Error{
+				Code:   codes.Inherit,
+				DocURL: "https://unexpected.url",
+				Err: &errors.Error{
+					Code:   codes.Invalid,
+					DocURL: "https://expected.url",
+				},
+			},
+			want: "https://expected.url",
+		},
+		{
+			name: "inherited external error",
+			err: &errors.Error{
+				Code:   codes.Inherit,
+				DocURL: "https://expected.url",
+				Err:    stderrors.New("external error"),
+			},
+			want: "https://expected.url",
+		},
+		{
+			name: "inherited with no wrapped error",
+			err: &errors.Error{
+				Code:   codes.Inherit,
+				DocURL: "https://expected.url",
+			},
+			want: "https://expected.url",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := errors.DocURL(tt.err), tt.want; got != want {
+				t.Errorf("unexpected error code -want/+got:\n\t- %q\n\t+ %q", got, want)
+			}
+		})
+	}
+}
+
 func errorString(err error) string {
 	if err != nil {
 		return err.Error()


### PR DESCRIPTION
This adds a DocURL field to flux errors which can be accessed by using
the `ErrorDocURL` function. The DocURL field is intended to be attached
to an error at the site it happens and `ErrorDocURL` is intended to
retrieve the most appropriate doc url for the ones that exist.

This does not modify the `errors` convenience functions in the
`internal/errors` package. We still haven't figured out how we want
those to look as part of this new pattern. For that reason, they have
not been modified especially since we would also have to change how they
are called.

Fixes #3092.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written