### PR TITLE
fix: remove time-column args from range function and update type sig

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -2415,9 +2415,6 @@ Range has the following properties:
 | ----        | ----   | -----------                                                                                                                                       |
 | start       | time   | Start inclusively specifies the lower bound (oldest) time of the range by which to filter records.                                                |
 | stop        | time   | Stop exclusively specifies the upper bound (newest) time of the range by which to filter records. Defaults to the value of the `now` option time. |
-| timeColumn  | string | Name of the time column to use. Defaults to `_time`.                                                                                              |
-| startColumn | string | StartColumn is the name of the column containing the start time. Defaults to `_start`.                                                            |
-| stopColumn  | string | StopColumn is the name of the column containing the stop time. Defaults to `_stop`.                                                               |
 
 Example:
 ```

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -41,7 +41,7 @@ var sourceHashes = map[string]string{
 	"libflux/src/core/scanner/unicode.rl":                                           "f923f3b385ddfa65c74427b11971785fc25ea806ca03d547045de808e16ef9a1",
 	"libflux/src/core/scanner/unicode.rl.COPYING":                                   "6cf2d5d26d52772ded8a5f0813f49f83dfa76006c5f398713be3854fe7bc4c7e",
 	"libflux/src/core/semantic/bootstrap.rs":                                        "7d64aa6fb61da815698073296c64e22e8d9f57ca20c1a0be2dc580e8d4daff30",
-	"libflux/src/core/semantic/builtins.rs":                                         "492b41416ac166b1c6be8c307a1963048b942511edf58aa560b847d24ad87058",
+	"libflux/src/core/semantic/builtins.rs":                                         "be94ed0407bdc313c41f1bcabbc3963517c293302b1b68dd1485ffbe084b6f4b",
 	"libflux/src/core/semantic/check.rs":                                            "acb29602ee01f636818ba3522b3f110018abca3e7b4a6b75c29eec97856a324e",
 	"libflux/src/core/semantic/convert.rs":                                          "393c32f2b23b60a485754751fe89b7f08c2e14dc93d87f6141fad91d6fba905d",
 	"libflux/src/core/semantic/env.rs":                                              "e031d5b752d207a8f93bacd8515639e832735d5a85e90db76690aaeee8168127",

--- a/libflux/src/core/semantic/builtins.rs
+++ b/libflux/src/core/semantic/builtins.rs
@@ -629,14 +629,12 @@ pub fn builtins() -> Builtins<'static> {
                 //   https://github.com/influxdata/flux/issues/2243
                 // Also, we should remove the column arguments so we can reuse A in the return type:
                 //   https://github.com/influxdata/flux/issues/2253
+
                 "range" => r#"(
-                        <-tables: [A],
+                        <-tables: [{A with _time: time}],
                         start: B,
-                        ?stop: C,
-                        ?timeColumn: string,
-                        ?startColumn: string,
-                        ?stopColumn: string
-                    ) => [D] where A: Record, D: Record "#,
+                        ?stop: C
+                    ) => [{A with _time: time, _start: time, _stop: time}]"#,
                 // This function could be updated to get better type inference:
                 //   https://github.com/influxdata/flux/issues/2254
                 "reduce" => r#"(

--- a/semantic/flatbuffers_test.go
+++ b/semantic/flatbuffers_test.go
@@ -834,9 +834,9 @@ func TestFlatBuffersRoundTrip(t *testing.T) {
 		       import "testing"
 		       test t = () => ({input: testing.loadStorage(csv: ""), want: testing.loadMem(csv: ""), fn: (table=<-) => table})`,
 			types: map[string]string{
-				"t": "forall [t0, t1, t2, t3, t4, t5] where t5: Record () -> {fn: (<-table: t0) -> t0 | " +
-					"input: [{_field: t1 | _field: t1 | _measurement: t2 | _measurement: t2 | _time: t3 | _time: t3 | t4}] " +
-					"| want: [t5]}",
+				"t": "forall [t0, t1, t2, t3, t4] where t4: Record () -> {fn: (<-table: t0) -> t0 | " +
+					"input: [{_field: t1 | _field: t1 | _measurement: t2 | _measurement: t2 | _start: time | _stop: time | _time: time | _time: time | t3}] " +
+					"| want: [t4]}",
 			},
 		},
 		{

--- a/stdlib/universe/range.go
+++ b/stdlib/universe/range.go
@@ -51,29 +51,9 @@ func createRangeOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operat
 		spec.Stop = flux.Now
 	}
 
-	if col, ok, err := args.GetString("timeColumn"); err != nil {
-		return nil, err
-	} else if ok {
-		spec.TimeColumn = col
-	} else {
-		spec.TimeColumn = execute.DefaultTimeColLabel
-	}
-
-	if label, ok, err := args.GetString("startColumn"); err != nil {
-		return nil, err
-	} else if ok {
-		spec.StartColumn = label
-	} else {
-		spec.StartColumn = execute.DefaultStartColLabel
-	}
-
-	if label, ok, err := args.GetString("stopColumn"); err != nil {
-		return nil, err
-	} else if ok {
-		spec.StopColumn = label
-	} else {
-		spec.StopColumn = execute.DefaultStopColLabel
-	}
+	spec.TimeColumn = execute.DefaultTimeColLabel
+	spec.StartColumn = execute.DefaultStartColLabel
+	spec.StopColumn = execute.DefaultStopColLabel
 
 	return spec, nil
 }

--- a/stdlib/universe/range_test.go
+++ b/stdlib/universe/range_test.go
@@ -59,7 +59,7 @@ func TestRange_NewQuery(t *testing.T) {
 		},
 		{
 			Name: "from csv with range",
-			Raw:  `import "csv" csv.from(csv: "1,2") |> range(start:-4h, stop:-2h, timeColumn: "_start") |> sum()`,
+			Raw:  `import "csv" csv.from(csv: "1,2") |> range(start:-4h, stop:-2h) |> sum()`,
 			Want: &flux.Spec{
 				Operations: []*flux.Operation{
 					{
@@ -79,7 +79,7 @@ func TestRange_NewQuery(t *testing.T) {
 								Relative:   -2 * time.Hour,
 								IsRelative: true,
 							},
-							TimeColumn:  "_start",
+							TimeColumn:  "_time",
 							StartColumn: "_start",
 							StopColumn:  "_stop",
 						},


### PR DESCRIPTION
BREAKING CHANGE: Remove timeColumn, startColumn and stopColumn arguments from
the range function and always use the defaults and update the type signature to
return a type based on the input. This eliminates return-type polymorphism from
the range function.

https://github.com/influxdata/flux/issues/2253


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
