### PR TITLE
fix: update comrak

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e35da16961500625e065fba09983bb300bbf3c6fbc1840bd5bbda595ee6d80"
+checksum = "b423acba50d5016684beaf643f9991e622633a4c858be6885653071c2da2b0c6"
 dependencies = [
  "clap",
  "entities",

--- a/libflux/fluxdoc/Cargo.toml
+++ b/libflux/fluxdoc/Cargo.toml
@@ -18,5 +18,5 @@ serde_derive = "^1.0.59"
 serde_json = "1.0"
 tera = "1"
 lazy_static = "1.4.0"
-comrak = "0.9.0"
+comrak = "0.10.1"
 

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,7 +12,7 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                            "3e548c7055e4d410d2424057d895766b4864ec3b3b62343d6304204da6905813",
+	"libflux/Cargo.lock":                                                            "952fa35cbd351f13dbb70db5f42b1281acb8060c0ebd601258399dc9ecd1be1d",
 	"libflux/Cargo.toml":                                                            "c15d0e819daae82f6f1cc05c556f48cb22d91eb6e7bd6d8c2ccf3f2450f925f2",
 	"libflux/flux-core/Cargo.toml":                                                  "250d498b2cec53225353a2a091660debd05c2ce69ad421e161c401b5dfc45df1",
 	"libflux/flux-core/benches/scanner.rs":                                          "da73723114b3a22ef3f497fbc7bf9b93b4ddc1e38d31d0fee974e027fb45f199",


### PR DESCRIPTION
As reported in [RUSTSEC-2021-0063](https://rustsec.org/advisories/RUSTSEC-2021-0063), the version of comrak
we use in `fluxdoc` has an XSS vulnerability. This patch updates comrak
to a version without the vulnerability.