### PR TITLE
feat(interpreter/compiler): added support for null values in string interpolation

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -97,7 +97,7 @@ func TestCompileAndEval(t *testing.T) {
 			input: values.NewObjectWithValues(map[string]values.Value{
 				"r": values.NewObjectWithValues(map[string]values.Value{}),
 			}),
-			wantEvalErr: true,
+			want: values.NewString("n = <null>"),
 		},
 		{
 			name: "simple ident return",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -332,6 +332,8 @@ Arbitrary Expression Interpolation example:
     t0 = time(v: "2016-06-13T17:43:50.1004002Z")
     "the answer is ${t0}" // the answer is 2016-06-13T17:43:50.1004002Z 
 
+If the interpolated expression evaluates to a null value, the expression will be displayed with the `<null>` string.
+
 #### Regular expression literals
 
 A regular expression literal represents a regular expression pattern, enclosed in forward slashes.

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -492,9 +492,6 @@ func (itrp *Interpreter) doStringPart(ctx context.Context, part semantic.StringE
 		v, err := itrp.doExpression(ctx, p.Expression, scope)
 		if err != nil {
 			return nil, err
-		} else if v.IsNull() {
-			return nil, errors.Newf(codes.Invalid, "%s: interpolated expression produced a null value",
-				p.Location())
 		} else {
 			o, err := values.Stringify(v)
 			if err != nil {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -58,7 +58,9 @@ func TestEval(t *testing.T) {
 			query: `
 				r = makeRecord(o: {a: "foo", b: 42})
 				"r._value = ${r._value}"`,
-			wantErr: any,
+			want: []values.Value{
+				values.NewString("r._value = <null>"),
+			},
 		},
 		{
 			name: "string interpolation non-string type",

--- a/values/values.go
+++ b/values/values.go
@@ -303,6 +303,9 @@ func NewRegexp(v *regexp.Regexp) Value {
 }
 
 func Stringify(v Value) (Value, error) {
+	if v.IsNull() {
+		return NewString("<null>"), nil
+	}
 	val := Unwrap(v)
 	switch v.Type().Nature() {
 	case semantic.Bool:


### PR DESCRIPTION
For null values passed into string interpolation, the null value is represented as the `<null>` string when displayed.


### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
