### PR TITLE
fix(lang): change extern parsing code to return a more descriptive error message

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -190,7 +190,7 @@ func (c FluxCompiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.P
 	if IsNonNullJSON(c.Extern) {
 		hdl, err := runtime.JSONToHandle(wrapFileJSONInPkg(c.Extern))
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, codes.Inherit, "extern json parse error")
 		}
 		return Compile(query, runtime, c.Now, WithExtern(hdl))
 	}

--- a/libflux/go/libflux/parser.go
+++ b/libflux/go/libflux/parser.go
@@ -135,7 +135,7 @@ func ParseJSON(bs []byte) (*ASTPkg, error) {
 		defer C.flux_free_bytes(cstr)
 
 		str := C.GoString(cstr)
-		return nil, errors.Newf(codes.Internal, "could not get handle from JSON AST: %v", str)
+		return nil, errors.New(codes.Invalid, str)
 	}
 	p := &ASTPkg{ptr: ptr}
 	runtime.SetFinalizer(p, free)


### PR DESCRIPTION
The error parsing code returned an internal error from the rust library
and gave a cryptic "error getting json handle" which was specific to
the libflux and go interaction. This has changed the library to make the
parser an invalid error and make the error message specifically cite
that the extern json was what caused the error.

Fixes #3014.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written