### PR TITLE
feat(flux): make experimental tracing an attribute of the context

### DIFF
--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -115,6 +115,7 @@ func CreateFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a execute.A
 type AllocatingFromProcedureSpec struct {
 	ByteCount int
 
+	id    execute.DatasetID
 	alloc *memory.Allocator
 	ts    []execute.Transformation
 }
@@ -138,7 +139,9 @@ func (AllocatingFromProcedureSpec) Cost(inStats []plan.Statistics) (cost plan.Co
 
 func CreateAllocatingFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
 	s := spec.(*AllocatingFromProcedureSpec)
+	s.id = id
 	s.alloc = a.Allocator()
+
 	return s, nil
 }
 
@@ -146,6 +149,9 @@ func (s *AllocatingFromProcedureSpec) Run(ctx context.Context) {
 	// Allocate the amount of memory as specified in the byte count.
 	// This memory is not used or returned.
 	_ = s.alloc.Allocate(s.ByteCount)
+	for _, t := range s.ts {
+		t.Finish(s.id, nil)
+	}
 }
 
 func (s *AllocatingFromProcedureSpec) AddTransformation(t execute.Transformation) {

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -4,6 +4,7 @@ package execute
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"runtime/debug"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/metadata"
 	"github.com/influxdata/flux/plan"
+	"github.com/opentracing/opentracing-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -249,6 +251,10 @@ func (es *executionState) do(ctx context.Context) {
 	for _, src := range es.sources {
 		wg.Add(1)
 		go func(src Source) {
+			if flux.IsExperimentalTracingEnabled(ctx) {
+				span, _ := opentracing.StartSpanFromContext(ctx, reflect.TypeOf(src).String())
+				defer span.Finish()
+			}
 			defer wg.Done()
 
 			// Setup panic handling on the source goroutines

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -200,7 +200,7 @@ func processMessage(ctx context.Context, t Transformation, m Message) (finished 
 	case ProcessMsg:
 		b := m.Table()
 		var span opentracing.Span
-		if flux.IsExperimentalTracingEnabled() {
+		if flux.IsExperimentalTracingEnabled(ctx) {
 			span, _ = opentracing.StartSpanFromContext(ctx, reflect.TypeOf(t).String())
 		}
 		err = t.Process(m.SrcDatasetID(), b)

--- a/tracing.go
+++ b/tracing.go
@@ -1,18 +1,27 @@
 package flux
 
-var experimentalTracingEnabled = false
+import (
+	"context"
+)
 
-// EnableExperimentalTracing will enable any experimental
-// tracing in the flux binary. Experimental tracing may provide
-// more insight, but it indicates that we have not tested that the
-// tracing doesn't have negative side effects when run in production.
-//
-// Traces that are enabled this way may be removed or may be enabled
-// by default in the future.
-func EnableExperimentalTracing() {
-	experimentalTracingEnabled = true
+const queryTracingContextKey = "query-tracing-enabled"
+
+// WithExperimentalTracingEnabled will return a child context
+// that will turn on experimental query tracing.
+func WithExperimentalTracingEnabled(parentCtx context.Context) context.Context {
+	return context.WithValue(parentCtx, queryTracingContextKey, true)
 }
 
-func IsExperimentalTracingEnabled() bool {
-	return experimentalTracingEnabled
+// IsExperimentalTracingEnabled will return true if the context
+// contains a key indicating that experimental tracing is enabled.
+func IsExperimentalTracingEnabled(ctx context.Context) bool {
+	v := ctx.Value(queryTracingContextKey)
+	if v == nil {
+		return false
+	}
+	b, ok := v.(bool)
+	if !ok {
+		return false
+	}
+	return b
 }


### PR DESCRIPTION
This turns experimental tracing from a global attribute to one that is set in the context. This will allow `influxdb` (OSS) to turn on experimental tracing in the context (or not) by looking at a feature flag.

This implements part of https://github.com/influxdata/influxdb/issues/16220.

### Done checklist
- [ ] docs/SPEC.md updated (N/A)
- [x] Test cases written
