### PR TITLE
docs(SPEC): add design for formal testing in Flux

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1001,6 +1001,7 @@ A statement controls execution.
 
     Statement = OptionAssignment
               | BuiltinStatement
+              | TestStatement
               | VariableAssignment
               | ReturnStatement
               | ExpressionStatement .
@@ -1113,6 +1114,30 @@ All such values must have a corresponding builtin statement to declare the exist
 Example
 
     builtin filter : (<-tables: [T], fn: (r: T) => bool) => [T]
+
+## Test Statements
+
+A test statment defines a block of code that describes a test.
+A test is a block of code to execute that can make assertions about its behavior.
+
+    TestStatement = "test" identifier  Block
+
+The test statement block is treated as if it were a file block within its own package block.
+Any statements inside the enclosing file block of the test statement are also part of the test package.
+Therefore each test case can be understood to execute in isolation from other tests in the same file.
+
+Example
+
+    import "testing"
+
+    test addition {
+        testing.assertEqual(got: 1 + 1, want: 2)
+    }
+
+    test changeNow {
+        option now = () => 2020-01-01T00:00:00Z
+        testing.assertEqual(got: now(), want: 2020-01-01T00:00:00Z)
+    }
 
 ### Date/Time constants
 


### PR DESCRIPTION
Flux currently has an undocumented `test` statement but it is very
limited in scope. The test must test the result of a Flux query and
cannot test arbitrary expressions.

This update to the Flux spec formalizes testing as a first class concept
to the Flux language.

As can be seen by the example in the SPEC the idea is that multiple
tests can be defined making use of various assertion methods in the
testing package. The testing package will work much like the profiler in
that it will add two results to the output of a query. One result which
is a mapping of test name with a pass/fail status and another which is a
table per test with each assertion results as a row. Assertions will be
identified by their source location.

In order to isolate test runs each test block will be rewritten as if it
were the only test in the file. A file with multiple test blocks will
get exploded into many test files/packages.

Example of how I expect that could work:

    package foo_test
    import "testing"

    answer = 42

    test addition {
        testing.assertEqual(got: 13 + 29, want: answer)
    }

    test multiplication {
        testing.assertEqual(got: 6 * 7, want: answer)
    }

Becomes two separate packages which would look like this:

    //addition.flux
    package main

    import "testing"

    answer = 42

    testing.assertEqual(got: 13 + 29, want: answer)

    //multiplication.flux
    package main

    import "testing"

    answer = 42

    testing.assertEqual(got: 6 * 7, want: answer)

This has the effect that each test is run in complete isolation but can
share common setup code across tests easily.
Additionally options can be specified per test case with this method.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
