### PR TITLE
fix(execute): propagate span context to source.Run

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -251,6 +251,7 @@ func (es *executionState) do(ctx context.Context) {
 	for _, src := range es.sources {
 		wg.Add(1)
 		go func(src Source) {
+			ctx := ctx
 			if flux.IsExperimentalTracingEnabled(ctx) {
 				span, ctxWithSpan := opentracing.StartSpanFromContext(ctx, reflect.TypeOf(src).String())
 				ctx = ctxWithSpan

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -252,7 +252,8 @@ func (es *executionState) do(ctx context.Context) {
 		wg.Add(1)
 		go func(src Source) {
 			if flux.IsExperimentalTracingEnabled(ctx) {
-				span, _ := opentracing.StartSpanFromContext(ctx, reflect.TypeOf(src).String())
+				span, ctxWithSpan := opentracing.StartSpanFromContext(ctx, reflect.TypeOf(src).String())
+				ctx = ctxWithSpan
 				defer span.Finish()
 			}
 			defer wg.Done()


### PR DESCRIPTION
Tracing in the `execute` package for sources did not propagate the context with a span to the call to the source's `Run(ctx)` method, so any additional spans created by the source did not have a parent. This fixes that.