### PR TITLE
fix: properly truncate timestamps to beginning of window bounds

### DIFF
--- a/execute/window.go
+++ b/execute/window.go
@@ -106,7 +106,11 @@ func (w Window) GetOverlappingBounds(b Bounds) []Bounds {
 // truncateByNsecs will truncate the time to the given number
 // of nanoseconds.
 func truncateByNsecs(t Time, d Duration) Time {
-	remainder := int64(t) % d.Nanoseconds()
+	dur := d.Nanoseconds()
+	remainder := int64(t) % dur
+	if remainder < 0 {
+		remainder += dur
+	}
 	return t - Time(remainder)
 }
 

--- a/execute/window_test.go
+++ b/execute/window_test.go
@@ -18,7 +18,7 @@ func TestNewWindow(t *testing.T) {
 			Period: values.ConvertDurationNsecs(time.Minute),
 			Offset: values.ConvertDurationNsecs(time.Second),
 		}
-		got := MustWindow(values.ConvertDurationNsecs(time.Minute), values.ConvertDurationNsecs(time.Minute), values.ConvertDurationNsecs(time.Second), false)
+		got := MustWindow(values.ConvertDurationNsecs(time.Minute), values.ConvertDurationNsecs(time.Minute), values.ConvertDurationNsecs(time.Second))
 		if !cmp.Equal(want, got) {
 			t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
 		}
@@ -34,7 +34,7 @@ func TestNewWindow(t *testing.T) {
 		got := MustWindow(
 			values.ConvertDurationNsecs(time.Minute),
 			values.ConvertDurationNsecs(time.Minute),
-			values.ConvertDurationNsecs(2*time.Minute+30*time.Second), false)
+			values.ConvertDurationNsecs(2*time.Minute+30*time.Second))
 		if !cmp.Equal(want, got) {
 			t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
 		}
@@ -50,7 +50,7 @@ func TestNewWindow(t *testing.T) {
 		got := MustWindow(
 			values.ConvertDurationNsecs(time.Minute),
 			values.ConvertDurationNsecs(time.Minute),
-			values.ConvertDurationNsecs(-2*time.Minute+30*time.Second), false)
+			values.ConvertDurationNsecs(-2*time.Minute+30*time.Second))
 		if !cmp.Equal(want, got) {
 			t.Errorf("window different; -want/+got:\n%v\n", cmp.Diff(want, got))
 		}
@@ -93,7 +93,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(5*time.Minute),
 				values.ConvertDurationNsecs(5*time.Minute),
-				values.ConvertDurationNsecs(0), false),
+				values.ConvertDurationNsecs(0)),
 			t: execute.Time(6 * time.Minute),
 			want: execute.Bounds{
 				Start: execute.Time(5 * time.Minute),
@@ -105,7 +105,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(5*time.Minute),
 				values.ConvertDurationNsecs(5*time.Minute),
-				values.ConvertDurationNsecs(30*time.Second), false),
+				values.ConvertDurationNsecs(30*time.Second)),
 			t: execute.Time(5 * time.Minute),
 			want: execute.Bounds{
 				Start: execute.Time(30 * time.Second),
@@ -117,7 +117,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationMonths(5),
 				values.ConvertDurationMonths(5),
-				values.ConvertDurationMonths(0), true),
+				values.ConvertDurationMonths(0)),
 			t: values.ConvertTime(time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)),
 			want: execute.Bounds{
 				Start: values.ConvertTime(time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)),
@@ -153,7 +153,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(2*time.Minute),
 				values.ConvertDurationNsecs(1*time.Minute),
