### PR TITLE
test: add more precision to http protection tests

### DIFF
--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -60,7 +60,7 @@ type TestValidator struct{}
 
 func (TestValidator) Validate(anUrl *url.URL) error {
 	if anUrl.Host == "test-validator.example.com" {
-		return errors.New(codes.Invalid, "url is not valid, it connects to a private IP")
+		return errors.New(codes.Invalid, "url validation error, it connects to a private IP")
 	}
 	return nil
 }

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -5,15 +5,18 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/flux/dependencies/url"
+	"github.com/influxdata/flux/codes"
+	depsUrl "github.com/influxdata/flux/dependencies/url"
+	"github.com/influxdata/flux/internal/errors"
 )
 
 func TestNewDefaultClient(t *testing.T) {
-	c := NewDefaultClient(url.PassValidator{})
+	c := NewDefaultClient(depsUrl.PassValidator{})
 	if c == nil {
 		t.Fail()
 	}
@@ -22,7 +25,7 @@ func TestNewDefaultClient(t *testing.T) {
 func TestLimitedDefaultClient(t *testing.T) {
 	t.Run("response larger than given size", func(t *testing.T) {
 		var size int64 = 1
-		c := LimitHTTPBody(*NewDefaultClient(url.PassValidator{}), size)
+		c := LimitHTTPBody(*NewDefaultClient(depsUrl.PassValidator{}), size)
 		body := "hello"
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
@@ -51,12 +54,23 @@ func TestLimitedDefaultClient(t *testing.T) {
 	})
 }
 
+// The TestValidator will let everything through _except_ a specific url, which
+// is redirected to from a http test server.
+type TestValidator struct{}
+
+func (TestValidator) Validate(anUrl *url.URL) error {
+	if anUrl.Host == "test-validator.example.com" {
+		return errors.New(codes.Invalid, "url is not valid, it connects to a private IP")
+	}
+	return nil
+}
+
 func TestInvalidRedirects(t *testing.T) {
 	t.Run("redirects to localhost are rejected", func(t *testing.T) {
-		client := NewDefaultClient(url.PrivateIPValidator{})
+		client := NewDefaultClient(TestValidator{})
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-			http.Redirect(w, request, "http://localhost", http.StatusMovedPermanently)
+			http.Redirect(w, request, "http://test-validator.example.com", http.StatusMovedPermanently)
 		}))
 		defer testServer.Close()
 

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -82,7 +82,7 @@ func TestInvalidRedirects(t *testing.T) {
 		if err == nil {
 			t.Fatal("Client did not error")
 		}
-		if !strings.HasSuffix(err.Error(), "url is not valid, it connects to a private IP") {
+		if !strings.HasSuffix(err.Error(), "url validation error, it connects to a private IP") {
 			t.Fatal(err)
 		}
 

--- a/dependencies/url/validator_test.go
+++ b/dependencies/url/validator_test.go
@@ -50,6 +50,10 @@ func TestPrivateIPValidator(t *testing.T) {
 			url:   "http://thisdnsnamedoesnotexistasitdoesnothavearootandhaslotsofentropy",
 			valid: false,
 		},
+		{
+			url:   "http://127.0.0.1:8093/debug/pprof",
+			valid: false,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc
@@ -61,9 +65,9 @@ func TestPrivateIPValidator(t *testing.T) {
 			err = v.Validate(u)
 			if tc.valid && err != nil || !tc.valid && err == nil {
 				if tc.valid {
-					t.Errorf("unexecpted validation error: %v", err)
+					t.Errorf("unexcepted validation error: %v", err)
 				} else {
-					t.Errorf("execpted validation error got nil")
+					t.Errorf("excepted validation error got nil")
 				}
 			}
 		})

--- a/dependencies/url/validator_test.go
+++ b/dependencies/url/validator_test.go
@@ -65,9 +65,9 @@ func TestPrivateIPValidator(t *testing.T) {
 			err = v.Validate(u)
 			if tc.valid && err != nil || !tc.valid && err == nil {
 				if tc.valid {
-					t.Errorf("unexcepted validation error: %v", err)
+					t.Errorf("unexpected validation error: %v", err)
 				} else {
-					t.Errorf("excepted validation error got nil")
+					t.Errorf("expected validation error got nil")
 				}
 			}
 		})


### PR DESCRIPTION
While chasing some issues with our http endpoint validation, I added
some tests and made some minor tweaks. The redirect test wasn't working,
because the original validation failed, so never got to the redirect, so
it needed to be adjusted.