### PR TITLE
fix(stdlib/strings): substring method now works on more indices

### DIFF
--- a/stdlib/strings/strings_test.go
+++ b/stdlib/strings/strings_test.go
@@ -2,7 +2,6 @@ package strings
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 	"unicode"
@@ -1330,7 +1329,6 @@ func TestSubstring(t *testing.T) {
 			start:     0,
 			end:       6,
 			want:      "influx",
-			expectErr: errors.New("indices out of bounds"),
 		},
 		{
 			name:      "simple substring",
@@ -1338,7 +1336,6 @@ func TestSubstring(t *testing.T) {
 			start:     2,
 			end:       5,
 			want:      "flu",
-			expectErr: errors.New("indices out of bounds"),
 		},
 		{
 			name:      "chinese",
@@ -1346,7 +1343,6 @@ func TestSubstring(t *testing.T) {
 			start:     2,
 			end:       5,
 			want:      "汉字汉",
-			expectErr: errors.New("indices out of bounds"),
 		},
 		{
 			name:      "chinese and space",
@@ -1354,31 +1350,34 @@ func TestSubstring(t *testing.T) {
 			start:     4,
 			end:       7,
 			want:      "字  ",
-			expectErr: errors.New("indices out of bounds"),
 		},
 		{
 			name:      "alpha",
 			v:         "ineedmesomeabcsoup",
 			start:     -1,
 			end:       7,
-			want:      "",
-			expectErr: errors.New("indices out of bounds"),
+			want:      "ineedme",
 		},
 		{
 			name:      "beta",
 			v:         "ineedmesomeabcsoup",
 			start:     0,
 			end:       3389,
-			want:      "",
-			expectErr: errors.New("indices out of bounds"),
+			want:      "ineedmesomeabcsoup",
 		},
 		{
 			name:      "alphabet",
 			v:         "ineedmesomeabcsoup",
 			start:     -289,
 			end:       23948,
-			want:      "",
-			expectErr: errors.New("indices out of bounds"),
+			want:      "ineedmesomeabcsoup",
+		},
+		{
+			name: "empty string",
+			v: "influx",
+			start: 0,
+			end: 0,
+			want: "",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
The substring method in the strings package now works properly when the
start or end index isn't within the bounds of the existing string. It
truncates these indices to be the start or end of the string. This
reduces the need to check the length of the string to get a substring of
a certain size and makes it work more similar to how the javascript
substring operates.

This also fixes the case where both the start and the end index are
zero. This was erroneously creating a string of 1 character when it
should have been zero.

Fixes #3368.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written