### PR TITLE
feat(tests): add ways to execute tests from tar and zip archives

### DIFF
--- a/internal/errors/std.go
+++ b/internal/errors/std.go
@@ -1,0 +1,8 @@
+package errors
+
+import "errors"
+
+// Is is a wrapper around the errors.Is function.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}


### PR DESCRIPTION
The test command can now execute tests from tar or zip archives. It can
also execute tests from individual `.flux` files that are specified on
the command line.

This can be used for downloading a zip archive of the flux source code
from github and then executing the tests without unzipping the file.

Fixes #3334.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written