### PR TITLE
chore: remove table flux hook

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/colm/tableflux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/spec"
@@ -187,14 +186,6 @@ func IsNonNullJSON(bs json.RawMessage) bool {
 
 func (c FluxCompiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Program, error) {
 	query := c.Query
-
-	if tableflux.Enabled() {
-		ok, flux, err, _ := tableflux.TableFlux(query)
-		if !ok {
-			return nil, errors.Newf(codes.Invalid, "tableflux transformation failed: %s", err)
-		}
-		query = flux
-	}
 
 	// Ignore context, it will be provided upon Program Start.
 	if IsNonNullJSON(c.Extern) {


### PR DESCRIPTION
The TableFlux experiment is not currently under active development. Remove the
call point from the compile command. This call transforms table flux code to
flux and was never meant to be a permanent part of the system.