### PR TITLE
feat(ast/astutil): Expose a function for ast.Package formatting

### DIFF
--- a/ast/astutil/format.go
+++ b/ast/astutil/format.go
@@ -7,7 +7,7 @@ import (
 	"github.com/influxdata/flux/runtime"
 )
 
-// Format will format the AST to a string.
+// Format will format an AST File to a string.
 func Format(f *ast.File) (string, error) {
 	pkg := &ast.Package{
 		Files: []*ast.File{f},
@@ -15,6 +15,11 @@ func Format(f *ast.File) (string, error) {
 	if f.Package != nil && f.Package.Name != nil {
 		pkg.Package = f.Package.Name.Name
 	}
+	return FormatPackage(pkg)
+}
+
+// FormatPackage will format an AST Package to a string.
+func FormatPackage(pkg *ast.Package) (string, error) {
 	data, err := json.Marshal(pkg)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Checks and Notifications produce `*ast.Package` structures instead of `*ast.File`. There are still cases where a function that accepts `*ast.File` is useful, but having one that can handle the package is needed. This exposes that behavior so it can be used directly.
