### PR TITLE
chore: add support for rust 1.48

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       GOPATH: /tmp/go
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
       SCCACHE_CACHE_SIZE: 1G
+      # XXX: rockstar (23 Nov 2020) - rust 1.48 has issues with sccache. It can be re-enabled
+      # when this bug is addressed: https://github.com/mozilla/sccache/issues/887
+      RUSTC_WRAPPER: ""
     steps:
       - checkout
       # Populate GOPATH/pkg.
@@ -18,12 +21,13 @@ jobs:
           keys:
             - flux-gomod-{{checksum "go.sum"}}
       # Populate Rust cache
-      - restore_cache:
-          name: Restoring Rust Cache
-          keys:
-            - flux-rust-{{ .Branch }}-{{ .Revision }} # Matches when retrying a single run.
-            - flux-rust-{{ .Branch }}-                # Matches a new commit on an existing branch.
-            - flux-rust-                              # Matches a new branch.
+      # Disable use of sccache for now
+      #- restore_cache:
+      #    name: Restoring Rust Cache
+      #    keys:
+      #      - flux-rust-{{ .Branch }}-{{ .Revision }} # Matches when retrying a single run.
+      #      - flux-rust-{{ .Branch }}-                # Matches a new commit on an existing branch.
+      #      - flux-rust-                              # Matches a new branch.
       # Run tests
       - run: make checkfmt
       - run: make checktidy
@@ -41,12 +45,13 @@ jobs:
           key: flux-gomod-{{checksum "go.sum"}}
           paths:
             - /tmp/go/pkg/mod
-      - save_cache:
-          name: Saving Rust Cache
-          key: flux-rust-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - "~/.cache/sccache"
-          when: always
+      # Disable use of sccache for now
+      #- save_cache:
+      #    name: Saving Rust Cache
+      #    key: flux-rust-{{ .Branch }}-{{ .Revision }}
+      #    paths:
+      #      - "~/.cache/sccache"
+      #    when: always
   test-race:
     docker:
       - image: quay.io/influxdb/flux-build:latest
@@ -55,6 +60,7 @@ jobs:
       GOPATH: /tmp/go
       GOFLAGS: -p=8
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
+      RUSTC_WRAPPER: ""
     steps:
       - checkout
       # Building go with -race does not use the cache
@@ -73,6 +79,7 @@ jobs:
       GOPATH: /tmp/go
       GOFLAGS: -p=1
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
+      RUSTC_WRAPPER: ""
     steps:
       - checkout
       - restore_cache:
@@ -85,6 +92,8 @@ jobs:
   test-valgrind:
     docker:
       - image: quay.io/influxdb/flux-build:latest
+    environment:
+      RUSTC_WRAPPER: ""
     steps:
       - checkout
       - run: make test-valgrind

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -28,7 +28,7 @@ var sourceHashes = map[string]string{
 	"libflux/src/core/ast/walk/mod.rs":                                              "855701066e8d11a620855d2db986ce3df27555a91e2fcaf7a0cd3b12aa4cc4f0",
 	"libflux/src/core/ast/walk/tests.rs":                                            "f7b2d7dd5643bb795a86c04b6979b136b0de46b52b213caff094aed6d204a05d",
 	"libflux/src/core/build.rs":                                                     "7e8c3626b9034dc4a31c2b748b2a174260949d852455299d071a0fd128c18a5a",
-	"libflux/src/core/formatter/mod.rs":                                             "84850874eeede529971ee52f79f4a920da83bcda8f6d8f57ef1b09747ab1813d",
+	"libflux/src/core/formatter/mod.rs":                                             "cbb20c9ab2e0db275f7c3b435cedf2beab89775f06232819efc2946a636e39e8",
 	"libflux/src/core/formatter/tests.rs":                                           "8ca7eaa9e8d6b5f504553736eba5628fcec67890ad9dd107ca5677ad2ac78d43",
 	"libflux/src/core/lib.rs":                                                       "ee7c9cfd10e82f1127ac988a28c2f78dfe031c6cd37d236401e2997b22bcdab5",
 	"libflux/src/core/parser/mod.rs":                                                "8109f5152bf181ae22ff8da59a2d65c431d5b34efecb2a32fa2241d8c0707011",

--- a/libflux/src/core/formatter/mod.rs
+++ b/libflux/src/core/formatter/mod.rs
@@ -1051,7 +1051,7 @@ impl Formatter {
             f.push_str(&frac_nano);
 
             if v.timezone().local_minus_utc() == 0 {
-                f.push_str("Z")
+                f.push('Z')
             } else {
                 f.push_str(&v.format("%:z").to_string());
             }


### PR DESCRIPTION
Rust 1.48 was released a few days ago. This patch adds the fixes that
will get flux passing in CI again. The following things needed
addressed:

  - There is a new lint introduced that checks for `push_str` on a
single char `str`, and recommends using `push` instead.
  - There is an open issue with `sccache` and rust 1.48. As a result,
`sccache` is desabled for now. See https://github.com/mozilla/sccache/issues/887