### PR TITLE
chore: bump the go version of the docker container

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,6 +1,6 @@
 # This file describes an image that is capable of building Flux.
 
-FROM golang:1.12
+FROM golang:1.13
 
 # Install common packages
 RUN apt-get update && \


### PR DESCRIPTION
Go 1.12 is no longer supported, so bump the test container to 1.13.
Certain downstream consumers *only* support 1.13+, so this will enable
running compatibility tests with those consumers.