### PR TITLE
fix: change the default test discovery path

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -45,7 +45,7 @@ func TestCommand(setup TestSetupFunc) *cobra.Command {
 			runFluxTests(setup, flags)
 		},
 	}
-	testCommand.Flags().StringVarP(&flags.path, "path", "p", "./stdlib", "The root level directory for all packages.")
+	testCommand.Flags().StringVarP(&flags.path, "path", "p", ".", "The root level directory for all packages.")
 	testCommand.Flags().StringSliceVar(&flags.testNames, "test", []string{}, "The name of a specific test to run.")
 	testCommand.Flags().CountVarP(&flags.verbosity, "verbose", "v", "verbose (-v, or -vv)")
 	return testCommand


### PR DESCRIPTION
This patch changes the default test path from `./stdlib` to `.`. After
implementing the test runners downstream, the original path was a bad
default.