### PR TITLE
feat(values): improve performance for accessing data within a Value

### DIFF
--- a/internal/errors/std.go
+++ b/internal/errors/std.go
@@ -6,3 +6,8 @@ import "errors"
 func Is(err, target error) bool {
 	return errors.Is(err, target)
 }
+
+// As is a wrapper around the errors.As function.
+func As(err error, target interface{}) bool {
+	return errors.As(err, target)
+}

--- a/semantic/monotype.go
+++ b/semantic/monotype.go
@@ -21,6 +21,7 @@ type fbTabler interface {
 type MonoType struct {
 	mt  fbsemantic.MonoType
 	tbl fbTabler
+	n   Nature
 }
 
 // NewMonoType constructs a new monotype from a FlatBuffers table and the given kind of monotype.
@@ -45,14 +46,23 @@ func NewMonoType(tbl flatbuffers.Table, t fbsemantic.MonoType) (MonoType, error)
 		return MonoType{}, errors.Newf(codes.Internal, "unknown type (%v)", t)
 	}
 	tbler.Init(tbl.Bytes, tbl.Pos)
-	return MonoType{mt: t, tbl: tbler}, nil
+	return MonoType{
+		mt:  t,
+		tbl: tbler,
+		n:   nature(tbl, t),
+	}, nil
 }
 
 func (mt MonoType) Nature() Nature {
-	switch mt.mt {
+	return mt.n
+}
+
+func nature(tbl flatbuffers.Table, t fbsemantic.MonoType) Nature {
+	switch t {
 	case fbsemantic.MonoTypeBasic:
-		t, _ := mt.Basic()
-		switch t {
+		var basic fbsemantic.Basic
+		basic.Init(tbl.Bytes, tbl.Pos)
+		switch basic.T() {
 		case fbsemantic.TypeBool:
 			return Bool
 		case fbsemantic.TypeInt:

--- a/values/values_test.go
+++ b/values/values_test.go
@@ -2,9 +2,14 @@ package values_test
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -35,5 +40,88 @@ func TestNewNull(t *testing.T) {
 	v := values.NewNull(semantic.BasicString)
 	if want, got := true, v.IsNull(); want != got {
 		t.Fatalf("unexpected value -want/+got\n\t- %v\n\t+ %v", want, got)
+	}
+}
+
+func TestUnexpectedKind(t *testing.T) {
+	err := values.UnexpectedKind(semantic.String, semantic.Float)
+	if want, got := "unexpected kind: got \"string\" expected \"float\", trace:", err.Error(); !strings.HasPrefix(got, want) {
+		t.Fatalf("unexpected error -want prefix/+got\n\t- %q\n\t+ %q", want, got)
+	}
+
+	// Ensure that it can be read as a *flux.Error.
+	var ferr *flux.Error
+	if !errors.As(err, &ferr) {
+		t.Fatal("could not read unexpected kind error as a flux error")
+	}
+
+	if want, got := codes.Internal, ferr.Code; want != got {
+		t.Fatalf("unexpected code -want/+got:\n\t- %s\n\t+ %s", want, got)
+	}
+}
+
+// result stores results from the benchmark at the package level.
+// Assigning to a global value prevents the optimizer from removing
+// the assignment as it cannot determine whether the value will
+// be read or not.
+var result struct {
+	Str      string
+	Bytes    []byte
+	Int      int64
+	Uint     uint64
+	Float    float64
+	Bool     bool
+	Time     values.Time
+	Duration values.Duration
+}
+
+func BenchmarkValue_Str(b *testing.B) {
+	v := values.NewString("abc")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result.Str = v.Str()
+	}
+}
+
+func BenchmarkValue_Bytes(b *testing.B) {
+	v := values.NewBytes([]byte("abc"))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result.Bytes = v.Bytes()
+	}
+}
+
+func BenchmarkValue_Int(b *testing.B) {
+	// Numbers 0-255 do not cause an allocation because
+	// of an optimization in go 1.15. We want to avoid this
+	// optimization to avoid skewing the benchmark.
+	v := values.NewInt(int64(rand.Intn(1000) + 256))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result.Int = v.Int()
+	}
+}
+
+func BenchmarkValue_UInt(b *testing.B) {
+	v := values.NewUInt(rand.Uint64())
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result.Uint = v.UInt()
+	}
+}
+
+func BenchmarkValue_Float(b *testing.B) {
+	v := values.NewFloat(rand.Float64())
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result.Float = v.Float()
+	}
+}
+
+func BenchmarkValue_Bool(b *testing.B) {
+	v := values.NewBool(true)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result.Bool = v.Bool()
 	}
 }


### PR DESCRIPTION
The `values.Value` interface represents a flux value and it is used by a
large number of runtime functions. The default implementation of the
basic values implements the data access functions, such as `Float()` and
`Int()`, for those respective types.

These access functions were deemed too complex to inline and so
performance was worse for accessing this data.

    values/values.go:69:6: cannot inline value.Float: function too complex: cost 135 exceeds budget 80

One reason is because `semantic.MonoType` required accessing the
flatbuffers data to determine the type nature. Instead of looking up the
type nature through a large function, this lookup has been moved to the
creation of the `semantic.MonoType` so that checking the nature is
accessing a member variable. For basic types, which generally use the
cached `semantic.BasicString`, this means that the type lookup is
incurred once instead of each time the value is accessed.

The other reason is because the panic function, `UnexpectedKind`, was
deemed too hairy by the go inliner. In order to optimize this function,
a new `unexpectedKind` error type was created and used to construct the
error. This `unexpectedKind` error type implements the `errors.As()`
function and can be accessed as a `*flux.Error`.

    err := values.UnexpectedKind(...)
    var ferr *flux.Error
    if errors.As(err, &ferr) {
        // As a flux error.
    }

This is the standard method of casting error types in go since 1.13.

Now, the `Float()` method is simpler and can be inlined.

    values/values.go:69:6: can inline value.Float with cost 31 as: method(value) func() float64 { CheckKind(v.t.Nature(), semantic.Float); return v.v.(float64) }

While the function itself and faster and can be inlined, there is still
a possibility that it will be faster but not inlined. This is because
`values.Value` is an interface and inlining isn't generally possible.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written