### PR TITLE
docs(libflux): document `fluxcore::semantic::bootsrap` module

### DIFF
--- a/libflux/flux-core/src/semantic/bootstrap.rs
+++ b/libflux/flux-core/src/semantic/bootstrap.rs
@@ -79,7 +79,7 @@ impl From<&str> for Error {
         }
     }
 }
-/// Infers the types of the standard library returning two [`Importer`]s, one for the prelude
+/// Infers the types of the standard library returning two [`PolyTypeMap`]s, one for the prelude
 /// and one for the standard library, as well as a type variable [`Fresher`].
 #[allow(clippy::type_complexity)]
 pub fn infer_stdlib() -> Result<(PolyTypeMap, PolyTypeMap, Fresher, Vec<String>), Error> {

--- a/libflux/flux-core/src/semantic/bootstrap.rs
+++ b/libflux/flux-core/src/semantic/bootstrap.rs
@@ -224,9 +224,9 @@ fn dependencies<'a>(
     }
 }
 
-/// Constructs a polytype, or more specifically a generic row type, from a hash map.
+/// Constructs a polytype, or more specifically a generic record type, from a hash map.
 pub fn build_polytype(from: PolyTypeMap, f: &mut Fresher) -> Result<PolyType, Error> {
-    let (r, cons) = build_row(from, f);
+    let (r, cons) = build_record(from, f);
     let mut kinds = TvarKinds::new();
     let sub = infer::solve(&cons, &mut kinds, f)?;
     Ok(infer::generalize(
@@ -236,7 +236,7 @@ pub fn build_polytype(from: PolyTypeMap, f: &mut Fresher) -> Result<PolyType, Er
     ))
 }
 
-fn build_row(from: PolyTypeMap, f: &mut Fresher) -> (Record, Constraints) {
+fn build_record(from: PolyTypeMap, f: &mut Fresher) -> (Record, Constraints) {
     let mut r = Record::Empty;
     let mut cons = Constraints::empty();
 

--- a/libflux/flux-core/src/semantic/bootstrap.rs
+++ b/libflux/flux-core/src/semantic/bootstrap.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)]
+//! Flux start-up.
 
 use std::collections::HashSet;
 use std::fs;
@@ -27,8 +27,10 @@ const PRELUDE: [&str; 2] = ["universe", "influxdata/influxdb"];
 
 type AstFileMap = SemanticMap<String, ast::File>;
 
+/// Error returned during bootstrap.
 #[derive(Debug, PartialEq)]
 pub struct Error {
+    /// Error message.
     pub msg: String,
 }
 
@@ -77,10 +79,9 @@ impl From<&str> for Error {
         }
     }
 }
-
+/// Infers the types of the standard library returning two [`Importer`]s, one for the prelude
+/// and one for the standard library, as well as a type variable [`Fresher`].
 #[allow(clippy::type_complexity)]
-// Infer the types of the standard library returning two importers, one for the prelude
-// and one for the standard library, as well as a type variable fresher.
 pub fn infer_stdlib() -> Result<(PolyTypeMap, PolyTypeMap, Fresher, Vec<String>), Error> {
     let mut f = Fresher::default();
 
@@ -223,7 +224,7 @@ fn dependencies<'a>(
     }
 }
 
