### PR TITLE
Feat/fluxdoc Fix bootstrap link quotes

### DIFF
--- a/libflux/fluxdoc/templates/base.html
+++ b/libflux/fluxdoc/templates/base.html
@@ -9,7 +9,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="shortcut icon" href="/img/favicon.png" type="image/png" sizes="32x32">
-    <link rel=“stylesheet” href=“https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css” integrity=“sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm” crossorigin=“anonymous”>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/stylesheet.css" media="screen"/>
 
     <meta name="Copyright" content="InfluxData Inc." />


### PR DESCRIPTION
The bootstrap <link> tag appears to be using smart quotes, this replaces them with normal ones