### PR TITLE
fix(csv): update csv to handle large files

### DIFF
--- a/dependencies/filesystem/ioutil.go
+++ b/dependencies/filesystem/ioutil.go
@@ -21,6 +21,15 @@ func ReadFile(ctx context.Context, filename string) ([]byte, error) {
 	return ioutil.ReadAll(f)
 }
 
+// OpenFile will open the file from the service.
+func OpenFile(ctx context.Context, filename string) (File, error) {
+	fs, err := Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fs.Open(filename)
+}
+
 // Stat will retrieve the os.FileInfo for a file.
 func Stat(ctx context.Context, filename string) (os.FileInfo, error) {
 	fs, err := Get(ctx)


### PR DESCRIPTION
Prior to this change the contents of a CSV file was read into memory in
its entirety. Now if a file is provided the file is read off disk in
batches as the parsing dictates.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
