### PR TITLE
fix: single value integral interpolation

### DIFF
--- a/stdlib/universe/integral.go
+++ b/stdlib/universe/integral.go
@@ -258,9 +258,24 @@ func (t *integralTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 		if in == nil {
 			continue
 		}
-		in.interpolateStop()
-		if err := builder.AppendFloat(colMap[j], in.value()); err != nil {
-			return err
+		switch in.points {
+		case 0:
+			if err := builder.AppendFloat(colMap[j], 0.0); err != nil {
+				return err
+			}
+		case 1:
+			v := in.vs[0] * float64(in.bounds[1]-in.bounds[0])
+			if !in.interpolate {
+				v = 0
+			}
+			if err := builder.AppendFloat(colMap[j], v); err != nil {
+				return err
+			}
+		default:
+			in.interpolateStop()
+			if err := builder.AppendFloat(colMap[j], in.value()); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/stdlib/universe/integral_test.go
+++ b/stdlib/universe/integral_test.go
@@ -586,6 +586,99 @@ func TestIntegral_Process(t *testing.T) {
 			}},
 			wantErr: fmt.Errorf("integral function needs _start column to be part of group key"),
 		},
+		{
+			name: "single value interpolation",
+			spec: &universe.IntegralProcedureSpec{
+				Unit:            flux.ConvertDuration(1),
+				TimeColumn:      execute.DefaultTimeColLabel,
+				Interpolate:     true,
+				AggregateConfig: execute.DefaultAggregateConfig,
+			},
+			data: []flux.Table{&executetest.Table{
+				KeyCols: []string{"_start", "_stop"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_start", Type: flux.TTime},
+					{Label: "_stop", Type: flux.TTime},
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), execute.Time(10), execute.Time(2), 3.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				KeyCols: []string{"_start", "_stop"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_start", Type: flux.TTime},
+					{Label: "_stop", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), execute.Time(10), 30.0},
+				},
+			}},
+		},
+		{
+			name: "single value no interpolation",
+			spec: &universe.IntegralProcedureSpec{
+				Unit:            flux.ConvertDuration(1),
+				TimeColumn:      execute.DefaultTimeColLabel,
+				AggregateConfig: execute.DefaultAggregateConfig,
+			},
+			data: []flux.Table{&executetest.Table{
+				KeyCols: []string{"_start", "_stop"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_start", Type: flux.TTime},
+					{Label: "_stop", Type: flux.TTime},
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), execute.Time(10), execute.Time(2), 3.0},
+				},
+			}},
+			want: []*executetest.Table{{
+				KeyCols: []string{"_start", "_stop"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_start", Type: flux.TTime},
+					{Label: "_stop", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), execute.Time(10), 0.0},
+				},
+			}},
+		},
+		{
+			name: "no points",
+			spec: &universe.IntegralProcedureSpec{
+				Unit:            flux.ConvertDuration(1),
+				TimeColumn:      execute.DefaultTimeColLabel,
+				AggregateConfig: execute.DefaultAggregateConfig,
+			},
+			data: []flux.Table{&executetest.Table{
+				KeyCols:   []string{"_start", "_stop"},
+				KeyValues: []interface{}{execute.Time(0), execute.Time(10)},
+				ColMeta: []flux.ColMeta{
+					{Label: "_start", Type: flux.TTime},
+					{Label: "_stop", Type: flux.TTime},
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+			}},
+			want: []*executetest.Table{{
+				KeyCols:   []string{"_start", "_stop"},
+				KeyValues: []interface{}{execute.Time(0), execute.Time(10)},
+				ColMeta: []flux.ColMeta{
+					{Label: "_start", Type: flux.TTime},
+					{Label: "_stop", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+				},
+				Data: [][]interface{}{
+					{execute.Time(0), execute.Time(10), 0.0},
+				},
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Integral gave an incorrect estimate for tables with just a single data point when using linear interpolation. This PR fixes the estimate by using the value of the single data point for the value at both the `_start` and `_stop` times of the range.
