### PR TITLE
feat(execute): improve performance of random access group lookup by utilizing xxhash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/benbjohnson/immutable v0.2.1
 	github.com/bonitoo-io/go-sql-bigquery v0.3.4-1.4.0
 	github.com/c-bata/go-prompt v0.2.2
-	github.com/cespare/xxhash v1.1.0
+	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/dave/jennifer v1.2.0
 	github.com/denisenkom/go-mssqldb v0.0.0-20200428022330-06a60b6afbbc
 	github.com/eclipse/paho.mqtt.golang v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
+github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cespare/xxhash"
+	"github.com/cespare/xxhash/v2"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"


### PR DESCRIPTION
This improves the performance of the random access group lookup by
utilizing xxhash to perform the hashing instead of relying on the hash
for a string value.

The primary benefit for this is that xxhash can compute a hash value
while maintaining a constant buffer and memory size. The previous
implementation utilized a string builder which could potentially result
in more allocations. This allows us to put an item into the Go map using
a uint64 key instead of relying on the string key.

It also is able to add that uint64 key to the group key itself with
minimal disruption. This helps with the common pattern of `Lookup`
followed by `Set` to prevent recomputing the hash twice.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written