### PR TITLE
fix: staticcheck linter failures

### DIFF
--- a/ast/errors.go
+++ b/ast/errors.go
@@ -50,7 +50,7 @@ func check(n Node) int {
 		}
 		if hasImplicit && hasExplicit {
 			n.Errors = append(n.Errors, Error{
-				Msg: fmt.Sprintf("cannot mix implicit and explicit properties"),
+				Msg: "cannot mix implicit and explicit properties",
 			})
 		}
 	case *PipeExpression:

--- a/ast/fbuffers.go
+++ b/ast/fbuffers.go
@@ -162,7 +162,7 @@ func (p ParameterType) FromBuf(buf *fbast.ParameterType) *ParameterType {
 func newFBTable(f unionTableWriterFn, base *BaseNode) *flatbuffers.Table {
 	t := new(flatbuffers.Table)
 	if !f(t) {
-		base.Errors = append(base.Errors, Error{fmt.Sprint("serialization error")})
+		base.Errors = append(base.Errors, Error{"serialization error"})
 	}
 	return t
 }

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -273,7 +273,9 @@ func CreatePhysicalNode(id NodeID, spec PhysicalProcedureSpec) *PhysicalPlanNode
 	}
 }
 
-const NextPlanNodeIDKey = "NextPlanNodeID"
+type nodeIDKey string
+
+const NextPlanNodeIDKey nodeIDKey = "NextPlanNodeID"
 
 func CreateUniquePhysicalNode(ctx context.Context, prefix string, spec PhysicalProcedureSpec) *PhysicalPlanNode {
 	if value := ctx.Value(NextPlanNodeIDKey); value != nil {

--- a/plan/rules_test.go
+++ b/plan/rules_test.go
@@ -75,12 +75,14 @@ func TestRuleRegistration(t *testing.T) {
 	}
 }
 
+type contextKey string
+
 func TestRewriteWithContext(t *testing.T) {
 	plan.ClearRegisteredRules()
 
 	var (
-		ctxKey  = "contextKey"
-		rewrite = false
+		ctxKey  contextKey = "contextKey"
+		rewrite            = false
 		value   interface{}
 	)
 	functionRule := plantest.FunctionRule{
@@ -141,10 +143,9 @@ func TestRewriteWithContext(t *testing.T) {
 
 func TestRewriteWithContext_TableObjectCompiler(t *testing.T) {
 	plan.ClearRegisteredRules()
-
 	var (
-		ctxKey  = "contextKey"
-		rewrite = false
+		ctxKey  contextKey = "contextKey"
+		rewrite            = false
 		value   interface{}
 	)
 	functionRule := plantest.FunctionRule{

--- a/stdlib/sql/sqlite_test.go
+++ b/stdlib/sql/sqlite_test.go
@@ -2,7 +2,6 @@ package sql
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,27 +19,27 @@ func TestBoolTranslation(t *testing.T) {
 	}
 
 	// create table - column type can be anything
-	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS bools (name TEXT, age INT, employed BOOL)")
+	q := "CREATE TABLE IF NOT EXISTS bools (name TEXT, age INT, employed BOOL)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
 	// insert first row - BOOL as BOOL, which sqlite WILL accept as a write - and silently store true as 1
-	q = fmt.Sprintf("INSERT INTO bools (name, age, employed) VALUES (\"albert\",110,true)")
+	q = "INSERT INTO bools (name, age, employed) VALUES (\"albert\",110,true)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
 	// insert second row - BOOL as INT - again, will accept ok
-	q = fmt.Sprintf("INSERT INTO bools (name, age, employed) VALUES (\"mary\",10,1)")
+	q = "INSERT INTO bools (name, age, employed) VALUES (\"mary\",10,1)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
-	q = fmt.Sprintf("SELECT * FROM bools")
+	q = "SELECT * FROM bools"
 	results, err := db.Query(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
@@ -79,34 +78,34 @@ func TestNulTranslation(t *testing.T) {
 	}
 
 	// create table
-	q := fmt.Sprintf("CREATE TABLE IF NOT EXISTS magic (name TEXT, age INT, employed BADINTBOOL)")
+	q := "CREATE TABLE IF NOT EXISTS magic (name TEXT, age INT, employed BADINTBOOL)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
 	// insert first row - null string
-	q = fmt.Sprintf("INSERT INTO magic (age, employed) VALUES (11,true)")
+	q = "INSERT INTO magic (age, employed) VALUES (11,true)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
 	// insert second row - null int
-	q = fmt.Sprintf("INSERT INTO magic (name, employed) VALUES (\"mary\",true)")
+	q = "INSERT INTO magic (name, employed) VALUES (\"mary\",true)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
 	// insert third row - null bool
-	q = fmt.Sprintf("INSERT INTO magic (name, age) VALUES (\"casper\",10)")
+	q = "INSERT INTO magic (name, age) VALUES (\"casper\",10)"
 	_, err = db.Exec(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))
 	}
 
-	q = fmt.Sprintf("SELECT * FROM magic")
+	q = "SELECT * FROM magic"
 	results, err := db.Query(q)
 	if !cmp.Equal(err, nil) {
 		t.Fatalf("unexpected result -want/+got\n\n%s\n\n", cmp.Diff(nil, err))

--- a/tracing.go
+++ b/tracing.go
@@ -4,7 +4,9 @@ import (
 	"context"
 )
 
-const queryTracingContextKey = "query-tracing-enabled"
+type contextKey string
+
+const queryTracingContextKey contextKey = "query-tracing-enabled"
 
 // WithQueryTracingEnabled will return a child context
 // that will turn on experimental query tracing.


### PR DESCRIPTION
Fixed following static check linter failures -

1) should not use built-in type string as key for value; define your own type to avoid collisions (SA1029)
2) unnecessary use of fmt.Sprintf (S1039)


