### PR TITLE
feat: validate IP addresses from the dialer Control function

### DIFF
--- a/dependencies/http/http.go
+++ b/dependencies/http/http.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -53,17 +52,6 @@ func (l roundTripLimiter) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 	response.Body = limitReadCloser(response.Body, l.size)
 	return response, nil
-}
-
-// Check all redirects for invalid URLs.
-func checkRedirect(validator url.Validator) func(req *http.Request, via []*http.Request) error {
-	return func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-
-		return validator.Validate(req.URL)
-	}
 }
 
 // NewDefaultClient creates a client with sane defaults.

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -3,12 +3,15 @@ package http
 import (
 	"bytes"
 	"io/ioutil"
+	"log"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/foxcpp/go-mockdns"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/codes"
 	depsUrl "github.com/influxdata/flux/dependencies/url"
@@ -54,23 +57,87 @@ func TestLimitedDefaultClient(t *testing.T) {
 	})
 }
 
-// The TestValidator will let everything through _except_ a specific url, which
-// is redirected to from a http test server.
+// Mocking DNS to resolve to blocked IP ranges and ensuring the connections
+// fail. ADT: Would be nice to also test some pass cases, but it is unclear how
+// to prevent the actual network connection out to the public internet. It's
+// the dialer control function we are testing, so we can't mock the dialer to
+// achieve that.
+func TestIpValidation(t *testing.T) {
+	bad := map[string]mockdns.Zone{
+		"bad01.example.org.": {A: []string{"127.0.0.1"}},
+		"bad02.example.org.": {A: []string{"127.10.20.30"}},
+		"bad03.example.org.": {A: []string{"172.23.1.2"}},
+		"bad04.example.org.": {A: []string{"192.168.0.0"}},
+		"bad05.example.org.": {A: []string{"169.254.0.1"}},
+		"bad06.example.org.": {AAAA: []string{"0000:0000:0000:0000:0000:0000:0000:0001"}},
+		"bad07.example.org.": {AAAA: []string{"fc80:0000:0000:0000:0000:0000:0000:0001"}},
+		"bad08.example.org.": {AAAA: []string{"fc00:0000:0000:0000:0000:0000:0000:0001"}},
+	}
+
+	// Mock a dns server.
+	dnsLogger := log.New(ioutil.Discard, "mockdns server: ", log.LstdFlags)
+	srv, _ := mockdns.NewServerWithLogger(bad, dnsLogger, false)
+	defer srv.Close()
+
+	// Hack the default resolver to use this server.
+	srv.PatchNet(net.DefaultResolver)
+	defer mockdns.UnpatchNet(net.DefaultResolver)
+
+	client := NewDefaultClient(depsUrl.PrivateIPValidator{})
+
+	for k, _ := range bad {
+		req, err := http.NewRequest("POST", ("http://" + k + "/path"), bytes.NewReader([]byte{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = client.Do(req)
+		if err == nil {
+			t.Fatal("expected private IP validation error, but client.Do succeeded")
+		} else {
+			if !strings.HasSuffix(err.Error(), "it connects to a private IP") {
+				t.Fatalf("expected private IP validation error, but got %v", err)
+			}
+		}
+	}
+}
+
+// The TestValidator will let everything through _except_ a specific IP, which
+// is redirected to from an http test server. We must mock the validator
+// because the original connection goes to localhost and that must be
+// permitted, so it can send the redirect.
 type TestValidator struct{}
 
 func (TestValidator) Validate(anUrl *url.URL) error {
-	if anUrl.Host == "test-validator.example.com" {
+	return nil
+}
+
+func (TestValidator) ValidateIP(ip net.IP) error {
+	if ip.Equal( net.ParseIP("127.6.6.6") ) {
 		return errors.New(codes.Invalid, "url validation error, it connects to a private IP")
 	}
 	return nil
 }
 
 func TestInvalidRedirects(t *testing.T) {
+	bad := map[string]mockdns.Zone{
+		"bad01.example.com.": {A: []string{"127.6.6.6"}},
+	}
+
+	// Mock a dns server.
+	dnsLogger := log.New(ioutil.Discard, "mockdns server: ", log.LstdFlags)
+	srv, _ := mockdns.NewServerWithLogger(bad, dnsLogger, false)
+	defer srv.Close()
+
+	// Hack the default resolver to use this server.
+	srv.PatchNet(net.DefaultResolver)
+	defer mockdns.UnpatchNet(net.DefaultResolver)
+
 	t.Run("redirects to localhost are rejected", func(t *testing.T) {
 		client := NewDefaultClient(TestValidator{})
 
 		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-			http.Redirect(w, request, "http://test-validator.example.com", http.StatusMovedPermanently)
+			http.Redirect(w, request, "http://bad01.example.com", http.StatusMovedPermanently)
 		}))
 		defer testServer.Close()
 

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -86,7 +86,7 @@ func TestIpValidation(t *testing.T) {
 
 	client := NewDefaultClient(depsUrl.PrivateIPValidator{})
 
-	for k, _ := range bad {
+	for k := range bad {
 		req, err := http.NewRequest("POST", ("http://" + k + "/path"), bytes.NewReader([]byte{}))
 		if err != nil {
 			t.Fatal(err)
@@ -114,7 +114,7 @@ func (TestValidator) Validate(anUrl *url.URL) error {
 }
 
 func (TestValidator) ValidateIP(ip net.IP) error {
-	if ip.Equal( net.ParseIP("127.6.6.6") ) {
+	if ip.Equal(net.ParseIP("127.6.6.6")) {
 		return errors.New(codes.Invalid, "url validation error, it connects to a private IP")
 	}
 	return nil

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -61,7 +61,8 @@ func TestLimitedDefaultClient(t *testing.T) {
 // fail. ADT: Would be nice to also test some pass cases, but it is unclear how
 // to prevent the actual network connection out to the public internet. It's
 // the dialer control function we are testing, so we can't mock the dialer to
-// achieve that.
+// achieve that. Can really only replace the validator to pass a connetion to
+// localhost. Doing that below the redirect test.
 func TestIpValidation(t *testing.T) {
 	bad := map[string]mockdns.Zone{
 		"bad01.example.org.": {A: []string{"127.0.0.1"}},

--- a/dependencies/url/validator.go
+++ b/dependencies/url/validator.go
@@ -72,7 +72,7 @@ func init() {
 	}
 }
 
-//  IsPrivateIP reports whether an IP exists in a known private IP space.
+//  isPrivateIP reports whether an IP exists in a known private IP space.
 func isPrivateIP(ip net.IP) bool {
 	for _, block := range privateIPBlocks {
 		if block.Contains(ip) {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/dave/jennifer v1.2.0
 	github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc
 	github.com/eclipse/paho.mqtt.golang v1.2.0
+	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -197,6 +199,8 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104 h1:d8RFOZ2IiFtFWBcKEH
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/miekg/dns v1.1.22 h1:Jm64b3bO9kP43ddLjL2EY3Io6bmy1qGb9Xxz6TqS6rc=
+github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -278,6 +282,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
@@ -332,6 +337,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -366,6 +372,8 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -396,6 +404,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/stdlib/http/post.go
+++ b/stdlib/http/post.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
@@ -24,22 +23,10 @@ func init() {
 		"post",
 		runtime.MustLookupBuiltinType("http", "post"),
 		func(ctx context.Context, args values.Object) (values.Value, error) {
-			// Get and validate URL
+			// Get URL
 			uV, ok := args.Get("url")
 			if !ok {
 				return nil, errors.New(codes.Invalid, "missing \"url\" parameter")
-			}
-			u, err := url.Parse(uV.Str())
-			if err != nil {
-				return nil, err
-			}
-			deps := flux.GetDependencies(ctx)
-			validator, err := deps.URLValidator()
-			if err != nil {
-				return nil, err
-			}
-			if err := validator.Validate(u); err != nil {
-				return nil, err
 			}
 
 			// Construct data
@@ -72,6 +59,7 @@ func init() {
 			}
 
 			// Perform request
+			deps := flux.GetDependencies(ctx)
 			dc, err := deps.HTTPClient()
 			if err != nil {
 				return nil, errors.Wrap(err, codes.Aborted, "missing client in http.post")

--- a/stdlib/http/post_test.go
+++ b/stdlib/http/post_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
+	fluxhttp "github.com/influxdata/flux/dependencies/http"
 	"github.com/influxdata/flux/dependencies/url"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/runtime"
@@ -75,8 +76,7 @@ http.post(url:"http://127.1.1.1/path/a/b/c", headers: {x:"a",y:"b",z:"c"}, data:
 `
 
 	deps := flux.NewDefaultDependencies()
-	deps.Deps.HTTPClient = http.DefaultClient
-	deps.Deps.URLValidator = url.PrivateIPValidator{}
+	deps.Deps.HTTPClient = fluxhttp.NewDefaultClient(url.PrivateIPValidator{})
 	ctx := deps.Inject(context.Background())
 	_, _, err := runtime.Eval(ctx, script)
 	if err == nil {


### PR DESCRIPTION
The dialer provides a function that gets called after DNS resolution, but
before the network connection is initiated. Use that to validate IP addresses.
This replaces URL-based validation where the IP address is resolved before the
post, and during any redirects. This method prevents attacks where the IP
address is changed between validation and connect. Fixes influxdata/idpe#9480.