-				values.ConvertDurationNsecs(30*time.Second), false),
+				values.ConvertDurationNsecs(30*time.Second)),
 			t: execute.Time(3 * time.Minute),
 			want: execute.Bounds{
 				Start: execute.Time(3*time.Minute + 30*time.Second),
@@ -165,7 +165,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(2*time.Minute),
 				values.ConvertDurationNsecs(1*time.Minute),
-				values.ConvertDurationNsecs(30*time.Second), false),
+				values.ConvertDurationNsecs(30*time.Second)),
 			t: execute.Time(2*time.Minute + 45*time.Second),
 			want: execute.Bounds{
 				Start: execute.Time(3*time.Minute + 30*time.Second),
@@ -177,7 +177,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(1*time.Minute),
 				values.ConvertDurationNsecs(2*time.Minute),
-				values.ConvertDurationNsecs(30*time.Second), false),
+				values.ConvertDurationNsecs(30*time.Second)),
 			t: execute.Time(30 * time.Second),
 			want: execute.Bounds{
 				Start: execute.Time(-30 * time.Second),
@@ -189,7 +189,7 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(1*time.Minute),
 				values.ConvertDurationNsecs(3*time.Minute+30*time.Second),
-				values.ConvertDurationNsecs(30*time.Second), false),
+				values.ConvertDurationNsecs(30*time.Second)),
 			t: execute.Time(5*time.Minute + 45*time.Second),
 			want: execute.Bounds{
 				Start: execute.Time(3 * time.Minute),
@@ -201,11 +201,71 @@ func TestWindow_GetEarliestBounds(t *testing.T) {
 			w: MustWindow(
 				values.ConvertDurationNsecs(1*time.Minute),
 				values.ConvertDurationNsecs(3*time.Minute+30*time.Second),
-				values.ConvertDurationNsecs(30*time.Second), false),
+				values.ConvertDurationNsecs(30*time.Second)),
 			t: execute.Time(5 * time.Minute),
 			want: execute.Bounds{
 				Start: execute.Time(2 * time.Minute),
 				Stop:  execute.Time(5*time.Minute + 30*time.Second),
+			},
+		},
+		{
+			name: "truncate before offset",
+			w: MustWindow(
+				values.ConvertDurationNsecs(5*time.Second),
+				values.ConvertDurationNsecs(5*time.Second),
+				values.ConvertDurationNsecs(2*time.Second)),
+			t: execute.Time(1 * time.Second),
+			want: execute.Bounds{
+				Start: execute.Time(-3 * time.Second),
+				Stop:  execute.Time(2 * time.Second),
+			},
+		},
+		{
+			name: "truncate after offset",
+			w: MustWindow(
+				values.ConvertDurationNsecs(5*time.Second),
+				values.ConvertDurationNsecs(5*time.Second),
+				values.ConvertDurationNsecs(2*time.Second)),
+			t: execute.Time(3 * time.Second),
+			want: execute.Bounds{
+				Start: execute.Time(2 * time.Second),
+				Stop:  execute.Time(7 * time.Second),
+			},
+		},
+		{
+			name: "truncate before calendar offset",
+			w: MustWindow(
+				values.ConvertDurationMonths(5),
+				values.ConvertDurationMonths(5),
+				values.ConvertDurationMonths(2)),
+			t: mustParseTime("1970-02-01T00:00:00Z"),
+			want: execute.Bounds{
+				Start: mustParseTime("1969-10-01T00:00:00Z"),
+				Stop:  mustParseTime("1970-03-01T00:00:00Z"),
+			},
+		},
+		{
+			name: "truncate after calendar offset",
+			w: MustWindow(
+				values.ConvertDurationMonths(5),
+				values.ConvertDurationMonths(5),
+				values.ConvertDurationMonths(2)),
+			t: mustParseTime("1970-04-01T00:00:00Z"),
+			want: execute.Bounds{
+				Start: mustParseTime("1970-03-01T00:00:00Z"),
+				Stop:  mustParseTime("1970-08-01T00:00:00Z"),
+			},
+		},
+		{
+			name: "negative calendar offset",
+			w: MustWindow(
+				values.ConvertDurationMonths(5),
+				values.ConvertDurationMonths(5),
+				values.ConvertDurationMonths(-2)),
+			t: mustParseTime("1970-02-01T00:00:00Z"),
+			want: execute.Bounds{
+				Start: mustParseTime("1969-11-01T00:00:00Z"),
+				Stop:  mustParseTime("1970-04-01T00:00:00Z"),
 			},
 		},
 	}
@@ -419,7 +479,7 @@ func TestWindow_GetOverlappingBounds(t *testing.T) {
 	}
 }
 
