### PR TITLE
feat: add series cardinality function to influxdb package

### DIFF
--- a/cmd/flux/cmd/execute.go
+++ b/cmd/flux/cmd/execute.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
 	"github.com/influxdata/flux/dependencies/filesystem"
+	"github.com/influxdata/flux/dependencies/influxdb"
 	"github.com/influxdata/flux/repl"
 	"github.com/spf13/cobra"
 )
@@ -24,10 +25,29 @@ func init() {
 	rootCmd.AddCommand(executeCmd)
 }
 
-func execute(cmd *cobra.Command, args []string) error {
+const DefaultInfluxDBHost = "http://localhost:9999"
+
+func injectDependencies(ctx context.Context) (context.Context, flux.Dependencies) {
 	deps := flux.NewDefaultDependencies()
 	deps.Deps.FilesystemService = filesystem.SystemFS
-	ctx := deps.Inject(context.Background())
+
+	// inject the dependencies to the context.
+	// one useful example is socket.from, kafka.to, and sql.from/sql.to where we need
+	// to access the url validator in deps to validate the user-specified url.
+	ctx = deps.Inject(ctx)
+
+	ip := influxdb.Dependency{
+		Provider: &influxdb.HttpProvider{
+			DefaultConfig: influxdb.Config{
+				Host: DefaultInfluxDBHost,
+			},
+		},
+	}
+	return ip.Inject(ctx), deps
+}
+
+func execute(cmd *cobra.Command, args []string) error {
+	ctx, deps := injectDependencies(context.Background())
 	r := repl.New(ctx, deps)
 	if err := r.Input(args[0]); err != nil {
 		return fmt.Errorf("failed to execute query: %v", err)

--- a/cmd/flux/cmd/repl.go
+++ b/cmd/flux/cmd/repl.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"context"
 
-	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/builtin"
-	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/repl"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -18,12 +16,7 @@ var replCmd = &cobra.Command{
 	Short: "Launch a Flux REPL",
 	Long:  "Launch a Flux REPL (Read-Eval-Print-Loop)",
 	Run: func(cmd *cobra.Command, args []string) {
-		deps := flux.NewDefaultDependencies()
-		deps.Deps.FilesystemService = filesystem.SystemFS
-		// inject the dependencies to the context.
-		// one useful example is socket.from, kafka.to, and sql.from/sql.to where we need
-		// to access the url validator in deps to validate the user-specified url.
-		ctx := deps.Inject(context.Background())
+		ctx, deps := injectDependencies(context.Background())
 		r := repl.New(ctx, deps)
 		r.Run()
 	},

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -9,11 +9,9 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-const DefaultInfluxDBHost = "http://localhost:9999"
-
 func main() {
 	plan.RegisterLogicalRules(influxdb.DefaultFromAttributes{
-		Host: func(v string) *string { return &v }(DefaultInfluxDBHost),
+		Host: func(v string) *string { return &v }(cmd.DefaultInfluxDBHost),
 	})
 	cmd.Execute()
 }

--- a/csv/result.go
+++ b/csv/result.go
@@ -14,13 +14,13 @@ import (
 	"unicode/utf8"
 
 	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/arrow"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/iocounter"
-	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/values"
 )
 
@@ -78,7 +78,7 @@ type ResultDecoderConfig struct {
 	MaxBufferCount int
 	// Allocator is the memory allocator that will be used during decoding.
 	// The default is to use an unlimited allocator when this is not set.
-	Allocator *memory.Allocator
+	Allocator memory.Allocator
 	// Context is the context for this ResultDecoder.
 	// When the context is canceled, the decoder will also be canceled.
 	// This defaults to context.Background.

--- a/dependencies.go
+++ b/dependencies.go
@@ -2,6 +2,7 @@ package flux
 
 import (
 	"context"
+
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/http"

--- a/dependencies/influxdb/errors.go
+++ b/dependencies/influxdb/errors.go
@@ -1,0 +1,46 @@
+package influxdb
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+func handleError(target interface{}) error {
+	if errStr, ok := target.(string); ok {
+		return errors.New(codes.Unknown, errStr)
+	}
+	if internalErrMap, ok := target.(map[string]interface{}); ok {
+		internalErr := new(flux.Error)
+		if code, ok := internalErrMap["code"].(string); ok {
+			internalErr.Code = handleErrorCode(code)
+		}
+		if msg, ok := internalErrMap["message"].(string); ok {
+			internalErr.Msg = msg
+		}
+		if err, ok := internalErrMap["error"]; ok {
+			internalErr.Err = handleError(err)
+		}
+		return internalErr
+	}
+	return nil
+}
+
+func handleErrorCode(code string) codes.Code {
+	switch code {
+	case "internal error":
+		return codes.Internal
+	case "not found":
+		return codes.NotFound
+	case "invalid":
+		return codes.Invalid
+	case "unavailable":
+		return codes.Unavailable
+	case "forbidden":
+		return codes.PermissionDenied
+	case "unauthorized":
+		return codes.Unauthenticated
+	default:
+		return codes.Unknown
+	}
+}

--- a/dependencies/influxdb/http.go
+++ b/dependencies/influxdb/http.go
@@ -1,0 +1,443 @@
+package influxdb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	stdhttp "net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/dependencies/http"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// HttpProvider is an implementation of the Provider that
+// implements the read methods with HTTP calls to an influxdb query
+// endpoint.
+type HttpProvider struct {
+	DefaultConfig Config
+}
+
+var _ Provider = HttpProvider{}
+
+func (h HttpProvider) ReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error) {
+	c, err := h.clientFor(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+	return filteredHttpReader{
+		HttpClient:   c,
+		Bounds:       bounds,
+		PredicateSet: predicateSet,
+	}, nil
+}
+
+func (h HttpProvider) SeriesCardinalityReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error) {
+	// If any of the predicates use keep empty then they are not
+	// valid for series cardinality reader.
+	for _, p := range predicateSet {
+		if p.KeepEmpty {
+			return nil, errors.New(codes.Unimplemented, "keep empty filter option is not allowed for the series cardinality reader")
+		}
+	}
+
+	// Retrieve the client and create the http reader.
+	c, err := h.clientFor(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+	return seriesCardinalityHttpReader{
+		HttpClient:   c,
+		Bounds:       bounds,
+		PredicateSet: predicateSet,
+	}, nil
+}
+
+func (h HttpProvider) clientFor(ctx context.Context, conf Config) (*HttpClient, error) {
+	deps := flux.GetDependencies(ctx)
+	httpc, err := deps.HTTPClient()
+	if err != nil {
+		return nil, err
+	}
+
+	if conf.Org.IsZero() {
+		conf.Org = h.DefaultConfig.Org
+	}
+	if conf.Bucket.IsZero() {
+		conf.Bucket = h.DefaultConfig.Bucket
+	}
+	if conf.Host == "" {
+		conf.Host = h.DefaultConfig.Host
+	}
+	if err := h.validateHost(deps, conf.Host); err != nil {
+		return nil, err
+	}
+	if conf.Token == "" {
+		conf.Token = h.DefaultConfig.Token
+	}
+	return &HttpClient{
+		Client: httpc,
+		Config: conf,
+	}, nil
+}
+
+func (h HttpProvider) validateHost(deps flux.Dependencies, host string) error {
+	if host == "" {
+		return errors.New(codes.Invalid, "influxdb provider requires a host to be specified")
+	}
+
+	validator, err := deps.URLValidator()
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(host)
+	if err != nil {
+		return err
+	}
+	return validator.Validate(u)
+}
+
+// HttpClient is an http client for reading from an influxdb instance.
+type HttpClient struct {
+	Client http.Client
+	Config Config
+}
+
+// Query will create a new http.Request, send it to the server, then
+// decode the request as a flux.TableIterator and invoke the function with
+// each flux.Table.
+func (h *HttpClient) Query(ctx context.Context, f func(table flux.Table) error, file *ast.File, now time.Time, mem memory.Allocator) error {
+	req, err := h.newRequest(ctx, file, now)
+	if err != nil {
+		return err
+	}
+
+	resp, err := h.Client.Do(req)
+	if err != nil {
+		return err
+	} else if resp.StatusCode != 200 {
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return errors.Newf(codes.Invalid, "error when reading response body: %s", err)
+		}
+		return h.parseError(data)
+	}
+	return h.processResult(resp.Body, f, mem)
+}
+
+// newFile constructs a new ast.File with the default values filled in.
+func (h *HttpClient) newFile(imports map[string]*ast.ImportDeclaration) ast.File {
+	file := ast.File{
+		Package: &ast.PackageClause{
+			Name: &ast.Identifier{Name: "main"},
+		},
+		Name: "query.flux",
+	}
+	file.Imports = make([]*ast.ImportDeclaration, 0, len(imports))
+	for _, decl := range imports {
+		file.Imports = append(file.Imports, decl)
+	}
+	sort.Slice(file.Imports, func(i, j int) bool {
+		return file.Imports[i].Path.Value < file.Imports[j].Path.Value
+	})
+	return file
+}
+
+// appendFromArgs will append properties for the common from arguments
+// in the HttpClient.
+func (h *HttpClient) appendFromArgs(properties []*ast.Property) []*ast.Property {
+	if properties == nil {
+		properties = make([]*ast.Property, 0, 1)
+	}
+
+	var arg ast.Property
+	if bucket := h.Config.Bucket; bucket.ID != "" {
+		arg.Key = &ast.Identifier{Name: "bucketID"}
+		arg.Value = &ast.StringLiteral{Value: bucket.ID}
+	} else {
+		arg.Key = &ast.Identifier{Name: "bucket"}
+		arg.Value = &ast.StringLiteral{Value: bucket.Name}
+	}
+	return append(properties, &arg)
+}
+
+// appendRangeArgs will append properties for the common range arguments
+// in the HttpClient.
+func (h *HttpClient) appendRangeArgs(properties []*ast.Property, bounds flux.Bounds) []*ast.Property {
+	if properties == nil {
+		properties = make([]*ast.Property, 0, 2)
+	}
+
+	properties = append(properties, &ast.Property{
+		Key:   &ast.Identifier{Name: "start"},
+		Value: ast.DateTimeLiteralFromValue(bounds.Start.Time(bounds.Now)),
+	})
+	if !bounds.Stop.IsZero() {
+		properties = append(properties, &ast.Property{
+			Key:   &ast.Identifier{Name: "stop"},
+			Value: ast.DateTimeLiteralFromValue(bounds.Stop.Time(bounds.Now)),
+		})
+	}
+	return properties
+}
+
+// newRequest will create a new http.Request for the query endpoint.
+// The body will be an encoded ast.File.
+func (h *HttpClient) newRequest(ctx context.Context, file *ast.File, now time.Time) (*stdhttp.Request, error) {
+	u, err := url.Parse(h.Config.Host)
+	if err != nil {
+		return nil, err
+	}
+	u.Path += "/api/v2/query"
+
+	if org := h.Config.Org; org.IsValid() {
+		u.RawQuery = func() string {
+			params := make(url.Values)
+			if org.ID != "" {
+				params.Set("orgID", org.ID)
+			} else {
+				params.Set("org", org.Name)
+			}
+			return params.Encode()
+		}()
+	}
+
+	body, err := h.newRequestBody(file, now)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := stdhttp.NewRequest("POST", u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if token := h.Config.Token; token != "" {
+		req.Header.Set("Authorization", "Token "+token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req.WithContext(ctx), nil
+}
+
+// newRequestBody will produce a new request body for the http client
+// with a formatted ast.File.
+func (h *HttpClient) newRequestBody(file *ast.File, now time.Time) ([]byte, error) {
+	var req struct {
+		Query   string `json:"query"`
+		Dialect struct {
+			Header         bool     `json:"header"`
+			DateTimeFormat string   `json:"dateTimeFormat"`
+			Annotations    []string `json:"annotations"`
+		} `json:"dialect"`
+		Now time.Time `json:"now"`
+	}
+	req.Query = ast.Format(file)
+	req.Dialect.Header = true
+	req.Dialect.DateTimeFormat = "RFC3339Nano"
+	req.Dialect.Annotations = []string{"group", "datatype", "default"}
+	req.Now = now
+	return json.Marshal(req)
+}
+
+// processResult reads a single csv encoded result from the io.Reader.
+// Produced tables are passed to the function. If there is more than one
+// result, this method will discard any additional results.
+func (h *HttpClient) processResult(r io.ReadCloser, f func(flux.Table) error, mem memory.Allocator) error {
+	config := csv.ResultDecoderConfig{Allocator: mem}
+	dec := csv.NewMultiResultDecoder(config)
+	results, err := dec.Decode(r)
+	if err != nil {
+		return err
+	}
+	defer results.Release()
+
+	if !results.More() {
+		return nil
+	}
+	res := results.Next()
+	if err := res.Tables().Do(f); err != nil {
+		return err
+	}
+	results.Release()
+	return results.Err()
+}
+
+// parseError will parse an influxdb error.
+func (h *HttpClient) parseError(p []byte) error {
+	var e interface{}
+	if err := json.Unmarshal(p, &e); err != nil {
+		return err
+	}
+	return handleError(e)
+}
+
+// functionToAST will convert a resolved function back to its
+// ast representation. If the function references any imports,
+// this will reimport the values into the new script.
+func (h *HttpClient) functionToAST(fn Predicate, imports map[string]*ast.ImportDeclaration) ast.Expression {
+	// Iterate through the scope and include any imports.
+	fn.Scope.Range(func(k string, v values.Value) {
+		pkg, ok := v.(values.Package)
+		if !ok {
+			return
+		}
+
+		pkgpath := pkg.Path()
+		if pkgpath == "" {
+			return
+		}
+		h.includeImport(imports, k, pkgpath)
+	})
+	return semantic.ToAST(fn.Fn).(ast.Expression)
+}
+
+// includeImport will include the given import in the list of import declarations.
+// It does not resolve name or path conflicts.
+func (h *HttpClient) includeImport(imports map[string]*ast.ImportDeclaration, name, path string) {
+	// Look to see if we have already included an import
+	// with this name.
+	if _, ok := imports[name]; ok {
+		return
+	}
+
+	decl := &ast.ImportDeclaration{
+		Path: &ast.StringLiteral{Value: path},
+		As:   &ast.Identifier{Name: name},
+	}
+	imports[name] = decl
+}
+
+type filteredHttpReader struct {
+	*HttpClient
+	Bounds       flux.Bounds
+	PredicateSet PredicateSet
+}
+
+func (h filteredHttpReader) Read(ctx context.Context, f func(flux.Table) error, mem memory.Allocator) error {
+	imports := make(map[string]*ast.ImportDeclaration)
+	query := &ast.PipeExpression{
+		Argument: &ast.CallExpression{
+			Callee: &ast.Identifier{Name: "from"},
+			Arguments: []ast.Expression{
+				&ast.ObjectExpression{
+					Properties: h.appendFromArgs(nil),
+				},
+			},
+		},
+		Call: &ast.CallExpression{
+			Callee: &ast.Identifier{Name: "range"},
+			Arguments: []ast.Expression{
+				&ast.ObjectExpression{
+					Properties: h.appendRangeArgs(nil, h.Bounds),
+				},
+			},
+		},
+	}
+	for _, predicate := range h.PredicateSet {
+		params := []*ast.Property{{
+			Key:   &ast.Identifier{Name: "fn"},
+			Value: h.functionToAST(predicate, imports),
+		}}
+		if predicate.KeepEmpty {
+			params = append(params, &ast.Property{
+				Key:   &ast.Identifier{Name: "onEmpty"},
+				Value: ast.StringLiteralFromValue("keep"),
+			})
+		}
+		query = &ast.PipeExpression{
+			Argument: query,
+			Call: &ast.CallExpression{
+				Callee: &ast.Identifier{Name: "filter"},
+				Arguments: []ast.Expression{
+					&ast.ObjectExpression{
+						Properties: params,
+					},
+				},
+			},
+		}
+	}
+
+	file := h.newFile(imports)
+	file.Body = []ast.Statement{
+		&ast.ExpressionStatement{Expression: query},
+	}
+	return h.Query(ctx, f, &file, h.Bounds.Now, mem)
+}
+
+type seriesCardinalityHttpReader struct {
+	*HttpClient
+	Bounds       flux.Bounds
+	PredicateSet PredicateSet
+}
+
+func (h seriesCardinalityHttpReader) Read(ctx context.Context, f func(flux.Table) error, mem memory.Allocator) error {
+	properties := make([]*ast.Property, 0, 4)
+	properties = h.appendFromArgs(properties)
+	properties = h.appendRangeArgs(properties, h.Bounds)
+
+	imports := make(map[string]*ast.ImportDeclaration)
+	if len(h.PredicateSet) > 0 {
+		predicate := h.functionToAST(h.PredicateSet[0], imports)
+		for _, p := range h.PredicateSet[1:] {
+			predicate = &ast.LogicalExpression{
+				Operator: ast.AndOperator,
+				Left:     predicate,
+				Right:    h.functionToAST(p, imports),
+			}
+		}
+		properties = append(properties, &ast.Property{
+			Key:   &ast.Identifier{Name: "predicate"},
+			Value: predicate,
+		})
+	}
+
+	// Need to find an appropriate name for our required
+	// import. Unlike the function, we can name this anything
+	// we want. We prefer influxdb but let's try to disambiguate
+	// it in case the person used this name for something else.
+	const pkgpath = "influxdata/influxdb"
+	name, num := "influxdb", 1
+	for {
+		if decl, ok := imports[name]; ok && decl.Path.Value == pkgpath {
+			// Import already present and the correct path.
+			// This name is fine to use.
+			break
+		} else if ok {
+			// An import with this name exists, but it didn't
+			// match the path we want. We need to use a different
+			// name.
+			name, num = "influxdb"+strconv.Itoa(num), num+1
+			continue
+		}
+		// Add an import with the present name.
+		h.includeImport(imports, name, pkgpath)
+	}
+
+	file := h.newFile(imports)
+	file.Body = []ast.Statement{
+		&ast.ExpressionStatement{
+			Expression: &ast.CallExpression{
+				Callee: &ast.MemberExpression{
+					Object:   &ast.Identifier{Name: name},
+					Property: &ast.Identifier{Name: "cardinality"},
+				},
+				Arguments: []ast.Expression{
+					&ast.ObjectExpression{Properties: properties},
+				},
+			},
+		},
+	}
+	return h.Query(ctx, f, &file, h.Bounds.Now, mem)
+}

--- a/dependencies/influxdb/provider.go
+++ b/dependencies/influxdb/provider.go
@@ -1,0 +1,134 @@
+package influxdb
+
+import (
+	"context"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+)
+
+type key int
+
+const readerKey key = iota
+
+// Dependency will inject the Provider into the dependency chain.
+type Dependency struct {
+	Provider Provider
+}
+
+// Inject will inject the Provider into the dependency chain.
+func (d Dependency) Inject(ctx context.Context) context.Context {
+	return context.WithValue(ctx, readerKey, d.Provider)
+}
+
+// GetProvider will return the Provider for the current context.
+// If no Provider has been injected into the dependencies,
+// this will return a default provider.
+func GetProvider(ctx context.Context) Provider {
+	p := ctx.Value(readerKey)
+	if p == nil {
+		return HttpProvider{}
+	}
+	return p.(Provider)
+}
+
+// Config contains the common configuration for interacting with an influxdb instance.
+type Config struct {
+	Org    NameOrID
+	Bucket NameOrID
+	Host   string
+	Token  string
+}
+
+// Predicate defines a predicate to filter storage with.
+type Predicate struct {
+	interpreter.ResolvedFunction
+
+	// KeepEmpty determines if empty tables should be retained
+	// if none of the rows pass the filter.
+	KeepEmpty bool
+}
+
+// Copy produces a deep copy of the Predicate.
+func (p *Predicate) Copy() Predicate {
+	np := *p
+	np.ResolvedFunction = p.ResolvedFunction.Copy()
+	return np
+}
+
+// PredicateSet holds a set of predicates that will filter the results.
+type PredicateSet []Predicate
+
+// Copy produces a deep copy of the PredicateSet.
+func (ps PredicateSet) Copy() PredicateSet {
+	if ps == nil {
+		return nil
+	}
+
+	nps := make([]Predicate, len(ps))
+	for i := range ps {
+		nps[i] = ps[i].Copy()
+	}
+	return nps
+}
+
+// Provider is an interface for creating a Reader that will read
+// data from an influxdb instance.
+//
+// This provides different provider methods depending on the read
+// method. The read methods can be expanded so implementors of this
+// interface should embed the UnimplementedProvider to automatically
+// implement new methods with a default unimplemented stub.
+type Provider interface {
+	// ReaderFor will construct a Reader using the given configuration parameters.
+	// If the parameters are their zero values, appropriate defaults may be used
+	// or an error may be returned if the implementation does not have a default.
+	ReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error)
+
+	// SeriesCardinalityReaderFor will return a Reader
+	// for the SeriesCardinality operation.
+	SeriesCardinalityReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error)
+}
+
+// Reader reads tables from an influxdb instance.
+type Reader interface {
+	// Read will produce flux.Table values using the memory.Allocator
+	// and it will pass those tables to the given function.
+	Read(ctx context.Context, f func(flux.Table) error, mem memory.Allocator) error
+}
+
+// UnimplementedProvider provides default implementations for a Provider.
+// This implements all of the Provider methods by returning an error
+// with the code codes.Unimplemented.
+type UnimplementedProvider struct{}
+
+var _ Provider = UnimplementedProvider{}
+
+func (u UnimplementedProvider) ReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error) {
+	return nil, errors.New(codes.Unimplemented, "influxdb reader has not been implemented")
+}
+
+func (u UnimplementedProvider) SeriesCardinalityReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error) {
+	return nil, errors.New(codes.Unimplemented, "influxdb series cardinality reader has not been implemented")
+}
+
+// NameOrID signifies the name of an organization/bucket
+// or an ID for an organization/bucket.
+type NameOrID struct {
+	ID   string
+	Name string
+}
+
+// IsValid will return true if both the name and the id are not
+// set at the same time.
+func (n NameOrID) IsValid() bool {
+	return (n.ID != "" && n.Name == "") || (n.ID == "" && n.Name != "")
+}
+
+// IsZero will return true if neither the id nor name are set.
+func (n NameOrID) IsZero() bool {
+	return n.ID == "" && n.Name == ""
+}

--- a/dependencies/influxdb/provider_test.go
+++ b/dependencies/influxdb/provider_test.go
@@ -1,0 +1,25 @@
+package influxdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/dependencies/influxdb"
+)
+
+func TestGetProvider(t *testing.T) {
+	want := influxdb.HttpProvider{
+		DefaultConfig: influxdb.Config{
+			Host: "http://localhost:8086",
+		},
+	}
+	ctx := influxdb.Dependency{
+		Provider: want,
+	}.Inject(context.Background())
+
+	got := influxdb.GetProvider(ctx)
+	if !cmp.Equal(want, got) {
+		t.Fatalf("unexpected provider -want/+got:\n%s", cmp.Diff(want, got))
+	}
+}

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -81,7 +81,7 @@ func (t *Table) Normalize() {
 }
 
 func (t *Table) Empty() bool {
-	return len(t.Data) == 0
+	return len(t.Data) == 0 && t.Err == nil
 }
 
 func (t *Table) Cols() []flux.ColMeta {

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -162,7 +162,7 @@ var sourceHashes = map[string]string{
 	"stdlib/http/http.flux":                                                         "71e03fb4d76723a073d014f811a777f76fcfd4d90bd681feec32e2c871479c6b",
 	"stdlib/http/http_endpoint_test.flux":                                           "5fd57fe9ae7f57ddbd7ba430ffc558f749dad7b8f26d23ec6c3d9487b2233431",
 	"stdlib/http/http_path_encode_endpoint_test.flux":                               "e863b8826344dd7e0accd4497e1eb8cfa7754f3bf024c066e574b40f6c94c72c",
-	"stdlib/influxdata/influxdb/influxdb.flux":                                      "9b17c579a80fad6c26a971c125925b3d526e88c24415217b7191f72675511b13",
+	"stdlib/influxdata/influxdb/influxdb.flux":                                      "be021f15ffbcb03ca806a7104c985da5b20f52b480b422d54d01da56f02c445e",
 	"stdlib/influxdata/influxdb/monitor/check_test.flux":                            "0c7e4447926549d15b8ae51c28d4be09499efbeb04457e9069c832bba6a98aaa",
 	"stdlib/influxdata/influxdb/monitor/deadman_add_test.flux":                      "d3414e7ec15968ad0fdf64975fda51f6381778f905aa3f49e3b9aa1f3a12cd69",
 	"stdlib/influxdata/influxdb/monitor/deadman_sub_test.flux":                      "d523715a362f178b303575e4167b77f0d2cff5cc874ae85e487c3b402f62a470",

--- a/result.go
+++ b/result.go
@@ -46,6 +46,7 @@ type Table interface {
 	Done()
 
 	// Empty returns whether the table contains no records.
+	// This should not return true when the table is empty because of an error.
 	Empty() bool
 }
 

--- a/stdlib/influxdata/influxdb/cardinality.go
+++ b/stdlib/influxdata/influxdb/cardinality.go
@@ -1,0 +1,161 @@
+package influxdb
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependencies/influxdb"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/values"
+)
+
+const (
+	CardinalityFuncName = "cardinality"
+	CardinalityKind     = PackageName + "." + CardinalityFuncName
+)
+
+func init() {
+	cardinalitySignature := runtime.MustLookupBuiltinType(PackageName, CardinalityFuncName)
+
+	runtime.RegisterPackageValue(PackageName, CardinalityFuncName, flux.MustValue(flux.FunctionValue(CardinalityFuncName, createCardinalityOpSpec, cardinalitySignature)))
+	plan.RegisterProcedureSpec(CardinalityKind, newCardinalityProcedure, CardinalityKind)
+	execute.RegisterSource(CardinalityKind, createCardinalitySource)
+}
+
+func createCardinalityOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	spec := new(CardinalityOpSpec)
+
+	if b, ok, err := GetNameOrID(args, "bucket", "bucketID"); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, errors.New(codes.Invalid, "must specify only one of bucket or bucketID")
+	} else {
+		spec.Bucket = b
+	}
+
+	if o, ok, err := GetNameOrID(args, "org", "orgID"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Org = o
+	}
+
+	if h, ok, err := args.GetString("host"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Host = h
+	}
+
+	if token, ok, err := args.GetString("token"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Token = token
+	}
+
+	if start, err := args.GetRequiredTime("start"); err != nil {
+		return nil, err
+	} else {
+		spec.Start = start
+	}
+
+	if stop, ok, err := args.GetTime("stop"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.Stop = stop
+	} else {
+		spec.Stop = flux.Now
+	}
+
+	if fn, ok, err := args.GetFunction("predicate"); err != nil {
+		return nil, err
+	} else if ok {
+		predicate, err := interpreter.ResolveFunction(fn)
+		if err != nil {
+			return nil, err
+		}
+		spec.Predicate = influxdb.Predicate{
+			ResolvedFunction: predicate,
+		}
+	}
+	return spec, nil
+}
+
+type CardinalityOpSpec struct {
+	influxdb.Config
+	Start     flux.Time
+	Stop      flux.Time
+	Predicate influxdb.Predicate
+}
+
+func (s *CardinalityOpSpec) Kind() flux.OperationKind {
+	return CardinalityKind
+}
+
+type CardinalityProcedureSpec struct {
+	plan.DefaultCost
+	influxdb.Config
+	Bounds       flux.Bounds
+	PredicateSet influxdb.PredicateSet
+}
+
+func newCardinalityProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*CardinalityOpSpec)
+	if !ok {
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
+	}
+
+	var predicateSet influxdb.PredicateSet
+	if spec.Predicate.Fn != nil {
+		predicateSet = influxdb.PredicateSet{spec.Predicate}
+	}
+	return &CardinalityProcedureSpec{
+		Config: spec.Config,
+		Bounds: flux.Bounds{
+			Start: spec.Start,
+			Stop:  spec.Stop,
+			Now:   pa.Now(),
+		},
+		PredicateSet: predicateSet,
+	}, nil
+}
+
+func (s *CardinalityProcedureSpec) Kind() plan.ProcedureKind {
+	return CardinalityKind
+}
+
+func (s *CardinalityProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(CardinalityProcedureSpec)
+	*ns = *s
+	ns.PredicateSet = s.PredicateSet.Copy()
+	return ns
+}
+
+// TimeBounds implements plan.BoundsAwareProcedureSpec
+func (s *CardinalityProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bounds {
+	bounds := &plan.Bounds{
+		Start: values.ConvertTime(s.Bounds.Start.Time(s.Bounds.Now)),
+		Stop:  values.ConvertTime(s.Bounds.Stop.Time(s.Bounds.Now)),
+	}
+	if predecessorBounds != nil {
+		bounds = bounds.Intersect(predecessorBounds)
+	}
+	return bounds
+}
+
+func createCardinalitySource(ps plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	spec := ps.(*CardinalityProcedureSpec)
+	provider := influxdb.GetProvider(a.Context())
+
+	reader, err := provider.SeriesCardinalityReaderFor(a.Context(), spec.Config, spec.Bounds, spec.PredicateSet)
+	if err != nil {
+		return nil, err
+	}
+
+	itr := &sourceIterator{
+		reader: reader,
+		mem:    a.Allocator(),
+	}
+	return execute.CreateSourceFromIterator(itr, id)
+}

--- a/stdlib/influxdata/influxdb/flux_gen.go
+++ b/stdlib/influxdata/influxdb/flux_gen.go
@@ -21,11 +21,11 @@ var pkgAST = &ast.Package{
 			Errors: nil,
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
-					Column: 16,
-					Line:   5,
+					Column: 20,
+					Line:   10,
 				},
 				File:   "influxdb.flux",
-				Source: "package influxdb\n\nbuiltin from : (?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string) => [{B with _measurement: string , _field: string , _time: time , _value: A}]\nbuiltin to : (<-tables: [A], ?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string, ?timeColumn: string, ?measurementColumn: string, ?tagColumns: [string], ?fieldFn: (r: A) => B) => [A] where A: Record, B: Record\nbuiltin buckets",
+				Source: "package influxdb\n\nbuiltin from : (?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string) => [{B with _measurement: string , _field: string , _time: time , _value: A}]\nbuiltin to : (<-tables: [A], ?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string, ?timeColumn: string, ?measurementColumn: string, ?tagColumns: [string], ?fieldFn: (r: A) => B) => [A] where A: Record, B: Record\nbuiltin buckets : (?org: string, ?orgID: string, ?host: string, ?token: string) => [{name: string , id: string , organizationID: string , retentionPolicy: string , retentionPeriod: int}]\n\n// cardinality will return the cardinality of data for a given bucket.\n// If a predicate is specified, then the cardinality only includes series\n// that match the predicate.\nbuiltin cardinality",
 				Start: ast.Position{
 					Column: 1,
 					Line:   1,
@@ -2688,6 +2688,1349 @@ var pkgAST = &ast.Package{
 												Start: ast.Position{
 													Column: 182,
 													Line:   5,
+												},
+											},
+										},
+										Name: "int",
+									},
+								},
+							}},
+							Tvar: nil,
+						},
+					},
+				},
+			},
+		}, &ast.BuiltinStatement{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 20,
+						Line:   10,
+					},
+					File:   "influxdb.flux",
+					Source: "builtin cardinality",
+					Start: ast.Position{
+						Column: 1,
+						Line:   10,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 20,
+							Line:   10,
+						},
+						File:   "influxdb.flux",
+						Source: "cardinality",
+						Start: ast.Position{
+							Column: 9,
+							Line:   10,
+						},
+					},
+				},
+				Name: "cardinality",
+			},
+			Ty: ast.TypeExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 79,
+							Line:   20,
+						},
+						File:   "influxdb.flux",
+						Source: "(\n    ?bucket: string,\n    ?bucketID: string,\n    ?org: string,\n    ?orgID: string,\n    ?host: string,\n    ?token: string,\n    start: A,\n    ?stop: B,\n    ?predicate: (r: { T with _measurement: string, _field: string, _value: S }) => bool\n) => [{_start: time, _stop: time, _value: int}] where A: Timeable, B: Timeable",
+						Start: ast.Position{
+							Column: 23,
+							Line:   10,
+						},
+					},
+				},
+				Constraints: []*ast.TypeConstraint{&ast.TypeConstraint{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 66,
+								Line:   20,
+							},
+							File:   "influxdb.flux",
+							Source: "A: Timeable",
+							Start: ast.Position{
+								Column: 55,
+								Line:   20,
+							},
+						},
+					},
+					Kinds: []*ast.Identifier{&ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 66,
+									Line:   20,
+								},
+								File:   "influxdb.flux",
+								Source: "Timeable",
+								Start: ast.Position{
+									Column: 58,
+									Line:   20,
+								},
+							},
+						},
+						Name: "Timeable",
+					}},
+					Tvar: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 56,
+									Line:   20,
+								},
+								File:   "influxdb.flux",
+								Source: "A",
+								Start: ast.Position{
+									Column: 55,
+									Line:   20,
+								},
+							},
+						},
+						Name: "A",
+					},
+				}, &ast.TypeConstraint{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 79,
+								Line:   20,
+							},
+							File:   "influxdb.flux",
+							Source: "B: Timeable",
+							Start: ast.Position{
+								Column: 68,
+								Line:   20,
+							},
+						},
+					},
+					Kinds: []*ast.Identifier{&ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 79,
+									Line:   20,
+								},
+								File:   "influxdb.flux",
+								Source: "Timeable",
+								Start: ast.Position{
+									Column: 71,
+									Line:   20,
+								},
+							},
+						},
+						Name: "Timeable",
+					}},
+					Tvar: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 69,
+									Line:   20,
+								},
+								File:   "influxdb.flux",
+								Source: "B",
+								Start: ast.Position{
+									Column: 68,
+									Line:   20,
+								},
+							},
+						},
+						Name: "B",
+					},
+				}},
+				Ty: &ast.FunctionType{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 48,
+								Line:   20,
+							},
+							File:   "influxdb.flux",
+							Source: "(\n    ?bucket: string,\n    ?bucketID: string,\n    ?org: string,\n    ?orgID: string,\n    ?host: string,\n    ?token: string,\n    start: A,\n    ?stop: B,\n    ?predicate: (r: { T with _measurement: string, _field: string, _value: S }) => bool\n) => [{_start: time, _stop: time, _value: int}]",
+							Start: ast.Position{
+								Column: 23,
+								Line:   10,
+							},
+						},
+					},
+					Parameters: []*ast.ParameterType{&ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 20,
+									Line:   11,
+								},
+								File:   "influxdb.flux",
+								Source: "?bucket: string",
+								Start: ast.Position{
+									Column: 5,
+									Line:   11,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 12,
+										Line:   11,
+									},
+									File:   "influxdb.flux",
+									Source: "bucket",
+									Start: ast.Position{
+										Column: 6,
+										Line:   11,
+									},
+								},
+							},
+							Name: "bucket",
+						},
+						Ty: &ast.NamedType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 20,
+										Line:   11,
+									},
+									File:   "influxdb.flux",
+									Source: "string",
+									Start: ast.Position{
+										Column: 14,
+										Line:   11,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 20,
+											Line:   11,
+										},
+										File:   "influxdb.flux",
+										Source: "string",
+										Start: ast.Position{
+											Column: 14,
+											Line:   11,
+										},
+									},
+								},
+								Name: "string",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 22,
+									Line:   12,
+								},
+								File:   "influxdb.flux",
+								Source: "?bucketID: string",
+								Start: ast.Position{
+									Column: 5,
+									Line:   12,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 14,
+										Line:   12,
+									},
+									File:   "influxdb.flux",
+									Source: "bucketID",
+									Start: ast.Position{
+										Column: 6,
+										Line:   12,
+									},
+								},
+							},
+							Name: "bucketID",
+						},
+						Ty: &ast.NamedType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 22,
+										Line:   12,
+									},
+									File:   "influxdb.flux",
+									Source: "string",
+									Start: ast.Position{
+										Column: 16,
+										Line:   12,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 22,
+											Line:   12,
+										},
+										File:   "influxdb.flux",
+										Source: "string",
+										Start: ast.Position{
+											Column: 16,
+											Line:   12,
+										},
+									},
+								},
+								Name: "string",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 17,
+									Line:   13,
+								},
+								File:   "influxdb.flux",
+								Source: "?org: string",
+								Start: ast.Position{
+									Column: 5,
+									Line:   13,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 9,
+										Line:   13,
+									},
+									File:   "influxdb.flux",
+									Source: "org",
+									Start: ast.Position{
+										Column: 6,
+										Line:   13,
+									},
+								},
+							},
+							Name: "org",
+						},
+						Ty: &ast.NamedType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 17,
+										Line:   13,
+									},
+									File:   "influxdb.flux",
+									Source: "string",
+									Start: ast.Position{
+										Column: 11,
+										Line:   13,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 17,
+											Line:   13,
+										},
+										File:   "influxdb.flux",
+										Source: "string",
+										Start: ast.Position{
+											Column: 11,
+											Line:   13,
+										},
+									},
+								},
+								Name: "string",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 19,
+									Line:   14,
+								},
+								File:   "influxdb.flux",
+								Source: "?orgID: string",
+								Start: ast.Position{
+									Column: 5,
+									Line:   14,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 11,
+										Line:   14,
+									},
+									File:   "influxdb.flux",
+									Source: "orgID",
+									Start: ast.Position{
+										Column: 6,
+										Line:   14,
+									},
+								},
+							},
+							Name: "orgID",
+						},
+						Ty: &ast.NamedType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 19,
+										Line:   14,
+									},
+									File:   "influxdb.flux",
+									Source: "string",
+									Start: ast.Position{
+										Column: 13,
+										Line:   14,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 19,
+											Line:   14,
+										},
+										File:   "influxdb.flux",
+										Source: "string",
+										Start: ast.Position{
+											Column: 13,
+											Line:   14,
+										},
+									},
+								},
+								Name: "string",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 18,
+									Line:   15,
+								},
+								File:   "influxdb.flux",
+								Source: "?host: string",
+								Start: ast.Position{
+									Column: 5,
+									Line:   15,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 10,
+										Line:   15,
+									},
+									File:   "influxdb.flux",
+									Source: "host",
+									Start: ast.Position{
+										Column: 6,
+										Line:   15,
+									},
+								},
+							},
+							Name: "host",
+						},
+						Ty: &ast.NamedType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 18,
+										Line:   15,
+									},
+									File:   "influxdb.flux",
+									Source: "string",
+									Start: ast.Position{
+										Column: 12,
+										Line:   15,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 18,
+											Line:   15,
+										},
+										File:   "influxdb.flux",
+										Source: "string",
+										Start: ast.Position{
+											Column: 12,
+											Line:   15,
+										},
+									},
+								},
+								Name: "string",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 19,
+									Line:   16,
+								},
+								File:   "influxdb.flux",
+								Source: "?token: string",
+								Start: ast.Position{
+									Column: 5,
+									Line:   16,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 11,
+										Line:   16,
+									},
+									File:   "influxdb.flux",
+									Source: "token",
+									Start: ast.Position{
+										Column: 6,
+										Line:   16,
+									},
+								},
+							},
+							Name: "token",
+						},
+						Ty: &ast.NamedType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 19,
+										Line:   16,
+									},
+									File:   "influxdb.flux",
+									Source: "string",
+									Start: ast.Position{
+										Column: 13,
+										Line:   16,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 19,
+											Line:   16,
+										},
+										File:   "influxdb.flux",
+										Source: "string",
+										Start: ast.Position{
+											Column: 13,
+											Line:   16,
+										},
+									},
+								},
+								Name: "string",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 13,
+									Line:   17,
+								},
+								File:   "influxdb.flux",
+								Source: "start: A",
+								Start: ast.Position{
+									Column: 5,
+									Line:   17,
+								},
+							},
+						},
+						Kind: "Required",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 10,
+										Line:   17,
+									},
+									File:   "influxdb.flux",
+									Source: "start",
+									Start: ast.Position{
+										Column: 5,
+										Line:   17,
+									},
+								},
+							},
+							Name: "start",
+						},
+						Ty: &ast.TvarType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 13,
+										Line:   17,
+									},
+									File:   "influxdb.flux",
+									Source: "A",
+									Start: ast.Position{
+										Column: 12,
+										Line:   17,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 13,
+											Line:   17,
+										},
+										File:   "influxdb.flux",
+										Source: "A",
+										Start: ast.Position{
+											Column: 12,
+											Line:   17,
+										},
+									},
+								},
+								Name: "A",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 13,
+									Line:   18,
+								},
+								File:   "influxdb.flux",
+								Source: "?stop: B",
+								Start: ast.Position{
+									Column: 5,
+									Line:   18,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 10,
+										Line:   18,
+									},
+									File:   "influxdb.flux",
+									Source: "stop",
+									Start: ast.Position{
+										Column: 6,
+										Line:   18,
+									},
+								},
+							},
+							Name: "stop",
+						},
+						Ty: &ast.TvarType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 13,
+										Line:   18,
+									},
+									File:   "influxdb.flux",
+									Source: "B",
+									Start: ast.Position{
+										Column: 12,
+										Line:   18,
+									},
+								},
+							},
+							ID: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 13,
+											Line:   18,
+										},
+										File:   "influxdb.flux",
+										Source: "B",
+										Start: ast.Position{
+											Column: 12,
+											Line:   18,
+										},
+									},
+								},
+								Name: "B",
+							},
+						},
+					}, &ast.ParameterType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 88,
+									Line:   19,
+								},
+								File:   "influxdb.flux",
+								Source: "?predicate: (r: { T with _measurement: string, _field: string, _value: S }) => bool",
+								Start: ast.Position{
+									Column: 5,
+									Line:   19,
+								},
+							},
+						},
+						Kind: "Optional",
+						Name: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 15,
+										Line:   19,
+									},
+									File:   "influxdb.flux",
+									Source: "predicate",
+									Start: ast.Position{
+										Column: 6,
+										Line:   19,
+									},
+								},
+							},
+							Name: "predicate",
+						},
+						Ty: &ast.FunctionType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 88,
+										Line:   19,
+									},
+									File:   "influxdb.flux",
+									Source: "(r: { T with _measurement: string, _field: string, _value: S }) => bool",
+									Start: ast.Position{
+										Column: 17,
+										Line:   19,
+									},
+								},
+							},
+							Parameters: []*ast.ParameterType{&ast.ParameterType{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 79,
+											Line:   19,
+										},
+										File:   "influxdb.flux",
+										Source: "r: { T with _measurement: string, _field: string, _value: S }",
+										Start: ast.Position{
+											Column: 18,
+											Line:   19,
+										},
+									},
+								},
+								Kind: "Required",
+								Name: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 19,
+												Line:   19,
+											},
+											File:   "influxdb.flux",
+											Source: "r",
+											Start: ast.Position{
+												Column: 18,
+												Line:   19,
+											},
+										},
+									},
+									Name: "r",
+								},
+								Ty: &ast.RecordType{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 79,
+												Line:   19,
+											},
+											File:   "influxdb.flux",
+											Source: "{ T with _measurement: string, _field: string, _value: S }",
+											Start: ast.Position{
+												Column: 21,
+												Line:   19,
+											},
+										},
+									},
+									Properties: []*ast.PropertyType{&ast.PropertyType{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 50,
+													Line:   19,
+												},
+												File:   "influxdb.flux",
+												Source: "_measurement: string",
+												Start: ast.Position{
+													Column: 30,
+													Line:   19,
+												},
+											},
+										},
+										Name: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 42,
+														Line:   19,
+													},
+													File:   "influxdb.flux",
+													Source: "_measurement",
+													Start: ast.Position{
+														Column: 30,
+														Line:   19,
+													},
+												},
+											},
+											Name: "_measurement",
+										},
+										Ty: &ast.NamedType{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 50,
+														Line:   19,
+													},
+													File:   "influxdb.flux",
+													Source: "string",
+													Start: ast.Position{
+														Column: 44,
+														Line:   19,
+													},
+												},
+											},
+											ID: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 50,
+															Line:   19,
+														},
+														File:   "influxdb.flux",
+														Source: "string",
+														Start: ast.Position{
+															Column: 44,
+															Line:   19,
+														},
+													},
+												},
+												Name: "string",
+											},
+										},
+									}, &ast.PropertyType{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 66,
+													Line:   19,
+												},
+												File:   "influxdb.flux",
+												Source: "_field: string",
+												Start: ast.Position{
+													Column: 52,
+													Line:   19,
+												},
+											},
+										},
+										Name: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 58,
+														Line:   19,
+													},
+													File:   "influxdb.flux",
+													Source: "_field",
+													Start: ast.Position{
+														Column: 52,
+														Line:   19,
+													},
+												},
+											},
+											Name: "_field",
+										},
+										Ty: &ast.NamedType{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 66,
+														Line:   19,
+													},
+													File:   "influxdb.flux",
+													Source: "string",
+													Start: ast.Position{
+														Column: 60,
+														Line:   19,
+													},
+												},
+											},
+											ID: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 66,
+															Line:   19,
+														},
+														File:   "influxdb.flux",
+														Source: "string",
+														Start: ast.Position{
+															Column: 60,
+															Line:   19,
+														},
+													},
+												},
+												Name: "string",
+											},
+										},
+									}, &ast.PropertyType{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 77,
+													Line:   19,
+												},
+												File:   "influxdb.flux",
+												Source: "_value: S",
+												Start: ast.Position{
+													Column: 68,
+													Line:   19,
+												},
+											},
+										},
+										Name: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 74,
+														Line:   19,
+													},
+													File:   "influxdb.flux",
+													Source: "_value",
+													Start: ast.Position{
+														Column: 68,
+														Line:   19,
+													},
+												},
+											},
+											Name: "_value",
+										},
+										Ty: &ast.TvarType{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 77,
+														Line:   19,
+													},
+													File:   "influxdb.flux",
+													Source: "S",
+													Start: ast.Position{
+														Column: 76,
+														Line:   19,
+													},
+												},
+											},
+											ID: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 77,
+															Line:   19,
+														},
+														File:   "influxdb.flux",
+														Source: "S",
+														Start: ast.Position{
+															Column: 76,
+															Line:   19,
+														},
+													},
+												},
+												Name: "S",
+											},
+										},
+									}},
+									Tvar: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 24,
+													Line:   19,
+												},
+												File:   "influxdb.flux",
+												Source: "T",
+												Start: ast.Position{
+													Column: 23,
+													Line:   19,
+												},
+											},
+										},
+										Name: "T",
+									},
+								},
+							}},
+							Return: &ast.NamedType{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 88,
+											Line:   19,
+										},
+										File:   "influxdb.flux",
+										Source: "bool",
+										Start: ast.Position{
+											Column: 84,
+											Line:   19,
+										},
+									},
+								},
+								ID: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 88,
+												Line:   19,
+											},
+											File:   "influxdb.flux",
+											Source: "bool",
+											Start: ast.Position{
+												Column: 84,
+												Line:   19,
+											},
+										},
+									},
+									Name: "bool",
+								},
+							},
+						},
+					}},
+					Return: &ast.ArrayType{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 48,
+									Line:   20,
+								},
+								File:   "influxdb.flux",
+								Source: "[{_start: time, _stop: time, _value: int}]",
+								Start: ast.Position{
+									Column: 6,
+									Line:   20,
+								},
+							},
+						},
+						ElementType: &ast.RecordType{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 47,
+										Line:   20,
+									},
+									File:   "influxdb.flux",
+									Source: "{_start: time, _stop: time, _value: int}",
+									Start: ast.Position{
+										Column: 7,
+										Line:   20,
+									},
+								},
+							},
+							Properties: []*ast.PropertyType{&ast.PropertyType{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 20,
+											Line:   20,
+										},
+										File:   "influxdb.flux",
+										Source: "_start: time",
+										Start: ast.Position{
+											Column: 8,
+											Line:   20,
+										},
+									},
+								},
+								Name: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 14,
+												Line:   20,
+											},
+											File:   "influxdb.flux",
+											Source: "_start",
+											Start: ast.Position{
+												Column: 8,
+												Line:   20,
+											},
+										},
+									},
+									Name: "_start",
+								},
+								Ty: &ast.NamedType{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 20,
+												Line:   20,
+											},
+											File:   "influxdb.flux",
+											Source: "time",
+											Start: ast.Position{
+												Column: 16,
+												Line:   20,
+											},
+										},
+									},
+									ID: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 20,
+													Line:   20,
+												},
+												File:   "influxdb.flux",
+												Source: "time",
+												Start: ast.Position{
+													Column: 16,
+													Line:   20,
+												},
+											},
+										},
+										Name: "time",
+									},
+								},
+							}, &ast.PropertyType{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 33,
+											Line:   20,
+										},
+										File:   "influxdb.flux",
+										Source: "_stop: time",
+										Start: ast.Position{
+											Column: 22,
+											Line:   20,
+										},
+									},
+								},
+								Name: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 27,
+												Line:   20,
+											},
+											File:   "influxdb.flux",
+											Source: "_stop",
+											Start: ast.Position{
+												Column: 22,
+												Line:   20,
+											},
+										},
+									},
+									Name: "_stop",
+								},
+								Ty: &ast.NamedType{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 33,
+												Line:   20,
+											},
+											File:   "influxdb.flux",
+											Source: "time",
+											Start: ast.Position{
+												Column: 29,
+												Line:   20,
+											},
+										},
+									},
+									ID: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 33,
+													Line:   20,
+												},
+												File:   "influxdb.flux",
+												Source: "time",
+												Start: ast.Position{
+													Column: 29,
+													Line:   20,
+												},
+											},
+										},
+										Name: "time",
+									},
+								},
+							}, &ast.PropertyType{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 46,
+											Line:   20,
+										},
+										File:   "influxdb.flux",
+										Source: "_value: int",
+										Start: ast.Position{
+											Column: 35,
+											Line:   20,
+										},
+									},
+								},
+								Name: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 41,
+												Line:   20,
+											},
+											File:   "influxdb.flux",
+											Source: "_value",
+											Start: ast.Position{
+												Column: 35,
+												Line:   20,
+											},
+										},
+									},
+									Name: "_value",
+								},
+								Ty: &ast.NamedType{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 46,
+												Line:   20,
+											},
+											File:   "influxdb.flux",
+											Source: "int",
+											Start: ast.Position{
+												Column: 43,
+												Line:   20,
+											},
+										},
+									},
+									ID: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 46,
+													Line:   20,
+												},
+												File:   "influxdb.flux",
+												Source: "int",
+												Start: ast.Position{
+													Column: 43,
+													Line:   20,
 												},
 											},
 										},

