### PR TITLE
feat: make profiler available to tableFind and friends

### DIFF
--- a/compiler/runtime_test.go
+++ b/compiler/runtime_test.go
@@ -37,7 +37,7 @@ func TestFunctionValue_Resolve(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		itrp := interpreter.NewInterpreter(nil)
+		itrp := interpreter.NewInterpreter(nil, nil)
 		_, err = itrp.Eval(context.Background(), semPkg, scope, mockImporter{})
 		if err != nil {
 			t.Fatal(err)

--- a/execute/dependencies.go
+++ b/execute/dependencies.go
@@ -1,4 +1,4 @@
-package execdeps
+package execute
 
 import (
 	"context"
@@ -13,6 +13,11 @@ type key int
 
 const executionDependenciesKey key = iota
 
+type ExecutionOptions struct {
+	OperatorProfiler *OperatorProfiler
+	Profilers        []Profiler
+}
+
 // ExecutionDependencies represents the dependencies that a function call
 // executed by the Interpreter needs in order to trigger the execution of a flux.Program
 type ExecutionDependencies struct {
@@ -26,6 +31,8 @@ type ExecutionDependencies struct {
 	// Metadata is passed up from any invocations of execution up to the parent
 	// execution, and out through the statistics.
 	Metadata metadata.Metadata
+
+	ExecutionOptions *ExecutionOptions
 }
 
 func (d ExecutionDependencies) Inject(ctx context.Context) context.Context {
@@ -52,10 +59,11 @@ func NewExecutionDependencies(allocator *memory.Allocator, now *time.Time, logge
 		now = &nowVar
 	}
 	return ExecutionDependencies{
-		Allocator: allocator,
-		Now:       now,
-		Logger:    logger,
-		Metadata:  make(metadata.Metadata),
+		Allocator:        allocator,
+		Now:              now,
+		Logger:           logger,
+		Metadata:         make(metadata.Metadata),
+		ExecutionOptions: &ExecutionOptions{},
 	}
 }
 

--- a/execute/executetest/compile.go
+++ b/execute/executetest/compile.go
@@ -49,7 +49,7 @@ func FunctionExpression(t testing.TB, source string, args ...interface{}) *seman
 	// Interpret and resolve the function which will replace
 	// variables with their values (notably identifiers "true"
 	// and "false" will be replaced with boolean literals)
-	itrp := interpreter.NewInterpreter(nil)
+	itrp := interpreter.NewInterpreter(nil, nil)
 	se, err := itrp.Eval(context.Background(), pkg, prelude, stdlib)
 	if err != nil {
 		t.Fatal(err)

--- a/execute/profiler.go
+++ b/execute/profiler.go
@@ -183,15 +183,20 @@ func StartSpanFromContext(ctx context.Context, operationName string, label strin
 	if flux.IsQueryTracingEnabled(ctx) {
 		span, ctx = opentracing.StartSpanFromContext(ctx, operationName, opentracing.StartTime(start))
 	}
-	if tfp, ok := ctx.Value(OperatorProfilerContextKey).(*OperatorProfiler); ok {
-		span = &OperatorProfilingSpan{
-			Span:     span,
-			profiler: tfp,
-			Result: OperatorProfilingResult{
-				Type:  operationName,
-				Label: label,
-				Start: start,
-			},
+
+	if HaveExecutionDependencies(ctx) {
+		deps := GetExecutionDependencies(ctx)
+		if deps.ExecutionOptions.OperatorProfiler != nil {
+			tfp := deps.ExecutionOptions.OperatorProfiler
+			span = &OperatorProfilingSpan{
+				Span:     span,
+				profiler: tfp,
+				Result: OperatorProfilingResult{
+					Type:  operationName,
+					Label: label,
+					Start: start,
+				},
+			}
 		}
 	}
 	return ctx, span

--- a/execute/profiler_test.go
+++ b/execute/profiler_test.go
@@ -15,16 +15,32 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/execute/table"
+	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/metadata"
 	"github.com/influxdata/flux/mock"
 )
 
+// Simulates setting the profilers option in flux to "operator"
+func configureOperatorProfiler(ctx context.Context) *execute.OperatorProfiler {
+	profilerNames := []string{"operator"}
+
+	execOptsConfig := lang.ExecOptsConfig{}
+	execOptsConfig.ConfigureProfiler(ctx, profilerNames)
+
+	deps := execute.GetExecutionDependencies(ctx)
+	return deps.ExecutionOptions.OperatorProfiler
+}
+
 func TestOperatorProfiler_GetResult(t *testing.T) {
-	// Create an operator profiler
-	p := execute.AllProfilers["operator"]()
-	// And inject it to the context.
-	ctx := context.WithValue(context.Background(), execute.OperatorProfilerContextKey, p)
+	// Create a base execution dependencies.
+	deps := execute.DefaultExecutionDependencies()
+	ctx := deps.Inject(context.Background())
+
+	// Add operator profiler to context
+	p := configureOperatorProfiler(ctx)
+
+	// And inject it into the context.
 	// Build the "want" table.
 	// This table is built dynamically because the table includes time data which changes
 	// every time the test is run.

--- a/internal/spec/build.go
+++ b/internal/spec/build.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
-	"github.com/influxdata/flux/lang/execdeps"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -139,11 +139,11 @@ func FromScript(ctx context.Context, runtime flux.Runtime, now time.Time, script
 	}
 	s.Finish()
 
-	deps := execdeps.NewExecutionDependencies(nil, &now, nil)
+	deps := execute.NewExecutionDependencies(nil, &now, nil)
 	ctx = deps.Inject(ctx)
 
 	s, cctx := opentracing.StartSpanFromContext(ctx, "eval")
-	sideEffects, scope, err := runtime.Eval(cctx, astPkg, flux.SetNowOption(now))
+	sideEffects, scope, err := runtime.Eval(cctx, astPkg, nil, flux.SetNowOption(now))
 	if err != nil {
 		return nil, err
 	}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -28,34 +28,34 @@ const (
 // dependencies when they are interpreted. We cannot access them directly here
 // due to circular dependencies, so we use an interface, with an implementation
 // defined by the caller.
-type ExecutionOptions interface {
+type ExecOptsConfig interface {
 	ConfigureProfiler(ctx context.Context, profilerNames []string)
 	ConfigureNow(ctx context.Context, now time.Time)
 }
 
 // A default execution options implementation that discards the settings.
-type executionOptions struct{}
+type defExecOptsConfig struct{}
 
-func (es *executionOptions) ConfigureProfiler(ctx context.Context, profilerNames []string) {}
-func (es *executionOptions) ConfigureNow(ctx context.Context, now time.Time)               {}
+func (es *defExecOptsConfig) ConfigureProfiler(ctx context.Context, profilerNames []string) {}
+func (es *defExecOptsConfig) ConfigureNow(ctx context.Context, now time.Time)               {}
 
 type Interpreter struct {
-	sideEffects      []SideEffect // a list of the side effects occurred during the last call to `Eval`.
-	pkgName          string
-	executionOptions ExecutionOptions
+	sideEffects    []SideEffect // a list of the side effects occurred during the last call to `Eval`.
+	pkgName        string
+	execOptsConfig ExecOptsConfig
 }
 
-func NewInterpreter(pkg *Package, es ExecutionOptions) *Interpreter {
+func NewInterpreter(pkg *Package, eoc ExecOptsConfig) *Interpreter {
 	var pkgName string
 	if pkg != nil {
 		pkgName = pkg.Name()
 	}
-	if es == nil {
-		es = &executionOptions{}
+	if eoc == nil {
+		eoc = &defExecOptsConfig{}
 	}
 	return &Interpreter{
-		pkgName:          pkgName,
-		executionOptions: es,
+		pkgName:        pkgName,
+		execOptsConfig: eoc,
 	}
 }
 
@@ -200,7 +200,7 @@ func (irtp *Interpreter) evaluateNowOption(ctx context.Context, name string, ini
 	}
 	now := nowTime.Time().Time()
 
-	irtp.executionOptions.ConfigureNow(ctx, now)
+	irtp.execOptsConfig.ConfigureNow(ctx, now)
 }
 
 func convert(rules values.Array) ([]string, error) {
@@ -222,7 +222,7 @@ func (irtp *Interpreter) evaluateProfilerOption(ctx context.Context, pkg values.
 			return
 		}
 
-		irtp.executionOptions.ConfigureProfiler(ctx, profilerNames)
+		irtp.execOptsConfig.ConfigureProfiler(ctx, profilerNames)
 	}
 }
 

--- a/interpreter/package_test.go
+++ b/interpreter/package_test.go
@@ -89,7 +89,7 @@ func TestAccessNestedImport(t *testing.T) {
 
 	expectedError := fmt.Errorf(`cannot access imported package "a" of imported package "b"`)
 	ctx := dependenciestest.Default().Inject(context.Background())
-	_, err := interpreter.NewInterpreter(interpreter.NewPackage("")).Eval(ctx, node, values.NewScope(), &importer)
+	_, err := interpreter.NewInterpreter(interpreter.NewPackage(""), nil).Eval(ctx, node, values.NewScope(), &importer)
 
 	if err == nil {
 		t.Errorf("expected error")
@@ -367,7 +367,7 @@ func TestInterpreter_EvalPackage(t *testing.T) {
 func TestInterpreter_MutateOption(t *testing.T) {
 	pkg := interpreter.NewPackage("alert")
 	ctx := dependenciestest.Default().Inject(context.Background())
-	itrp := interpreter.NewInterpreter(pkg)
+	itrp := interpreter.NewInterpreter(pkg, nil)
 	script := `
 		package alert
 		import "planner"
@@ -393,7 +393,7 @@ func TestInterpreter_SetQualifiedOption(t *testing.T) {
 		},
 	}
 	ctx := dependenciestest.Default().Inject(context.Background())
-	itrp := interpreter.NewInterpreter(interpreter.NewPackage(""))
+	itrp := interpreter.NewInterpreter(interpreter.NewPackage(""), nil)
 	pkg := `
 		package foo
 		import "alert"

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -290,10 +290,6 @@ func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Quer
 	if execute.HaveExecutionDependencies(ctx) {
 		deps := execute.GetExecutionDependencies(ctx)
 		q.stats.Metadata.AddAll(deps.Metadata)
-
-		if deps.ExecutionOptions.OperatorProfiler != nil {
-			cctx = context.WithValue(cctx, execute.OperatorProfilerContextKey, deps.ExecutionOptions.OperatorProfiler)
-		}
 	}
 
 	q.stats.Metadata.Add("flux/query-plan",
@@ -374,7 +370,7 @@ func (p *AstProgram) GetAst() (flux.ASTHandle, error) {
 // The ExecOptsConfig structure implements the interpreter.ExecOptsConfig
 // interface, which the interpreter uses to configure options relevant to the
 // execution engine. The interpreter is able to invoke the execution engine via
-// tableFind and others, and thereore must be able to install these options
+// tableFind and others, and therefore must be able to install these options
 // into the execution dependency state. We use an interface to break the import
 // cycle implied by accessing the execution module from the interpreter.
 type ExecOptsConfig struct {
@@ -488,12 +484,6 @@ func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Q
 
 	// Execution.
 	s, cctx = opentracing.StartSpanFromContext(ctx, "start-program")
-	if p.tfProfiler != nil {
-		// If we have an active operator profiler, put that into the execution context
-		// so that the data sources and the transformations can properly create spans that link
-		// to this profiler and send over their profiling data.
-		cctx = context.WithValue(cctx, execute.OperatorProfilerContextKey, p.tfProfiler)
-	}
 	defer s.Finish()
 	return p.Program.Start(cctx, alloc)
 }

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -371,16 +371,16 @@ func (p *AstProgram) GetAst() (flux.ASTHandle, error) {
 	return p.Ast, nil
 }
 
-// The ExecutionOptions structure implements the interpreter.ExecutionOptions
+// The ExecOptsConfig structure implements the interpreter.ExecOptsConfig
 // interface, which the interpreter uses to configure options relevant to the
 // execution engine. The interpreter is able to invoke the execution engine via
 // tableFind and others, and thereore must be able to install these options
 // into the execution dependency state. We use an interface to break the import
 // cycle implied by accessing the execution module from the interpreter.
-type ExecutionOptions struct {
+type ExecOptsConfig struct {
 }
 
-func (es *ExecutionOptions) ConfigureProfiler(ctx context.Context, profilerNames []string) {
+func (eoc *ExecOptsConfig) ConfigureProfiler(ctx context.Context, profilerNames []string) {
 	var tfProfiler *execute.OperatorProfiler
 	dedupeMap := make(map[string]bool)
 	profilers := make([]execute.Profiler, 0)
@@ -415,7 +415,7 @@ func (es *ExecutionOptions) ConfigureProfiler(ctx context.Context, profilerNames
 	}
 }
 
-func (es *ExecutionOptions) ConfigureNow(ctx context.Context, now time.Time) {
+func (eoc *ExecOptsConfig) ConfigureNow(ctx context.Context, now time.Time) {
 	// Stash in the execution dependencies. The deps use a pointer and we
 	// overwrite the dest of the pointer. Overwritng the pointer would have no
 	// effect as context changes are passed down only.
@@ -432,7 +432,7 @@ func (p *AstProgram) getSpec(ctx context.Context, alloc *memory.Allocator) (*flu
 
 	s, cctx := opentracing.StartSpanFromContext(ctx, "eval")
 
-	sideEffects, scope, err := p.Runtime.Eval(cctx, ast, &ExecutionOptions{}, flux.SetNowOption(p.Now))
+	sideEffects, scope, err := p.Runtime.Eval(cctx, ast, &ExecOptsConfig{}, flux.SetNowOption(p.Now))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/lang/execopts_test.go
+++ b/lang/execopts_test.go
@@ -49,7 +49,7 @@ func TestExecutionOptions(t *testing.T) {
 	// dependencies. The goal of this test is to verify the option
 	// configuration is called, and also that they are installed into the
 	// execution environment.
-	itrp := interpreter.NewInterpreter(nil, &ExecutionOptions{})
+	itrp := interpreter.NewInterpreter(nil, &ExecOptsConfig{})
 
 	semPkg, err := runtime.AnalyzePackage(h)
 	if err != nil {

--- a/lang/execopts_test.go
+++ b/lang/execopts_test.go
@@ -1,0 +1,87 @@
+package lang
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/parser"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/values"
+)
+
+func TestExecutionOptions(t *testing.T) {
+	src := `
+		import "profiler"
+		option profiler.enabledProfilers = [ "query", "operator" ]
+		option now = () => ( 2020-10-15T00:00:00Z )
+	`
+
+	h, err := parser.ParseToHandle([]byte(src))
+	if err != nil {
+		t.Fatalf("failed to parse test case: %v", err)
+	}
+
+	prelude := []string{
+		"universe",
+		"influxdata/influxdb",
+	}
+
+	scope := values.NewScope()
+	importer := runtime.StdLib()
+	for _, p := range prelude {
+		pkg, err := importer.ImportPackageObject(p)
+		if err != nil {
+			panic(err)
+		}
+		pkg.Range(scope.Set)
+	}
+
+	// Prepare a context with execution dependencies.
+	ctx := context.TODO()
+	deps := execute.DefaultExecutionDependencies()
+	ctx = deps.Inject(ctx)
+
+	// Pass lang.ExecutionOptions as the options configurator. It is
+	// responsible for installing the configured options into the execution
+	// dependencies. The goal of this test is to verify the option
+	// configuration is called, and also that they are installed into the
+	// execution environment.
+	itrp := interpreter.NewInterpreter(nil, &ExecutionOptions{})
+
+	semPkg, err := runtime.AnalyzePackage(h)
+	if err != nil {
+		t.Fatalf("failed to evaluate test case: %v", err)
+	}
+
+	_, err = itrp.Eval(ctx, semPkg, scope, importer)
+	if err != nil {
+		t.Fatalf("failed to evaluate test case: %v", err)
+	}
+
+	// Verify Profilers was set.
+	if deps.ExecutionOptions.Profilers == nil {
+		t.Errorf("ProfilerNames was not configured")
+	} else {
+		if len(deps.ExecutionOptions.Profilers) != 2 {
+			t.Errorf("ProfilerNames not did not contain expected number of elements")
+		}
+	}
+
+	// Verify that the operator profiler was picked out.
+	if deps.ExecutionOptions.OperatorProfiler == nil {
+		t.Errorf("ProfilerNames was not configured")
+	}
+
+	// Verify that now was set.
+	if deps.Now == nil {
+		t.Errorf("Now was not configured")
+	} else {
+		expectedTime, _ := time.Parse(time.RFC3339, "2020-10-15T00:00:00Z")
+		if *deps.Now != expectedTime {
+			t.Errorf("now was set with the expected value, expected: %v got: %v", expectedTime, *deps.Now)
+		}
+	}
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -58,7 +58,7 @@ func New(ctx context.Context, deps flux.Dependencies) *REPL {
 		ctx:      ctx,
 		deps:     deps,
 		scope:    scope,
-		itrp:     interpreter.NewInterpreter(nil, &lang.ExecutionOptions{}),
+		itrp:     interpreter.NewInterpreter(nil, &lang.ExecOptsConfig{}),
 		analyzer: libflux.NewAnalyzer(),
 		importer: importer,
 	}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -18,7 +18,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/interpreter"
-	"github.com/influxdata/flux/lang/execdeps"
+	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/libflux/go/libflux"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/runtime"
@@ -58,7 +58,7 @@ func New(ctx context.Context, deps flux.Dependencies) *REPL {
 		ctx:      ctx,
 		deps:     deps,
 		scope:    scope,
-		itrp:     interpreter.NewInterpreter(nil),
+		itrp:     interpreter.NewInterpreter(nil, &lang.ExecutionOptions{}),
 		analyzer: libflux.NewAnalyzer(),
 		importer: importer,
 	}
@@ -160,7 +160,7 @@ func (r *REPL) Eval(t string) ([]interpreter.SideEffect, error) {
 		return nil, err
 	}
 
-	deps := execdeps.DefaultExecutionDependencies()
+	deps := execute.DefaultExecutionDependencies()
 	r.ctx = deps.Inject(r.ctx)
 
 	return r.itrp.Eval(r.ctx, pkg, r.scope, r.importer)

--- a/runtime.go
+++ b/runtime.go
@@ -22,7 +22,7 @@ type Runtime interface {
 	MergePackages(dst, src ASTHandle) error
 
 	// Eval accepts a Flux AST and evaluates it to produce a set of side effects (as a slice of values) and a scope.
-	Eval(ctx context.Context, astPkg ASTHandle, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error)
+	Eval(ctx context.Context, astPkg ASTHandle, es interpreter.ExecutionOptions, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error)
 
 	// IsPreludePackage will return if the named package is part
 	// of the prelude for this runtime.

--- a/runtime.go
+++ b/runtime.go
@@ -22,7 +22,7 @@ type Runtime interface {
 	MergePackages(dst, src ASTHandle) error
 
 	// Eval accepts a Flux AST and evaluates it to produce a set of side effects (as a slice of values) and a scope.
-	Eval(ctx context.Context, astPkg ASTHandle, es interpreter.ExecutionOptions, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error)
+	Eval(ctx context.Context, astPkg ASTHandle, es interpreter.ExecOptsConfig, opts ...ScopeMutator) ([]interpreter.SideEffect, values.Scope, error)
 
 	// IsPreludePackage will return if the named package is part
 	// of the prelude for this runtime.

--- a/runtime/global.go
+++ b/runtime/global.go
@@ -48,7 +48,7 @@ func Eval(ctx context.Context, flux string, opts ...flux.ScopeMutator) ([]interp
 	if err != nil {
 		return nil, nil, err
 	}
-	return Default.Eval(ctx, h, opts...)
+	return Default.Eval(ctx, h, nil, opts...)
 }
 
 // EvalAST accepts a Flux AST and evaluates it to produce a set of side effects (as a slice of values) and a scope.
@@ -61,11 +61,11 @@ func EvalAST(ctx context.Context, astPkg *ast.Package, opts ...flux.ScopeMutator
 	if err != nil {
 		return nil, nil, err
 	}
-	return Default.Eval(ctx, hdl, opts...)
+	return Default.Eval(ctx, hdl, nil, opts...)
 }
 
 // EvalOptions is like EvalAST, but only evaluates options.
-func EvalOptions(ctx context.Context, astPkg *ast.Package, opts ...flux.ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
+func EvalOptions(ctx context.Context, astPkg *ast.Package, opts []flux.ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
 	return EvalAST(ctx, options(astPkg), opts...)
 }
 

--- a/runtime/importer.go
+++ b/runtime/importer.go
@@ -77,7 +77,7 @@ func (imp *importer) ImportPackageObject(path string) (*interpreter.Package, err
 	// Run the interpreter on the package to construct the values
 	// created by the package. Pass in the previously initialized
 	// packages as importable packages as we evaluate these in order.
-	itrp := interpreter.NewInterpreter(nil)
+	itrp := interpreter.NewInterpreter(nil, nil)
 	if _, err := itrp.Eval(context.Background(), semPkg, scope, imp); err != nil {
 		return nil, err
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -117,7 +117,7 @@ func (r *runtime) Prelude() values.Scope {
 	return scope
 }
 
-func (r *runtime) Eval(ctx context.Context, astPkg flux.ASTHandle, opts ...flux.ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
+func (r *runtime) Eval(ctx context.Context, astPkg flux.ASTHandle, es interpreter.ExecutionOptions, opts ...flux.ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
 	semPkg, err := AnalyzePackage(astPkg)
 	if err != nil {
 		return nil, nil, err
@@ -136,7 +136,7 @@ func (r *runtime) Eval(ctx context.Context, astPkg flux.ASTHandle, opts ...flux.
 	}
 
 	// Execute the interpreter over the package.
-	itrp := interpreter.NewInterpreter(nil)
+	itrp := interpreter.NewInterpreter(nil, es)
 	sideEffects, err := itrp.Eval(ctx, semPkg, scope, importer)
 	if err != nil {
 		return nil, nil, err

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -117,7 +117,7 @@ func (r *runtime) Prelude() values.Scope {
 	return scope
 }
 
-func (r *runtime) Eval(ctx context.Context, astPkg flux.ASTHandle, es interpreter.ExecutionOptions, opts ...flux.ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
+func (r *runtime) Eval(ctx context.Context, astPkg flux.ASTHandle, es interpreter.ExecOptsConfig, opts ...flux.ScopeMutator) ([]interpreter.SideEffect, values.Scope, error) {
 	semPkg, err := AnalyzePackage(astPkg)
 	if err != nil {
 		return nil, nil, err

--- a/stdlib/date/date.go
+++ b/stdlib/date/date.go
@@ -9,7 +9,6 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
-	"github.com/influxdata/flux/lang/execdeps"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -37,7 +36,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					second := nowTime.Add(v1.Duration().Duration()).Second()
@@ -64,7 +63,7 @@ func init() {
 					return values.NewInt(int64(v1.Time().Time().Minute())), nil
 				}
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					minute := nowTime.Add(v1.Duration().Duration()).Minute()
@@ -91,7 +90,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					hour := nowTime.Add(v1.Duration().Duration()).Hour()
@@ -117,7 +116,7 @@ func init() {
 					return values.NewInt(int64(v1.Time().Time().Weekday())), nil
 				}
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					weekDay := nowTime.Add(v1.Duration().Duration()).Weekday()
@@ -143,7 +142,7 @@ func init() {
 					return values.NewInt(int64(v1.Time().Time().Day())), nil
 				}
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					day := nowTime.Add(v1.Duration().Duration()).Day()
@@ -170,7 +169,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					yearDay := nowTime.Add(v1.Duration().Duration()).YearDay()
@@ -197,7 +196,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					month := nowTime.Add(v1.Duration().Duration()).Month()
@@ -224,7 +223,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					year := nowTime.Add(v1.Duration().Duration()).Year()
@@ -253,7 +252,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					_, week := nowTime.Add(v1.Duration().Duration()).ISOWeek()
@@ -282,7 +281,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					month := nowTime.Add(v1.Duration().Duration()).Month()
@@ -310,7 +309,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					return values.NewInt(int64(nowTime.Add(v1.Duration().Duration()).Nanosecond()) / int64(time.Millisecond)), nil
@@ -337,7 +336,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					return values.NewInt(int64(nowTime.Add(v1.Duration().Duration()).Nanosecond()) / int64(time.Microsecond)), nil
@@ -364,7 +363,7 @@ func init() {
 				}
 
 				if v1.Type().Nature() == semantic.Duration {
-					deps := execdeps.GetExecutionDependencies(ctx)
+					deps := execute.GetExecutionDependencies(ctx)
 					nowTime := *deps.Now
 
 					return values.NewInt(int64(nowTime.Add(v1.Duration().Duration()).Nanosecond())), nil
@@ -408,7 +407,7 @@ func init() {
 							return nil, err
 						}
 
-						deps := execdeps.GetExecutionDependencies(ctx)
+						deps := execute.GetExecutionDependencies(ctx)
 						nowTime := *deps.Now
 
 						b := w.GetEarliestBounds(values.ConvertTime(nowTime.Add(v.Duration().Duration())))

--- a/stdlib/experimental/chain.go
+++ b/stdlib/experimental/chain.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/lang"
-	"github.com/influxdata/flux/lang/execdeps"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/values"
@@ -46,10 +46,10 @@ func chainCall(ctx context.Context, args values.Object) (values.Value, error) {
 		return nil, errors.Wrap(err, codes.Inherit, "error in table object compilation")
 	}
 
-	if !execdeps.HaveExecutionDependencies(ctx) {
+	if !execute.HaveExecutionDependencies(ctx) {
 		return nil, errors.New(codes.Internal, "no execution context for chain to use")
 	}
-	deps := execdeps.GetExecutionDependencies(ctx)
+	deps := execute.GetExecutionDependencies(ctx)
 
 	if program, ok := program.(lang.LoggingProgram); ok {
 		program.SetLogger(deps.Logger)

--- a/stdlib/experimental/chain_test.go
+++ b/stdlib/experimental/chain_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
-	"github.com/influxdata/flux/lang/execdeps"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/stdlib/experimental"
 	"github.com/influxdata/flux/values"
@@ -60,7 +60,7 @@ func makeArgs(first values.Value, second values.Value) values.Object {
 
 func TestChain(t *testing.T) {
 	context := dependenciestest.Default().Inject(context.Background())
-	context = execdeps.DefaultExecutionDependencies().Inject(context)
+	context = execute.DefaultExecutionDependencies().Inject(context)
 	_, scope, err := runtime.Eval(context, table1)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -98,12 +98,6 @@ func tableFind(ctx context.Context, to *flux.TableObject, fn *execute.TablePredi
 		p.SetLogger(deps.Logger)
 	}
 
-	// If there is an operator profiler in the execution options, and it is not
-	// in the context standalone, add it.
-	if deps.ExecutionOptions.OperatorProfiler != nil {
-		ctx = context.WithValue(ctx, execute.OperatorProfilerContextKey, deps.ExecutionOptions.OperatorProfiler)
-	}
-
 	q, err := p.Start(ctx, deps.Allocator)
 	if err != nil {
 		return nil, errors.Wrap(err, codes.Inherit, "error in table object start")

--- a/stdlib/universe/table_fns_test.go
+++ b/stdlib/universe/table_fns_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
-	"github.com/influxdata/flux/lang/execdeps"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -56,7 +56,7 @@ func evalOrFail(t *testing.T, script string) values.Scope {
 	t.Helper()
 
 	ctx := dependenciestest.Default().Inject(context.Background())
-	ctx = execdeps.DefaultExecutionDependencies().Inject(ctx)
+	ctx = execute.DefaultExecutionDependencies().Inject(ctx)
 	_, s, err := runtime.Eval(ctx, script)
 	if err != nil {
 		t.Fatal(err)
@@ -174,7 +174,7 @@ func TestTableFind_Call(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := dependenciestest.Default().Inject(context.Background())
 			if !tc.omitExecDeps {
-				ctx = execdeps.DefaultExecutionDependencies().Inject(ctx)
+				ctx = execute.DefaultExecutionDependencies().Inject(ctx)
 			}
 			_, scope, err := runtime.Eval(ctx, prelude)
 			if err != nil {
@@ -234,7 +234,7 @@ t = inj |> tableFind(fn: (key) => key.user == "user1")`
 
 	f := universe.NewGetColumnFunction()
 	ctx := dependenciestest.Default().Inject(context.Background())
-	ctx = execdeps.DefaultExecutionDependencies().Inject(ctx)
+	ctx = execute.DefaultExecutionDependencies().Inject(ctx)
 	res, err := f.Function().Call(ctx,
 		values.NewObjectWithValues(map[string]values.Value{
 			"table":  tbl.(*objects.Table),
@@ -277,7 +277,7 @@ t = inj |> tableFind(fn: (key) => key.user == "user1")`
 
 	f := universe.NewGetRecordFunction()
 	ctx := dependenciestest.Default().Inject(context.Background())
-	ctx = execdeps.DefaultExecutionDependencies().Inject(ctx)
+	ctx = execute.DefaultExecutionDependencies().Inject(ctx)
 	res, err := f.Function().Call(ctx,
 		values.NewObjectWithValues(map[string]values.Value{
 			"table": tbl.(*objects.Table),


### PR DESCRIPTION
The interpreter now installs profilers into the execution dependencies. Doing
this directly from the interpreter is not possible due to the import cycle.

 flux -> interpreter -> execute -> compiler -> interpreter -> execute

This is the same cycle that triggered the lifting of execution dependencies into
their own module. This time more of the execution state must get added in and
the simple lift fix doesn't work.

Instead adding an interface to the interpreter module that is specifically for
setting execution options. The lang package can then implement this interface
and install the options.

So this patch also includes the movement of execution dependencies back to the
execute module and using this new interface to also set the now option in the
execution dependencies.

Tested by setting profilers and now in a flux script and verifying the values
in the execution dependencies afterwards.

This patch does not work with repl, as some additional changes are required
there to make profiling work at all.