### PR TITLE
fix(json): dictionary encoding

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4490,6 +4490,16 @@ Slices v into substrings separated by the expression and returns a slice of the 
 
 Example: `splitRegex(r: regexp.compile("a*"), v: "abaabaccadaaae", i: 5)` returns string array `["", "b", "b", "c", "cadaaae"]`.
 
+#### JSON Operations
+
+##### encode
+
+Convert a value into JSON bytes.
+
+Example: `encode(v: {label: "abcd})` returns JSON encoded value of the record as bytes.
+
+Types `record` and `dictionary` are encoded as JSON objects.
+
 ### Composite data types
 
 A composite data type is a collection of primitive data types that together have a higher meaning.

--- a/stdlib/json/encode.go
+++ b/stdlib/json/encode.go
@@ -3,6 +3,7 @@ package json
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/influxdata/flux/codes"
@@ -100,7 +101,7 @@ func convertValue(v values.Value) (interface{}, error) {
 		return nil, errors.New(codes.Invalid, "cannot encode a function value")
 	case semantic.Dictionary:
 		dict := v.Dict()
-		d := make(map[interface{}]interface{}, dict.Len())
+		d := make(map[string]interface{}, dict.Len())
 		var rangeErr error
 		dict.Range(func(k, v values.Value) {
 			if rangeErr != nil {
@@ -116,7 +117,7 @@ func convertValue(v values.Value) (interface{}, error) {
 				rangeErr = err
 				return
 			}
-			d[key] = val
+			d[fmt.Sprintf("%v", key)] = val
 		})
 		if rangeErr != nil {
 			return nil, rangeErr

--- a/stdlib/json/encode.go
+++ b/stdlib/json/encode.go
@@ -3,7 +3,6 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/influxdata/flux/codes"
@@ -101,15 +100,20 @@ func convertValue(v values.Value) (interface{}, error) {
 		return nil, errors.New(codes.Invalid, "cannot encode a function value")
 	case semantic.Dictionary:
 		dict := v.Dict()
+		// Go JSON encoder requires that map key type is either a primitive type or implements encoding.TextMarshaler interface.
+		// Since Go maps are encoded as JSON objects with string keys (https://www.json.org/json-en.html), and dictionary keys
+		// are primitive Flux types, we can safely convert Flux dictionary to Go map with string keys and use string values of keys.
 		d := make(map[string]interface{}, dict.Len())
 		var rangeErr error
 		dict.Range(func(k, v values.Value) {
 			if rangeErr != nil {
 				return // short circuit if we already hit an error
 			}
-			key, err := convertValue(k)
-			if err != nil {
-				rangeErr = err
+			var key string
+			if vs, ok := k.(values.ValueStringer); ok {
+				key = vs.String()
+			} else {
+				rangeErr = errors.Newf(codes.Invalid, "cannot encode a dictionary with %v key type", k.Type().Nature())
 				return
 			}
 			val, err := convertValue(v)
@@ -117,7 +121,7 @@ func convertValue(v values.Value) (interface{}, error) {
 				rangeErr = err
 				return
 			}
-			d[fmt.Sprintf("%v", key)] = val
+			d[key] = val
 		})
 		if rangeErr != nil {
 			return nil, rangeErr

--- a/stdlib/json/encode_test.go
+++ b/stdlib/json/encode_test.go
@@ -25,8 +25,9 @@ o = {
     d: false,
     e: /.*/,
 	f: 2019-08-14T10:03:12Z,
+    g: [1: "hi", 2: "there"]
 }
-json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":\"1m\"},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\"}")  or testutil.fail()
+json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":\"1m\"},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\",\"g\":{\"1\":\"hi\",\"2\":\"there\"}}") or testutil.fail()
 `
 	ctx := dependenciestest.Default().Inject(context.Background())
 	if _, _, err := runtime.Eval(ctx, script); err != nil {


### PR DESCRIPTION
This PR fixes #3603. 

Since Go maps are encoded as JSON objects where keys are strings, map key is changed from `interface{}` to `string` and keys values are simply formated as strings.

Example:
```
import "json"
attributes = ["region": "EU"]
json.encode(v: attributes)
```

Returns:
```
{"region": "EU"}
```

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
