### PR TITLE
chore: install a working sccache

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -137,7 +137,14 @@ RUN rustup target add \
     x86_64-apple-darwin
 
 # Install wasm-pack and sccache
-RUN cargo install wasm-pack sccache
+RUN cargo install wasm-pack
+# XXX: rockstar (30 Nov 2020) - The most recently released sccache has an
+# issue with rust 1.48. This revision from master gets us a working sccache.
+# See https://github.com/influxdata/flux/issues/3357
+RUN cargo install \
+    --git https://github.com/mozilla/sccache.git \
+    --rev 6628e1f70db3d583cb5e79210603ad878de3d315 \
+    sccache
 RUN rustup component add rust-std --target wasm32-unknown-unknown
 
 # Use sccache rustc wrapper for friendly build caching


### PR DESCRIPTION
This patch installs a working `sccache` from the `master` branch. Once
this image is built, we can re-enable `sccache` in flux.