### PR TITLE
fix(ast): Ensure ast.TextPart is properly escaped when formatting

### DIFF
--- a/ast/format.go
+++ b/ast/format.go
@@ -593,7 +593,7 @@ func (f *formatter) formatStringExpressionPart(n StringExpressionPart) {
 }
 
 func (f *formatter) formatTextPart(n *TextPart) {
-	f.writeString(n.Value)
+	f.writeString(escapeStr(n.Value))
 }
 
 func (f *formatter) formatInterpolatedPart(n *InterpolatedPart) {

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -55,7 +55,7 @@ func TestFormat_Nodes(t *testing.T) {
 			script: `"\"a + b = ${a + b}; c\""`,
 		},
 		{
-			name:   "string interpolation with nested in strings",
+			name:   "string interpolation with nested strings",
 			script: `"\"a + b = ${a + b}; \\\"quoted string\\\"\""`,
 		},
 		{

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -47,6 +47,10 @@ func TestFormat_Nodes(t *testing.T) {
 			script: `"a + b = ${a + b}"`,
 		},
 		{
+			name:   "string interpolation with quotes",
+			script: `"a + b = ${a + b}; \"quoted string\""`,
+		},
+		{
 			name:   "binary_op",
 			script: `1 + 1 - 2`,
 		},

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -52,7 +52,11 @@ func TestFormat_Nodes(t *testing.T) {
 		},
 		{
 			name:   "string interpolation wrapped in quotes",
-			script: `"\"a + b = ${a + b}; stringy\""`,
+			script: `"\"a + b = ${a + b}; c\""`,
+		},
+		{
+			name:   "string interpolation with nested in strings",
+			script: `"\"a + b = ${a + b}; \\\"quoted string\\\"\""`,
 		},
 		{
 			name:   "binary_op",

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -51,6 +51,10 @@ func TestFormat_Nodes(t *testing.T) {
 			script: `"a + b = ${a + b}; \"quoted string\""`,
 		},
 		{
+			name:   "string interpolation wrapped in quotes",
+			script: `"\"a + b = ${a + b}; stringy\""`,
+		},
+		{
 			name:   "binary_op",
 			script: `1 + 1 - 2`,
 		},


### PR DESCRIPTION
📎 https://github.com/influxdata/flux/issues/3223

This adds escaping we do for `ast.StringLiteral` formatting to `ast.TextPart` as part of `ast.StringExpression` parts.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
