### PR TITLE
test(stdlib): add a test cases for using table functions inside map

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -477,6 +477,8 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/string_max_test.flux":                                          "78c162ba2901856e0091f7990018b4d6e31b9fd34f7152002fcca1c2c155abf7",
 	"stdlib/universe/string_sort_test.flux":                                         "3ee25884c1b5b02dd36d153929714dedfced7176d7e2f54ebcdfb5797bd8bbde",
 	"stdlib/universe/sum_test.flux":                                                 "dbc5ae649610f6ffdbe8f9ea3f2b31fc1a2bf1e95bad579a07f39a838c8c5980",
+	"stdlib/universe/table_fns_findcolumn_map_test.flux":                            "d9d6ba97b5c902fdfec07f1feb3c95fd83b0c70a7141c769bfc3863134c1c319",
+	"stdlib/universe/table_fns_findrecord_map_test.flux":                            "4a0f36e698250e6d7467059b98064001c5f8e90678fea263fbbb6f1a98a6f41c",
 	"stdlib/universe/table_fns_test.flux":                                           "9b7c90f0e8df57ceda8a36c08f24d28d18507c9bd99016b27537f978012d49d2",
 	"stdlib/universe/tail_offset_test.flux":                                         "37e4ac52a8d6c7bb300e5ddd4901486fc466a9ac10579ae3fe465b2d1cafdeb9",
 	"stdlib/universe/tail_test.flux":                                                "42b7af0693a4a51ba59c4d4e35444a55526006098ae546b998c594b39f87c768",

--- a/stdlib/universe/table_fns_findcolumn_map_test.flux
+++ b/stdlib/universe/table_fns_findcolumn_map_test.flux
@@ -1,0 +1,89 @@
+package universe_test
+
+import "testing"
+import "csv"
+import "experimental"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+// _value column in "times" field are timestamps, starting from
+// 1970-01-02, 1970-01-03, etc
+inData = "
+#datatype,string,long,string,string,dateTime:RFC3339,long,string
+#group,false,false,true,true,false,false,true
+#default,_result,,,,,,
+,result,table,_field,_measurement,_time,_value,city
+,,0,times,events,2020-08-11T17:56:20Z,86400000000000,New York
+,,1,times,events,2020-08-11T17:56:20Z,172800000000000,Chicago
+,,2,times,events,2020-08-11T17:56:20Z,259200000000000,Los Angeles
+,,3,times,events,2020-08-11T17:56:20Z,345600000000000,Boston
+
+#datatype,string,long,string,string,dateTime:RFC3339,double,string
+#group,false,false,true,true,false,false,true
+#default,_result,,,,,,
+,result,table,_field,_measurement,_time,_value,city
+,,4,temp,city_data,1970-01-02T00:00:10Z,20.0,New York
+,,4,temp,city_data,1970-01-02T00:00:20Z,21.0,New York
+,,4,temp,city_data,1970-01-02T00:00:30Z,22.0,New York
+,,4,temp,city_data,1970-01-02T00:00:40Z,23.0,New York
+,,4,temp,city_data,1970-01-02T00:00:50Z,24.0,New York
+
+,,5,temp,city_data,1970-01-03T00:00:10Z,18.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:20Z,19.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:30Z,20.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:40Z,21.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:50Z,22.0,Chicago
+
+,,6,temp,city_data,1970-01-04T00:00:10Z,47.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:20Z,48.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:30Z,49.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:40Z,50.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:50Z,51.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:00Z,52.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:10Z,53.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:20Z,54.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:30Z,55.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:40Z,56.0,Los Angeles
+
+,,7,temp,city_data,1970-01-05T00:00:10Z,15.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:20Z,16.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:30Z,17.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:40Z,18.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:50Z,19.0,Boston
+
+,,8,temp,city_data,1970-01-06T00:00:10Z,65.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:20Z,66.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:30Z,67.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:40Z,68.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:50Z,69.0,Austin
+"
+
+outData = "
+#datatype,string,long,string,dateTime:RFC3339,double,string
+#group,false,false,true,false,false,true
+#default,_result,,,,,
+,result,table,_field,_time,_value,city
+,,0,event_temp_mean,1970-01-05T01:00:00Z,17,Boston
+,,1,event_temp_mean,1970-01-03T01:00:00Z,20,Chicago
+,,2,event_temp_mean,1970-01-04T01:00:00Z,49,Los Angeles
+,,3,event_temp_mean,1970-01-02T01:00:00Z,22,New York
+"
+
+t_table_fns_findcolumn_map = (table=<-) =>
+  table
+  |> range(start: 2020-08-10T00:00:00Z)
+  |> filter(fn: (r) => r._measurement == "events" and r._field == "times")
+  |> map(fn: (r) => {
+    start = time(v: r._value)
+    stop = experimental.addDuration(to: start, d: 1h)
+    city = r.city
+    agg = csv.from(csv: inData)
+      |> range(start, stop)
+      |> filter(fn: (r) => r._measurement == "city_data" and r._field == "temp" and r.city == city)
+      |> mean()
+      |> findColumn(fn: (key) => true, column: "_value")
+    return {city: r.city, _time: stop, _value: agg[0], _field: "event_temp_mean"}
+  })
+
+test _table_fns_findcolumn_map = () =>
+  ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_table_fns_findcolumn_map})

