### PR TITLE
chore: runtime: better "builtins not finalized" panic message

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -18,6 +18,8 @@ import (
 // required to execute a flux script.
 var Default = &runtime{}
 
+const panicNotFinalized = "builtins not finalized (you may be missing an `import _ \"github.com/influxdata/idpe/fluxinit/static\"` statement)"
+
 // runtime contains the flux runtime for interpreting and
 // executing queries.
 type runtime struct {
@@ -107,7 +109,7 @@ func (r *runtime) registerPackageValue(pkgpath, name string, value values.Value,
 
 func (r *runtime) Prelude() values.Scope {
 	if !r.finalized {
-		panic("builtins not finalized")
+		panic(panicNotFinalized)
 	}
 	importer := r.Stdlib()
 	scope, err := r.newScopeFor("main", importer)
@@ -175,7 +177,7 @@ func (r *runtime) newScopeFor(pkgpath string, imp interpreter.Importer) (values.
 
 func (r *runtime) Stdlib() interpreter.Importer {
 	if !r.finalized {
-		panic("builtins not finalized")
+		panic(panicNotFinalized)
 	}
 	return &importer{r: r}
 }

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -18,7 +18,7 @@ import (
 // required to execute a flux script.
 var Default = &runtime{}
 
-const panicNotFinalized = "builtins not finalized (you may be missing an `import _ \"github.com/influxdata/idpe/fluxinit/static\"` statement)"
+const panicNotFinalized = "builtins not finalized (you may be missing an `import _ \"github.com/influxdata/REPO/fluxinit/static\"` statement)"
 
 // runtime contains the flux runtime for interpreting and
 // executing queries.


### PR DESCRIPTION
This panic often happens because the `fluxinit/static` package
has not been imported, leading to developer confusion.
Mention this common cause in the panic message.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
