### PR TITLE
fix(compiler): fix compiler type inference with extended records

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -446,6 +446,22 @@ func TestCompileAndEval(t *testing.T) {
 			}),
 			want: values.Null,
 		},
+		{
+			name: "superseding record field type",
+			fn: `
+				(str) => {
+					m = (s) => ({s with v: 10.0})
+					f = (t=<-) => t.v == 10.0
+					return m(s: {v: str}) |> f()
+				}`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("str"), Value: semantic.BasicString},
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"str": values.NewString("foo"),
+			}),
+			want: values.NewBool(true),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -427,6 +427,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/map_extension_with_test.flux":                                  "8e2f31fae11e6b11e25bc8ffa9dee0baccd2c0b771f6058ed168509ab88eac9d",
 	"stdlib/universe/map_extern_dynamic_var_test.flux":                              "968517648bfc320c69a970c005a07ca416421ca25a477b426882e5637b024db1",
 	"stdlib/universe/map_extern_var_test.flux":                                      "d3dda5a1ab5a76900e2d5c8bac28d3e1bcbf770b9524c6ea4a0060ff6c894dc3",
+	"stdlib/universe/map_field_type_change_test.flux":                               "13fabfe40850ae5c571ff71e5f75016e62cdb9a67ee0e803eb2129ef990fec2a",
 	"stdlib/universe/map_local_var_test.flux":                                       "bfac82093b3a3067f9681842ca8e83450724c306c56b6baccf5586aba01a05a8",
 	"stdlib/universe/map_nulls_test.flux":                                           "89dbbfc350af04bec198ee737466177d4b2cf0590d623348d4aaa34e4e64eba6",
 	"stdlib/universe/map_polymorphism_test.flux":                                    "7959a28ed1dc7a7a4c974e52a8c28d2d67a8fc47c103d64732b5a8476c41c3d8",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -427,7 +427,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/map_extension_with_test.flux":                                  "8e2f31fae11e6b11e25bc8ffa9dee0baccd2c0b771f6058ed168509ab88eac9d",
 	"stdlib/universe/map_extern_dynamic_var_test.flux":                              "968517648bfc320c69a970c005a07ca416421ca25a477b426882e5637b024db1",
 	"stdlib/universe/map_extern_var_test.flux":                                      "d3dda5a1ab5a76900e2d5c8bac28d3e1bcbf770b9524c6ea4a0060ff6c894dc3",
-	"stdlib/universe/map_field_type_change_test.flux":                               "13fabfe40850ae5c571ff71e5f75016e62cdb9a67ee0e803eb2129ef990fec2a",
+	"stdlib/universe/map_field_type_change_test.flux":                               "751f5660912224b24c7af58ecd8b6937262e7f18d22a8529a734aded43e18afd",
 	"stdlib/universe/map_local_var_test.flux":                                       "bfac82093b3a3067f9681842ca8e83450724c306c56b6baccf5586aba01a05a8",
 	"stdlib/universe/map_nulls_test.flux":                                           "89dbbfc350af04bec198ee737466177d4b2cf0590d623348d4aaa34e4e64eba6",
 	"stdlib/universe/map_polymorphism_test.flux":                                    "7959a28ed1dc7a7a4c974e52a8c28d2d67a8fc47c103d64732b5a8476c41c3d8",

--- a/stdlib/universe/map_field_type_change_test.flux
+++ b/stdlib/universe/map_field_type_change_test.flux
@@ -6,7 +6,7 @@ option now = () => (2030-01-01T00:00:00Z)
 
 inData = "
 #datatype,string,long,string,string,dateTime:RFC3339,double
-#group,false,false,false,false,false,false
+#group,false,false,true,true,false,false
 #default,_result,,,,,
 ,result,table,_measurement,_field,_time,_value
 ,,0,m,f,2018-01-01T00:00:00Z,2
@@ -14,7 +14,7 @@ inData = "
 
 outData = "
 #datatype,string,long,string,string,dateTime:RFC3339,string
-#group,false,false,false,false,false,false
+#group,false,false,true,true,false,false
 #default,_result,,,,,
 ,result,table,_measurement,_field,_time,_value
 ,,0,m,f,2018-01-01T00:00:00Z,hello

--- a/stdlib/universe/map_field_type_change_test.flux
+++ b/stdlib/universe/map_field_type_change_test.flux
@@ -1,0 +1,33 @@
+package universe_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,string,string,dateTime:RFC3339,double
+#group,false,false,false,false,false,false
+#default,_result,,,,,
+,result,table,_measurement,_field,_time,_value
+,,0,m,f,2018-01-01T00:00:00Z,2
+"
+
+outData = "
+#datatype,string,long,string,string,dateTime:RFC3339,string
+#group,false,false,false,false,false,false
+#default,_result,,,,,
+,result,table,_measurement,_field,_time,_value
+,,0,m,f,2018-01-01T00:00:00Z,hello
+"
+
+t_map_field_type_change = (table=<-) =>
+    (table
+        |> range(start: 2018-01-01T00:00:00Z)
+        |> drop(columns: ["_start", "_stop"])
+        |> map(fn: (r) => ({r with _value: 2.0})) // establish _value as a double column in output
+        |> map(fn: (r) => ({r with _value: "hello"})) // convert to a string
+        |> filter(fn: (r) => r._value == "hello") // previously this would produce an error
+    )
+
+test _map_field_type_change = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_map_field_type_change})


### PR DESCRIPTION
Fixes #3153.

This addresses an issue revealed by a test case like this one:
```
import "experimental/array"

array.from(rows: [{v: 0.1}])
  |> map(fn: (r) => ({r with v: "foo"}))
  |> filter(fn: (r) => r.v != "foo")
```
The output of `array.from` is `{v: float}`, and the output of map is `{v: string | v: float}`. This is strange but it's how records work in our type system. The first item `v: string` is the real type of `v` and the second item is just hanging around and is not generally useful.

The `filter` function invokes the "compiler" which uses the inferred type of the filter's `fn` argument to look for type errors. It ensures that column in the table have the expected type. However in this case `v` is expected to have both `string` and `float` types, which is impossible, and an error `float != string` would occur.

The fix is to ignore fields that have same name after seeing the first one. The first such field will always be the expected actual type of the field.