### PR TITLE
chore: remove redundant test

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -274,7 +274,7 @@ var sourceHashes = map[string]string{
 	"stdlib/strings/replaceAll_test.flux":                                           "150855a7397ceb1d91d86f9db4a927b102956f59e520f895eea5c677e4be25c3",
 	"stdlib/strings/replace_test.flux":                                              "51d08cf36386e05767c37745f66e980b3e97249482794c78c7b8a9979acd4c8e",
 	"stdlib/strings/strings.flux":                                                   "e7530ea357aaa63ad1a3fd3149ed621ae0d08d153304617361a1e6a9694e2575",
-	"stdlib/strings/strings_test.flux":                                              "35db0f8abc6fa7788af40edcdc665700a6314ea78a77a6a44e8a1bdf8ac52ad1",
+	"stdlib/strings/strings_test.flux":                                              "e2d6a68ad5d337df502aae76cb5d93caa477af9ddceb4a12cf05b063dcb343f1",
 	"stdlib/strings/subset_test.flux":                                               "21b349deb37812a6f58b54fd0914de90cdb3743d456e92cc19a78edcf38dd7fd",
 	"stdlib/strings/substring_test.flux":                                            "825ef54ae0372ab2a433f3507d694451558cdc03c2f1b5b52b385ca18b33df73",
 	"stdlib/strings/title_test.flux":                                                "3783991b1081d1116a690293d5689c41912e69faa5fbb97c7af663ee1f6f64cf",

--- a/stdlib/strings/strings_test.flux
+++ b/stdlib/strings/strings_test.flux
@@ -118,26 +118,6 @@ testcase string_subset {
     testing.diff(got: result, want: testing.loadMem(csv: outData))
 }
 
-testcase string_subset {
-    outData = "
-#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,string
-#group,false,false,true,true,false,false,true,true,true,true,true,true
-#default,_result,,,,,,,,,,,
-,result,table,_start,_stop,_time,_value,_field,_measurement,device,fstype,host,path
-,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:26Z,字,used_percent,disk,disk1,apfs,host.local,/
-,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:36Z,k,used_percent,disk,disk1,apfs,host.local,/
-,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:46Z,b,used_percent,disk,disk1,apfs,host.local,/
-,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:53:56Z,2,used_percent,disk,disk1,apfs,host.local,/
-,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:06Z,c,used_percent,disk,disk1,apfs,host.local,/
-,,0,2018-05-22T19:53:26Z,2030-01-01T00:00:00Z,2018-05-22T19:54:16Z,1,used_percent,disk,disk1,apfs,host.local,/
-"
-    result = testing.loadStorage(csv: inData)
-		|> range(start: 2018-05-22T19:53:26Z)
-		|> map(fn: (r) =>
-        			({r with _value: strings.substring(v: r._value, start: 0, end: 1)}))
-    testing.diff(got: result, want: testing.loadMem(csv: outData))
-}
-
 testcase string_replaceAll {
     outData = "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,string


### PR DESCRIPTION
This patch removes a redundant `testcase_subset` test that I noticed
as I was working to run these tests in idpe.