### PR TITLE
fix(stdlib/contrib): repair endpoint examples

### DIFF
--- a/stdlib/contrib/chobbs/discord/README.md
+++ b/stdlib/contrib/chobbs/discord/README.md
@@ -76,7 +76,7 @@ Here's an example definition for the `discord.endpoint()` function
       |> endpoint(mapFn: (r) => ({
               content: "Great Scott!- Disk usage is: \"${r.status}\".",
             })
-         )
+         )()
 
 ## Contact
 

--- a/stdlib/contrib/sranka/opsgenie/README.md
+++ b/stdlib/contrib/sranka/opsgenie/README.md
@@ -80,7 +80,7 @@ Basic Example:
               details: "{}",
               visibleTo: []
             })
-         )
+         )()
 
 
 ## Contact

--- a/stdlib/contrib/sranka/sensu/README.md
+++ b/stdlib/contrib/sranka/sensu/README.md
@@ -74,7 +74,7 @@ Basic Example:
               text: "Great Scott!- Disk usage is: **${r.status}**.", 
               status: 0
             })
-         )
+         )()
 
 
 ## Contact

--- a/stdlib/contrib/sranka/teams/README.md
+++ b/stdlib/contrib/sranka/teams/README.md
@@ -59,7 +59,7 @@ Basic Example:
               text: "Great Scott!- Disk usage is: **${r.status}**.",
               summary: "Disk Usage is ${r.status}"
             })
-         )
+         )()
 
 ## Contact
 

--- a/stdlib/contrib/sranka/telegram/README.md
+++ b/stdlib/contrib/sranka/telegram/README.md
@@ -77,7 +77,7 @@ Basic Example:
               text: "Great Scott!- Disk usage is: **${r.status}**.", 
               silent: true
             })
-         )
+         )()
 
 ## Contact
 


### PR DESCRIPTION
This PR repairs examples in `stdlib/contrib` packages, a pipe destination must be a function call.