### PR TITLE
chore: add semgrep with ci and single initial rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,17 @@ jobs:
     steps:
       - checkout
       - run: make test-valgrind
+  static:
+    docker:
+      - image: returntocorp/semgrep
+    steps:
+      - checkout
+      - run: semgrep --error --config=p/ci .
+      - run: pwd
+      - run: ls -lsa
+      # These are currently experimental and informational. Run them so we know the
+      # config is in good shape.
+      - run: semgrep --config=/home/semgrep/project/.semgrep.yml stdlib/
 
   release:
     docker:
@@ -126,6 +137,7 @@ workflows:
       - test-race
       - test-bench
       - test-valgrind
+      - static
 
   release:
     jobs:

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,8 @@
+rules:
+  - id: flux.loadStorage-deprecated
+    patterns:
+      - pattern-not-inside: 'test $NAME = () =>...({...input: ...})'
+      - pattern: '... testing.loadStorage(csv: ...) ...'
+    message: "testing.loadStorage is deprecated. Use testing.load instead"
+    languages: [generic]
+    severity: WARNING


### PR DESCRIPTION
This patch adds support for [semgrep](https://semgrep.dev/). It adds a
CI step that runs the generic CI ruleset for semgrep (which did find a
couple issues that were fixed recently). Additionally, it adds a
warning-level semgrep for our custom rules, and adds a single new rule,
which can't be enforced until #3593 can be completed all the way
through.