### PR TITLE
fix: Odd behaviour when going over the Go Rust boundary multiple times using JSON serialization.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -736,9 +736,9 @@ func (s *TestStatement) Copy() Node {
 // TestCaseStatement declares a Flux test case
 type TestCaseStatement struct {
 	BaseNode
-	ID      *Identifier
-	Extends *StringLiteral `json:",omitempty"`
-	Block   *Block
+	ID      *Identifier    `json:"id"`
+	Extends *StringLiteral `json:"extends,omitempty"`
+	Block   *Block         `json:"block"`
 }
 
 // Type is the abstract type

--- a/ast/astutil/format_test.go
+++ b/ast/astutil/format_test.go
@@ -186,6 +186,25 @@ builtin baz : int`; want != got {
 	}
 }
 
+func TestFormatWithTestCaseStmt(t *testing.T) {
+	src := `testcase my_test { a = 1 }`
+	pkg := parser.ParseSource(src)
+	if ast.Check(pkg) > 0 {
+		t.Fatalf("unexpected error: %s", ast.GetError(pkg))
+	} else if len(pkg.Files) != 1 {
+		t.Fatalf("expected one file in the package, got %d", len(pkg.Files))
+	}
+
+	got, err := astutil.Format(pkg.Files[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := "testcase my_test {\n    a = 1\n}"; want != got {
+		t.Errorf("unexpected formatted file -want/+got:\n\t- %q\n\t+ %q", want, got)
+	}
+}
+
 func TestFormatWithComments(t *testing.T) {
 	src := `    // hi
     // there

--- a/ast/json_test.go
+++ b/ast/json_test.go
@@ -499,6 +499,24 @@ func TestJSONMarshal(t *testing.T) {
 			want: `{"type":"TestStatement","assignment":{"type":"VariableAssignment","id":{"type":"Identifier","name":"mean"},"init":{"type":"ObjectExpression","properties":[{"type":"Property","key":{"type":"Identifier","name":"want"},"value":{"type":"IntegerLiteral","value":"0"}},{"type":"Property","key":{"type":"Identifier","name":"got"},"value":{"type":"IntegerLiteral","value":"0"}}]}}}`,
 		},
 		{
+			name: "test case statement",
+			node: &ast.TestCaseStatement{
+
+				ID: &ast.Identifier{Name: "test case statement id"},
+				Extends: &ast.StringLiteral{
+					Value: "extended test case",
+				},
+				Block: &ast.Block{
+					Body: []ast.Statement{
+						&ast.ExpressionStatement{
+							Expression: &ast.StringLiteral{Value: "expression statement"},
+						},
+					},
+				},
+			},
+			want: `{"type":"TestCaseStatement","id":{"type":"Identifier","name":"test case statement id"},"extends":{"type":"StringLiteral","value":"extended test case"},"block":{"type":"Block","body":[{"type":"ExpressionStatement","expression":{"type":"StringLiteral","value":"expression statement"}}]}}`,
+		},
+		{
 			name: "qualified option statement",
 			node: &ast.OptionStatement{
 				Assignment: &ast.MemberAssignment{

--- a/libflux/flux-core/src/ast/tests.rs
+++ b/libflux/flux-core/src/ast/tests.rs
@@ -1044,6 +1044,43 @@ fn test_json_test_statement() {
     let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
     assert_eq!(deserialized, n)
 }
+
+#[test]
+fn test_json_test_case_statement() {
+    let n = Statement::TestCase(Box::new(TestCaseStmt {
+        base: BaseNode::default(),
+        id: Identifier {
+            base: BaseNode::default(),
+            name: "my_test".to_string(),
+        },
+        extends: None,
+        block: Block {
+            base: BaseNode::default(),
+            lbrace: vec![],
+            body: vec![Statement::Variable(Box::new(VariableAssgn {
+                base: BaseNode::default(),
+                id: Identifier {
+                    base: BaseNode::default(),
+                    name: "a".to_string(),
+                },
+                init: Expression::Integer(IntegerLit {
+                    base: Default::default(),
+                    value: 1,
+                }),
+            }))],
+            rbrace: vec![],
+        },
+    }));
+
+    let serialized = serde_json::to_string(&n).unwrap();
+    assert_eq!(
+        serialized,
+        r#"{"type":"TestCaseStatement","id":{"name":"my_test"},"block":{"type":"Block","body":[{"type":"VariableAssignment","id":{"name":"a"},"init":{"type":"IntegerLiteral","value":"1"}}]}}"#
+    );
+    let deserialized: Statement = serde_json::from_str(serialized.as_str()).unwrap();
+    assert_eq!(deserialized, n)
+}
+
 /*
 {
     name: "qualified option statement",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -23,7 +23,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/flatbuffers/monotype.rs":                             "3458c71780a0eff7ab1f99dc11a0b927c8f8e68513e0da01e82cba363e608ecc",
 	"libflux/flux-core/src/ast/flatbuffers/tests.rs":                                "bc6bd70fecd933332b198f327e1121ec29fbcc47e6c0d1816d7f4568bd892714",
 	"libflux/flux-core/src/ast/mod.rs":                                              "1b371ae53fa4258d55c5f490101195100b4151718db73d0bc0696f8fec0621c3",
-	"libflux/flux-core/src/ast/tests.rs":                                            "968312928c54af3a43d4e2290a024c1fdb57add97fba58f780fbdd9be19d8642",
+	"libflux/flux-core/src/ast/tests.rs":                                            "bc7f77d569d8bbd4b9d00653f48bacd47eed46f53024dce836d3c8bbb6a80555",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                         "8f1c9a842374f44cb72b92f18a13cd831912ce96cd34f491e68c90bf4f1d36fa",
 	"libflux/flux-core/src/ast/walk/tests.rs":                                       "f7b2d7dd5643bb795a86c04b6979b136b0de46b52b213caff094aed6d204a05d",
 	"libflux/flux-core/src/formatter/mod.rs":                                        "f244f1439dbad254f8b4c3bc4039009e4e601714146082825ea72a14e0d2a67b",


### PR DESCRIPTION
In the `TestCaseStmt` statement, `id` & `block` are missing in the flux file because of which we are getting the following error. 
`format_test.go:206: missing field `id` at line 1 column 3335`
` format_test.go:206: missing field `block` at line 1 column 3335 `

Adding default to struct TestCaseStmt fixes the issue. 

fixes: #3715 



