### PR TITLE
fix: panic when having invalid type in map object property

### DIFF
--- a/stdlib/universe/map.go
+++ b/stdlib/universe/map.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/influxdata/flux"
@@ -295,9 +296,13 @@ func (t *mapTransformation) createSchema(fn *execute.RowMapPreparedFn, b execute
 		if nature == semantic.Invalid {
 			continue
 		}
+		ty := execute.ConvertFromKind(nature)
+		if ty == flux.TInvalid {
+			return fmt.Errorf(`map object property "%s" is %v type which is not supported in a flux table`, k, nature)
+		}
 		if _, err := b.AddCol(flux.ColMeta{
 			Label: k,
-			Type:  execute.ConvertFromKind(nature),
+			Type:  ty,
 		}); err != nil {
 			return err
 		}

--- a/stdlib/universe/map.go
+++ b/stdlib/universe/map.go
@@ -2,7 +2,6 @@ package universe
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/influxdata/flux"
@@ -298,7 +297,7 @@ func (t *mapTransformation) createSchema(fn *execute.RowMapPreparedFn, b execute
 		}
 		ty := execute.ConvertFromKind(nature)
 		if ty == flux.TInvalid {
-			return fmt.Errorf(`map object property "%s" is %v type which is not supported in a flux table`, k, nature)
+			return errors.Newf(codes.Invalid, `map object property "%s" is %v type which is not supported in a flux table`, k, nature)
 		}
 		if _, err := b.AddCol(flux.ColMeta{
 			Label: k,

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -716,6 +716,120 @@ f
 			}},
 		},
 		{
+			name: `error returning array property`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, `(r) => ({_value: ["str"]})`),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+				},
+			}},
+			wantErr: errors.New(`map object property "_value" is array type which is not supported in a flux table`),
+		},
+		{
+			name: `error returning regexp property`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, `(r) => ({_value: /ab?/})`),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+				},
+			}},
+			wantErr: errors.New(`map object property "_value" is regexp type which is not supported in a flux table`),
+		},
+		{
+			name: `error returning function property`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, `(r) => ({_value: (p) => 1})`),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+				},
+			}},
+			wantErr: errors.New(`map object property "_value" is function type which is not supported in a flux table`),
+		},
+		{
+			name: `error returning duration property`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, `(r) => ({_value: 1d})`),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+				},
+			}},
+			wantErr: errors.New(`map object property "_value" is duration type which is not supported in a flux table`),
+		},
+		{
+			name: `error returning object property`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, `(r) => ({_value: {v: 1}})`),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+				},
+			}},
+			wantErr: errors.New(`map object property "_value" is object type which is not supported in a flux table`),
+		},
+		{
+			name: `error returning byte property`,
+			spec: &universe.MapProcedureSpec{
+				Fn: interpreter.ResolvedFunction{
+					Scope: builtIns,
+					Fn:    executetest.FunctionExpression(t, `(r) => ({_value: bytes(v: "123")})`),
+				},
+			},
+			data: []flux.Table{&executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TUInt},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), uint64(1)},
+				},
+			}},
+			wantErr: errors.New(`map object property "_value" is bytes type which is not supported in a flux table`),
+		},
+		{
 			name: `float("foo") produces error`,
 			spec: &universe.MapProcedureSpec{
 				Fn: interpreter.ResolvedFunction{
@@ -730,7 +844,6 @@ f
 				},
 				Data: [][]interface{}{
 					{execute.Time(1), uint64(1)},
-					{execute.Time(2), uint64(6)},
 				},
 			}},
 			wantErr: errors.New(`failed to evaluate map function: strconv.ParseFloat: parsing "foo": invalid syntax`),


### PR DESCRIPTION
`map()` cannot generate a table with the following column data types:
* Bytes: `(r) => ({_value: bytes(v: "123")})`
* Duration: `(r) => ({_value: 1d})`
* Regexp: `(r) => ({_value: /ab?/})`
* Array: `(r) => ({_value: ["str"]})` <-- the one that caused our issue
* Object: `(r) => ({_value: {v: 1}})`
* Function: `(r) => ({_value: (p) => 1})`

When given properties with invalid type, Flux panics and it should instead give a friendly error message.