### PR TITLE
fix(quantile): Track and reduce memory used by tdigest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e
 	github.com/influxdata/pkg-config v0.2.5
 	github.com/influxdata/promql/v2 v2.12.0
-	github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9
+	github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/influxdata/flux
 
 go 1.12
 
-replace github.com/influxdata/tdigest => /home/flux/code/tdigest
-
 require (
 	cloud.google.com/go v0.52.0
 	cloud.google.com/go/bigtable v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/influxdata/flux
 
 go 1.12
 
+replace github.com/influxdata/tdigest => /home/flux/code/tdigest
+
 require (
 	cloud.google.com/go v0.52.0
 	cloud.google.com/go/bigtable v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -170,10 +170,6 @@ github.com/influxdata/pkg-config v0.2.5 h1:iC19aXlkUPiwxjxeeKk8TT8S5s3pargNPLgZE
 github.com/influxdata/pkg-config v0.2.5/go.mod h1:EMS7Ll0S4qkzDk53XS3Z72/egBsPInt+BeRxb0WeSwk=
 github.com/influxdata/promql/v2 v2.12.0 h1:kXn3p0D7zPw16rOtfDR+wo6aaiH8tSMfhPwONTxrlEc=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
-github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9 h1:MHTrDWmQpHq/hkq+7cw9oYAt2PqUw52TZazRA0N7PGE=
-github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
-github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
-github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b h1:i44CesU68ZBRvtCjBi3QSosCIKrjmMbYlQMFAwVLds4=
 github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,10 @@ github.com/influxdata/promql/v2 v2.12.0 h1:kXn3p0D7zPw16rOtfDR+wo6aaiH8tSMfhPwON
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9 h1:MHTrDWmQpHq/hkq+7cw9oYAt2PqUw52TZazRA0N7PGE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
+github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
+github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
+github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b h1:i44CesU68ZBRvtCjBi3QSosCIKrjmMbYlQMFAwVLds4=
+github.com/influxdata/tdigest v0.0.2-0.20210216194612-fc98d27c9e8b/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -226,10 +226,7 @@ func createQuantileTransformation(id execute.DatasetID, mode execute.Accumulatio
 	return t, d, nil
 }
 
-// This function does not follow normal copy semantics, since it modifies
-// the original. For our purposes, this behavior is fine, but it should be
-// noted that `Copy` is a misnomer.
-func (a *QuantileAgg) Copy() *QuantileAgg {
+func (a *QuantileAgg) Recycle() *QuantileAgg {
 	na := new(QuantileAgg)
 	*na = *a
 	na.digest.Reset()
@@ -249,7 +246,7 @@ func (a *QuantileAgg) NewUIntAgg() execute.DoUIntAgg {
 }
 
 func (a *QuantileAgg) NewFloatAgg() execute.DoFloatAgg {
-	return a.Copy()
+	return a.Recycle()
 }
 
 func (a *QuantileAgg) NewStringAgg() execute.DoStringAgg {

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -226,6 +226,9 @@ func createQuantileTransformation(id execute.DatasetID, mode execute.Accumulatio
 	return t, d, nil
 }
 
+// This function does not follow normal copy semantics, since it modifies
+// the original. For our purposes, this behavior is fine, but it should be
+// noted that `Copy` is a misnomer.
 func (a *QuantileAgg) Copy() *QuantileAgg {
 	na := new(QuantileAgg)
 	*na = *a

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -217,11 +217,7 @@ func createQuantileTransformation(id execute.DatasetID, mode execute.Accumulatio
 	if !ok {
 		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
-	agg := &QuantileAgg{
-		Quantile:    ps.Quantile,
-		Compression: ps.Compression,
-		digest:      tdigest.NewWithCompression(ps.Compression),
-	}
+	agg := NewQuantileAgg(ps.Quantile, ps.Compression)
 	_ = a.Allocator().Account(tdigest.ByteSizeForCompression(agg.Compression))
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, agg, ps.AggregateConfig, a.Allocator())
 	return t, d, nil

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -218,7 +218,10 @@ func createQuantileTransformation(id execute.DatasetID, mode execute.Accumulatio
 		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", ps)
 	}
 	agg := NewQuantileAgg(ps.Quantile, ps.Compression)
-	_ = a.Allocator().Account(tdigest.ByteSizeForCompression(agg.Compression))
+	err := a.Allocator().Account(tdigest.ByteSizeForCompression(agg.Compression))
+	if err != nil {
+		return nil, nil, errors.Newf(codes.Internal, "could not allocate memory for tdigest: %s", err)
+	}
 	t, d := execute.NewAggregateTransformationAndDataset(id, mode, agg, ps.AggregateConfig, a.Allocator())
 	return t, d, nil
 }

--- a/stdlib/universe/quantile_test.go
+++ b/stdlib/universe/quantile_test.go
@@ -458,10 +458,7 @@ func TestQuantile_Process(t *testing.T) {
 			if tc.exact {
 				agg = &universe.ExactQuantileAgg{Quantile: tc.quantile}
 			} else {
-				agg = &universe.QuantileAgg{
-					Quantile:    tc.quantile,
-					Compression: 1000,
-				}
+				agg = universe.NewQuantileAgg(tc.quantile, 1000.0)
 			}
 			executetest.AggFuncTestHelper(
 				t,
@@ -790,10 +787,7 @@ func BenchmarkQuantile(b *testing.B) {
 	data := arrow.NewFloat(NormalData, &memory.Allocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
-		&universe.QuantileAgg{
-			Quantile:    0.9,
-			Compression: 1000,
-		},
+		universe.NewQuantileAgg(0.9, 1000.0),
 		data,
 		13.842132136909889,
 	)


### PR DESCRIPTION
Closes #3455 

~Requires https://github.com/influxdata/tdigest/pull/27 to merge first.~

- Uses `tdigest`'s new `ByteSizeForCompression` function to get the appropriate byte size to pass to the allocator.
- Moves creation of a digest from `QuantileAgg.Copy()` to `createQuantileTransformation` and simply resets the digest every time the aggregate is copied.
- Adds a NewQuantileAgg function for convenience in testing.

***Benchmarks before change:***
```
go test -bench=Quantile$ -run=^Benchmark -benchmem ./stdlib/universe
goos: linux
goarch: amd64
pkg: github.com/influxdata/flux/stdlib/universe
BenchmarkQuantile-24                   6         188348059 ns/op         1513738 B/op        137 allocs/op
PASS
ok      github.com/influxdata/flux/stdlib/universe      4.296s
```

***Benchmarks after change:***
```
go test -bench=Quantile$ -run=^Benchmark -benchmem ./stdlib/universe
goos: linux
goarch: amd64
pkg: github.com/influxdata/flux/stdlib/universe
BenchmarkQuantile-24                   6         184495440 ns/op           29280 B/op          8 allocs/op
PASS
ok      github.com/influxdata/flux/stdlib/universe      4.436s
```
