### PR TITLE
feat(tests): add a test harness that can read flux files from various sources

### DIFF
--- a/dependencies/tests/tests.go
+++ b/dependencies/tests/tests.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// Harness defines a test harness which will run a test query.
+type Harness interface {
+	RunTest(ctx context.Context, query string) error
+}
+
+// RunTests will run the given file paths against the Harness
+// by reading the files from different sources.
+//
+// This method supports reading from files on disk,
+// zip archives, and tarballs (including gzipped).
+// If this reads an archive, only the files that have
+// the pattern `*_test.flux` will be passed to the
+// test harness.
+func RunTests(ctx context.Context, h Harness, paths ...string) error {
+	for _, path := range paths {
+		var runner func(ctx context.Context, h Harness, filename string) error
+		if strings.HasSuffix(path, ".tar.gz") || strings.HasSuffix(path, ".tar") {
+			runner = runTarArchive
+		} else if strings.HasSuffix(path, ".zip") {
+			runner = runZipArchive
+		} else if strings.HasSuffix(path, ".flux") {
+			runner = runFile
+		} else {
+			return fmt.Errorf("no test runner for file: %s", path)
+		}
+
+		if err := runner(ctx, h, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runTest(ctx context.Context, h Harness, fp io.ReadCloser) error {
+	defer func() { _ = fp.Close() }()
+	data, err := ioutil.ReadAll(fp)
+	if err != nil {
+		return err
+	}
+	_ = fp.Close()
+	query := string(data)
+	return h.RunTest(ctx, query)
+}
+
+func runFile(ctx context.Context, h Harness, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	return runTest(ctx, h, f)
+}
+
+func runTarArchive(ctx context.Context, h Harness, filename string) error {
+	var f io.ReadCloser
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if strings.HasSuffix(filename, ".gz") {
+		r, err := gzip.NewReader(f)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = r.Close() }()
+		f = r
+	}
+
+	archive := tar.NewReader(f)
+	for {
+		hdr, err := archive.Next()
+		if err != nil {
+			return err
+		}
+
+		info := hdr.FileInfo()
+		if info.IsDir() || !strings.HasSuffix(hdr.Name, "_test.flux") {
+			continue
+		}
+
+		fp := ioutil.NopCloser(archive)
+		if err := runTest(ctx, h, fp); err != nil {
+			return err
+		}
+	}
+}
+
+func runZipArchive(ctx context.Context, h Harness, filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	zipf, err := zip.NewReader(f, info.Size())
+	if err != nil {
+		return err
+	}
+
+	for _, file := range zipf.File {
+		info := file.FileInfo()
+		if info.IsDir() || !strings.HasSuffix(file.Name, "_test.flux") {
+			continue
+		}
+
+		if err := func() error {
+			fp, err := file.Open()
+			if err != nil {
+				return err
+			}
+			return runTest(ctx, h, fp)
+		}(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/dependencies/tests/tests_test.go
+++ b/dependencies/tests/tests_test.go
@@ -1,0 +1,129 @@
+package tests_test
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/andreyvit/diff"
+	"github.com/influxdata/flux/dependencies/tests"
+)
+
+type MockHarness struct {
+	Queries []string
+}
+
+func (m *MockHarness) RunTest(ctx context.Context, query string) error {
+	m.Queries = append(m.Queries, query)
+	return nil
+}
+
+func TestRunTests_File(t *testing.T) {
+	file, err := ioutil.TempFile("", "flux-tests-*.flux")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(file.Name()) }()
+
+	want := `package main
+import "testing"
+
+answer = 42
+
+test addition {
+    testing.assertEqual(got: 13 + 29, want: answer)
+}
+`
+	_, _ = io.WriteString(file, want)
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	h := MockHarness{}
+	if err := tests.RunTests(context.Background(), &h, file.Name()); err != nil {
+		t.Fatal(err)
+	}
+
+	// There should have been one query that was executed.
+	if want, got := 1, len(h.Queries); want != got {
+		t.Fatalf("unexpected number of executed queries -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	if got := h.Queries[0]; want != got {
+		lines := diff.LineDiff(want, got)
+		t.Fatalf("unexpected query -want/+got:\n%s", lines)
+	}
+}
+
+type FileCreateFunc func(name string) (io.Writer, error)
+
+func writeArchive(create FileCreateFunc) error {
+	for _, file := range []struct {
+		name     string
+		contents string
+	}{
+		{
+			name: "myscript.flux",
+			contents: `package main
+from(bucket: "telegraf")
+    |> range(start: -5m)
+    |> filter(fn: (r) => r._measurement == "cpu")
+    |> mean()
+`,
+		},
+		{
+			name: "myscript_test.flux",
+			contents: `package main
+inData = "..."
+test mean {
+    /* test contents */
+}
+`,
+		},
+	} {
+		f, err := create(file.name)
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.WriteString(f, file.contents); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestRunTests_Zip(t *testing.T) {
+	file, err := ioutil.TempFile("", "flux-tests-*.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(file.Name()) }()
+
+	w := zip.NewWriter(file)
+	if err := writeArchive(w.Create); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	h := MockHarness{}
+	if err := tests.RunTests(context.Background(), &h, file.Name()); err != nil {
+		t.Fatal(err)
+	}
+
+	// There should have been one query that was executed.
+	if want, got := 1, len(h.Queries); want != got {
+		t.Fatalf("unexpected number of executed queries -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	if !strings.Contains(h.Queries[0], "/* test contents */") {
+		t.Fatal("unable to find /* test contents */ string in the query")
+	}
+}


### PR DESCRIPTION
The test harness can be implemented to use different ways of interacting
with a flux provider. Each of these test harnesses can use the same
scaffolding to read tests directly from the filesystem or to read them
from an archive on the filesystem.

Fixes #3334.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written