### PR TITLE
fix: switch from HashMap to BTreeMap in ast/semantic conversion functions

### DIFF
--- a/libflux/core/src/semantic/convert.rs
+++ b/libflux/core/src/semantic/convert.rs
@@ -5,7 +5,7 @@ use crate::semantic::types;
 use crate::semantic::types::MonoType;
 use crate::semantic::types::MonoTypeMap;
 use crate::semantic::types::SemanticMap;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::result;
 
 pub type SemanticError = String;
@@ -148,7 +148,7 @@ fn convert_builtin_statement(stmt: ast::BuiltinStmt, fresher: &mut Fresher) -> R
 
 fn convert_monotype(
     ty: ast::MonoType,
-    tvars: &mut HashMap<String, types::Tvar>,
+    tvars: &mut BTreeMap<String, types::Tvar>,
     f: &mut Fresher,
 ) -> Result<MonoType> {
     match ty {
@@ -246,7 +246,7 @@ pub fn convert_polytype(
     type_expression: ast::TypeExpression,
     f: &mut Fresher,
 ) -> Result<types::PolyType> {
-    let mut tvars = HashMap::<String, types::Tvar>::new();
+    let mut tvars = BTreeMap::<String, types::Tvar>::new();
     let expr = convert_monotype(type_expression.monotype, &mut tvars, f)?;
     let mut vars = Vec::<types::Tvar>::new();
     let mut cons = SemanticMap::<types::Tvar, Vec<types::Kind>>::new();
@@ -2924,7 +2924,7 @@ mod tests {
                 name: "int".to_string(),
             },
         });
-        let mut m = HashMap::<String, types::Tvar>::new();
+        let mut m = BTreeMap::<String, types::Tvar>::new();
         let got = convert_monotype(monotype, &mut m, &mut fresh::Fresher::default()).unwrap();
         let want = MonoType::Int;
         assert_eq!(want, got);
@@ -2954,7 +2954,7 @@ mod tests {
                 }),
             }],
         });
-        let mut m = HashMap::<String, types::Tvar>::new();
+        let mut m = BTreeMap::<String, types::Tvar>::new();
         let got = convert_monotype(monotype, &mut m, &mut fresh::Fresher::default()).unwrap();
         let want = MonoType::Record(Box::new(types::Record::Extension {
             head: types::Property {
@@ -2992,7 +2992,7 @@ mod tests {
                 },
             }),
         }));
-        let mut m = HashMap::<String, types::Tvar>::new();
+        let mut m = BTreeMap::<String, types::Tvar>::new();
         let got = convert_monotype(monotype_ex, &mut m, &mut fresh::Fresher::default()).unwrap();
         let mut opt = MonoTypeMap::new();
         opt.insert(String::from("A"), MonoType::Int);

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -41,7 +41,7 @@ var sourceHashes = map[string]string{
 	"libflux/core/src/scanner/unicode.rl.COPYING":                                   "6cf2d5d26d52772ded8a5f0813f49f83dfa76006c5f398713be3854fe7bc4c7e",
 	"libflux/core/src/semantic/bootstrap.rs":                                        "5a985054be5744d781d0adf6950b5f7f7027cd03061f78a3e44899c3c61f4e33",
 	"libflux/core/src/semantic/check.rs":                                            "acb29602ee01f636818ba3522b3f110018abca3e7b4a6b75c29eec97856a324e",
-	"libflux/core/src/semantic/convert.rs":                                          "51d31d65e68865b86aa83b8756294b7e4e45e1567ff40b2ff6fbf9e794110ab2",
+	"libflux/core/src/semantic/convert.rs":                                          "92ba98214c49829833334b1674637ad0f70efa1d55f9ecc88d0e99d5c50a8ca6",
 	"libflux/core/src/semantic/env.rs":                                              "e031d5b752d207a8f93bacd8515639e832735d5a85e90db76690aaeee8168127",
 	"libflux/core/src/semantic/flatbuffers/mod.rs":                                  "8565009d99ad45b66fcb7d39d35836908141785ec9a6bbba936e6372515dcddd",
 	"libflux/core/src/semantic/flatbuffers/semantic_generated.rs":                   "5bcb44432b3f0c5cb2c52bf7ac6a2d64892f83ad022f4fa29f36f33222c27cfb",


### PR DESCRIPTION
Using HashMap results in a prelude.data and stdlib.data that varies from build to
build, given the same source. This breaks reproducible builds and adds churn to
the deployments process. The variation is caused by iterating the HashMap,
which doesn't guarantee any particular order.

Helps with influxdata/idpe#6331