### PR TITLE
fix(csv): adds length check to csv annotation parsing

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -384,10 +384,19 @@ func readMetadata(r *bufferedCSVReader, c ResultDecoderConfig) (tableMetadata, e
 			}
 			switch annotation := strings.TrimPrefix(line[annotationIdx], commentPrefix); annotation {
 			case datatypeAnnotation:
+				if defaultRecordStartIdx > len(line) {
+					return tableMetadata{}, errors.Wrap(csv.ErrFieldCount, codes.Invalid, "failed to read \"datatype\" annotation")
+				}
 				datatypes = copyLine(line[defaultRecordStartIdx:])
 			case groupAnnotation:
+				if defaultRecordStartIdx > len(line) {
+					return tableMetadata{}, errors.Wrap(csv.ErrFieldCount, codes.Invalid, "failed to read \"group\" annotation")
+				}
 				groups = copyLine(line[defaultRecordStartIdx:])
 			case defaultAnnotation:
+				if defaultRecordStartIdx > len(line) {
+					return tableMetadata{}, errors.Wrap(csv.ErrFieldCount, codes.Invalid, "failed to read \"default\" annotation")
+				}
 				resultID = line[resultIdx]
 				tableID = line[tableIdx]
 				if _, err := strconv.ParseInt(tableID, 10, 64); tableID != "" && err != nil {

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -1495,6 +1495,33 @@ data1,data2,data3
 				}},
 			},
 		},
+		{
+			name:          "error on short annotation datatype",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded:       toCRLF("#datatype,long"),
+			result: &executetest.Result{
+				Nm:  "_result",
+				Err: errors.New("failed to read metadata: failed to read \"datatype\" annotation: wrong number of fields"),
+			},
+		},
+		{
+			name:          "error on short annotation group",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded:       toCRLF("#group,false"),
+			result: &executetest.Result{
+				Nm:  "_result",
+				Err: errors.New("failed to read metadata: failed to read \"group\" annotation: wrong number of fields"),
+			},
+		},
+		{
+			name:          "error on short annotation default",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded:       toCRLF("#default,1"),
+			result: &executetest.Result{
+				Nm:  "_result",
+				Err: errors.New("failed to read metadata: failed to read \"default\" annotation: wrong number of fields"),
+			},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Prior to this change csv that had annotations with less than three
fields would cause the csv decoder to panic. Now an appropriate error
message is returned.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
