### PR TITLE
test: added a test case for group-aggregate

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -227,6 +227,7 @@ var sourceHashes = map[string]string{
 	"stdlib/planner/bare_min_push_test.flux":                                        "85ad8822162b94ffcf7cecaeb142036a1df96630b05c514ede116b280d4fad4d",
 	"stdlib/planner/bare_sum_eval_test.flux":                                        "57a6ab2bc9cf1660127709326a9362ff89830e2288eb99756e81d9f8c67f1548",
 	"stdlib/planner/bare_sum_push_test.flux":                                        "2b7d7b048202f54f2ac624b30a069924e2bafda2b8ff0605c29b80aab8aae660",
+	"stdlib/planner/group_agg_uneven_keys_test.flux":                                "1c9e8cf246a3f46b44ad6b97a9de939c6de57903efd941b38050c71cc429d671",
 	"stdlib/planner/group_count_eval_test.flux":                                     "a55d1190988bd071aa6916f5185c5ec50e7f8e0ee1afd2d6df248dc2258be54f",
 	"stdlib/planner/group_count_push_test.flux":                                     "dfc47c5a9c631ec861e95222299c1239cbe8dfd97fbf580bd4c65f53677e47f5",
 	"stdlib/planner/group_max_eval_test.flux":                                       "b7dff5c8876b112b1906f874199b07be6dfda197d5d9641228810d6174617f39",

--- a/stdlib/planner/flux_test_gen.go
+++ b/stdlib/planner/flux_test_gen.go
@@ -17885,6 +17885,1437 @@ var FluxTestPackages = []*ast.Package{&ast.Package{
 			Loc: &ast.SourceLocation{
 				End: ast.Position{
 					Column: 4,
+					Line:   68,
+				},
+				File:   "group_agg_uneven_keys_test.flux",
+				Source: "package planner_test\n\nimport \"testing\"\n\noption now = () => (2030-01-01T00:00:00Z)\n\ninput = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,hostA,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,hostA,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,hostA,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,hostA,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,hostA,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,hostA,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,hostB,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,hostB,load3,1.97\n\n,,3,2018-05-22T19:53:46Z,system,hostC,load1,1.92\n,,3,2018-05-22T19:53:56Z,system,hostC,load1,1.89\n,,3,2018-05-22T19:54:16Z,system,hostC,load1,1.93\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,double\n#group,false,false,false,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_time,_measurement,host,other,_field,_value\n,,2,2018-05-22T19:53:26Z,system,hostC,o1,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,hostC,o1,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,hostC,o1,load5,1.91\n\"\n\noutput = \"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,double\n#group,false,false,true,true,true,false,false\n#default,_result,,,,,,\n,result,table,_start,_stop,host,_field,_value\n,,0,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostA,load1,1.91\n,,1,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostB,load3,1.98\n\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double\n#group,false,false,true,true,true,false,false,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,host,other,_field,_value\n,,2,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostC,o1,load5,1.95\n\"\n\ngroup_max_fn = (tables=<-) => tables\n    |> range(start: 2018-05-22T19:00:00Z)\n    |> group(columns:[\"_start\", \"_stop\",\"host\"])\n    |> max()\n    |> drop(columns: [\"_measurement\", \"_time\"])\n\ntest group_max_pushdown = () =>\n\t({\n\t\tinput: testing.loadStorage(csv: input),\n\t\twant: testing.loadMem(csv: output),\n\t\tfn: group_max_fn\n\t})",
+				Start: ast.Position{
+					Column: 1,
+					Line:   4,
+				},
+			},
+		},
+		Body: []ast.Statement{&ast.OptionStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 42,
+							Line:   8,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "now = () => (2030-01-01T00:00:00Z)",
+						Start: ast.Position{
+							Column: 8,
+							Line:   8,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 11,
+								Line:   8,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "now",
+							Start: ast.Position{
+								Column: 8,
+								Line:   8,
+							},
+						},
+					},
+					Name: "now",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 42,
+								Line:   8,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "() => (2030-01-01T00:00:00Z)",
+							Start: ast.Position{
+								Column: 14,
+								Line:   8,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 42,
+									Line:   8,
+								},
+								File:   "group_agg_uneven_keys_test.flux",
+								Source: "(2030-01-01T00:00:00Z)",
+								Start: ast.Position{
+									Column: 20,
+									Line:   8,
+								},
+							},
+						},
+						Expression: &ast.DateTimeLiteral{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 41,
+										Line:   8,
+									},
+									File:   "group_agg_uneven_keys_test.flux",
+									Source: "2030-01-01T00:00:00Z",
+									Start: ast.Position{
+										Column: 21,
+										Line:   8,
+									},
+								},
+							},
+							Value: parser.MustParseTime("2030-01-01T00:00:00Z"),
+						},
+					},
+					Params: []*ast.Property{},
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 42,
+						Line:   8,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "option now = () => (2030-01-01T00:00:00Z)",
+					Start: ast.Position{
+						Column: 1,
+						Line:   8,
+					},
+				},
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   40,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "input = \"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,hostA,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,hostA,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,hostA,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,hostA,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,hostA,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,hostA,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,hostB,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,hostB,load3,1.97\n\n,,3,2018-05-22T19:53:46Z,system,hostC,load1,1.92\n,,3,2018-05-22T19:53:56Z,system,hostC,load1,1.89\n,,3,2018-05-22T19:54:16Z,system,hostC,load1,1.93\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,double\n#group,false,false,false,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_time,_measurement,host,other,_field,_value\n,,2,2018-05-22T19:53:26Z,system,hostC,o1,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,hostC,o1,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,hostC,o1,load5,1.91\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   10,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 6,
+							Line:   10,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "input",
+						Start: ast.Position{
+							Column: 1,
+							Line:   10,
+						},
+					},
+				},
+				Name: "input",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   40,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,hostA,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,hostA,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,hostA,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,hostA,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,hostA,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,hostA,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,hostB,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,hostB,load3,1.97\n\n,,3,2018-05-22T19:53:46Z,system,hostC,load1,1.92\n,,3,2018-05-22T19:53:56Z,system,hostC,load1,1.89\n,,3,2018-05-22T19:54:16Z,system,hostC,load1,1.93\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,double\n#group,false,false,false,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_time,_measurement,host,other,_field,_value\n,,2,2018-05-22T19:53:26Z,system,hostC,o1,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,hostC,o1,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,hostC,o1,load5,1.91\n\"",
+						Start: ast.Position{
+							Column: 9,
+							Line:   10,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,string,string,string,double\n#group,false,false,false,true,true,true,false\n#default,_result,,,,,,\n,result,table,_time,_measurement,host,_field,_value\n,,0,2018-05-22T19:53:26Z,system,hostA,load1,1.83\n,,0,2018-05-22T19:53:36Z,system,hostA,load1,1.72\n,,0,2018-05-22T19:53:37Z,system,hostA,load1,1.77\n,,0,2018-05-22T19:53:56Z,system,hostA,load1,1.63\n,,0,2018-05-22T19:54:06Z,system,hostA,load1,1.91\n,,0,2018-05-22T19:54:16Z,system,hostA,load1,1.84\n\n,,1,2018-05-22T19:53:26Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:53:36Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:46Z,system,hostB,load3,1.97\n,,1,2018-05-22T19:53:56Z,system,hostB,load3,1.96\n,,1,2018-05-22T19:54:06Z,system,hostB,load3,1.98\n,,1,2018-05-22T19:54:16Z,system,hostB,load3,1.97\n\n,,3,2018-05-22T19:53:46Z,system,hostC,load1,1.92\n,,3,2018-05-22T19:53:56Z,system,hostC,load1,1.89\n,,3,2018-05-22T19:54:16Z,system,hostC,load1,1.93\n\n#datatype,string,long,dateTime:RFC3339,string,string,string,string,double\n#group,false,false,false,true,true,true,true,false\n#default,_result,,,,,,,\n,result,table,_time,_measurement,host,other,_field,_value\n,,2,2018-05-22T19:53:26Z,system,hostC,o1,load5,1.95\n,,2,2018-05-22T19:53:36Z,system,hostC,o1,load5,1.92\n,,2,2018-05-22T19:53:41Z,system,hostC,o1,load5,1.91\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 2,
+						Line:   55,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "output = \"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,double\n#group,false,false,true,true,true,false,false\n#default,_result,,,,,,\n,result,table,_start,_stop,host,_field,_value\n,,0,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostA,load1,1.91\n,,1,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostB,load3,1.98\n\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double\n#group,false,false,true,true,true,false,false,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,host,other,_field,_value\n,,2,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostC,o1,load5,1.95\n\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   42,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 7,
+							Line:   42,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "output",
+						Start: ast.Position{
+							Column: 1,
+							Line:   42,
+						},
+					},
+				},
+				Name: "output",
+			},
+			Init: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 2,
+							Line:   55,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "\"\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,double\n#group,false,false,true,true,true,false,false\n#default,_result,,,,,,\n,result,table,_start,_stop,host,_field,_value\n,,0,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostA,load1,1.91\n,,1,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostB,load3,1.98\n\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double\n#group,false,false,true,true,true,false,false,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,host,other,_field,_value\n,,2,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostC,o1,load5,1.95\n\"",
+						Start: ast.Position{
+							Column: 10,
+							Line:   42,
+						},
+					},
+				},
+				Value: "\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,double\n#group,false,false,true,true,true,false,false\n#default,_result,,,,,,\n,result,table,_start,_stop,host,_field,_value\n,,0,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostA,load1,1.91\n,,1,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostB,load3,1.98\n\n#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double\n#group,false,false,true,true,true,false,false,false\n#default,_result,,,,,,,\n,result,table,_start,_stop,host,other,_field,_value\n,,2,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostC,o1,load5,1.95\n",
+			},
+		}, &ast.VariableAssignment{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 48,
+						Line:   61,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "group_max_fn = (tables=<-) => tables\n    |> range(start: 2018-05-22T19:00:00Z)\n    |> group(columns:[\"_start\", \"_stop\",\"host\"])\n    |> max()\n    |> drop(columns: [\"_measurement\", \"_time\"])",
+					Start: ast.Position{
+						Column: 1,
+						Line:   57,
+					},
+				},
+			},
+			ID: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 13,
+							Line:   57,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "group_max_fn",
+						Start: ast.Position{
+							Column: 1,
+							Line:   57,
+						},
+					},
+				},
+				Name: "group_max_fn",
+			},
+			Init: &ast.FunctionExpression{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 48,
+							Line:   61,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "(tables=<-) => tables\n    |> range(start: 2018-05-22T19:00:00Z)\n    |> group(columns:[\"_start\", \"_stop\",\"host\"])\n    |> max()\n    |> drop(columns: [\"_measurement\", \"_time\"])",
+						Start: ast.Position{
+							Column: 16,
+							Line:   57,
+						},
+					},
+				},
+				Body: &ast.PipeExpression{
+					Argument: &ast.PipeExpression{
+						Argument: &ast.PipeExpression{
+							Argument: &ast.PipeExpression{
+								Argument: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 37,
+												Line:   57,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "tables",
+											Start: ast.Position{
+												Column: 31,
+												Line:   57,
+											},
+										},
+									},
+									Name: "tables",
+								},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 42,
+											Line:   58,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "tables\n    |> range(start: 2018-05-22T19:00:00Z)",
+										Start: ast.Position{
+											Column: 31,
+											Line:   57,
+										},
+									},
+								},
+								Call: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 41,
+													Line:   58,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "start: 2018-05-22T19:00:00Z",
+												Start: ast.Position{
+													Column: 14,
+													Line:   58,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 41,
+														Line:   58,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "start: 2018-05-22T19:00:00Z",
+													Start: ast.Position{
+														Column: 14,
+														Line:   58,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 19,
+															Line:   58,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "start",
+														Start: ast.Position{
+															Column: 14,
+															Line:   58,
+														},
+													},
+												},
+												Name: "start",
+											},
+											Value: &ast.DateTimeLiteral{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 41,
+															Line:   58,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "2018-05-22T19:00:00Z",
+														Start: ast.Position{
+															Column: 21,
+															Line:   58,
+														},
+													},
+												},
+												Value: parser.MustParseTime("2018-05-22T19:00:00Z"),
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 42,
+												Line:   58,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "range(start: 2018-05-22T19:00:00Z)",
+											Start: ast.Position{
+												Column: 8,
+												Line:   58,
+											},
+										},
+									},
+									Callee: &ast.Identifier{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 13,
+													Line:   58,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "range",
+												Start: ast.Position{
+													Column: 8,
+													Line:   58,
+												},
+											},
+										},
+										Name: "range",
+									},
+								},
+							},
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 49,
+										Line:   59,
+									},
+									File:   "group_agg_uneven_keys_test.flux",
+									Source: "tables\n    |> range(start: 2018-05-22T19:00:00Z)\n    |> group(columns:[\"_start\", \"_stop\",\"host\"])",
+									Start: ast.Position{
+										Column: 31,
+										Line:   57,
+									},
+								},
+							},
+							Call: &ast.CallExpression{
+								Arguments: []ast.Expression{&ast.ObjectExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 48,
+												Line:   59,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "columns:[\"_start\", \"_stop\",\"host\"]",
+											Start: ast.Position{
+												Column: 14,
+												Line:   59,
+											},
+										},
+									},
+									Properties: []*ast.Property{&ast.Property{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 48,
+													Line:   59,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "columns:[\"_start\", \"_stop\",\"host\"]",
+												Start: ast.Position{
+													Column: 14,
+													Line:   59,
+												},
+											},
+										},
+										Key: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 21,
+														Line:   59,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "columns",
+													Start: ast.Position{
+														Column: 14,
+														Line:   59,
+													},
+												},
+											},
+											Name: "columns",
+										},
+										Value: &ast.ArrayExpression{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 48,
+														Line:   59,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "[\"_start\", \"_stop\",\"host\"]",
+													Start: ast.Position{
+														Column: 22,
+														Line:   59,
+													},
+												},
+											},
+											Elements: []ast.Expression{&ast.StringLiteral{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 31,
+															Line:   59,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "\"_start\"",
+														Start: ast.Position{
+															Column: 23,
+															Line:   59,
+														},
+													},
+												},
+												Value: "_start",
+											}, &ast.StringLiteral{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 40,
+															Line:   59,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "\"_stop\"",
+														Start: ast.Position{
+															Column: 33,
+															Line:   59,
+														},
+													},
+												},
+												Value: "_stop",
+											}, &ast.StringLiteral{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 47,
+															Line:   59,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "\"host\"",
+														Start: ast.Position{
+															Column: 41,
+															Line:   59,
+														},
+													},
+												},
+												Value: "host",
+											}},
+										},
+									}},
+									With: nil,
+								}},
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 49,
+											Line:   59,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "group(columns:[\"_start\", \"_stop\",\"host\"])",
+										Start: ast.Position{
+											Column: 8,
+											Line:   59,
+										},
+									},
+								},
+								Callee: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 13,
+												Line:   59,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "group",
+											Start: ast.Position{
+												Column: 8,
+												Line:   59,
+											},
+										},
+									},
+									Name: "group",
+								},
+							},
+						},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 13,
+									Line:   60,
+								},
+								File:   "group_agg_uneven_keys_test.flux",
+								Source: "tables\n    |> range(start: 2018-05-22T19:00:00Z)\n    |> group(columns:[\"_start\", \"_stop\",\"host\"])\n    |> max()",
+								Start: ast.Position{
+									Column: 31,
+									Line:   57,
+								},
+							},
+						},
+						Call: &ast.CallExpression{
+							Arguments: nil,
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 13,
+										Line:   60,
+									},
+									File:   "group_agg_uneven_keys_test.flux",
+									Source: "max()",
+									Start: ast.Position{
+										Column: 8,
+										Line:   60,
+									},
+								},
+							},
+							Callee: &ast.Identifier{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 11,
+											Line:   60,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "max",
+										Start: ast.Position{
+											Column: 8,
+											Line:   60,
+										},
+									},
+								},
+								Name: "max",
+							},
+						},
+					},
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 48,
+								Line:   61,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "tables\n    |> range(start: 2018-05-22T19:00:00Z)\n    |> group(columns:[\"_start\", \"_stop\",\"host\"])\n    |> max()\n    |> drop(columns: [\"_measurement\", \"_time\"])",
+							Start: ast.Position{
+								Column: 31,
+								Line:   57,
+							},
+						},
+					},
+					Call: &ast.CallExpression{
+						Arguments: []ast.Expression{&ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 47,
+										Line:   61,
+									},
+									File:   "group_agg_uneven_keys_test.flux",
+									Source: "columns: [\"_measurement\", \"_time\"]",
+									Start: ast.Position{
+										Column: 13,
+										Line:   61,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 47,
+											Line:   61,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "columns: [\"_measurement\", \"_time\"]",
+										Start: ast.Position{
+											Column: 13,
+											Line:   61,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 20,
+												Line:   61,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "columns",
+											Start: ast.Position{
+												Column: 13,
+												Line:   61,
+											},
+										},
+									},
+									Name: "columns",
+								},
+								Value: &ast.ArrayExpression{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 47,
+												Line:   61,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "[\"_measurement\", \"_time\"]",
+											Start: ast.Position{
+												Column: 22,
+												Line:   61,
+											},
+										},
+									},
+									Elements: []ast.Expression{&ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 37,
+													Line:   61,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "\"_measurement\"",
+												Start: ast.Position{
+													Column: 23,
+													Line:   61,
+												},
+											},
+										},
+										Value: "_measurement",
+									}, &ast.StringLiteral{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 46,
+													Line:   61,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "\"_time\"",
+												Start: ast.Position{
+													Column: 39,
+													Line:   61,
+												},
+											},
+										},
+										Value: "_time",
+									}},
+								},
+							}},
+							With: nil,
+						}},
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 48,
+									Line:   61,
+								},
+								File:   "group_agg_uneven_keys_test.flux",
+								Source: "drop(columns: [\"_measurement\", \"_time\"])",
+								Start: ast.Position{
+									Column: 8,
+									Line:   61,
+								},
+							},
+						},
+						Callee: &ast.Identifier{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 12,
+										Line:   61,
+									},
+									File:   "group_agg_uneven_keys_test.flux",
+									Source: "drop",
+									Start: ast.Position{
+										Column: 8,
+										Line:   61,
+									},
+								},
+							},
+							Name: "drop",
+						},
+					},
+				},
+				Params: []*ast.Property{&ast.Property{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 26,
+								Line:   57,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "tables=<-",
+							Start: ast.Position{
+								Column: 17,
+								Line:   57,
+							},
+						},
+					},
+					Key: &ast.Identifier{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 23,
+									Line:   57,
+								},
+								File:   "group_agg_uneven_keys_test.flux",
+								Source: "tables",
+								Start: ast.Position{
+									Column: 17,
+									Line:   57,
+								},
+							},
+						},
+						Name: "tables",
+					},
+					Value: &ast.PipeLiteral{BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 26,
+								Line:   57,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "<-",
+							Start: ast.Position{
+								Column: 24,
+								Line:   57,
+							},
+						},
+					}},
+				}},
+			},
+		}, &ast.TestStatement{
+			Assignment: &ast.VariableAssignment{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 4,
+							Line:   68,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "group_max_pushdown = () =>\n\t({\n\t\tinput: testing.loadStorage(csv: input),\n\t\twant: testing.loadMem(csv: output),\n\t\tfn: group_max_fn\n\t})",
+						Start: ast.Position{
+							Column: 6,
+							Line:   63,
+						},
+					},
+				},
+				ID: &ast.Identifier{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 24,
+								Line:   63,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "group_max_pushdown",
+							Start: ast.Position{
+								Column: 6,
+								Line:   63,
+							},
+						},
+					},
+					Name: "group_max_pushdown",
+				},
+				Init: &ast.FunctionExpression{
+					BaseNode: ast.BaseNode{
+						Errors: nil,
+						Loc: &ast.SourceLocation{
+							End: ast.Position{
+								Column: 4,
+								Line:   68,
+							},
+							File:   "group_agg_uneven_keys_test.flux",
+							Source: "() =>\n\t({\n\t\tinput: testing.loadStorage(csv: input),\n\t\twant: testing.loadMem(csv: output),\n\t\tfn: group_max_fn\n\t})",
+							Start: ast.Position{
+								Column: 27,
+								Line:   63,
+							},
+						},
+					},
+					Body: &ast.ParenExpression{
+						BaseNode: ast.BaseNode{
+							Errors: nil,
+							Loc: &ast.SourceLocation{
+								End: ast.Position{
+									Column: 4,
+									Line:   68,
+								},
+								File:   "group_agg_uneven_keys_test.flux",
+								Source: "({\n\t\tinput: testing.loadStorage(csv: input),\n\t\twant: testing.loadMem(csv: output),\n\t\tfn: group_max_fn\n\t})",
+								Start: ast.Position{
+									Column: 2,
+									Line:   64,
+								},
+							},
+						},
+						Expression: &ast.ObjectExpression{
+							BaseNode: ast.BaseNode{
+								Errors: nil,
+								Loc: &ast.SourceLocation{
+									End: ast.Position{
+										Column: 3,
+										Line:   68,
+									},
+									File:   "group_agg_uneven_keys_test.flux",
+									Source: "{\n\t\tinput: testing.loadStorage(csv: input),\n\t\twant: testing.loadMem(csv: output),\n\t\tfn: group_max_fn\n\t}",
+									Start: ast.Position{
+										Column: 3,
+										Line:   64,
+									},
+								},
+							},
+							Properties: []*ast.Property{&ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 41,
+											Line:   65,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "input: testing.loadStorage(csv: input)",
+										Start: ast.Position{
+											Column: 3,
+											Line:   65,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 8,
+												Line:   65,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "input",
+											Start: ast.Position{
+												Column: 3,
+												Line:   65,
+											},
+										},
+									},
+									Name: "input",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 40,
+													Line:   65,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "csv: input",
+												Start: ast.Position{
+													Column: 30,
+													Line:   65,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 40,
+														Line:   65,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "csv: input",
+													Start: ast.Position{
+														Column: 30,
+														Line:   65,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 33,
+															Line:   65,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 30,
+															Line:   65,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 40,
+															Line:   65,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "input",
+														Start: ast.Position{
+															Column: 35,
+															Line:   65,
+														},
+													},
+												},
+												Name: "input",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 41,
+												Line:   65,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "testing.loadStorage(csv: input)",
+											Start: ast.Position{
+												Column: 10,
+												Line:   65,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 29,
+													Line:   65,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "testing.loadStorage",
+												Start: ast.Position{
+													Column: 10,
+													Line:   65,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 17,
+														Line:   65,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 10,
+														Line:   65,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 29,
+														Line:   65,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "loadStorage",
+													Start: ast.Position{
+														Column: 18,
+														Line:   65,
+													},
+												},
+											},
+											Name: "loadStorage",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 37,
+											Line:   66,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "want: testing.loadMem(csv: output)",
+										Start: ast.Position{
+											Column: 3,
+											Line:   66,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 7,
+												Line:   66,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "want",
+											Start: ast.Position{
+												Column: 3,
+												Line:   66,
+											},
+										},
+									},
+									Name: "want",
+								},
+								Value: &ast.CallExpression{
+									Arguments: []ast.Expression{&ast.ObjectExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 36,
+													Line:   66,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "csv: output",
+												Start: ast.Position{
+													Column: 25,
+													Line:   66,
+												},
+											},
+										},
+										Properties: []*ast.Property{&ast.Property{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 36,
+														Line:   66,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "csv: output",
+													Start: ast.Position{
+														Column: 25,
+														Line:   66,
+													},
+												},
+											},
+											Key: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 28,
+															Line:   66,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "csv",
+														Start: ast.Position{
+															Column: 25,
+															Line:   66,
+														},
+													},
+												},
+												Name: "csv",
+											},
+											Value: &ast.Identifier{
+												BaseNode: ast.BaseNode{
+													Errors: nil,
+													Loc: &ast.SourceLocation{
+														End: ast.Position{
+															Column: 36,
+															Line:   66,
+														},
+														File:   "group_agg_uneven_keys_test.flux",
+														Source: "output",
+														Start: ast.Position{
+															Column: 30,
+															Line:   66,
+														},
+													},
+												},
+												Name: "output",
+											},
+										}},
+										With: nil,
+									}},
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 37,
+												Line:   66,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "testing.loadMem(csv: output)",
+											Start: ast.Position{
+												Column: 9,
+												Line:   66,
+											},
+										},
+									},
+									Callee: &ast.MemberExpression{
+										BaseNode: ast.BaseNode{
+											Errors: nil,
+											Loc: &ast.SourceLocation{
+												End: ast.Position{
+													Column: 24,
+													Line:   66,
+												},
+												File:   "group_agg_uneven_keys_test.flux",
+												Source: "testing.loadMem",
+												Start: ast.Position{
+													Column: 9,
+													Line:   66,
+												},
+											},
+										},
+										Object: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 16,
+														Line:   66,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "testing",
+													Start: ast.Position{
+														Column: 9,
+														Line:   66,
+													},
+												},
+											},
+											Name: "testing",
+										},
+										Property: &ast.Identifier{
+											BaseNode: ast.BaseNode{
+												Errors: nil,
+												Loc: &ast.SourceLocation{
+													End: ast.Position{
+														Column: 24,
+														Line:   66,
+													},
+													File:   "group_agg_uneven_keys_test.flux",
+													Source: "loadMem",
+													Start: ast.Position{
+														Column: 17,
+														Line:   66,
+													},
+												},
+											},
+											Name: "loadMem",
+										},
+									},
+								},
+							}, &ast.Property{
+								BaseNode: ast.BaseNode{
+									Errors: nil,
+									Loc: &ast.SourceLocation{
+										End: ast.Position{
+											Column: 19,
+											Line:   67,
+										},
+										File:   "group_agg_uneven_keys_test.flux",
+										Source: "fn: group_max_fn",
+										Start: ast.Position{
+											Column: 3,
+											Line:   67,
+										},
+									},
+								},
+								Key: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 5,
+												Line:   67,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "fn",
+											Start: ast.Position{
+												Column: 3,
+												Line:   67,
+											},
+										},
+									},
+									Name: "fn",
+								},
+								Value: &ast.Identifier{
+									BaseNode: ast.BaseNode{
+										Errors: nil,
+										Loc: &ast.SourceLocation{
+											End: ast.Position{
+												Column: 19,
+												Line:   67,
+											},
+											File:   "group_agg_uneven_keys_test.flux",
+											Source: "group_max_fn",
+											Start: ast.Position{
+												Column: 7,
+												Line:   67,
+											},
+										},
+									},
+									Name: "group_max_fn",
+								},
+							}},
+							With: nil,
+						},
+					},
+					Params: []*ast.Property{},
+				},
+			},
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 4,
+						Line:   68,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "test group_max_pushdown = () =>\n\t({\n\t\tinput: testing.loadStorage(csv: input),\n\t\twant: testing.loadMem(csv: output),\n\t\tfn: group_max_fn\n\t})",
+					Start: ast.Position{
+						Column: 1,
+						Line:   63,
+					},
+				},
+			},
+		}},
+		Imports: []*ast.ImportDeclaration{&ast.ImportDeclaration{
+			As: nil,
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 17,
+						Line:   6,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "import \"testing\"",
+					Start: ast.Position{
+						Column: 1,
+						Line:   6,
+					},
+				},
+			},
+			Path: &ast.StringLiteral{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 17,
+							Line:   6,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "\"testing\"",
+						Start: ast.Position{
+							Column: 8,
+							Line:   6,
+						},
+					},
+				},
+				Value: "testing",
+			},
+		}},
+		Metadata: "parser-type=rust",
+		Name:     "group_agg_uneven_keys_test.flux",
+		Package: &ast.PackageClause{
+			BaseNode: ast.BaseNode{
+				Errors: nil,
+				Loc: &ast.SourceLocation{
+					End: ast.Position{
+						Column: 21,
+						Line:   4,
+					},
+					File:   "group_agg_uneven_keys_test.flux",
+					Source: "package planner_test",
+					Start: ast.Position{
+						Column: 1,
+						Line:   4,
+					},
+				},
+			},
+			Name: &ast.Identifier{
+				BaseNode: ast.BaseNode{
+					Errors: nil,
+					Loc: &ast.SourceLocation{
+						End: ast.Position{
+							Column: 21,
+							Line:   4,
+						},
+						File:   "group_agg_uneven_keys_test.flux",
+						Source: "planner_test",
+						Start: ast.Position{
+							Column: 9,
+							Line:   4,
+						},
+					},
+				},
+				Name: "planner_test",
+			},
+		},
+	}, &ast.File{
+		BaseNode: ast.BaseNode{
+			Errors: nil,
+			Loc: &ast.SourceLocation{
+				End: ast.Position{
+					Column: 4,
 					Line:   58,
 				},
 				File:   "group_count_eval_test.flux",

--- a/stdlib/planner/group_agg_uneven_keys_test.flux
+++ b/stdlib/planner/group_agg_uneven_keys_test.flux
@@ -1,0 +1,68 @@
+// The goal of this test is to send an uneven tag key list in input rows that
+// are grouped together and selected.
+
+package planner_test
+
+import "testing"
+
+option now = () => (2030-01-01T00:00:00Z)
+
+input = "
+#datatype,string,long,dateTime:RFC3339,string,string,string,double
+#group,false,false,false,true,true,true,false
+#default,_result,,,,,,
+,result,table,_time,_measurement,host,_field,_value
+,,0,2018-05-22T19:53:26Z,system,hostA,load1,1.83
+,,0,2018-05-22T19:53:36Z,system,hostA,load1,1.72
+,,0,2018-05-22T19:53:37Z,system,hostA,load1,1.77
+,,0,2018-05-22T19:53:56Z,system,hostA,load1,1.63
+,,0,2018-05-22T19:54:06Z,system,hostA,load1,1.91
+,,0,2018-05-22T19:54:16Z,system,hostA,load1,1.84
+
+,,1,2018-05-22T19:53:26Z,system,hostB,load3,1.98
+,,1,2018-05-22T19:53:36Z,system,hostB,load3,1.97
+,,1,2018-05-22T19:53:46Z,system,hostB,load3,1.97
+,,1,2018-05-22T19:53:56Z,system,hostB,load3,1.96
+,,1,2018-05-22T19:54:06Z,system,hostB,load3,1.98
+,,1,2018-05-22T19:54:16Z,system,hostB,load3,1.97
+
+,,3,2018-05-22T19:53:46Z,system,hostC,load1,1.92
+,,3,2018-05-22T19:53:56Z,system,hostC,load1,1.89
+,,3,2018-05-22T19:54:16Z,system,hostC,load1,1.93
+
+#datatype,string,long,dateTime:RFC3339,string,string,string,string,double
+#group,false,false,false,true,true,true,true,false
+#default,_result,,,,,,,
+,result,table,_time,_measurement,host,other,_field,_value
+,,2,2018-05-22T19:53:26Z,system,hostC,o1,load5,1.95
+,,2,2018-05-22T19:53:36Z,system,hostC,o1,load5,1.92
+,,2,2018-05-22T19:53:41Z,system,hostC,o1,load5,1.91
+"
+
+output = "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,true,false,false
+#default,_result,,,,,,
+,result,table,_start,_stop,host,_field,_value
+,,0,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostA,load1,1.91
+,,1,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostB,load3,1.98
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,double
+#group,false,false,true,true,true,false,false,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,host,other,_field,_value
+,,2,2018-05-22T19:00:00Z,2030-01-01T00:00:00Z,hostC,o1,load5,1.95
+"
+
+group_max_fn = (tables=<-) => tables
+    |> range(start: 2018-05-22T19:00:00Z)
+    |> group(columns:["_start", "_stop","host"])
+    |> max()
+    |> drop(columns: ["_measurement", "_time"])
+
+test group_max_pushdown = () =>
+	({
+		input: testing.loadStorage(csv: input),
+		want: testing.loadMem(csv: output),
+		fn: group_max_fn
+	})


### PR DESCRIPTION
Added a test case for group-aggregage where tag key sets are uneven in length
among the input rows that are aggregate/selected in the output grouping.
