### PR TITLE
chore: add release validation and overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,9 +133,6 @@ vet: libflux-go
 bench: libflux-go
 	$(GO_TEST) -bench=. -run=^$$ ./...
 
-release:
-	./release.sh
-
 libflux/scanner.c: libflux/src/core/scanner/scanner.rl
 	ragel -C -o libflux/scanner.c libflux/src/core/scanner/scanner.rl
 


### PR DESCRIPTION
This patch, first and foremost, removes `make release`, as it was only
calling a single script that contained the logic needed; calling the
script directly is just as verbose. This also allows for an override of
the script, where one can specify the tag rather than having it guessed
(it guesses wrong many times outside the happy path).

Additionally, the release script will now verify that the `HEAD`
revision is has a success status in github. There were instances where
a release was cut that wasn't passing those tests. As integration tests
become part of the CI, this will become more important.