### PR TITLE
docs(libflux): document `fluxcore::semantic::sub` module

### DIFF
--- a/libflux/flux-core/src/semantic/sub.rs
+++ b/libflux/flux-core/src/semantic/sub.rs
@@ -1,19 +1,18 @@
-#![allow(missing_docs)]
+//! Substitutions during type inference.
 
 use crate::semantic::types::{MonoType, SubstitutionMap, Tvar};
 
-// A substitution defines a function that takes a monotype as input
-// and returns a monotype as output. The output type is interpreted
-// as being equivalent to the input type.
-//
-// Substitutions are idempotent. Given a substitution s and an input
-// type x, we have s(s(x)) = s(x).
-//
+/// A substitution defines a function that takes a monotype as input
+/// and returns a monotype as output. The output type is interpreted
+/// as being equivalent to the input type.
+///
+/// Substitutions are idempotent. Given a substitution *s* and an input
+/// type *x*, we have *s*(*s*(*x*)) = *s*(*x*).
 #[derive(Debug, PartialEq)]
 pub struct Substitution(SubstitutionMap);
 
-// Derive a substitution from a hash map.
 impl From<SubstitutionMap> for Substitution {
+    /// Derive a substitution from a hash map.
     fn from(values: SubstitutionMap) -> Substitution {
         Substitution(values)
     }
@@ -22,20 +21,21 @@ impl From<SubstitutionMap> for Substitution {
 // The `allow` attribute below is a side effect of the orphan impl rule as
 // well as the implicit_hasher lint. For more info, see
 // https://github.com/rust-lang/rfcs/issues/1856
-
-// Derive a hash map from a substitution.
 #[allow(clippy::implicit_hasher)]
 impl From<Substitution> for SubstitutionMap {
+    /// Derive a hash map from a substitution.
     fn from(sub: Substitution) -> SubstitutionMap {
         sub.0
     }
 }
 
 impl Substitution {
+    /// Return a new empty substitution.
     pub fn empty() -> Substitution {
         Substitution(SubstitutionMap::new())
     }
 
+    /// Apply a substitution to a type variable.
     pub fn apply(&self, tv: Tvar) -> MonoType {
         match self.0.get(&tv) {
             Some(t) => t.clone(),
@@ -43,6 +43,7 @@ impl Substitution {
         }
     }
 
+    /// Merge two substitutions.
     pub fn merge(self, with: Substitution) -> Substitution {
         let applied: SubstitutionMap = self
             .0
@@ -53,8 +54,10 @@ impl Substitution {
     }
 }
 
-// A type is substitutable if a substitution can be applied to it.
+/// A type is `Substitutable` if a substitution can be applied to it.
 pub trait Substitutable {
+    /// Apply a substitution to a type variable.
     fn apply(self, sub: &Substitution) -> Self;
+    /// Get all free type variables in a type.
     fn free_vars(&self) -> Vec<Tvar>;
 }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -52,7 +52,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/infer.rs":                                       "d13847646255eff053262102c3350351158e5c2e6bd9e6edeb47117eb93c05f3",
 	"libflux/flux-core/src/semantic/mod.rs":                                         "cb5713727948e7bce5c504d025a2d6cf267be313fdcad9b449d5b8c8927c6ac2",
 	"libflux/flux-core/src/semantic/nodes.rs":                                       "50fc92e52defcd444d98f3456e4b39e6b1826b31c0f572c106ec7924a32c2f52",
-	"libflux/flux-core/src/semantic/sub.rs":                                         "f40c4b8907f45bd2b2d0c76ac25376e64d8747798ac2b809c730eca0a1d75340",
+	"libflux/flux-core/src/semantic/sub.rs":                                         "7a6300e22d1e3ff8f4263c17b9af6df806d7d214128d62a099d9b1ba209f5621",
 	"libflux/flux-core/src/semantic/tests.rs":                                       "c47f20d346aaa40efd681fdc2e4a2f0948bde68d09d93babe53eeb2671a591e7",
 	"libflux/flux-core/src/semantic/types.rs":                                       "9cb4f24e231b9719661dfeab5f9f728330b3617184302cab45e28f54add68474",
 	"libflux/flux-core/src/semantic/walk/_walk.rs":                                  "22212d415fb6fa77c259c7db6a241ac7175b369b408bb8c2554af9fa394f2a29",


### PR DESCRIPTION
Removes `#![allow(missing_docs)]`.
