### PR TITLE
fix(execute): use random dataset ids instead of ones hashed from the name

### DIFF
--- a/execute/dataset.go
+++ b/execute/dataset.go
@@ -61,8 +61,20 @@ func (id DatasetID) IsZero() bool {
 	return id == ZeroDatasetID
 }
 
+// DatasetIDFromNodeID constructs a DatasetID from
+// the plan.NodeID.
+//
+// This method is used to create **consistent** DatasetID
+// values from a plan.NodeID. If two nodes have the same id,
+// they will have the same DatasetID.
 func DatasetIDFromNodeID(id plan.NodeID) DatasetID {
 	return DatasetID(uuid.NewV5(uuid.UUID{}, string(id)))
+}
+
+// RandomDatasetID will construct a new random DatasetID.
+func RandomDatasetID() (DatasetID, error) {
+	did, err := uuid.NewV4()
+	return DatasetID(did), err
 }
 
 type dataset struct {
@@ -83,6 +95,10 @@ func NewDataset(id DatasetID, accMode AccumulationMode, cache DataCache) *datase
 		accMode: accMode,
 		cache:   cache,
 	}
+}
+
+func (d *dataset) ID() DatasetID {
+	return d.id
 }
 
 func (d *dataset) AddTransformation(t Transformation) {
@@ -182,6 +198,10 @@ type PassthroughDataset struct {
 // NewPassthroughDataset constructs a new PassthroughDataset.
 func NewPassthroughDataset(id DatasetID) *PassthroughDataset {
 	return &PassthroughDataset{id: id}
+}
+
+func (d *PassthroughDataset) ID() DatasetID {
+	return d.id
 }
 
 func (d *PassthroughDataset) AddTransformation(t Transformation) {

--- a/execute/executetest/dataset.go
+++ b/execute/executetest/dataset.go
@@ -17,7 +17,7 @@ func RandomDatasetID() execute.DatasetID {
 }
 
 type Dataset struct {
-	ID                    execute.DatasetID
+	DatasetID             execute.DatasetID
 	Retractions           []flux.GroupKey
 	ProcessingTimeUpdates []execute.Time
 	WatermarkUpdates      []execute.Time
@@ -27,8 +27,12 @@ type Dataset struct {
 
 func NewDataset(id execute.DatasetID) *Dataset {
 	return &Dataset{
-		ID: id,
+		DatasetID: id,
 	}
+}
+
+func (d *Dataset) ID() execute.DatasetID {
+	return d.DatasetID
 }
 
 func (d *Dataset) AddTransformation(t execute.Transformation) {
@@ -83,7 +87,7 @@ func TransformationPassThroughTestHelper(t *testing.T, newTr NewTransformation) 
 	tr.Finish(parentID, nil)
 
 	exp := &Dataset{
-		ID:                    d.ID,
+		DatasetID:             d.DatasetID,
 		ProcessingTimeUpdates: []execute.Time{now},
 		WatermarkUpdates:      []execute.Time{now},
 		Finished:              true,

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -153,7 +153,10 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 	}
 	spec := node.ProcedureSpec()
 	kind := spec.Kind()
-	id := DatasetIDFromNodeID(node.ID())
+	id, err := RandomDatasetID()
+	if err != nil {
+		return err
+	}
 
 	if yieldSpec, ok := spec.(plan.YieldProcedureSpec); ok {
 		r := newResult(yieldSpec.YieldName())
@@ -180,7 +183,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 	}
 
 	for i, pred := range nonYieldPredecessors(node) {
-		ec.parents[i] = DatasetIDFromNodeID(pred.ID())
+		ec.parents[i] = v.nodes[pred].ID()
 	}
 
 	// If node is a leaf, create a source

--- a/execute/source.go
+++ b/execute/source.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Node interface {
+	ID() DatasetID
 	AddTransformation(t Transformation)
 }
 

--- a/execute/source_iterator.go
+++ b/execute/source_iterator.go
@@ -37,6 +37,10 @@ type sourceDecoder struct {
 	ts      []Transformation
 }
 
+func (c *sourceDecoder) ID() DatasetID {
+	return c.id
+}
+
 func (c *sourceDecoder) Do(ctx context.Context, f func(flux.Table) error) error {
 	err := c.decoder.Connect(ctx)
 	if err != nil {
@@ -108,6 +112,10 @@ type sourceIterator struct {
 	id       DatasetID
 	ts       []Transformation
 	iterator SourceIterator
+}
+
+func (s *sourceIterator) ID() DatasetID {
+	return s.id
 }
 
 func (s *sourceIterator) AddTransformation(t Transformation) {

--- a/internal/execute/table/dataset.go
+++ b/internal/execute/table/dataset.go
@@ -24,6 +24,10 @@ func NewDataset(id execute.DatasetID, cache *BuilderCache) execute.Dataset {
 	}
 }
 
+func (d *dataset) ID() execute.DatasetID {
+	return d.id
+}
+
 func (d *dataset) AddTransformation(t execute.Transformation) {
 	d.ts = append(d.ts, t)
 }

--- a/mock/source.go
+++ b/mock/source.go
@@ -10,8 +10,13 @@ import (
 // By default it does nothing.
 type Source struct {
 	execute.ExecutionNode
+	id                  execute.DatasetID
 	AddTransformationFn func(transformation execute.Transformation)
 	RunFn               func(ctx context.Context)
+}
+
+func (s *Source) ID() execute.DatasetID {
+	return s.id
 }
 
 func (s *Source) AddTransformation(t execute.Transformation) {
@@ -30,5 +35,5 @@ func (s *Source) Run(ctx context.Context) {
 // of your test:
 //    execute.RegisterSource(influxdb.FromKind, mock.CreateMockFromSource)
 func CreateMockFromSource(spec plan.ProcedureSpec, id execute.DatasetID, ctx execute.Administration) (execute.Source, error) {
-	return &Source{}, nil
+	return &Source{id: id}, nil
 }

--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -131,6 +131,10 @@ type CSVSource struct {
 	alloc *memory.Allocator
 }
 
+func (c *CSVSource) ID() execute.DatasetID {
+	return c.id
+}
+
 func (c *CSVSource) AddTransformation(t execute.Transformation) {
 	c.ts = append(c.ts, t)
 }

--- a/stdlib/experimental/array/from.go
+++ b/stdlib/experimental/array/from.go
@@ -97,6 +97,10 @@ type tableSource struct {
 	ts   execute.TransformationSet
 }
 
+func (s *tableSource) ID() execute.DatasetID {
+	return s.id
+}
+
 func (s *tableSource) AddTransformation(t execute.Transformation) {
 	s.ts = append(s.ts, t)
 }

--- a/stdlib/influxdata/influxdb/source.go
+++ b/stdlib/influxdata/influxdb/source.go
@@ -60,6 +60,10 @@ func CreateSource(id execute.DatasetID, spec RemoteProcedureSpec, a execute.Admi
 	return s, nil
 }
 
+func (s *source) ID() execute.DatasetID {
+	return s.id
+}
+
 func (s *source) AddTransformation(t execute.Transformation) {
 	s.ts = append(s.ts, t)
 }

--- a/stdlib/influxdata/influxdb/v1/from_influx_json.go
+++ b/stdlib/influxdata/influxdb/v1/from_influx_json.go
@@ -145,6 +145,10 @@ type JSONSource struct {
 	ts      []execute.Transformation
 }
 
+func (c *JSONSource) ID() execute.DatasetID {
+	return c.id
+}
+
 func (c *JSONSource) AddTransformation(t execute.Transformation) {
 	c.ts = append(c.ts, t)
 }

--- a/stdlib/internal/gen/tables.go
+++ b/stdlib/internal/gen/tables.go
@@ -161,6 +161,10 @@ type Source struct {
 	alloc  *memory.Allocator
 }
 
+func (s *Source) ID() execute.DatasetID {
+	return s.id
+}
+
 func (s *Source) AddTransformation(t execute.Transformation) {
 	s.ts = append(s.ts, t)
 }

--- a/stdlib/internal/promql/empty_table.go
+++ b/stdlib/internal/promql/empty_table.go
@@ -74,6 +74,10 @@ type EmptyTableSource struct {
 	ts []execute.Transformation
 }
 
+func (s *EmptyTableSource) ID() execute.DatasetID {
+	return s.id
+}
+
 func (s *EmptyTableSource) AddTransformation(t execute.Transformation) {
 	s.ts = append(s.ts, t)
 }

--- a/stdlib/socket/from.go
+++ b/stdlib/socket/from.go
@@ -189,6 +189,10 @@ type socketSource struct {
 	ts      []execute.Transformation
 }
 
+func (ss *socketSource) ID() execute.DatasetID {
+	return ss.d
+}
+
 func (ss *socketSource) AddTransformation(t execute.Transformation) {
 	ss.ts = append(ss.ts, t)
 }


### PR DESCRIPTION
The executor would create the dataset id by using the plan node name.
While plan node names are usually unique, they aren't necessarily
guaranteed to be unique. This would cause multiple datasets to have the
same id and could cause a conflict.

This further protects against that situation by changing uuid generation
for dataset ids to use the v4 algorithm which uses a random number
generator.

Fixes #3053.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written