### PR TITLE
refactor(execute): expose direct access to process message for transformations

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -62,7 +62,7 @@ type executionState struct {
 	sources []Source
 	metaCh  chan metadata.Metadata
 
-	transports []Transport
+	transports []AsyncTransport
 
 	dispatcher *poolDispatcher
 	logger     *zap.Logger
@@ -216,7 +216,6 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 			return err
 		}
 
-		tr.SetLabel(string(node.ID()))
 		if ppn.TriggerSpec == nil {
 			ppn.TriggerSpec = plan.DefaultTriggerSpec
 		}
@@ -225,7 +224,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 
 		for _, p := range nonYieldPredecessors(node) {
 			executionNode := v.nodes[p]
-			transport := newConsecutiveTransport(v.es.dispatcher, tr, node)
+			transport := newConsecutiveTransport(v.es.dispatcher, tr, node, v.es.alloc)
 			v.es.transports = append(v.es.transports, transport)
 			executionNode.AddTransformation(transport)
 		}

--- a/execute/transformation.go
+++ b/execute/transformation.go
@@ -21,8 +21,6 @@ type Transformation interface {
 	// Finish indicates that the Transformation is done processing. It is
 	// the last method called on the Transformation
 	Finish(id DatasetID, err error)
-	SetLabel(label string)
-	Label() string
 }
 
 // TransformationSet is a group of transformations.

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -7,26 +7,38 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/internal/execute/table"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 )
 
+// Transport is an interface for handling raw messages.
 type Transport interface {
-	Transformation
-	// Finished reports when the Transport has completed and there is no more work to do.
+	// ProcessMessage will process a message in the Transport.
+	ProcessMessage(m Message) error
+}
+
+// AsyncTransport is a Transport that performs its work in a separate goroutine.
+type AsyncTransport interface {
+	Transport
+	// Finished reports when the AsyncTransport has completed and there is no more work to do.
 	Finished() <-chan struct{}
 }
 
