### PR TITLE
fix(compiler): do not panic when a string expression evaluates to null

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -55,6 +55,19 @@ func TestCompileAndEval(t *testing.T) {
 			wantCompileErr: true,
 		},
 		{
+			name: "interpolated string expression null",
+			fn:   `(r) => "n = ${r.n}"`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("r"), Value: semantic.NewObjectType([]semantic.PropertyType{
+					{Key: []byte("n"), Value: semantic.BasicString},
+				})},
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"r": values.NewObjectWithValues(map[string]values.Value{}),
+			}),
+			wantEvalErr: true,
+		},
+		{
 			name: "simple ident return",
 			fn:   `(r) => r`,
 			inType: semantic.NewObjectType([]semantic.PropertyType{

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -150,6 +150,10 @@ func (e *stringExpressionEvaluator) Eval(ctx context.Context, scope Scope) (valu
 		if err != nil {
 			return nil, err
 		}
+
+		if v.IsNull() {
+			return nil, errors.New(codes.Invalid, "string expression evaluated to null")
+		}
 		b.WriteString(v.Str())
 	}
 	return values.NewString(b.String()), nil


### PR DESCRIPTION
A string expression could be inferred as a string but evaluate to null.
It then caused a panic when it tried to access the value as a string.
This checks to see if the value is null and returns an error if it is.

Fixes #3284.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written