### PR TITLE
fix(csv/result): ensure that meta columns are never part of group key

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -1047,6 +1047,10 @@ func writeGroups(writer *csv.Writer, row []string, cols []colMeta, key flux.Grou
 			row[j] = commentPrefix + groupAnnotation
 			continue
 		}
+		if j == resultIdx || j == tableIdx {
+			row[j] = "false"
+			continue
+		}
 		row[j] = strconv.FormatBool(key.HasCol(c.Label))
 	}
 	return writer.Write(row)


### PR DESCRIPTION
Close #3161 

This PR ensures that "result" and "table" meta columns are never part of a group key (i.e. value in the #group annotation is always `false`)
### Done checklist
- [x] Test cases written
