### PR TITLE
fix(stdlib/csv): csv no longer deadlocks when next transformation does not consume table

### DIFF
--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -143,7 +143,10 @@ func (c *CSVSource) Run(ctx context.Context) {
 		// transformation. Unlike other sources, tables from csv sources
 		// are not read-only. They contain mutable state and therefore
 		// cannot be shared among goroutines.
-		decoder := csv.NewResultDecoder(csv.ResultDecoderConfig{Allocator: c.alloc})
+		decoder := csv.NewResultDecoder(csv.ResultDecoderConfig{
+			Allocator: c.alloc,
+			Context:   ctx,
+		})
 		result, decodeErr := decoder.Decode(strings.NewReader(c.tx))
 		if decodeErr != nil {
 			err = decodeErr


### PR DESCRIPTION
The `csv.from()` call would deadlock when the next transformation
returned an error and did not consume the table. This is because it
ignored the context and did not cancel when told to. Instead, it kept
waiting for the next transformation to read the table even though that
transformation had already told it to exit.

This only happened when the number of rows exceeded the csv row buffer
limit.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written