### PR TITLE
fix(compiler): do not allow containers within a record to be null

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -455,10 +455,12 @@ func compile(n semantic.Node, subst map[uint64]semantic.MonoType, scope Scope) (
 		if err != nil {
 			return nil, err
 		}
+		t := apply(subst, nil, n.TypeOf())
 		return &memberEvaluator{
 			t:        apply(subst, nil, n.TypeOf()),
 			object:   object,
 			property: n.Property,
+			nullable: isNullable(t),
 		}, nil
 	case *semantic.IndexExpression:
 		arr, err := compile(n.Array, subst, scope)
@@ -689,4 +691,10 @@ func containsStr(strs []string, str string) bool {
 		}
 	}
 	return false
+}
+
+// isNullable will report if the MonoType is capable of being nullable.
+func isNullable(t semantic.MonoType) bool {
+	n := t.Nature()
+	return n != semantic.Array && n != semantic.Object && n != semantic.Dictionary
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -475,6 +475,52 @@ func TestCompileAndEval(t *testing.T) {
 			}),
 			want: values.NewBool(true),
 		},
+		{
+			name: "null array",
+			fn:   `(r) => r.a[0]`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("r"), Value: semantic.NewObjectType([]semantic.PropertyType{
+					{Key: []byte("a"), Value: semantic.NewArrayType(semantic.BasicString)},
+				})},
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"r": values.NewObjectWithValues(nil),
+			}),
+			wantEvalErr: true,
+		},
+		{
+			name: "null record",
+			fn:   `(r) => r.a["b"]`,
+			inType: semantic.NewObjectType([]semantic.PropertyType{
+				{Key: []byte("r"), Value: semantic.NewObjectType([]semantic.PropertyType{
+					{Key: []byte("a"), Value: semantic.NewObjectType([]semantic.PropertyType{
+						{Key: []byte("b"), Value: semantic.BasicString},
+					})},
+				})},
+			}),
+			input: values.NewObjectWithValues(map[string]values.Value{
+				"r": values.NewObjectWithValues(nil),
+			}),
+			wantEvalErr: true,
+		},
+		// TODO(jsternberg): We presently have not implemented dictionary support for
+		// runtime functions. There aren't any builtins that use this functionality,
+		// but when we do, this test will need to be uncommented to ensure that
+		// a null dictionary does not sneak in.
+		// {
+		// 	name: "null dict",
+		//	fn: `import "dict"
+		// (r) => dict.get(dict: r.a, key: "b", default: "")`,
+		//	inType: semantic.NewObjectType([]semantic.PropertyType{
+		//		{Key: []byte("r"), Value: semantic.NewObjectType([]semantic.PropertyType{
+		//			{Key: []byte("a"), Value: semantic.NewDictType(semantic.BasicString, semantic.BasicString)},
+		//		})},
+		//	}),
+		//	input: values.NewObjectWithValues(map[string]values.Value{
+		//		"r": values.NewObjectWithValues(nil),
+		//	}),
+		//	wantEvalErr: true,
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -487,6 +487,7 @@ type memberEvaluator struct {
 	t        semantic.MonoType
 	object   Evaluator
 	property string
+	nullable bool
 }
 
 func (e *memberEvaluator) Type() semantic.MonoType {
@@ -498,7 +499,10 @@ func (e *memberEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, 
 	if err != nil {
 		return nil, err
 	}
-	v, _ := o.Object().Get(e.property)
+	v, ok := o.Object().Get(e.property)
+	if !ok && !e.nullable {
+		return nil, errors.Newf(codes.Invalid, "member %q with type %s is not in the record", e.property, e.t.Nature())
+	}
 	return v, nil
 }
 


### PR DESCRIPTION
When we retrieve a missing parameter from a record, we should not allow
it to return a null value if we know we are supposed to be returning one
of the container types (array, record, or dict). Those three are not
nullable so it is not valid for null to be returned. Instead, an error
is returned instead.

Fixes #3374.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written