### PR TITLE
feat(profiler): Aggregate results for operator profiler

### DIFF
--- a/execute/profiler.go
+++ b/execute/profiler.go
@@ -168,7 +168,7 @@ func (o *OperatorProfiler) GetResult(q flux.Query, alloc *memory.Allocator) (flu
 	return tbl, nil
 }
 
-// GetSortedResult is identical to GetResult, except it accept it calls Sort()
+// GetSortedResult is identical to GetResult, except it calls Sort()
 // on the ColListTableBuilder to make testing easier.
 // sortKeys and desc are passed directly into the Sort() call
 func (o *OperatorProfiler) GetSortedResult(q flux.Query, alloc *memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error) {
@@ -313,7 +313,7 @@ func (s *QueryProfiler) GetResult(q flux.Query, alloc *memory.Allocator) (flux.T
 	return tbl, nil
 }
 
-// GetSortedResult is identical to GetResult, except it accept it calls Sort()
+// GetSortedResult is identical to GetResult, except it calls Sort()
 // on the ColListTableBuilder to make testing easier.
 // sortKeys and desc are passed directly into the Sort() call
 func (s *QueryProfiler) GetSortedResult(q flux.Query, alloc *memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error) {

--- a/execute/profiler_test.go
+++ b/execute/profiler_test.go
@@ -41,41 +41,133 @@ func TestOperatorProfiler_GetResult(t *testing.T) {
 	// Add operator profiler to context
 	p := configureOperatorProfiler(ctx)
 
-	// And inject it into the context.
 	// Build the "want" table.
 	// This table is built dynamically because the table includes time data which changes
 	// every time the test is run.
 	var wantStr bytes.Buffer
 	// Need to have the goroutines to sync on their writes to the buffer.
 	wantStr.WriteString(`
-#datatype,string,long,string,long,long,long,long,double
-#group,false,false,true,false,false,false,false,false
-#default,_profiler,,,,,,,
-,result,table,_measurement,OperationCount,MinimumDuration,MaximumDuration,DurationSum,MeanDuration
+#datatype,string,long,string,string,string,long,long,long,long,double
+#group,false,false,true,false,false,false,false,false,false,false
+#default,_profiler,,,,,,,,,
+,result,table,_measurement,Type,Label,Count,MinDuration,MaxDuration,DurationSum,MeanDuration
 `)
-	count := 2
+	count := 4
 	wg := sync.WaitGroup{}
 	wg.Add(count)
-	fn := func(label string, ctx context.Context, offset int) {
+	fn := func(opType string, label string, ctx context.Context, offset int) {
 		st := time.Date(2020, 10, 14, 12, 30, 0, 0, time.UTC)
-		_, span := execute.StartSpanFromContext(ctx, "tf", label, opentracing.StartTime(st))
+		_, span := execute.StartSpanFromContext(ctx, opType, label, opentracing.StartTime(st))
 		profilerSpan := span.(*execute.OperatorProfilingSpan)
 		// Finish() will write the data to the profiler
 		// In Flux runtime, this is called when an execution node finishes execution
 		profilerSpan.FinishWithOptions(opentracing.FinishOptions{
-			FinishTime: time.Date(2020, 10, 14, 12, 30, 0, 1234+offset, time.UTC),
+			FinishTime: time.Date(2020, 10, 14, 12, 30, 0, 1000+offset, time.UTC),
 		})
 		wg.Done()
 	}
 	for i := 0; i < count; i++ {
-		go fn(fmt.Sprintf("op%d", i), ctx, 100*(i+1))
+		op := fmt.Sprintf("type%d", i%2)
+		go fn(op, "lab0", ctx, 100+i*i)
+		// Waiting between each loop seems to ensure better consistency of row order
+		// for final table. However, this is still not guaranteed, becausethe result
+		// aggregates are stored in a map, and thus order is not 100% guaranteed.
+		time.Sleep(100 * time.Millisecond)
 	}
-	wantStr.WriteString(fmt.Sprintf(",,0,profiler/operator,%d,%d,%d,%d,%f\n",
+	wantStr.WriteString(fmt.Sprintf(",,0,profiler/operator,%s,%s,%d,%d,%d,%d,%f\n",
+		"type0",
+		"lab0",
 		2,
-		1334,
-		1434,
-		2768,
-		1384.0,
+		1100,
+		1104,
+		2204,
+		1102.0,
+	))
+	wantStr.WriteString(fmt.Sprintf(",,0,profiler/operator,%s,%s,%d,%d,%d,%d,%f\n",
+		"type1",
+		"lab0",
+		2,
+		1101,
+		1109,
+		2210,
+		1105.0,
+	))
+	wg.Wait()
+	// Wait a bit for the profiling results to be added.
+	// In the query code path this is guaranteed because we only access the result
+	// after the query finishes execution AND its result tables are read and encoded.
+	time.Sleep(100 * time.Millisecond)
+	tbl, err := p.GetResult(nil, &memory.Allocator{})
+	if err != nil {
+		t.Error(err)
+	}
+	result := table.NewProfilerResult(tbl)
+	got := flux.NewSliceResultIterator([]flux.Result{&result})
+	dec := csv.NewMultiResultDecoder(csv.ResultDecoderConfig{})
+	want, e := dec.Decode(ioutil.NopCloser(strings.NewReader(wantStr.String())))
+	if e != nil {
+		t.Error(err)
+	}
+	if err := executetest.EqualResultIterators(want, got); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOperatorProfiler_GroupByLabel(t *testing.T) {
+	// Create an operator profiler
+	p := execute.AllProfilers["operator"]()
+	// And inject it to the context.
+	ctx := context.WithValue(context.Background(), execute.OperatorProfilerContextKey, p)
+	// Build the "want" table.
+	// This table is built dynamically because the table includes time data which changes
+	// every time the test is run.
+	var wantStr bytes.Buffer
+	// Need to have the goroutines to sync on their writes to the buffer.
+	wantStr.WriteString(`
+#datatype,string,long,string,string,string,long,long,long,long,double
+#group,false,false,true,false,false,false,false,false,false,false
+#default,_profiler,,,,,,,,,
+,result,table,_measurement,Type,Label,Count,MinDuration,MaxDuration,DurationSum,MeanDuration
+`)
+	count := 4
+	wg := sync.WaitGroup{}
+	wg.Add(count)
+	fn := func(opType string, label string, ctx context.Context, offset int) {
+		st := time.Date(2020, 10, 14, 12, 30, 0, 0, time.UTC)
+		_, span := execute.StartSpanFromContext(ctx, opType, label, opentracing.StartTime(st))
+		profilerSpan := span.(*execute.OperatorProfilingSpan)
+		// Finish() will write the data to the profiler
+		// In Flux runtime, this is called when an execution node finishes execution
+		profilerSpan.FinishWithOptions(opentracing.FinishOptions{
+			FinishTime: time.Date(2020, 10, 14, 12, 30, 0, 1000+offset, time.UTC),
+		})
+		wg.Done()
+	}
+	for i := 0; i < count; i++ {
+		label := fmt.Sprintf("lab%d", i%2)
+		go fn("type0", label, ctx, 100+i*i)
+		// Waiting between each loop seems to ensure better consistency of row order
+		// for final table. However, this is still not guaranteed, becausethe result
+		// aggregates are stored in a map, and thus order is not 100% guaranteed.
+		time.Sleep(100 * time.Millisecond)
+	}
+	wantStr.WriteString(fmt.Sprintf(",,0,profiler/operator,%s,%s,%d,%d,%d,%d,%f\n",
+		"type0",
+		"lab0",
+		2,
+		1100,
+		1104,
+		2204,
+		1102.0,
+	))
+	wantStr.WriteString(fmt.Sprintf(",,0,profiler/operator,%s,%s,%d,%d,%d,%d,%f\n",
+		"type0",
+		"lab1",
+		2,
+		1101,
+		1109,
+		2210,
+		1105.0,
 	))
 	wg.Wait()
 	// Wait a bit for the profiling results to be added.

--- a/execute/profiler_test.go
+++ b/execute/profiler_test.go
@@ -42,10 +42,7 @@ func TestOperatorProfiler_GetResult(t *testing.T) {
 	p := configureOperatorProfiler(ctx)
 
 	// Build the "want" table.
-	// This table is built dynamically because the table includes time data which changes
-	// every time the test is run.
 	var wantStr bytes.Buffer
-	// Need to have the goroutines to sync on their writes to the buffer.
 	wantStr.WriteString(`
 #datatype,string,long,string,string,string,long,long,long,long,double
 #group,false,false,true,false,false,false,false,false,false,false
@@ -70,8 +67,8 @@ func TestOperatorProfiler_GetResult(t *testing.T) {
 		op := fmt.Sprintf("type%d", i%2)
 		go fn(op, "lab0", ctx, 100+i*i)
 		// Waiting between each loop seems to ensure better consistency of row order
-		// for final table. However, this is still not guaranteed, becausethe result
-		// aggregates are stored in a map, and thus order is not 100% guaranteed.
+		// for final table. However, because the result aggregates are stored in a map,
+		// the order in which the rows are written cannot be guaranteed
 		time.Sleep(100 * time.Millisecond)
 	}
 	wantStr.WriteString(fmt.Sprintf(",,0,profiler/operator,%s,%s,%d,%d,%d,%d,%f\n",
@@ -119,10 +116,7 @@ func TestOperatorProfiler_GroupByLabel(t *testing.T) {
 	// And inject it to the context.
 	ctx := context.WithValue(context.Background(), execute.OperatorProfilerContextKey, p)
 	// Build the "want" table.
-	// This table is built dynamically because the table includes time data which changes
-	// every time the test is run.
 	var wantStr bytes.Buffer
-	// Need to have the goroutines to sync on their writes to the buffer.
 	wantStr.WriteString(`
 #datatype,string,long,string,string,string,long,long,long,long,double
 #group,false,false,true,false,false,false,false,false,false,false
@@ -147,7 +141,7 @@ func TestOperatorProfiler_GroupByLabel(t *testing.T) {
 		label := fmt.Sprintf("lab%d", i%2)
 		go fn("type0", label, ctx, 100+i*i)
 		// Waiting between each loop seems to ensure better consistency of row order
-		// for final table. However, this is still not guaranteed, becausethe result
+		// for final table. However, this is still not guaranteed, because the result
 		// aggregates are stored in a map, and thus order is not 100% guaranteed.
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
Closes #3203

Groups profiler results by operation type and label, and aggregates the results into count, min, max, sum, and mean.

Allows explicit times to be passed into `OperatorProfilerSpan.finish()` and `StartSpanFromContext` to make testing easier.

Adds `GetSortedResult()` method to the `Profiler` interface to allow for easier testing without requiring results to be sorted in production.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
