### PR TITLE
fix: set CARGO_HOME after privilege drop

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -71,6 +71,7 @@ ARG GID=1000
 RUN groupadd -g $GID -o $UNAME
 RUN useradd -m -u $UID -g $UNAME -s /bin/bash $UNAME
 USER $UNAME
-ENV HOME=/home/$UNAME
+ENV HOME=/home/$UNAME \
+    CARGO_HOME=/home/$UNAME/.cargo
 
 WORKDIR $HOME


### PR DESCRIPTION
The current docker image can't build rust libraries because CARGO_HOME
is set to a read-only directory. This patch fixes that.