### PR TITLE
fix(cmd/test): find parent root should skip the current directory

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -503,6 +503,10 @@ func findParentTestRoot(path string) (string, filesystem.Service, bool, error) {
 	if err != nil {
 		return "", nil, false, err
 	}
+	// Start with the parent directory of the path.
+	// A test root starting at the path will be found
+	// by the normal discovery mechanism.
+	cur = filepath.Dir(cur)
 
 	for cur != "/" {
 		fpath := filepath.Join(cur, testRootFilename)


### PR DESCRIPTION
If the path specified is a test root, the current code will try to add
that path twice which results in a duplicate test root error.

The parent root search is intended to find directories above the
filepath and not within the filepath. So this is now changed to find the
absolute path and then start with the parent directory of that path.

For the directory search, this means the parent directory. For the file
search, this means the directory that the file is located in.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written