### PR TITLE
chore: update rustup install command

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -118,11 +118,10 @@ USER $UNAME
 ENV HOME=/home/$UNAME
 
 # The latest stable rust version
-# TODO: Update manually.
 ENV RUST_LATEST_VERSION=1.51.0
 
 # Install Rust
-RUN curl https://sh.rustup.rs -sSf | \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- --default-toolchain "$RUST_LATEST_VERSION" -y
 ENV PATH="$HOME/.cargo/bin:${PATH}"
 RUN rustup component add rustfmt clippy --toolchain $RUST_LATEST_VERSION


### PR DESCRIPTION
The current rustup install command uses SSL v3.0 by default in `curl`.
SSL v3 has been EOL'd for quite some time, and even TLS 1.2 was EOL'd
last year. It *appears* that the migration/update policy with regard to
the rustup.rs server is to fail occasionally on the older protocols,
more often and often until it fails for good.

This patch updates the rustup commands to specifically use tls 1.2 as
described on [rustup.rs](http://rustup.rs). This change has already been
made in idpe.

Additionally, I discovered `libflux/Dockerfile`, which had a manually
specified rust version like in the flux-build image. I updated that and
added a note to ensure that we don't get drift between them again. The
_right_ fix here might actually just be to either (a) delete
`libflux/Dockerfile` altogether, or have it be based on the image from
`./Dockerfile_build`. Both of those are outside the scope of this patch.