### PR TITLE
fix: delimited multi result encoder properly releases results before checking error

### DIFF
--- a/result.go
+++ b/result.go
@@ -311,6 +311,7 @@ func (e *DelimitedMultiResultEncoder) Encode(w io.Writer, results ResultIterator
 			f.Flush()
 		}
 	}
+	results.Release()
 
 	// If we have any outlying errors in results, encode them
 	// If we have an error in the result and we have not written


### PR DESCRIPTION
The error is only guaranteed to be populated after `Release()` is called
on the `ResultIterator`. The `DelimitedMultiResultEncoder` now releases
the result iterator after it has finished reading to guarantee that the
error has been set.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written