-func MustWindow(every, period, offset execute.Duration, months bool) execute.Window {
+func MustWindow(every, period, offset execute.Duration) execute.Window {
 	w, err := execute.NewWindow(every, period, offset)
 	if err != nil {
 		panic(err)

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -528,6 +528,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/unique_test.flux":                                              "170c17cc23b614a806ce2f4ecdce8f2c0d9b0ffd56ebbbff99087e70d8203271",
 	"stdlib/universe/universe.flux":                                                 "126f22fe56861db52d67bc831fc01dd7d94e8d4a1a268401889296d00cfac0ad",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                         "616e7c4ec942d52963a01f1231b17d8653312b163bc2b4012acd0d8c42458fb6",
+	"stdlib/universe/window_aggregate_test.flux":                                    "6065ead71f6ba5a72ffaa0ed1808f8297d5be70de2bdeaebf8bbdbbc42534f5f",
 	"stdlib/universe/window_default_start_align_test.flux":                          "54fd2e6bc45814ee60428af3b53666536b92ec508a004d4c87351a7e900961ae",
 	"stdlib/universe/window_generate_empty_test.flux":                               "c929db635e600d668bd3f7cbf18fee4551d6b3e81ce4066059ec2db2d7a5d782",
 	"stdlib/universe/window_group_mean_ungroup_test.flux":                           "6a7c10430c50b4a95c058a30200a0ada43ced4d7fa1c74d2f0c3bd441b35892b",

--- a/stdlib/universe/window_aggregate_test.flux
+++ b/stdlib/universe/window_aggregate_test.flux
@@ -1,0 +1,47 @@
+package universe_test
+ 
+import "testing"
+
+inData = "
+#datatype,string,long,dateTime:RFC3339,long,string,string,string
+#group,false,false,false,false,true,true,true
+#default,_result,,,,,,
+,result,table,_time,_value,_field,_measurement,k
+,,0,1970-01-01T00:00:00Z,0,f,m0,k0
+,,0,1970-01-01T00:00:01Z,1,f,m0,k0
+,,0,1970-01-01T00:00:02Z,2,f,m0,k0
+,,0,1970-01-01T00:00:03Z,3,f,m0,k0
+,,0,1970-01-01T00:00:04Z,4,f,m0,k0
+,,0,1970-01-01T00:00:05Z,5,f,m0,k0
+,,0,1970-01-01T00:00:06Z,6,f,m0,k0
+,,0,1970-01-01T00:00:07Z,5,f,m0,k0
+,,0,1970-01-01T00:00:08Z,0,f,m0,k0
+,,0,1970-01-01T00:00:09Z,6,f,m0,k0
+,,0,1970-01-01T00:00:10Z,6,f,m0,k0
+,,0,1970-01-01T00:00:11Z,7,f,m0,k0
+,,0,1970-01-01T00:00:12Z,5,f,m0,k0
+,,0,1970-01-01T00:00:13Z,8,f,m0,k0
+,,0,1970-01-01T00:00:14Z,9,f,m0,k0
+,,0,1970-01-01T00:00:15Z,5,f,m0,k0
+"
+
+outData = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string
+#group,false,false,true,true,false,true,true,true
+#default,_result,,,,,,,
+,result,table,_start,_stop,_value,_field,_measurement,k
+,,0,1970-01-01T00:00:00Z,1970-01-01T00:00:02Z,2,f,m0,k0
+,,1,1970-01-01T00:00:02Z,1970-01-01T00:00:07Z,5,f,m0,k0
+,,2,1970-01-01T00:00:07Z,1970-01-01T00:00:12Z,5,f,m0,k0
+,,3,1970-01-01T00:00:12Z,1970-01-01T00:00:15Z,3,f,m0,k0
+"
+
+t_window = (table=<-) =>
+    table
+        |> range(start: 1970-01-01T00:00:00Z, stop: 1970-01-01T00:00:15Z)
+        |> window(every: 5s, offset: 2s)
+        |> count()
+
+test _window = () =>
+	({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_window})
+


### PR DESCRIPTION
### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
