### PR TITLE
fix(lang): perform testing checks as part of query done

### DIFF
--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependencies/testing"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/spec"
@@ -279,6 +278,7 @@ func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Quer
 	s, cctx := opentracing.StartSpanFromContext(ctx, "execute")
 	results := make(chan flux.Result)
 	q := &query{
+		ctx:     cctx,
 		results: results,
 		alloc:   alloc,
 		span:    s,
@@ -326,9 +326,6 @@ func (p *Program) processResults(ctx context.Context, q *query, resultMap map[st
 			return
 		}
 	}
-
-	// If the testing framework was configured, verify all expectations.
-	q.err = testing.Check(ctx)
 }
 
 func (p *Program) readMetadata(q *query, metaCh <-chan metadata.Metadata) {


### PR DESCRIPTION
Now as part of the query Done method testing checks are verified.
This avoids a race where the query was started but the results had not
been consumed before the checks were verified.

Fixes #3567


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
