### PR TITLE
fix(csv): add error handling for wrong number of fields for raw csv

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -601,7 +601,10 @@ func (d *tableDecoder) advance() (bool, error) {
 		}
 		// whatever this line is, it's not part of this table so goto DONE
 		if len(line) != d.meta.NumFields {
-			if len(line) > annotationIdx && line[annotationIdx] == "" {
+			// If this line is another annotation then the current table has no more data.
+			// Otherwise if this line is not another annotation or if we are not expecting annotations
+			// we have an ErrFieldCount, meaning that a row we expected to be a data row has the wrong number of fields.
+			if d.c.NoAnnotations || (len(line) > annotationIdx && line[annotationIdx] == "") {
 				return false, csv.ErrFieldCount
 			}
 			goto DONE

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -448,6 +448,21 @@ func TestResultDecoder(t *testing.T) {
 			},
 		},
 		{
+			name: "single table no annotations bad header",
+			decoderConfig: csv.ResultDecoderConfig{
+				NoAnnotations: true,
+			},
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`
+col1,col2,col3,col4
+data1,data2,data3
+`),
+			result: &executetest.Result{
+				Nm:  "_result",
+				Err: errors.New("wrong number of fields"),
+			},
+		},
+		{
 			name:          "multiple tables",
 			encoderConfig: csv.DefaultEncoderConfig(),
 			encoded: toCRLF(`#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
@@ -1517,7 +1532,7 @@ func TestResultDecoder(t *testing.T) {
 
 			cmpOpts := cmpopts.IgnoreFields(executetest.Result{}, "Err")
 			if !cmp.Equal(got, tc.result, cmpOpts) {
-				t.Error("unexpected results -want/+got", cmp.Diff(tc.result, got))
+				t.Error("unexpected results -want/+got", cmp.Diff(tc.result, got, cmpOpts))
 			}
 			if (got.Err == nil) != (tc.result.Err == nil) {
 				t.Errorf("error mismatch in result: -want/+got:\n- %q\n+ %q", tc.result.Err, got.Err)


### PR DESCRIPTION
Previously if a data row in a csv file had the wrong number of fields
the error would not be caught and the csv parser would get stuck in an
infinite loop.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