--- a/stdlib/universe/table_fns_findrecord_map_test.flux
+++ b/stdlib/universe/table_fns_findrecord_map_test.flux
@@ -1,0 +1,89 @@
+package universe_test
+
+import "testing"
+import "csv"
+import "experimental"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+// _value column in "times" field are timestamps, starting from
+// 1970-01-02, 1970-01-03, etc
+inData = "
+#datatype,string,long,string,string,dateTime:RFC3339,long,string
+#group,false,false,true,true,false,false,true
+#default,_result,,,,,,
+,result,table,_field,_measurement,_time,_value,city
+,,0,times,events,2020-08-11T17:56:20Z,86400000000000,New York
+,,1,times,events,2020-08-11T17:56:20Z,172800000000000,Chicago
+,,2,times,events,2020-08-11T17:56:20Z,259200000000000,Los Angeles
+,,3,times,events,2020-08-11T17:56:20Z,345600000000000,Boston
+
+#datatype,string,long,string,string,dateTime:RFC3339,double,string
+#group,false,false,true,true,false,false,true
+#default,_result,,,,,,
+,result,table,_field,_measurement,_time,_value,city
+,,4,temp,city_data,1970-01-02T00:00:10Z,20.0,New York
+,,4,temp,city_data,1970-01-02T00:00:20Z,21.0,New York
+,,4,temp,city_data,1970-01-02T00:00:30Z,22.0,New York
+,,4,temp,city_data,1970-01-02T00:00:40Z,23.0,New York
+,,4,temp,city_data,1970-01-02T00:00:50Z,24.0,New York
+
+,,5,temp,city_data,1970-01-03T00:00:10Z,18.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:20Z,19.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:30Z,20.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:40Z,21.0,Chicago
+,,5,temp,city_data,1970-01-03T00:00:50Z,22.0,Chicago
+
+,,6,temp,city_data,1970-01-04T00:00:10Z,47.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:20Z,48.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:30Z,49.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:40Z,50.0,Los Angeles
+,,6,temp,city_data,1970-01-04T00:00:50Z,51.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:00Z,52.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:10Z,53.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:20Z,54.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:30Z,55.0,Los Angeles
+,,6,temp,city_data,1970-01-04T01:01:40Z,56.0,Los Angeles
+
+,,7,temp,city_data,1970-01-05T00:00:10Z,15.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:20Z,16.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:30Z,17.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:40Z,18.0,Boston
+,,7,temp,city_data,1970-01-05T00:00:50Z,19.0,Boston
+
+,,8,temp,city_data,1970-01-06T00:00:10Z,65.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:20Z,66.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:30Z,67.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:40Z,68.0,Austin
+,,8,temp,city_data,1970-01-06T00:00:50Z,69.0,Austin
+"
+
+outData = "
+#datatype,string,long,string,dateTime:RFC3339,double,string
+#group,false,false,true,false,false,true
+#default,_result,,,,,
+,result,table,_field,_time,_value,city
+,,0,event_temp_mean,1970-01-05T01:00:00Z,17,Boston
+,,1,event_temp_mean,1970-01-03T01:00:00Z,20,Chicago
+,,2,event_temp_mean,1970-01-04T01:00:00Z,49,Los Angeles
+,,3,event_temp_mean,1970-01-02T01:00:00Z,22,New York
+"
+
+t_table_fns_findrecord_map = (table=<-) =>
+  table
+  |> range(start: 2020-08-10T00:00:00Z)
+  |> filter(fn: (r) => r._measurement == "events" and r._field == "times")
+  |> map(fn: (r) => {
+    start = time(v: r._value)
+    stop = experimental.addDuration(to: start, d: 1h)
+    city = r.city
+    agg = csv.from(csv: inData)
+      |> range(start, stop)
+      |> filter(fn: (r) => r._measurement == "city_data" and r._field == "temp" and r.city == city)
+      |> mean()
+      |> findRecord(fn: (key) => true, idx: 0)
+    return {city: r.city, _time: stop, _value: agg._value, _field: "event_temp_mean"}
+  })
+
+test _table_fns_findrecord_map = () =>
+  ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_table_fns_findrecord_map})


### PR DESCRIPTION
This just adds a couple test cases that use `findColumn` and `findRecord` inside a call to `map`.

~~This will in part help address #3057, but this test won't pass in influxdb, so I will skip it there and add a launcher test.~~
It turns out that this test case works okay in influxdb, so it is sufficient to fix #3057.