### PR TITLE
feat(sql): add Oracle database support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/godror/godror v0.23.1
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,9 +109,13 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
+github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/godror/godror v0.23.1 h1:JllRZ14r/2+65m8bn+rJJTKjfsYXN/FM2kpUs4TbiB8=
+github.com/godror/godror v0.23.1/go.mod h1:wZv/9vPiUib6tkoDl+AZ/QLf5YZgMravZ7jxH2eQWAE=
 github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -181,6 +185,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -129,6 +129,8 @@ func createFromSQLSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID, a ex
 		newRowReader = NewBigQueryRowReader
 	case "hdb":
 		newRowReader = NewHdbRowReader
+	case "oracle":
+		newRowReader = NewOracleRowReader
 	default:
 		return nil, errors.Newf(codes.Invalid, "sql driver %s not supported", spec.DriverName)
 	}

--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -90,6 +90,14 @@ func TestFromSqlUrlValidation(t *testing.T) {
 			},
 			ErrMsg: "",
 		}, {
+			Name: "ok oracle",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "oracle",
+				DataSourceName: "user/password@//localhost:1521/xe",
+				Query:          "",
+			},
+			ErrMsg: "",
+		}, {
 			Name: "invalid driver",
 			Spec: &FromSQLProcedureSpec{
 				DriverName:     "voltdb",
@@ -131,6 +139,14 @@ func TestFromSqlUrlValidation(t *testing.T) {
 				Query:          "",
 			},
 			ErrMsg: "invalid prefix",
+		}, {
+			Name: "invalid oracle",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "oracle",
+				DataSourceName: "user/password@127.0.0.1:1521/orcl",
+				Query:          "",
+			},
+			ErrMsg: "invalid connection string",
 		}, {
 			Name: "invalid sqlmock",
 			Spec: &FromSQLProcedureSpec{

--- a/stdlib/sql/open.go
+++ b/stdlib/sql/open.go
@@ -38,6 +38,8 @@ func getOpenFunc(driverName, dataSourceName string) openFunc {
 	switch driverName {
 	case "mssql", "sqlserver":
 		return mssqlOpenFunction(driverName, dataSourceName)
+	case "oracle":
+		return oracleOpenFunction(driverName, dataSourceName)
 	default:
 		return defaultOpenFunction(driverName, dataSourceName)
 	}

--- a/stdlib/sql/oracle.go
+++ b/stdlib/sql/oracle.go
@@ -1,0 +1,276 @@
+package sql
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/godror/godror"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/values"
+)
+
+// Oracle database support.
+// Notes:
+//   * uses Go SQL driver https://github.com/godror/godror
+//   * supports Easy Connect string format: https://www.orafaq.com/wiki/EZCONNECT
+//     Syntax: username/password@[//]host[:port][/service_name]
+//     Examples:
+//       "scott/tiger@sales-server:1521/ORCL"
+//       "scott/tiger@//75.184.3.22:1522/xepdb1"
+//   * ODPI-C wrapper is required at compile time https://github.com/oracle/odpi
+//   * Oracle Instant Client is required at runtime
+//     - https://www.oracle.com/database/technologies/instant-client.html
+//     - client version should match the server, or it should be ensured that timezone files match.
+//       Otherwise, errors such as "ORA-01805: possible error in date/time operation"
+//       may occur when working with columns of data types with time zone information.
+// Issues:
+//   * BOOLEAN type does not exist in Oracle. Output mapping uses most(?) recommended approach (CHAR(1)).
+//   * INTERVAL types are scanned to time.Duration, but there is no corresponding flux.ColType (yet?),
+//     so these types are mapped converted to string. However, duration string representation in Flux
+//     is nothing like in Oracle, so an attempt to write such value directly to interval type column fails
+//     with "ORA-01867: the interval is invalid".
+//   * TIMESTAMP types workaround https://github.com/godror/godror#timestamp is used (in sql.ExecuteQueries()),
+//     as they are not properly supported by the driver. It also seems to solve time zone modification for
+//     TIMESTAMP WITH TIME ZONE type.
+
+type OracleRowReader struct {
+	Cursor      *sql.Rows
+	columns     []interface{}
+	columnTypes []flux.ColType
+	columnNames []string
+	sqlTypes    []*sql.ColumnType
+	NextFunc    func() bool
+	CloseFunc   func() error
+}
+
+// Next prepares OracleRowReader to return rows
+func (m *OracleRowReader) Next() bool {
+	if m.NextFunc != nil {
+		return m.NextFunc()
+	}
+	next := m.Cursor.Next()
+	if next {
+		columnNames, err := m.Cursor.Columns()
+		if err != nil {
+			return false
+		}
+		m.columns = make([]interface{}, len(columnNames))
+		columnPointers := make([]interface{}, len(columnNames))
+		for i := 0; i < len(columnNames); i++ {
+			columnPointers[i] = &m.columns[i]
+		}
+		if err := m.Cursor.Scan(columnPointers...); err != nil {
+			return false
+		}
+	}
+	return next
+}
+
+func (m *OracleRowReader) GetNextRow() ([]values.Value, error) {
+	row := make([]values.Value, len(m.columns))
+	for i, column := range m.columns {
+		switch value := column.(type) {
+		case bool, int64, float64:
+			row[i] = values.New(value)
+		case int:
+			row[i] = values.NewInt(int64(value))
+		case int8:
+			row[i] = values.NewInt(int64(value))
+		case int16:
+			row[i] = values.NewInt(int64(value))
+		case int32:
+			row[i] = values.NewInt(int64(value))
+		case float32:
+			row[i] = values.NewFloat(float64(value))
+		case []uint8: // NUMBER in go-ora
+			switch m.columnTypes[i] {
+			case flux.TInt:
+				newInt, err := UInt8ToInt64(value)
+				if err != nil {
+					return nil, err
+				}
+				row[i] = values.NewInt(newInt)
+			case flux.TFloat:
+				newFloat, err := UInt8ToFloat(value)
+				if err != nil {
+					return nil, err
+				}
+				row[i] = values.NewFloat(newFloat)
+			default:
+				row[i] = values.NewString(string(value))
+			}
+		case string:
+			switch m.columnTypes[i] {
+			case flux.TFloat:
+				f, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					return nil, err
+				}
+				row[i] = values.NewFloat(f)
+			case flux.TInt:
+				d, err := strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				row[i] = values.NewInt(d)
+			default:
+				row[i] = values.New(value)
+			}
+		case time.Duration: // INTERVAL ... types
+			row[i] = values.NewString(value.String())
+		case time.Time:
+			// DATE, TIMESTAMP and TIMESTAMP WITH LOCAL TIME ZONE types are scanned to time.Time by the driver,
+			// but they have no counterpart in Flux therefore will be represented as string
+			switch m.sqlTypes[i].DatabaseTypeName() {
+			case "DATE":
+				row[i] = values.NewString(value.Format(layoutDate))
+			case "TIMESTAMP":
+				row[i] = values.NewString(value.Format(layoutTimeStampNtz))
+			case "TIMESTAMP WITH LOCAL TIME ZONE":
+				row[i] = values.NewString(value.Format(layoutTimeStampNtz))
+			default:
+				row[i] = values.NewTime(values.ConvertTime(value))
+			}
+		case nil:
+			row[i] = values.NewNull(flux.SemanticType(m.columnTypes[i]))
+		default:
+			execute.PanicUnknownType(flux.TInvalid)
+		}
+	}
+	return row, nil
+}
+
+func (m *OracleRowReader) InitColumnNames(names []string) {
+	m.columnNames = names
+}
+
+func (m *OracleRowReader) InitColumnTypes(types []*sql.ColumnType) {
+	fluxTypes := make([]flux.ColType, len(types))
+	for i := 0; i < len(types); i++ {
+		switch types[i].DatabaseTypeName() {
+		case "NUMBER":
+			_, scale, ok := types[i].DecimalSize()
+			if ok && scale == 0 {
+				fluxTypes[i] = flux.TInt
+			} else {
+				fluxTypes[i] = flux.TFloat
+			}
+		case "FLOAT", "DOUBLE":
+			fluxTypes[i] = flux.TFloat
+		case "BOOLEAN":
+			fluxTypes[i] = flux.TBool
+		case "TIMESTAMP WITH TIME ZONE": // "DATE", "TIMESTAMP" and "TIMESTAMP WITH LOCAL TIME ZONE" will be represented as string
+			fluxTypes[i] = flux.TTime
+		default:
+			fluxTypes[i] = flux.TString
+		}
+	}
+	m.columnTypes = fluxTypes
+	m.sqlTypes = types
+}
+
+func (m *OracleRowReader) ColumnNames() []string {
+	return m.columnNames
+}
+
+func (m *OracleRowReader) ColumnTypes() []flux.ColType {
+	return m.columnTypes
+}
+
+func (m *OracleRowReader) SetColumnTypes(types []flux.ColType) {
+	m.columnTypes = types
+}
+
+func (m *OracleRowReader) SetColumns(i []interface{}) {
+	m.columns = i
+}
+
+func (m *OracleRowReader) Close() error {
+	if m.CloseFunc != nil {
+		return m.CloseFunc()
+	}
+	if err := m.Cursor.Err(); err != nil {
+		return err
+	}
+	return m.Cursor.Close()
+}
+
+func NewOracleRowReader(r *sql.Rows) (execute.RowReader, error) {
+	reader := &OracleRowReader{
+		Cursor: r,
+	}
+	cols, err := r.Columns()
+	if err != nil {
+		return nil, err
+	}
+	reader.InitColumnNames(cols)
+
+	types, err := r.ColumnTypes()
+	if err != nil {
+		return nil, err
+	}
+	reader.InitColumnTypes(types)
+
+	return reader, nil
+}
+
+var fluxToOracle = map[flux.ColType]string{
+	flux.TFloat:  "BINARY_DOUBLE", // double-precision (64-bit) IEEE 754 floating-point
+	flux.TInt:    "NUMBER(38)",
+	flux.TUInt:   "NUMBER(38)",
+	flux.TString: "VARCHAR2(4000)",
+	flux.TBool:   "CHAR(1)", // most(?) recommended solution ('Y', 'N')
+	flux.TTime:   "TIMESTAMP WITH TIME ZONE",
+}
+
+// OracleTranslateColumn translates flux colTypes into their corresponding Oracle column type
+func OracleColumnTranslateFunc() translationFunc {
+	return func(f flux.ColType, colName string) (string, error) {
+		s, found := fluxToOracle[f]
+		if !found {
+			return "", errors.Newf(codes.Internal, "Oracle does not support column type %s", f.String())
+		}
+		return colName + " " + s, nil
+	}
+}
+
+// oracleOpenFunction opens connection to Oracle DB and sets date and timestamp formats.
+// The driver name for user is "oracle", but real driver is "godror".
+// For Go older then 1.14.6, it is recommended to disable pooling (https://godror.github.io/godror/doc/connection.html#-oracle-session-pooling).
+// Flux can be built with 1.12, but InfluxDb requires 1.15, so we do nothing here about it (the pooling can be affected with connection string option as well).
+func oracleOpenFunction(driverName, dataSourceName string) openFunc {
+	return func() (*sql.DB, error) {
+		P, err := godror.ParseDSN(dataSourceName)
+		if err != nil {
+			return nil, err
+		}
+		P.SetSessionParamOnInit("NLS_DATE_FORMAT", "YYYY-MM-DD")
+		P.SetSessionParamOnInit("NLS_TIMESTAMP_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF")
+		P.SetSessionParamOnInit("NLS_TIMESTAMP_TZ_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FFTZH:TZM")
+		connector := godror.NewConnector(P)
+		db := sql.OpenDB(connector)
+		return db, nil
+	}
+}
+
+// template for conditional query by table existence check
+var oracleDoIfTableNotExistsTemplate = `DECLARE
+    v_count BINARY_INTEGER;
+BEGIN
+    SELECT COUNT(*) INTO v_count FROM user_tables WHERE table_name = UPPER('%s');
+    IF (v_count = 0)
+    THEN
+        EXECUTE IMMEDIATE '%s';
+    END IF;
+END;
+`
+
+// oracleAddIfNotExist adds Oracle specific table existence check to CREATE TABLE statement.
+func oracleAddIfNotExist(table string, query string) string {
+	return fmt.Sprintf(oracleDoIfTableNotExistsTemplate, []interface{}{table, query}...)
+}

--- a/stdlib/sql/source_validator.go
+++ b/stdlib/sql/source_validator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bonitoo-io/go-sql-bigquery"
 	"github.com/go-sql-driver/mysql"
+	"github.com/godror/godror"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/internal/errors"
@@ -107,6 +108,16 @@ func validateDataSource(validator url.Validator, driverName string, dataSourceNa
 		u, err = neturl.Parse(dataSourceName)
 		if err != nil {
 			return errors.Newf(codes.Invalid, "invalid data source url: %v", err)
+		}
+	case "oracle":
+		// an example is: user/password@//server/database
+		params, err := godror.ParseDSN(dataSourceName)
+		if err != nil {
+			return errors.Newf(codes.Invalid, "invalid data source dsn: %v", err)
+		}
+		u, err = neturl.Parse(params.ConnectString)
+		if err != nil {
+			return errors.Newf(codes.Invalid, "invalid connection string: %v", err)
 		}
 	default:
 		return errors.Newf(codes.Invalid, "sql driver %s not supported", driverName)


### PR DESCRIPTION
This PR adds Oracle database support to `sql` package.

It uses [godror](https://github.com/godror/godror) **c-go** driver and supports _Easy Connect_ string format (https://www.orafaq.com/wiki/EZCONNECT).
Examples:
  * `scott/tiger@sales-server:1521/ORCL`
  *  `scott/tiger@//75.184.3.22:1522/xepdb1`

[Oracle Instant Client](https://www.oracle.com/database/technologies/instant-client.html) is required at runtime. _Client version should match the server, or it should be ensured that timezone files match. Otherwise, errors such as "ORA-01805: possible error in date/time operation" may occur when working with columns of data types with time zone information._

Known issues and/or limitations:
  * `BOOLEAN` type does not exist in Oracle. Output mapping uses most(?) recommended approach (`CHAR(1)`).
  * `INTERVAL` types are scanned to `time.Duration`, but there is no corresponding `flux.ColType` (yet?), so these types are mapped converted to string. However, duration string representation in Flux is nothing like in Oracle, so an attempt to write such value directly to interval type column fails with _"ORA-01867: the interval is invalid"_.

### Done checklist
- [x] Test cases written