--- a/stdlib/influxdata/influxdb/influxdb.flux
+++ b/stdlib/influxdata/influxdb/influxdb.flux
@@ -3,3 +3,18 @@ package influxdb
 builtin from : (?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string) => [{B with _measurement: string , _field: string , _time: time , _value: A}]
 builtin to : (<-tables: [A], ?bucket: string, ?bucketID: string, ?org: string, ?orgID: string, ?host: string, ?token: string, ?timeColumn: string, ?measurementColumn: string, ?tagColumns: [string], ?fieldFn: (r: A) => B) => [A] where A: Record, B: Record
 builtin buckets : (?org: string, ?orgID: string, ?host: string, ?token: string) => [{name: string , id: string , organizationID: string , retentionPolicy: string , retentionPeriod: int}]
+
+// cardinality will return the cardinality of data for a given bucket.
+// If a predicate is specified, then the cardinality only includes series
+// that match the predicate.
+builtin cardinality : (
+    ?bucket: string,
+    ?bucketID: string,
+    ?org: string,
+    ?orgID: string,
+    ?host: string,
+    ?token: string,
+    start: A,
+    ?stop: B,
+    ?predicate: (r: { T with _measurement: string, _field: string, _value: S }) => bool
+) => [{_start: time, _stop: time, _value: int}] where A: Timeable, B: Timeable

