### PR TITLE
feat(stdlib): improve window errors

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -222,7 +222,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 
 		for _, p := range nonYieldPredecessors(node) {
 			executionNode := v.nodes[p]
-			transport := newConsecutiveTransport(v.es.dispatcher, tr)
+			transport := newConsecutiveTransport(v.es.dispatcher, tr, node)
 			v.es.transports = append(v.es.transports, transport)
 			executionNode.AddTransformation(transport)
 		}

--- a/execute/window.go
+++ b/execute/window.go
@@ -38,7 +38,9 @@ type truncateFunc func(t Time, d Duration) Time
 func (w *Window) getTruncateFunc(d Duration) (truncateFunc, error) {
 	switch months, nsecs := d.Months(), d.Nanoseconds(); {
 	case months != 0 && nsecs != 0:
-		return nil, errors.New(codes.Invalid, "duration used as an interval cannot mix month and nanosecond units")
+		const docURL = "https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/window/#calendar-months-and-years"
+		return nil, errors.New(codes.Invalid, "duration used as an interval cannot mix month and nanosecond units").
+			WithDocURL(docURL)
 	case months != 0:
 		return truncateByMonths, nil
 	case nsecs != 0:

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -47,15 +47,15 @@ func (e *Error) Unwrap() error {
 	return e.Err
 }
 
-func New(code codes.Code, msg ...interface{}) error {
+func New(code codes.Code, msg ...interface{}) *Error {
 	return Wrap(nil, code, msg...)
 }
 
-func Newf(code codes.Code, fmtStr string, args ...interface{}) error {
+func Newf(code codes.Code, fmtStr string, args ...interface{}) *Error {
 	return Wrapf(nil, code, fmtStr, args...)
 }
 
-func Wrap(err error, code codes.Code, msg ...interface{}) error {
+func Wrap(err error, code codes.Code, msg ...interface{}) *Error {
 	var s string
 	if len(msg) > 0 {
 		s = fmt.Sprint(msg...)
@@ -67,7 +67,7 @@ func Wrap(err error, code codes.Code, msg ...interface{}) error {
 	}
 }
 
-func Wrapf(err error, code codes.Code, format string, a ...interface{}) error {
+func Wrapf(err error, code codes.Code, format string, a ...interface{}) *Error {
 	return &Error{
 		Code: code,
 		Msg:  fmt.Sprintf(format, a...),
@@ -119,4 +119,27 @@ func DocURL(err error) string {
 			return ""
 		}
 	}
+}
+
+// WithDocURL will annotate an error with a DocURL.
+// If the error is an Error and the DocURL is not filled,
+// it will be set. If the error is not an Error or the DocURL
+// is filled, it will wrap the error and set the DocURL
+// on the wrapper error.
+func WithDocURL(err error, docURL string) *Error {
+	if e, ok := err.(*Error); ok && e.DocURL == "" {
+		e.DocURL = docURL
+		return e
+	}
+	return &Error{
+		Code:   codes.Inherit,
+		DocURL: docURL,
+		Err:    err,
+	}
+}
+
+// WithDocURL can be used to add a documentation URL to the error.
+func (e *Error) WithDocURL(docURL string) *Error {
+	e.DocURL = docURL
+	return e
 }

--- a/operation.go
+++ b/operation.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
 )
 
 // Operation denotes a single operation in a query.
 type Operation struct {
-	ID   OperationID   `json:"id"`
-	Spec OperationSpec `json:"spec"`
+	ID     OperationID     `json:"id"`
+	Spec   OperationSpec   `json:"spec"`
+	Source OperationSource `json:"source"`
 }
 
 func (o *Operation) UnmarshalJSON(data []byte) error {
@@ -69,6 +71,12 @@ type NewOperationSpec func() OperationSpec
 type OperationSpec interface {
 	// Kind returns the kind of the operation.
 	Kind() OperationKind
+}
+
+// OperationSource specifies the source location that created
+// an operation.
+type OperationSource struct {
+	Stack []interpreter.StackEntry `json:"stack"`
 }
 
 // OperationID is a unique ID within a query for the operation.

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+
+	"github.com/influxdata/flux/interpreter"
 )
 
 // PhysicalPlanner performs transforms a logical plan to a physical plan,
@@ -179,6 +181,7 @@ func (physicalConverterRule) Rewrite(ctx context.Context, pn Node) (Node, bool, 
 		bounds: ln.bounds,
 		id:     ln.id,
 		Spec:   pspec,
+		Source: ln.Source,
 	}
 
 	ReplaceNode(pn, &newNode)
@@ -197,8 +200,9 @@ type PhysicalProcedureSpec interface {
 type PhysicalPlanNode struct {
 	edges
 	bounds
-	id   NodeID
-	Spec PhysicalProcedureSpec
+	id     NodeID
+	Spec   PhysicalProcedureSpec
+	Source []interpreter.StackEntry
 
 	// The trigger spec defines how and when a transformation
 	// sends its tables to downstream operators
@@ -234,6 +238,10 @@ func (ppn *PhysicalPlanNode) ReplaceSpec(newSpec ProcedureSpec) error {
 // Kind returns the procedure kind for this plan node.
 func (ppn *PhysicalPlanNode) Kind() ProcedureKind {
 	return ppn.Spec.Kind()
+}
+
+func (ppn *PhysicalPlanNode) CallStack() []interpreter.StackEntry {
+	return ppn.Source
 }
 
 func (ppn *PhysicalPlanNode) ShallowCopy() Node {

--- a/plan/types.go
+++ b/plan/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/interpreter"
 )
 
 type Planner interface {
@@ -36,6 +37,12 @@ type Node interface {
 
 	// Kind returns the type of procedure represented by this node.
 	Kind() ProcedureKind
+
+	// CallStack returns the list of StackEntry values that created this
+	// Node. A Node may have no associated call stack. This happens
+	// when a Node is constructed from a planner rule and not from a
+	// source location.
+	CallStack() []interpreter.StackEntry
 
 	// Helper methods for manipulating a plan
 	// These methods are used during planning

--- a/querytest/compile.go
+++ b/querytest/compile.go
@@ -32,6 +32,7 @@ var opts = append(
 	cmp.AllowUnexported(universe.JoinOpSpec{}),
 	cmpopts.IgnoreUnexported(flux.Spec{}),
 	cmpopts.IgnoreUnexported(universe.JoinOpSpec{}),
+	cmpopts.IgnoreFields(flux.Operation{}, "Source"),
 	valuestest.ScopeTransformer,
 )
 

--- a/stdlib/universe/window.go
+++ b/stdlib/universe/window.go
@@ -44,19 +44,31 @@ func createWindowOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 	}
 
 	spec := new(WindowOpSpec)
-	every, everySet, err := args.GetDuration("every")
-	if err != nil {
-		return nil, err
-	}
-	if everySet {
-		if every.IsNegative() {
-			return nil, errors.New(codes.Invalid, `every parameter must be nonnegative`)
+
+	every, everySet, err := func() (flux.Duration, bool, error) {
+		d, ok, err := args.GetDuration("every")
+		if err != nil || !ok {
+			return flux.Duration{}, ok, err
 		}
+
+		if d.IsNegative() {
+			return flux.Duration{}, false, errors.New(codes.Invalid, `parameter "every" must be nonnegative`)
+		} else if d.IsZero() {
+			return flux.Duration{}, false, errors.New(codes.Invalid, `parameter "every" must be nonzero`)
+		}
+		return d, true, nil
+	}()
+	if err != nil {
+		const docURL = "https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/window/#every"
+		return nil, errors.WithDocURL(err, docURL)
+	} else if everySet {
 		spec.Every = every
 	}
+
 	period, periodSet, err := args.GetDuration("period")
 	if err != nil {
-		return nil, err
+		const docURL = "https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/window/#period"
+		return nil, errors.WithDocURL(err, docURL)
 	}
 	if periodSet {
 		spec.Period = period
@@ -68,7 +80,9 @@ func createWindowOpSpec(args flux.Arguments, a *flux.Administration) (flux.Opera
 	}
 
 	if !everySet && !periodSet {
-		return nil, errors.New(codes.Invalid, `window function requires at least one of "every" or "period" to be set`)
+		const docURL = "https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/window/"
+		return nil, errors.New(codes.Invalid, `window function requires at least one of "every" or "period" to be set`).
+			WithDocURL(docURL)
 	}
 
 	if label, ok, err := args.GetString("timeColumn"); err != nil {
@@ -169,7 +183,9 @@ func createWindowTransformation(id execute.DatasetID, mode execute.AccumulationM
 
 	bounds := a.StreamContext().Bounds()
 	if bounds == nil {
-		return nil, nil, errors.New(codes.Invalid, "nil bounds passed to window")
+		const docURL = "https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/window/#nil-bounds-passed-to-window"
+		return nil, nil, errors.New(codes.Invalid, "nil bounds passed to window; use range to set the window range").
+			WithDocURL(docURL)
 	}
 
 	w, err := execute.NewWindow(
@@ -241,7 +257,9 @@ func (t *fixedWindowTransformation) RetractTable(id execute.DatasetID, key flux.
 func (t *fixedWindowTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	timeIdx := execute.ColIdx(t.timeCol, tbl.Cols())
 	if timeIdx < 0 {
-		return errors.Newf(codes.FailedPrecondition, "missing time column %q", t.timeCol)
+		const docURL = "https://v2.docs.influxdata.com/v2.0/reference/flux/stdlib/built-in/transformations/window/#missing-time-column"
+		return errors.Newf(codes.FailedPrecondition, "missing time column %q", t.timeCol).
+			WithDocURL(docURL)
 	}
 
 	newCols := make([]flux.ColMeta, 0, len(tbl.Cols())+2)

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -49,6 +49,16 @@ func TestWindow_NewQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:    "negative every window",
+			Raw:     `from(bucket:"mybucket") |> window(every:-1h)`,
+			WantErr: true,
+		},
+		{
+			Name:    "zero every window",
+			Raw:     `from(bucket:"mybucket") |> window(every:0s)`,
+			WantErr: true,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION
This improves all of the window errors to ensure they produce source
information and doc urls for all of the failure locations.

This also introduces automatic line information for runtime errors that
are produced from a transformation. The stack is maintained by the
interpreter within the context. Each time a function is called, the
stack is retrieved a new entry is then injected into the context. This
stack is then included in the `flux.Spec` and then inserted onto the
planner nodes as they are created.

Nodes that are created from the planner that do not have a source
equivalent will not have a call stack and will not include an error
within the source.

Fixes #3085.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written