### PR TITLE
fix(execute): remove deadlock when an error happens while the dispatcher is stopping

### DIFF
--- a/execute/dispatcher_test.go
+++ b/execute/dispatcher_test.go
@@ -1,0 +1,38 @@
+package execute
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+)
+
+func TestDispatcher_Stop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := newPoolDispatcher(10, zaptest.NewLogger(t))
+	d.Start(100, ctx)
+
+	for i := 0; i < 100; i++ {
+		d.Schedule(func(ctx context.Context, throughput int) {
+			<-ctx.Done()
+			panic("expected")
+		})
+	}
+	cancel()
+
+	if err := d.Stop(); err == nil {
+		t.Fatal("expected error")
+	} else if got, want := err.Error(), "panic: expected"; got != want {
+		t.Fatalf("unexpected error -want/+got:\n\t- %s\n\t+ %s", want, got)
+	}
+}
+
+func TestDispatcher_MultipleStops(t *testing.T) {
+	d := newPoolDispatcher(10, zaptest.NewLogger(t))
+	d.Start(1, context.Background())
+
+	// Stopping repeatedly should not deadlock.
+	for i := 0; i < 10; i++ {
+		_ = d.Stop()
+	}
+}


### PR DESCRIPTION
If the dispatcher had an error, such as a panic, while stopping, it
would attempt to set the error on the dispatcher. The `Stop()` method,
which could be triggered by a previous error, would take the lock and
then wait for the workers to finish.

But a worker could then try to set the error before it exited and
setting an error also attempted to take the lock. This created a
deadlock where stopping required waiting for the worker, but the worker
was waiting for stop to release the lock.

This modifies the dispatcher so that it does not hold the lock while it
is waiting and only holds it while using the shared state.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written