--- a/stdlib/influxdata/influxdb/source.go
+++ b/stdlib/influxdata/influxdb/source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/csv"
+	"github.com/influxdata/flux/dependencies/influxdb"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
@@ -196,4 +197,13 @@ func (s *source) parseError(p []byte) error {
 		return err
 	}
 	return handleError(e)
+}
+
+type sourceIterator struct {
+	reader influxdb.Reader
+	mem    *memory.Allocator
+}
+
+func (s *sourceIterator) Do(ctx context.Context, f func(flux.Table) error) error {
+	return s.reader.Read(ctx, f, s.mem)
 }


### PR DESCRIPTION
This adds a `cardinality()` function to the influxdb package to
determine the cardinality of a bucket with a filter for a specific
range. This is a source and can be chained to flux transformations.

To implement this, a dependency interface was created to act as an
influxdb provider. This dependency will cover reading and eventually
writing to influxdb. The interface allows us to define flux
transformations that interact with influxdb both in a remote way, such
as through http calls, and embedded within influxdb itself.

The interface is divided into a provider and a reader. The provider
contains a complete list of the different types of readers which is one
for each one. This provider is documented to be able to change and it is
advised to use the `UnimplementedProvider` as a base to ensure that all
of the methods continue to be implemented.

The readers are divided into one specific method for each method of
reading. If a provider returns a reader interface, it is expected that
the functionality is supported.

This allows us to have different implementations and also to allow an
implementation to make decisions around which type of reader it wants to
use. For example, a direct storage access implementation might fallback
to the http provider when a host is used.

The interface for directly reading through a normal read has been
stubbed out but hasn't been implemented. But, this will allow us to
consolidate the reading code to a single location instead of relying on
the planner and allow more of the flux code to live in the flux
repository instead of influxdb.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written