-// Constructs a polytype, or more specifically a generic row type, from a hash map
+/// Constructs a polytype, or more specifically a generic row type, from a hash map.
 pub fn build_polytype(from: PolyTypeMap, f: &mut Fresher) -> Result<PolyType, Error> {
     let (r, cons) = build_row(from, f);
     let mut kinds = TvarKinds::new();

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -39,7 +39,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/scanner/token.rs":                                        "5090c2ac4b341566a85f7d9ed9b48746dd2084ec2f3effdb4a7dc16cf34d44b9",
 	"libflux/flux-core/src/scanner/unicode.rl":                                      "f923f3b385ddfa65c74427b11971785fc25ea806ca03d547045de808e16ef9a1",
 	"libflux/flux-core/src/scanner/unicode.rl.COPYING":                              "6cf2d5d26d52772ded8a5f0813f49f83dfa76006c5f398713be3854fe7bc4c7e",
-	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "cca67b857da902c718efc3ed83c3a7f07c4935dd6e1753d28524c3ccf6c7d61f",
+	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "2918f4f61e97622857f9efe25154d959fcdd6b8fc03fd9b7b87e9d6ca1b95355",
 	"libflux/flux-core/src/semantic/check.rs":                                       "476db74a4479baff7091bb85a5ac2b8e9ffc07883bec92f9543a1024366ff9db",
 	"libflux/flux-core/src/semantic/convert.rs":                                     "fc78500a57dbfb9521303a5c5140939efe583ce855cd232afd5e6d43a8817893",
 	"libflux/flux-core/src/semantic/env.rs":                                         "7bbc29da93f07f7ad795e90d3b444791a195d98f6688a7bad5feffff9784902e",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -39,7 +39,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/scanner/token.rs":                                        "5090c2ac4b341566a85f7d9ed9b48746dd2084ec2f3effdb4a7dc16cf34d44b9",
 	"libflux/flux-core/src/scanner/unicode.rl":                                      "f923f3b385ddfa65c74427b11971785fc25ea806ca03d547045de808e16ef9a1",
 	"libflux/flux-core/src/scanner/unicode.rl.COPYING":                              "6cf2d5d26d52772ded8a5f0813f49f83dfa76006c5f398713be3854fe7bc4c7e",
-	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "2918f4f61e97622857f9efe25154d959fcdd6b8fc03fd9b7b87e9d6ca1b95355",
+	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "bf43b893782048d0eec2158a2897f5bfebd4323612cac0edbe92d9562ef2f73b",
 	"libflux/flux-core/src/semantic/check.rs":                                       "476db74a4479baff7091bb85a5ac2b8e9ffc07883bec92f9543a1024366ff9db",
 	"libflux/flux-core/src/semantic/convert.rs":                                     "fc78500a57dbfb9521303a5c5140939efe583ce855cd232afd5e6d43a8817893",
 	"libflux/flux-core/src/semantic/env.rs":                                         "7bbc29da93f07f7ad795e90d3b444791a195d98f6688a7bad5feffff9784902e",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -39,7 +39,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/scanner/token.rs":                                        "5090c2ac4b341566a85f7d9ed9b48746dd2084ec2f3effdb4a7dc16cf34d44b9",
 	"libflux/flux-core/src/scanner/unicode.rl":                                      "f923f3b385ddfa65c74427b11971785fc25ea806ca03d547045de808e16ef9a1",
 	"libflux/flux-core/src/scanner/unicode.rl.COPYING":                              "6cf2d5d26d52772ded8a5f0813f49f83dfa76006c5f398713be3854fe7bc4c7e",
-	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "bf43b893782048d0eec2158a2897f5bfebd4323612cac0edbe92d9562ef2f73b",
+	"libflux/flux-core/src/semantic/bootstrap.rs":                                   "bbcc03dcfa6c4beb47ec3f1b03f48ca4efb5bd7aafa91051edfd5ff1e9bebe25",
 	"libflux/flux-core/src/semantic/check.rs":                                       "476db74a4479baff7091bb85a5ac2b8e9ffc07883bec92f9543a1024366ff9db",
 	"libflux/flux-core/src/semantic/convert.rs":                                     "fc78500a57dbfb9521303a5c5140939efe583ce855cd232afd5e6d43a8817893",
 	"libflux/flux-core/src/semantic/env.rs":                                         "7bbc29da93f07f7ad795e90d3b444791a195d98f6688a7bad5feffff9784902e",


### PR DESCRIPTION
Removes `#![allow(missing_docs)]`.

The meaning of this module was not entirely clear to me. Can we say more about what "bootstrap" means here? 🤔 