### PR TITLE
feat(values): add duration conversion

### DIFF
--- a/values/time.go
+++ b/values/time.go
@@ -60,6 +60,16 @@ func ConvertDurationMonths(v time.Duration) Duration {
 	}
 }
 
+// MakeDuration takes nanoseconds and months as int64 and negative as a bool to construct a Duration
+// with mixed units
+func MakeDuration(nsecs int64, months int64, negative bool) Duration {
+	return Duration{
+		months:   months,
+		nsecs:    nsecs,
+		negative: negative,
+	}
+}
+
 func (t Time) Round(d Duration) Time {
 	if !d.IsPositive() {
 		return t


### PR DESCRIPTION
This is a helper function to create Durations when given the required `nsecs`, `months` and `negative` values. Its to support this PR https://github.com/influxdata/idpe/pull/8636 as seen in this example: https://github.com/influxdata/idpe/pull/8636/files#diff-8933e9d3894291e6c9aca3e7a3da1139R98-R99. 