### PR TITLE
fix(quantile): sets default quantile method when not specified

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -460,6 +460,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/pivot_task_test_test.flux":                                     "e5b6f21d6fb307e3711e7e81bd90b052d2e7dc085c7b7fb732fe95666e598589",
 	"stdlib/universe/pivot_test.flux":                                               "fbc450c30dda9a39b767226bcb8c5ae5719355d5db1e4778457cd11caeb2dade",
 	"stdlib/universe/quantile_aggregate_test.flux":                                  "5af954cf00573adb026fcccb3886770ba97564edc7c479429641ae6138bf63f1",
+	"stdlib/universe/quantile_defaults_test.flux":                                   "a1c87e62030b0b830c12f37c7b7038c9c85158f11f2c5e5e35aac156f62b6604",
 	"stdlib/universe/quantile_tdigest_test.flux":                                    "c2063bf1c67c324b048c2ac3886d6e6a9c19f1f83924d05090b3090fc8ed7e4b",
 	"stdlib/universe/quantile_test.flux":                                            "56b7e04de071ec2852d92c1a113d825d186e0e983b86c706f2f519afea579e30",
 	"stdlib/universe/range_stop_test.flux":                                          "6c6d94af38f096664938330b874c7eb458e4ecee877b785bd8e1230a0aed5fd3",

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -24,6 +24,8 @@ const (
 	methodEstimateTdigest = "estimate_tdigest"
 	methodExactMean       = "exact_mean"
 	methodExactSelector   = "exact_selector"
+
+	defaultMethod = methodEstimateTdigest
 )
 
 type QuantileOpSpec struct {
@@ -67,6 +69,8 @@ func createQuantileOpSpec(args flux.Arguments, a *flux.Administration) (flux.Ope
 		return nil, err
 	} else if ok {
 		spec.Method = m
+	} else {
+		spec.Method = defaultMethod
 	}
 
 	if c, ok, err := args.GetFloat("compression"); err != nil {

--- a/stdlib/universe/quantile_defaults_test.flux
+++ b/stdlib/universe/quantile_defaults_test.flux
@@ -1,0 +1,34 @@
+package universe_test
+
+
+import "testing"
+
+option now = () =>
+	(2030-01-01T00:00:00Z)
+
+inData = "
+#datatype,string,long,string,string,dateTime:RFC3339,double
+#group,false,false,true,true,false,false
+#default,_result,,,,,
+,result,table,_measurement,_field,_time,_value
+,,0,SOYcRk,NC7N,2018-12-18T21:12:45Z,-61.68790887989735
+,,0,SOYcRk,NC7N,2018-12-18T21:12:55Z,-6.3173755351186465
+,,0,SOYcRk,NC7N,2018-12-18T21:13:05Z,-26.049728557657513
+,,0,SOYcRk,NC7N,2018-12-18T21:13:15Z,114.285955884979
+,,0,SOYcRk,NC7N,2018-12-18T21:13:25Z,16.140262630578995
+,,0,SOYcRk,NC7N,2018-12-18T21:13:35Z,29.50336437998469
+"
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,true,true,false
+#default,_result,,,,,,
+,result,table,_start,_stop,_measurement,_field,_value
+,,0,2018-01-01T00:00:00Z,2030-01-01T00:00:00Z,SOYcRk,NC7N,29.50336437998469
+"
+t_quantile = (table=<-) =>
+	(table
+		|> range(start: 2018-01-01T00:00:00Z)
+		|> quantile(q: 0.75))
+
+test _quantile_tdigest = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_quantile})

--- a/stdlib/universe/quantile_test.go
+++ b/stdlib/universe/quantile_test.go
@@ -227,6 +227,48 @@ func TestQuantile_NewQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "default",
+			Raw:  `from(bucket:"testdb") |> range(start: -1h) |> quantile(q: 0.99)`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "testdb"},
+						},
+					},
+					{
+						ID: "range1",
+						Spec: &universe.RangeOpSpec{
+							Start: flux.Time{
+								Relative:   -1 * time.Hour,
+								IsRelative: true,
+							},
+							Stop: flux.Time{
+								IsRelative: true,
+							},
+							TimeColumn:  "_time",
+							StartColumn: "_start",
+							StopColumn:  "_stop",
+						},
+					},
+					{
+						ID: "quantile2",
+						Spec: &universe.QuantileOpSpec{
+							Quantile:        0.99,
+							Compression:     1000,
+							Method:          "estimate_tdigest",
+							AggregateConfig: execute.DefaultAggregateConfig,
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "range1"},
+					{Parent: "range1", Child: "quantile2"},
+				},
+			},
+		},
 		// errors
 		{
 			Name:    "wrong method",


### PR DESCRIPTION
The quantile method type signature specified that the "method" parameter
was optional but did not apply a default if it was missing. This change
now applies the default.

Fixes #2648


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
