### PR TITLE
fix(values): add new display API for values

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -194,7 +194,8 @@ func (r *REPL) executeLine(t string) error {
 					return err
 				}
 			} else {
-				fmt.Println(se.Value)
+				values.Display(os.Stdout, se.Value)
+				fmt.Println()
 			}
 		}
 	}

--- a/stdlib/math/math_test.go
+++ b/stdlib/math/math_test.go
@@ -175,7 +175,7 @@ func TestNulls(t *testing.T) {
 					t.Fatal(err)
 				}
 				if !v.IsNull() {
-					t.Errorf("expected null value; got %s instead", v.(values.ValueStringer).String())
+					t.Errorf("expected null value; got %s instead", values.DisplayString(v))
 				}
 			})
 		}
@@ -210,7 +210,7 @@ func TestNulls(t *testing.T) {
 					t.Fatal(err)
 				}
 				if !v.IsNull() {
-					t.Errorf("expected null value; got %s instead", v.(values.ValueStringer).String())
+					t.Errorf("expected null value; got %s instead", values.DisplayString(v))
 				}
 			})
 		}

--- a/stdlib/sql/sql_test.go
+++ b/stdlib/sql/sql_test.go
@@ -127,7 +127,7 @@ func TestFromRowReader(t *testing.T) {
 			got := buffer.GetRow(i)
 			// the second row has a lot of nil values.Value which cannot pass values.Value.Equals() check.
 			if !(i == 0 && got.Equal(want)) &&
-				!(i == 1 && got.(fmt.Stringer).String() == want.(fmt.Stringer).String()) {
+				!(i == 1 && values.DisplayString(got) == values.DisplayString(want)) {
 				t.Fatalf("unexpected result -want/+got:\n%s", cmp.Diff(want, got))
 			}
 		}

--- a/values/array.go
+++ b/values/array.go
@@ -1,10 +1,8 @@
 package values
 
 import (
-	"fmt"
 	"regexp"
 	"sort"
-	"strings"
 
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
@@ -43,18 +41,6 @@ func NewArrayWithBacking(arrType semantic.MonoType, elements []Value) Array {
 
 func (a *array) IsNull() bool {
 	return false
-}
-func (a *array) String() string {
-	b := new(strings.Builder)
-	b.WriteString("[")
-	a.Range(func(i int, v Value) {
-		if i != 0 {
-			b.WriteString(", ")
-		}
-		fmt.Fprint(b, v)
-	})
-	b.WriteString("]")
-	return b.String()
 }
 
 func (a *array) Type() semantic.MonoType {

--- a/values/dict.go
+++ b/values/dict.go
@@ -1,9 +1,7 @@
 package values
 
 import (
-	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/benbjohnson/immutable"
 	"github.com/influxdata/flux/codes"
@@ -125,10 +123,6 @@ func (d emptyDict) Equal(v Value) bool {
 	return d.t.Equal(v.Type()) && v.Dict().Len() == 0
 }
 
-func (d emptyDict) String() string {
-	return "[:]"
-}
-
 type dict struct {
 	t    semantic.MonoType
 	data *immutable.SortedMap
@@ -241,28 +235,6 @@ func (d dict) Equal(v Value) bool {
 		equal = value.Equal(v.(Value))
 	})
 	return equal
-}
-func (d dict) String() string {
-	b := strings.Builder{}
-	multiline := d.Len() > 3
-	b.WriteString("[")
-	sep := " "
-	if multiline {
-		sep = "\n"
-	}
-	b.WriteString(sep)
-	d.Range(func(k, v Value) {
-		if multiline {
-			b.WriteString("    ")
-		}
-		fmt.Fprint(&b, k)
-		b.WriteString(": ")
-		fmt.Fprint(&b, v)
-		b.WriteString(",")
-		b.WriteString(sep)
-	})
-	b.WriteString("]")
-	return b.String()
 }
 
 type (

--- a/values/display.go
+++ b/values/display.go
@@ -1,0 +1,250 @@
+package values
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/influxdata/flux/semantic"
+)
+
+// DisplayString formats the value into a string
+func DisplayString(v Value) string {
+	b := strings.Builder{}
+	_ = Display(&b, v)
+	return b.String()
+}
+
+// Display formats the value into the writer
+func Display(w io.Writer, v Value) error {
+	bw := bufio.NewWriter(w)
+	err := display(bw, v, 0)
+	if err != nil {
+		return err
+	}
+	return bw.Flush()
+}
+
+func display(w *bufio.Writer, v Value, indent int) (err error) {
+	if v.IsNull() {
+		_, err = w.WriteString("<null>")
+		return
+	}
+	switch v.Type().Nature() {
+	default:
+		_, err = w.WriteString("<unknown value>")
+		return
+	case semantic.Invalid:
+		_, err = w.WriteString("<invalid>")
+		return
+	case semantic.String:
+		_, err = w.WriteString(v.Str())
+		return
+	case semantic.Bytes:
+		_, err = fmt.Fprint(w, v.Bytes())
+		return
+	case semantic.Int:
+		_, err = fmt.Fprint(w, v.Int())
+		return
+	case semantic.UInt:
+		_, err = fmt.Fprint(w, v.UInt())
+		return
+	case semantic.Float:
+		_, err = fmt.Fprint(w, v.Float())
+		return
+	case semantic.Bool:
+		_, err = fmt.Fprint(w, v.Bool())
+		return
+	case semantic.Time:
+		_, err = w.WriteString(v.Time().String())
+		return
+	case semantic.Duration:
+		_, err = w.WriteString(v.Duration().String())
+		return
+	case semantic.Regexp:
+		_, err = w.WriteString(v.Regexp().String())
+		return
+	case semantic.Array:
+		a := v.Array()
+		multiline := a.Len() > 3
+		_, err = w.WriteString("[")
+		if err != nil {
+			return
+		}
+		if multiline {
+			err = newline(w, indent+1)
+			if err != nil {
+				return
+			}
+		}
+		a.Range(func(i int, v Value) {
+			if err != nil {
+				return
+			}
+			if i != 0 {
+				_, err = w.WriteString(", ")
+				if err != nil {
+					return
+				}
+				if multiline {
+					err = newline(w, indent+1)
+					if err != nil {
+						return
+					}
+				}
+			}
+			err = display(w, v, indent+1)
+		})
+		if err != nil {
+			return
+		}
+		if multiline {
+			err = newline(w, indent)
+			if err != nil {
+				return
+			}
+		}
+		_, err = w.WriteString("]")
+		return
+	case semantic.Object:
+		o := v.Object()
+		multiline := o.Len() > 3
+		_, err = w.WriteString("{")
+		if err != nil {
+			return
+		}
+		if multiline {
+			err = newline(w, indent+1)
+			if err != nil {
+				return
+			}
+		}
+		keys := make([]string, 0, o.Len())
+		o.Range(func(k string, v Value) {
+			keys = append(keys, k)
+		})
+		sort.Strings(keys)
+		for i, k := range keys {
+			v, _ := o.Get(k)
+			if i != 0 {
+				_, err = w.WriteString(", ")
+				if err != nil {
+					return
+				}
+				if multiline {
+					err = newline(w, indent+1)
+					if err != nil {
+						return
+					}
+				}
+			}
+			i++
+			_, err = w.WriteString(k)
+			if err != nil {
+				return
+			}
+			_, err = w.WriteString(": ")
+			if err != nil {
+				return
+			}
+			err = display(w, v, indent+1)
+			if err != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+		if multiline {
+			err = newline(w, indent)
+			if err != nil {
+				return
+			}
+		}
+		_, err = w.WriteString("}")
+		return
+	case semantic.Function:
+		_, err = w.WriteString(v.Type().CanonicalString())
+		return
+	case semantic.Dictionary:
+		d := v.Dict()
+		if d.Len() == 0 {
+			_, err = w.WriteString("[:]")
+			return
+		}
+		multiline := d.Len() > 3
+		_, err = w.WriteString("[")
+		if err != nil {
+			return
+		}
+		if multiline {
+			err = newline(w, indent+1)
+			if err != nil {
+				return
+			}
+		}
+		i := 0
+		d.Range(func(k, v Value) {
+			if err != nil {
+				return
+			}
+			if i != 0 {
+				_, err = w.WriteString(", ")
+				if err != nil {
+					return
+				}
+				if multiline {
+					err = newline(w, indent+1)
+					if err != nil {
+						return
+					}
+				}
+			}
+			i++
+			err = display(w, k, indent+1)
+			if err != nil {
+				return
+			}
+			_, err = w.WriteString(": ")
+			if err != nil {
+				return
+			}
+			err = display(w, v, indent+1)
+			if err != nil {
+				return
+			}
+		})
+		if err != nil {
+			return
+		}
+		if multiline {
+			err = newline(w, indent)
+			if err != nil {
+				return
+			}
+		}
+		_, err = w.WriteString("]")
+		return
+	}
+}
+
+const indentStr = "    "
+
+func writeIndent(w *bufio.Writer, indent int) (err error) {
+	for i := 0; i < indent; i++ {
+		_, err = w.WriteString(indentStr)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+func newline(w *bufio.Writer, indent int) (err error) {
+	_, err = w.WriteRune('\n')
+	if err != nil {
+		return
+	}
+	return writeIndent(w, indent)
+}

--- a/values/display_test.go
+++ b/values/display_test.go
@@ -1,0 +1,155 @@
+package values_test
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func TestDisplay(t *testing.T) {
+	testCases := []struct {
+		value   values.Value
+		display string
+	}{
+		{
+			value:   values.NewNull(semantic.BasicInt),
+			display: "<null>",
+		},
+		{
+			value:   values.NewString("hi"),
+			display: "hi",
+		},
+		{
+			value:   values.NewBytes([]byte{10, 11, 12}),
+			display: "[10 11 12]",
+		},
+		{
+			value:   values.NewInt(1),
+			display: "1",
+		},
+		{
+			value:   values.NewUInt(1),
+			display: "1",
+		},
+		{
+			value:   values.NewFloat(1.1),
+			display: "1.1",
+		},
+		{
+			value:   values.NewBool(true),
+			display: "true",
+		},
+		{
+			value:   values.NewTime(values.ConvertTime(time.Date(2020, 4, 12, 1, 2, 3, 4, time.UTC))),
+			display: "2020-04-12T01:02:03.000000004Z",
+		},
+		{
+			value:   values.NewDuration(values.ConvertDurationNsecs(time.Minute + time.Second)),
+			display: "1m1s",
+		},
+		{
+			value:   values.NewRegexp(regexp.MustCompile(".*")),
+			display: ".*",
+		},
+		{
+			value: values.NewArrayWithBacking(
+				semantic.NewArrayType(semantic.BasicInt),
+				[]values.Value{
+					values.NewInt(1),
+					values.NewInt(2),
+					values.NewInt(3),
+				},
+			),
+			display: "[1, 2, 3]",
+		},
+		{
+			value: values.NewArrayWithBacking(
+				semantic.NewArrayType(semantic.BasicInt),
+				[]values.Value{
+					values.NewInt(1),
+					values.NewInt(2),
+					values.NewInt(3),
+					values.NewInt(4),
+				},
+			),
+			display: "[\n    1, \n    2, \n    3, \n    4\n]",
+		},
+		{
+			value: values.NewObjectWithValues(
+				map[string]values.Value{
+					"a": values.NewInt(1),
+					"b": values.NewInt(1),
+					"c": values.NewInt(1),
+				},
+			),
+			display: "{a: 1, b: 1, c: 1}",
+		},
+		{
+			value: values.NewObjectWithValues(
+				map[string]values.Value{
+					"a": values.NewInt(1),
+					"b": values.NewInt(1),
+					"c": values.NewInt(1),
+					"d": values.NewInt(1),
+				},
+			),
+			display: "{\n    a: 1, \n    b: 1, \n    c: 1, \n    d: 1\n}",
+		},
+		{
+			value:   values.NewEmptyDict(semantic.NewDictType(semantic.BasicInt, semantic.BasicInt)),
+			display: "[:]",
+		},
+		{
+			value: func() values.Value {
+				b := values.NewDictBuilder(semantic.NewDictType(semantic.BasicInt, semantic.BasicInt))
+				b.Insert(values.NewInt(1), values.NewInt(0))
+				b.Insert(values.NewInt(2), values.NewInt(0))
+				b.Insert(values.NewInt(3), values.NewInt(0))
+				return b.Dict()
+			}(),
+			display: "[1: 0, 2: 0, 3: 0]",
+		},
+		{
+			value: func() values.Value {
+				b := values.NewDictBuilder(semantic.NewDictType(semantic.BasicInt, semantic.BasicInt))
+				b.Insert(values.NewInt(1), values.NewInt(0))
+				b.Insert(values.NewInt(2), values.NewInt(0))
+				b.Insert(values.NewInt(3), values.NewInt(0))
+				b.Insert(values.NewInt(4), values.NewInt(0))
+				return b.Dict()
+			}(),
+			display: "[\n    1: 0, \n    2: 0, \n    3: 0, \n    4: 0\n]",
+		},
+		{
+			value: values.NewFunction(
+				"foo",
+				semantic.NewFunctionType(semantic.BasicInt, nil),
+				func(ctx context.Context, args values.Object) (values.Value, error) {
+					return values.NewInt(1), nil
+				},
+				false,
+			),
+			display: "() -> int",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.display, func(t *testing.T) {
+			b := strings.Builder{}
+			err := values.Display(&b, tc.value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := b.String()
+			if tc.display != got {
+				t.Errorf("unexpected display strings diff: %s", cmp.Diff(tc.display, got))
+			}
+		})
+	}
+}

--- a/values/function.go
+++ b/values/function.go
@@ -2,7 +2,6 @@ package values
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	"github.com/influxdata/flux/semantic"
@@ -39,9 +38,6 @@ type function struct {
 
 func (f *function) IsNull() bool {
 	return false
-}
-func (f *function) String() string {
-	return fmt.Sprintf("%s()", f.name)
 }
 
 func (f *function) Type() semantic.MonoType {

--- a/values/object.go
+++ b/values/object.go
@@ -1,7 +1,6 @@
 package values
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -158,22 +157,6 @@ func NewObjectWithValues(vals map[string]Value) Object {
 
 func (o *object) IsNull() bool {
 	return false
-}
-func (o *object) String() string {
-	b := new(strings.Builder)
-	b.WriteString("{")
-	i := 0
-	o.Range(func(k string, v Value) {
-		if i != 0 {
-			b.WriteString(", ")
-		}
-		i++
-		b.WriteString(k)
-		b.WriteString(": ")
-		fmt.Fprint(b, v)
-	})
-	b.WriteString("}")
-	return b.String()
 }
 
 func (o *object) Type() semantic.MonoType {

--- a/values/values.go
+++ b/values/values.go
@@ -35,10 +35,6 @@ type Value interface {
 	Equal(Value) bool
 }
 
-type ValueStringer interface {
-	String() string
-}
-
 type value struct {
 	t semantic.MonoType
 	v interface{}


### PR DESCRIPTION
Prior to this change it was not clear how to display a values.Value into
a string. The intended method was to type assert to the
values.ValueStringer interface and call String().

Since values.ValueStringer was not part of the values.Value interface it
was optional to implement the String() method and it was required that
it was implemented on each implementation of the various values. This
meant that it was easy to forget to add String() support to new value
types (see #3687) and that if anyone wrapped the types in their own
implementation they would loose this ability.

This change instead adds a explicit Display functions to the package
that consume a given value. This way the Display code is clearly marked
and easily tested. When adding a new type it will be clear that Display
has not been implemented for that type and it does not require that each
implementation implement the String() method.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
