### PR TITLE
docs(libflux): Document `fluxcore::semantic::env`

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -42,7 +42,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "1888311dbf8d157a35f3716ace6464b1e909083e8073d7066d3a6e104c166960",
 	"libflux/flux-core/src/semantic/check.rs":                                       "82f6e3b90dfd784f09107feee1f519b794964eeb73deb9f6494b416425e86cae",
 	"libflux/flux-core/src/semantic/convert.rs":                                     "0835292eebe2a61ce1cb3e9ef19f1d2cb1c5bbfa3eb1a9b75a6be0c898adddd5",
-	"libflux/flux-core/src/semantic/env.rs":                                         "e031d5b752d207a8f93bacd8515639e832735d5a85e90db76690aaeee8168127",
+	"libflux/flux-core/src/semantic/env.rs":                                         "0f9f4ab4a02f11aeeb5ae8daf4f8b2862e4ec7770ab6d99c5f3c497b589b7b38",
 	"libflux/flux-core/src/semantic/flatbuffers/mod.rs":                             "8565009d99ad45b66fcb7d39d35836908141785ec9a6bbba936e6372515dcddd",
 	"libflux/flux-core/src/semantic/flatbuffers/semantic_generated.rs":              "5bcb44432b3f0c5cb2c52bf7ac6a2d64892f83ad022f4fa29f36f33222c27cfb",
 	"libflux/flux-core/src/semantic/flatbuffers/tests.rs":                           "6d3fcd497eff602d2872d9508506cb52eab9f247b4db08cc93e58bcd6ff3888c",


### PR DESCRIPTION
Documents all items in the module.