### PR TITLE
docs(libflux): cleanup docs for AST `base` methods

### DIFF
--- a/libflux/flux-core/src/ast/mod.rs
+++ b/libflux/flux-core/src/ast/mod.rs
@@ -177,7 +177,7 @@ pub enum Expression {
 }
 
 impl Expression {
-    /// `base` is an utility method that returns the BaseNode for an Expression.
+    /// Returns the [`BaseNode`] for an [`Expression`].
     pub fn base(&self) -> &BaseNode {
         match self {
             Expression::Identifier(wrapped) => &wrapped.base,
@@ -232,7 +232,7 @@ pub enum Statement {
 }
 
 impl Statement {
-    /// `base` is an utility method that returns the BaseNode for a Statement.
+    /// Returns the [`BaseNode`] for a [`Statement`].
     pub fn base(&self) -> &BaseNode {
         match self {
             Statement::Expr(wrapped) => &wrapped.base,
@@ -246,7 +246,7 @@ impl Statement {
         }
     }
 
-    /// returns a integer based type value.
+    /// Returns an integer-based type value.
     pub fn typ(&self) -> i8 {
         match self {
             Statement::Expr(_) => 0,
@@ -272,7 +272,7 @@ pub enum Assignment {
 }
 
 impl Assignment {
-    /// `base` is an utility method that returns the BaseNode for an Assignment.
+    /// Returns the [`BaseNode`] for an [`Assignment`].
     pub fn base(&self) -> &BaseNode {
         match self {
             Assignment::Variable(wrapped) => &wrapped.base,
@@ -291,7 +291,7 @@ pub enum PropertyKey {
 }
 
 impl PropertyKey {
-    /// `base` is an utility method that returns the BaseNode for a PropertyKey.
+    /// Returns the [`BaseNode`] for a [`PropertyKey`].
     pub fn base(&self) -> &BaseNode {
         match self {
             PropertyKey::Identifier(wrapped) => &wrapped.base,
@@ -313,7 +313,7 @@ pub enum FunctionBody {
 }
 
 impl FunctionBody {
-    /// `base` is an utility method that returns the BaseNode for a FunctionBody.
+    /// Returns the [`BaseNode`] for a [`FunctionBody`].
     pub fn base(&self) -> &BaseNode {
         match self {
             FunctionBody::Block(wrapped) => &wrapped.base,

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -22,7 +22,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/flatbuffers/mod.rs":                                  "a346e953c9902b32999b3300f8cab23f79684fc2ff9e48549d209b0c16d55fec",
 	"libflux/flux-core/src/ast/flatbuffers/monotype.rs":                             "3458c71780a0eff7ab1f99dc11a0b927c8f8e68513e0da01e82cba363e608ecc",
 	"libflux/flux-core/src/ast/flatbuffers/tests.rs":                                "bc6bd70fecd933332b198f327e1121ec29fbcc47e6c0d1816d7f4568bd892714",
-	"libflux/flux-core/src/ast/mod.rs":                                              "1b371ae53fa4258d55c5f490101195100b4151718db73d0bc0696f8fec0621c3",
+	"libflux/flux-core/src/ast/mod.rs":                                              "d298bc3be9cc317fc3ca7cbf654fe6f0c053158d51d06be901ea61eceb2ab050",
 	"libflux/flux-core/src/ast/tests.rs":                                            "bc7f77d569d8bbd4b9d00653f48bacd47eed46f53024dce836d3c8bbb6a80555",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                         "8f1c9a842374f44cb72b92f18a13cd831912ce96cd34f491e68c90bf4f1d36fa",
 	"libflux/flux-core/src/ast/walk/tests.rs":                                       "f7b2d7dd5643bb795a86c04b6979b136b0de46b52b213caff094aed6d204a05d",


### PR DESCRIPTION
Also add intra-doc links.