-// consecutiveTransport implements Transport by transporting data consecutively to the downstream Transformation.
+var _ Transformation = (*consecutiveTransport)(nil)
+
+// consecutiveTransport implements AsyncTransport by transporting data consecutively to the downstream Transformation.
 type consecutiveTransport struct {
 	dispatcher Dispatcher
 
-	t        Transformation
-	messages MessageQueue
-	stack    []interpreter.StackEntry
+	t         Transport
+	messages  MessageQueue
+	op, label string
+	stack     []interpreter.StackEntry
 
 	finished chan struct{}
 	errMu    sync.Mutex
@@ -36,12 +48,14 @@ type consecutiveTransport struct {
 	inflight       int32
 }
 
-func newConsecutiveTransport(dispatcher Dispatcher, t Transformation, n plan.Node) *consecutiveTransport {
+func newConsecutiveTransport(dispatcher Dispatcher, t Transformation, n plan.Node, mem memory.Allocator) *consecutiveTransport {
 	return &consecutiveTransport{
 		dispatcher: dispatcher,
-		t:          t,
+		t:          WrapTransformationInTransport(t, mem),
 		// TODO(nathanielc): Have planner specify message queue initial buffer size.
 		messages: newMessageQueue(64),
+		op:       OperationType(t),
+		label:    string(n.ID()),
 		stack:    n.CallStack(),
 		finished: make(chan struct{}),
 	}
@@ -159,6 +173,11 @@ func (t *consecutiveTransport) pushMsg(m Message) {
 	t.schedule()
 }
 
+func (t *consecutiveTransport) ProcessMessage(m Message) error {
+	t.pushMsg(m)
+	return nil
+}
+
 const (
 	// consecutiveTransport schedule states
 	idle int32 = iota
@@ -188,7 +207,7 @@ PROCESS:
 	i := 0
 	for m := t.messages.Pop(); m != nil; m = t.messages.Pop() {
 		atomic.AddInt32(&t.inflight, -1)
-		if f, err := processMessage(ctx, t.t, m); err != nil || f {
+		if f, err := t.processMessage(ctx, m); err != nil || f {
 			// Set the error if there was any
 			t.setErr(err)
 
@@ -196,7 +215,11 @@ PROCESS:
 			if t.tryTransition(running, finished) {
 				// Call Finish if we have not already
 				if !f {
-					t.t.Finish(m.SrcDatasetID(), t.err())
+					m := &finishMsg{
+						srcMessage: srcMessage(m.SrcDatasetID()),
+						err:        t.err(),
+					}
+					_ = t.t.ProcessMessage(m)
 				}
 				// We are finished
 				close(t.finished)
@@ -223,36 +246,17 @@ PROCESS:
 	}
 }
 
-func (t *consecutiveTransport) Label() string {
-	return t.t.Label()
-}
-
-func (t *consecutiveTransport) SetLabel(label string) {
-	t.t.SetLabel(label)
-}
-
 // processMessage processes the message on t.
 // The return value is true if the message was a FinishMsg.
-func processMessage(ctx context.Context, t Transformation, m Message) (finished bool, err error) {
-	switch m := m.(type) {
-	case RetractTableMsg:
-		err = t.RetractTable(m.SrcDatasetID(), m.Key())
-	case ProcessMsg:
-		b := m.Table()
-		_, span := StartSpanFromContext(ctx, reflect.TypeOf(t).String(), t.Label())
-		err = t.Process(m.SrcDatasetID(), b)
-		if span != nil {
-			span.Finish()
-		}
-	case UpdateWatermarkMsg:
-		err = t.UpdateWatermark(m.SrcDatasetID(), m.WatermarkTime())
-	case UpdateProcessingTimeMsg:
-		err = t.UpdateProcessingTime(m.SrcDatasetID(), m.ProcessingTime())
-	case FinishMsg:
-		t.Finish(m.SrcDatasetID(), m.Error())
-		finished = true
+func (t *consecutiveTransport) processMessage(ctx context.Context, m Message) (finished bool, err error) {
+	if _, span := StartSpanFromContext(ctx, t.op, t.label); span != nil {
+		defer span.Finish()
 	}
-	return
+	if err := t.t.ProcessMessage(m); err != nil {
+		return false, err
+	}
+	finished = isFinishMessage(m)
+	return finished, nil
 }
 
 type Message interface {
@@ -263,10 +267,24 @@ type Message interface {
 type MessageType int
 
 const (
+	// RetractTableType is sent when the previous table for
+	// a given group key should be retracted.
 	RetractTableType MessageType = iota
+
+	// ProcessType is sent when there is an entire flux.Table
+	// ready to be processed from the upstream Dataset.
 	ProcessType
+
+	// UpdateWatermarkType is sent when there will be no more
+	// points older than the watermark for any key.
 	UpdateWatermarkType
+
+	// UpdateProcessingTimeType is sent to update the current time.
 	UpdateProcessingTimeType
+
+	// FinishType is sent when there are no more messages from
+	// the upstream Dataset or an upstream error occurred that
+	// caused the execution to abort.
 	FinishType
 )
 
@@ -359,4 +377,70 @@ func (m *finishMsg) Type() MessageType {
 }
 func (m *finishMsg) Error() error {
 	return m.err
+}
+
+// transformationTransportAdapter will translate Message values sent to
+// a Transport to an underlying Transformation.
+type transformationTransportAdapter struct {
+	t     Transformation
+	cache table.BuilderCache
+}
+
+// WrapTransformationInTransport will wrap a Transformation into
+// a Transport to be used for the execution engine.
+func WrapTransformationInTransport(t Transformation, mem memory.Allocator) Transport {
+	// If the Transformation implements the Transport interface,
+	// then we can just use that directly.
+	if tr, ok := t.(Transport); ok {
+		return tr
+	}
+	return &transformationTransportAdapter{
+		t: t,
+		cache: table.BuilderCache{
+			New: func(key flux.GroupKey) table.Builder {
+				return table.NewBufferedBuilder(key, mem)
+			},
+		},
+	}
+}
+
+func (t *transformationTransportAdapter) ProcessMessage(m Message) error {
+	switch m := m.(type) {
+	case RetractTableMsg:
+		return t.t.RetractTable(m.SrcDatasetID(), m.Key())
+	case ProcessMsg:
+		b := m.Table()
+		return t.t.Process(m.SrcDatasetID(), b)
+	case UpdateWatermarkMsg:
+		return t.t.UpdateWatermark(m.SrcDatasetID(), m.WatermarkTime())
+	case UpdateProcessingTimeMsg:
+		return t.t.UpdateProcessingTime(m.SrcDatasetID(), m.ProcessingTime())
+	case FinishMsg:
+		t.t.Finish(m.SrcDatasetID(), m.Error())
+		return nil
+	default:
+		// Message is not handled by older Transformation implementations.
+		return nil
+	}
+}
+
+func (t *transformationTransportAdapter) OperationType() string {
+	return OperationType(t.t)
+}
+
+// isFinishMessage will return true if the Message is a FinishMsg.
+func isFinishMessage(m Message) bool {
+	_, ok := m.(FinishMsg)
+	return ok
+}
+
+// OperationType returns a string representation of the transformation
+// operation represented by the Transport.
+func OperationType(t interface{}) string {
+	if t, ok := t.(interface {
+		OperationType() string
+	}); ok {
+		return t.OperationType()
+	}
+	return reflect.TypeOf(t).String()
 }


### PR DESCRIPTION
The `ProcessMessage` method can now be directly implemented by
transformations and the adapter code is present for existing
transformations.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written