### PR TITLE
chore: update rust version to 1.52.0

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -118,7 +118,7 @@ USER $UNAME
 ENV HOME=/home/$UNAME
 
 # The latest stable rust version
-ENV RUST_LATEST_VERSION=1.51.0
+ENV RUST_LATEST_VERSION=1.52.0
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \


### PR DESCRIPTION
`rust` 1.52.0 was released today. This patch updates the build file.