### PR TITLE
chore: Add spec for flux doc comments

### DIFF
--- a/libflux/flux/FLUXDOC.md
+++ b/libflux/flux/FLUXDOC.md
@@ -1,10 +1,11 @@
-# Flux Doc Comments
+# Flux doc comments
 
-In the interest of establishing a single source of authority for Flux documentation,
+## Project background and goals
+
+In order to establish a single source for Flux documentation,
 Flux will soon support doc comments in `stdlib`. Work is underway to integrate the
 documentation generated from doc comments into the `flux` crate, and expose them
-as JSON data for broader consumption. This document defines the details of how
-Flux doc comments should be written and formatted.
+as JSON data for broader consumption.
 
 The end goals of this project are as follows:
 
@@ -13,39 +14,41 @@ The end goals of this project are as follows:
 2. Expose documentation via the the Flux Language Server Protocol.
 3. Use the docs to generate a static site that will become the new home of the official Flux documentation.
 
-## Design Considerations
+This document defines how Flux doc comments should be written and formatted.
 
-The generated Flux docs will need to support different formats for different consumers.
-As an example, the Flux LSP and the InfluxDB UI will need to produce a condensed 
+## Writing Flux doc comments
+
+A Flux doc comment is any uninterrupted series of line comments immediately preceding
+one of the following:
+
+- [package clause](#packages)
+- [package value (assignment or builtin statement)](#package-values)
+- [function declaration](#functions)
+- [option declaration](#options)
+
+Flux doc comments support Markdown formatting in accordance with the
+[CommonMark specification](https://spec.commonmark.org/0.29/).
+
+### Headlines and descriptions
+
+Flux docs need to support different formats for different consumers.
+For example, the Flux LSP and the InfluxDB UI will need to produce a condensed
 version of the documentation for any given identifier in the Flux standard library.
-In contrast, the official docs site will need to present much more detailed information
+In contrast, the docs site will need to present more detailed information
 to readers. Consumers should be able to decide which format they want to use by
 selecting only the parts of the docs that are required for their use case.
 
-To allow for this, Flux doc comments are formatted so that the doc comment parser
-can easily distinguish the short-form content from the long-form content. In most
-cases throughout this document, these will be referred to as the "headline" and
-the "description", respectively.
+To allow for this, Flux doc comments consist of a _headline_ and a _description_.
+A description may contain one or more _code examples_.
 
-## Writing Flux Doc Comments
-
-Flux will treat any uninterrupted series of line comments immediately preceding
-an assignment statement, builtin statement, package clause, or option declaration, as a doc comment.
-
-Flux doc comments support markdown formatting in accordance with the 
-[CommonMark specification](https://spec.commonmark.org/0.29/).
-
-### Documenting Packages
-
-The documentation for a Flux package consists of a short headline, and a description,
-which may contain one or more code examples.
+### Packages
 
 #### Headline
 
 This is a one-sentence description of the package. The beginning of the sentence
 should read `Package <package-name> provides...`, and should be on its own line.
 
-Follow the headline with a blank line comment.
+There must be a blank line comment between the headline and description.
 
 #### Description
 
@@ -53,20 +56,20 @@ This section provides a detailed description of the package and its
 contents.
 
 If the package provides any constants that require documentation, that documentation
-should be included here. Otherwise, constants will just be listed by name in the 
+should be included here. Otherwise, constants are listed by name in the
 generated package documentation, with no further elaboration.
 
-Any code examples should be contained in a markdown-formatted code block, and may be
+Code examples should be contained in a Markdown-formatted code block, and may be
 included anywhere in the description. Readers should be able to copy and paste any
 any example code into the InfluxDB data explorer and run it with no modifications.
 Any sample data used in a code example should come from an `array.from()` call in
-the example code itself, rather than being represented as a markdown- or html-formatted table.
+the example code itself, rather than being represented as a Markdown- or html-formatted table.
 
-Future iterations on this project may add extra functionality around code examples
-(for instance, allowing users to run them interactively on the docs site). For now,
-they will just be treated as plain markdown.
+> Future iterations on this project may add extra functionality around code examples
+> (for instance, allowing users to run them interactively on the docs site). For now,
+> they will just be treated as plain Markdown.
 
-### Documenting package values
+### Package values
 
 Packages expose values via assignment statements and builtin statements.
 These values should be documented with a headline and optional description.
@@ -83,7 +86,7 @@ Follow the headline with a blank line comment.
 
 _Example:_
 
-Here's what the doc comment might look like for the pi constant in the math package.
+Here's what the doc comment might look like for the pi constant in the `math` package.
 
 ```
 // pi is a floating point representation of the mathematical constant pi.
@@ -92,17 +95,16 @@ builtin pi : float
 
 #### Description
 
-This section follows the same guidelines as those outlined in the `Description` section
-under the `Documenting Packages` heading earlier in this document.
+Package value descriptions are the same as [package descriptions](#description) above.
 
 _Example:_
 
-Here's what the doc comment might look like for the hypothetical constant forty-two from the math package.
+Here's what the doc comment might look like for a fictional constant `fortyTwo` from the math package.
 
 ```
 // fortyTwo is the integer 42.
 //
-// The constant fortyTwo can be used to deteremine the answer to import questions
+// The constant fortyTwo can be used to deteremine the answer to important questions.
 //
 // ```
 // import "math"
@@ -113,7 +115,7 @@ Here's what the doc comment might look like for the hypothetical constant forty-
 fortyTwo = 42
 ```
 
-### Documenting functions
+### Functions
 
 When a package exposes a value that is a function we want to include additional information
 about the function's parameters. Documentation for Flux functions consists of a short headline, a detailed description,
@@ -137,8 +139,7 @@ _Example:_
 
 #### Description
 
-This section follows the same guidelines as those outlined in the `Description` section
-under the `Documenting Packages` heading earlier in this document,
+Function descriptions are formatted the same as [package descriptions](#description) above,
 with the exception that every function description should include documentation
 for the function's parameters.
 
@@ -149,23 +150,23 @@ Every function description should include at least one code example.
 Documentation for function parameters is required, but it can appear anywhere in
 the function description.
 
-The parameters should be organized into a markdown-formatted unordered list, and
-should be immediately preceded by a markdown H2 header entitled `Parameters`.
+The parameters should be organized into a Markdown-formatted unordered list, and
+should be immediately preceded by a Markdown H2 header, `## Parameters`.
 Each list item should start with the name of the parameter as it appears in the
-function signature, followed by a brief, one-line description. Each list item
+function signature, followed by a brief one-line description. Each list item
 should read as a complete sentence, and should be properly punctuated.
 
 The parameters in the list should be ordered exactly as they are in the function
-signature, and no parameter should be omitted.
+signature. No parameter should be omitted.
 
 While the top-level list item for each parameter is limited to a short, one-line
-description, the parameter list may include extra markdown content after each list item.
+description, the parameter list may include extra Markdown content after each list item.
 Much like the distinction between a headline and a full description outlined
-earlier in this document, it can be helpful to think of the top-level list item 
+earlier in this document, it can be helpful to think of the top-level list item
 as a condensed description fit for short-form docs, and the notes that come after
 each list item as a more detailed explanation for use in long-form docs.
 
-Only the top-level list items are required in the parameter list. The extra notes
+Only top-level list items are required in the parameter list. Extra notes
 for each parameter are optional, and may be omitted.
 
 See the [`lists`](https://spec.commonmark.org/0.29/#lists) section in the CommonMark spec for specifics on supported formatting in the parameter list.
@@ -205,20 +206,20 @@ Here's what a parameter list might look like for the `aggregateWindow` function.
 // - tables is a stream of input tables.
 ```
 
-#### Other Information
+#### Other information
 
 There are other details about Flux functions that we will want to document, like
 the full type signature of each function, and which of the parameters are required.
-That information can be found in the function signature, and does not need be 
+That information can be found in the function signature, and does not need be
 included in the doc comment.
 
-#### Example
+#### Example function documentation
 
 Here's an example of a full doc comment for the `join` function.
 
 ```
-// join merges two input streams based on columns with equal values. 
-// 
+// join merges two input streams based on columns with equal values.
+//
 // Null values are not considered equal when comparing column
 // values. The resulting schema is the union of the input schemas. The resulting
 // group key is the union of the input group keys.
@@ -226,7 +227,7 @@ Here's an example of a full doc comment for the `join` function.
 // ## Parameters
 // - `tables` is a stream of tables
 // - `method` is the method to use when joining
-//    
+//
 //    Currently, this function only supports inner joins.
 //    Performaing an inner join will require both input
 //    tables to match their columns based on the `on` parameter.
@@ -234,7 +235,7 @@ Here's an example of a full doc comment for the `join` function.
 // - `on` is a list of column names on which to join.
 //
 // ## Joining two tables
-// 
+//
 // ```
 // import "array"
 //
@@ -263,7 +264,7 @@ Here's an example of a full doc comment for the `join` function.
 // ## Output schema of a joined table
 //
 // The column schema of the output stream is the union
-// of the input schemas. It is also the same for the 
+// of the input schemas. It is also the same for the
 // output group key. Columns are renamed using the pattern
 // `<column>_<table>` to prevent ambiguity in joined tables.
 //
@@ -290,7 +291,7 @@ Here's an example of a full doc comment for the `join` function.
 // ```
 ```
 
-### Documenting Flux Options
+### Options
 
 #### Headline
 
@@ -303,8 +304,8 @@ Follow the headline with a blank line comment.
 #### Description
 
 This section contains a detailed explanation of the how the option can be used
-in a Flux query, and should follow the same formatting rules as the `Description`
-section described under the `Documenting Packages` heading earlier in this document.
+in a Flux query, and should follow the same formatting rules as the 
+[package descriptions](#description) above.
 
 #### Example
 
@@ -321,7 +322,7 @@ the `profiler` package.
 // ## Enabling the profilers
 //
 // Add the following lines to your flux query to see profiler results in the output.
-// 
+//
 // ```
 // import "profiler"
 // option profiler.enabledProfilers = ["query", "operator"]
@@ -329,9 +330,10 @@ the `profiler` package.
 option enabledProfilers = [""]
 ```
 
-### Docs as Rust Data Structures
+### Doc comments as Rust types
 
-The goal for this project is parse the new docs into rust data structures
+<!-- How is this goal related to the three goals above? -->
+Another goal for this project is to parse doc comments into Rust types
 that we can then serialize into JSON for broader consumption.
 
 Below is a proposal for how to define those data structures.

--- a/libflux/flux/FLUXDOC.md
+++ b/libflux/flux/FLUXDOC.md
@@ -62,14 +62,14 @@ any example code into the InfluxDB data explorer and run it with no modification
 Any sample data used in a code example should come from an `array.from()` call in
 the example code itself, rather than being represented as a markdown- or html-formatted table.
 
-For the first iteration on this project, code examples will not be processed any 
-differently from the other markdown in the description by the parser. Future
-iterations may add extra features to make code examples more interactive.
+Future iterations on this project may add extra functionality around code examples
+(for instance, allowing users to run them interactively on the docs site). For now,
+they will just be treated as plain markdown.
 
 ### Documenting functions
 
 Documentation for Flux functions consists of a short headline, a detailed description,
-and list of the function's parameters.
+and a list of the function's parameters.
 
 #### Headline
 
@@ -250,12 +250,13 @@ The first line of a doc comment for a flux option should start with the name of
 the option, followed by a brief explanation of what the option is, or how it is
 used.
 
+Follow the headline with a blank line comment.
+
 #### Description
 
-This section contains a detailed explanation of the how the option can be used,
-in a Flux query, and will make up the bulk of the long-form docs. This section
-should follow the same formatting rules as the `Description` section described
-under the `Documenting Packages` heading earlier in this document.
+This section contains a detailed explanation of the how the option can be used
+in a Flux query, and should follow the same formatting rules as the `Description`
+section described under the `Documenting Packages` heading earlier in this document.
 
 #### Example
 

--- a/libflux/flux/FLUXDOC.md
+++ b/libflux/flux/FLUXDOC.md
@@ -30,7 +30,7 @@ the "description", respectively.
 ## Writing Flux Doc Comments
 
 Flux will treat any uninterrupted series of line comments immediately preceding
-a function definition, package clause, or option declaration, as a doc comment.
+an assignment statement, builtin statement, package clause, or option declaration, as a doc comment.
 
 Flux doc comments support markdown formatting in accordance with the 
 [CommonMark specification](https://spec.commonmark.org/0.29/).
@@ -66,9 +66,57 @@ Future iterations on this project may add extra functionality around code exampl
 (for instance, allowing users to run them interactively on the docs site). For now,
 they will just be treated as plain markdown.
 
+### Documenting package values
+
+Packages expose values via assignment statements and builtin statements.
+These values should be documented with a headline and optional description.
+
+#### Headline
+
+Documentation for values should begin with the headline: a one-line description
+of the value that begins with the value name. The value name should be
+written exactly as it appears in the assignment statement, and should be followed
+by a brief explanation of the purpose of the value or how it can be used. The entire
+headline should read as one complete sentence.
+
+Follow the headline with a blank line comment.
+
+_Example:_
+
+Here's what the doc comment might look like for the pi constant in the math package.
+
+```
+// pi is a floating point representation of the mathematical constant pi.
+builtin pi : float
+```
+
+#### Description
+
+This section follows the same guidelines as those outlined in the `Description` section
+under the `Documenting Packages` heading earlier in this document.
+
+_Example:_
+
+Here's what the doc comment might look like for the hypothetical constant forty-two from the math package.
+
+```
+// fortyTwo is the integer 42.
+//
+// The constant fortyTwo can be used to deteremine the answer to import questions
+//
+// ```
+// import "math"
+//
+// question = (answer) => answer
+// question(answer: math.fortyTwo)
+// ```
+fortyTwo = 42
+```
+
 ### Documenting functions
 
-Documentation for Flux functions consists of a short headline, a detailed description,
+When a package exposes a value that is a function we want to include additional information
+about the function's parameters. Documentation for Flux functions consists of a short headline, a detailed description,
 and a list of the function's parameters.
 
 #### Headline
@@ -261,7 +309,7 @@ section described under the `Documenting Packages` heading earlier in this docum
 #### Example
 
 Here's what a doc comment might look like for the `enabledProfilers` option in
-the `profiler` packge.
+the `profiler` package.
 ```
 // enabledProfilers sets a list of profilers that should be enabled during execution.
 //
@@ -289,34 +337,43 @@ that we can then serialize into JSON for broader consumption.
 Below is a proposal for how to define those data structures.
 
 ```rust
+// Doc represents a documentation for Flux source code.
 enum Doc {
+// Package represents documentation for an entire Flux package.
 	Package(Box<PackageDoc>),
+    // Value represents documentation for a value exposed from a package.
+	Value(Box<ValueDoc>),
+    // Builtin represents documentation for a builtin value exposed from a package.
+	Builtin(Box<ValueDoc>),
+    // Option represents documentation for a option value exposed from a package.
+	Option(Box<ValueDoc>),
+    // Function represents documentation for a function value exposed from a package.
 	Function(Box<FunctionDoc>),
-	Opt(Box<OptionDoc>),
 }
 
 struct PackageDoc {
 	name: String,
 	headline: String,
-	description: String,
+	description: Option<String>,
 	members: HashMap<String, Doc>,
 }
 
-struct OptionDoc {
+struct ValueDoc {
 	name: String,
 	headline: String,
-	description: String,
+	description: Option<String>,
+	flux_type: String,
 }
 
 struct FunctionDoc {
 	name: String,
 	headline: String,
 	description: String,
-	parameters: Vec<Parameter>,
+	parameters: Vec<ParameterDoc>,
 	flux_type: String,
 }
 
-struct Parameter {
+struct ParameterDoc {
 	name: String,
 	headline: String,
 	description: Option<String>,

--- a/libflux/flux/FLUXDOC.md
+++ b/libflux/flux/FLUXDOC.md
@@ -1,0 +1,324 @@
+# Flux Doc Comments
+
+In the interest of establishing a single source of authority for Flux documentation,
+Flux will soon support doc comments in `stdlib`. Work is underway to integrate the
+documentation generated from doc comments into the `flux` crate, and expose them
+as JSON data for broader consumption. This document defines the details of how
+Flux doc comments should be written and formatted.
+
+The end goals of this project are as follows:
+
+1. Continuously populate the Flux documentation search bar in the InfluxDB data
+   explorer with the latest version of the docs.
+2. Expose documentation via the the Flux Language Server Protocol.
+3. Use the docs to generate a static site that will become the new home of the official Flux documentation.
+
+## Design Considerations
+
+The generated Flux docs will need to support different formats for different consumers.
+As an example, the Flux LSP and the InfluxDB UI will need to produce a condensed 
+version of the documentation for any given identifier in the Flux standard library.
+In contrast, the official docs site will need to present much more detailed information
+to readers. Consumers should be able to decide which format they want to use by
+selecting only the parts of the docs that are required for their use case.
+
+To allow for this, Flux doc comments are formatted so that the doc comment parser
+can easily distinguish the short-form content from the long-form content. In most
+cases throughout this document, these will be referred to as the "headline" and
+the "description", respectively.
+
+## Writing Flux Doc Comments
+
+Flux will treat any uninterrupted series of line comments immediately preceding
+a function definition, package clause, or option declaration, as a doc comment.
+
+Flux doc comments support markdown formatting in accordance with the 
+[CommonMark specification](https://spec.commonmark.org/0.29/).
+
+### Documenting Packages
+
+The documentation for a Flux package consists of a short headline, and a description,
+which may contain one or more code examples.
+
+#### Headline
+
+This is a one-sentence description of the package. The beginning of the sentence
+should read `Package <package-name> provides...`, and should be on its own line.
+
+Follow the headline with a blank line comment.
+
+#### Description
+
+This section provides a detailed description of the package and its
+contents.
+
+If the package provides any constants that require documentation, that documentation
+should be included here. Otherwise, constants will just be listed by name in the 
+generated package documentation, with no further elaboration.
+
+Any code examples should be contained in a markdown-formatted code block, and may be
+included anywhere in the description. Readers should be able to copy and paste any
+any example code into the InfluxDB data explorer and run it with no modifications.
+Any sample data used in a code example should come from an `array.from()` call in
+the example code itself, rather than being represented as a markdown- or html-formatted table.
+
+For the first iteration on this project, code examples will not be processed any 
+differently from the other markdown in the description by the parser. Future
+iterations may add extra features to make code examples more interactive.
+
+### Documenting functions
+
+Documentation for Flux functions consists of a short headline, a detailed description,
+and list of the function's parameters.
+
+#### Headline
+
+Documentation for functions should begin with the headline: a one-line description
+of the function that begins with the function name. The function name should be
+written exactly as it appears in the function signature, and should be followed
+by a brief explanation of what the function does or how it can be used. The entire
+headline should read as one complete sentence.
+
+Follow the headline with a blank line comment.
+
+_Example:_
+
+```
+// join merges two input streams based on columns with equal values.
+```
+
+#### Description
+
+This section follows the same guidelines as those outlined in the `Description` section
+under the `Documenting Packages` heading earlier in this document,
+with the exception that every function description should include documentation
+for the function's parameters.
+
+Every function description should include at least one code example.
+
+#### Parameters
+
+Documentation for function parameters is required, but it can appear anywhere in
+the function description.
+
+The parameters should be organized into a markdown-formatted unordered list, and
+should be immediately preceded by a markdown H2 header entitled `Parameters`.
+Each list item should start with the name of the parameter as it appears in the
+function signature, followed by a brief, one-line description. Each list item
+should read as a complete sentence, and should be properly punctuated.
+
+The parameters in the list should be ordered exactly as they are in the function
+signature, and no parameter should be omitted.
+
+While the top-level list item for each parameter is limited to a short, one-line
+description, the parameter list may include extra markdown content after each list item.
+Much like the distinction between a headline and a full description outlined
+earlier in this document, it can be helpful to think of the top-level list item 
+as a condensed description fit for short-form docs, and the notes that come after
+each list item as a more detailed explanation for use in long-form docs.
+
+Only the top-level list items are required in the parameter list. The extra notes
+for each parameter are optional, and may be omitted.
+
+See the [`lists`](https://spec.commonmark.org/0.29/#lists) section in the CommonMark spec for specifics on supported formatting in the parameter list.
+
+_Example:_
+
+Here's what a parameter list might look like for the `aggregateWindow` function.
+```
+// ## Parameters
+// - every is the duration of each window.
+// - fn is the aggregate function to be used in the operation.
+//
+//        Acceptable arguments for `fn` are: "min", "max", "mean",
+//        "sum", "count", "first", and "last"
+//
+// - offset is the offset of each window.
+// - column is the column on which to operate.
+//
+//        If no argument is provided for `column`, it will
+//        default to `_value`.
+//
+// - timeSrc is the time column from which time is copied for the aggregate record.
+//
+//        If no argument is provided for `timeSrc` it will
+//        default to `_stop`.
+//
+// - timeDst is the column to which time is copied for the aggregate record.
+//
+//        If no argument is provided for `timeDst`, it will
+//        default to `_time`.
+//
+// - createEmpty decides if windows with no data should be included in the final output.
+//
+//        If no argument is provided for `createEmpty`, it will
+//        default to `true`.
+//
+// - tables is a stream of input tables.
+```
+
+#### Other Information
+
+There are other details about Flux functions that we will want to document, like
+the full type signature of each function, and which of the parameters are required.
+That information can be found in the function signature, and does not need be 
+included in the doc comment.
+
+#### Example
+
+Here's an example of a full doc comment for the `join` function.
+
+```
+// join merges two input streams based on columns with equal values. 
+// 
+// Null values are not considered equal when comparing column
+// values. The resulting schema is the union of the input schemas. The resulting
+// group key is the union of the input group keys.
+//
+// ## Parameters
+// - `tables` is a stream of tables
+// - `method` is the method to use when joining
+//    
+//    Currently, this function only supports inner joins.
+//    Performaing an inner join will require both input
+//    tables to match their columns based on the `on` parameter.
+//
+// - `on` is a list of column names on which to join.
+//
+// ## Joining two tables
+// 
+// ```
+// import "array"
+//
+// sf_temp = array.from(
+//     rows: [
+//         {_time: 2021-06-01T01:00:00Z, _field: "temp", _value: 70},
+//         {_time: 2021-06-01T02:00:00Z, _field: "temp", _value: 75},
+//         {_time: 2021-06-01T03:00:00Z, _field: "temp", _value: 72},
+//     ],
+// )
+//
+// ny_temp = array.from(
+//     rows: [
+//         {_time: 2021-06-01T01:00:00Z, _field: "temp", _value: 55},
+//         {_time: 2021-06-01T02:00:00Z, _field: "temp", _value: 56},
+//         {_time: 2021-06-01T03:00:00Z, _field: "temp", _value: 57},
+//     ],
+// )
+//
+// join(
+//   tables: {sf: sf_temp, ny: ny_temp},
+//   on: ["_time", "_field"]
+// )
+// ```
+//
+// ## Output schema of a joined table
+//
+// The column schema of the output stream is the union
+// of the input schemas. It is also the same for the 
+// output group key. Columns are renamed using the pattern
+// `<column>_<table>` to prevent ambiguity in joined tables.
+//
+// ```
+// import "array"
+//
+// data_1 = array.from(
+//     rows: [
+//         {_time: 2021-06-01T01:00:00Z, _field: "meter", _value: 100},
+//         {_time: 2021-06-01T02:00:00Z, _field: "meter", _value: 200},
+//         {_time: 2021-06-01T03:00:00Z, _field: "meter", _value: 300},
+//     ],
+// ) |> group(columns: ["_time", "_field"])
+//
+// data_2 = array.from(
+//     rows: [
+//         {_time: 2021-06-01T01:00:00Z, _field: "meter", _value: 400},
+//         {_time: 2021-06-01T02:00:00Z, _field: "meter", _value: 500},
+//         {_time: 2021-06-01T03:00:00Z, _field: "meter", _value: 600},
+//     ],
+// ) |> group(columns: ["_time", "_field"])
+//
+// join(tables: {d1: data_1, d2: data_2}, on: ["_time"]) // group key should be [_time, _field_d1, _field_d2]
+// ```
+```
+
+### Documenting Flux Options
+
+#### Headline
+
+The first line of a doc comment for a flux option should start with the name of
+the option, followed by a brief explanation of what the option is, or how it is
+used.
+
+#### Description
+
+This section contains a detailed explanation of the how the option can be used,
+in a Flux query, and will make up the bulk of the long-form docs. This section
+should follow the same formatting rules as the `Description` section described
+under the `Documenting Packages` heading earlier in this document.
+
+#### Example
+
+Here's what a doc comment might look like for the `enabledProfilers` option in
+the `profiler` packge.
+```
+// enabledProfilers sets a list of profilers that should be enabled during execution.
+//
+// There are two profilers available: the query profiler and the operator profiler.
+//
+// - The query profiler measures time spent in various phases of query execution
+// - The operator profiler measures time spent in each operator of the query
+//
+// ## Enabling the profilers
+//
+// Add the following lines to your flux query to see profiler results in the output.
+// 
+// ```
+// import "profiler"
+// option profiler.enabledProfilers = ["query", "operator"]
+// ```
+option enabledProfilers = [""]
+```
+
+### Docs as Rust Data Structures
+
+The goal for this project is parse the new docs into rust data structures
+that we can then serialize into JSON for broader consumption.
+
+Below is a proposal for how to define those data structures.
+
+```rust
+enum Doc {
+	Package(Box<PackageDoc>),
+	Function(Box<FunctionDoc>),
+	Opt(Box<OptionDoc>),
+}
+
+struct PackageDoc {
+	name: String,
+	headline: String,
+	description: String,
+	members: HashMap<String, Doc>,
+}
+
+struct OptionDoc {
+	name: String,
+	headline: String,
+	description: String,
+}
+
+struct FunctionDoc {
+	name: String,
+	headline: String,
+	description: String,
+	parameters: Vec<Parameter>,
+	flux_type: String,
+}
+
+struct Parameter {
+	name: String,
+	headline: String,
+	description: Option<String>,
+	required: bool,
+}
+```

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -60,8 +60,13 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/walk/test_utils.rs":                             "ffec273fc2e54c640ba5f2ce5c1faa1516a3d98b1365d6f4cab762f582102650",
 	"libflux/flux-core/src/semantic/walk/walk_mut.rs":                               "845e0b706c90fd84b1f7ef08ab85d86a5af24392d7973415ed6d1c778a67e012",
 	"libflux/flux-core/tests/analyze_test.rs":                                       "537fcf7722f940794646d5916e3484262769fd90a7fa5e74e8095fb732136be6",
+<<<<<<< HEAD
 	"libflux/flux/Cargo.toml":                                                       "8275ea00b53d2825ae65cf85c0f6ba9c1df1135ad6615d762796538256d74085",
 	"libflux/flux/FLUXDOC.md":                                                       "c325dd30aecc0b3d8fff76c43b5af83729e8c76e5d91406281e2a00caf6ec783",
+=======
+	"libflux/flux/Cargo.toml":                                                       "175b344e3f74684a63bbbfc934cdfee3e4fe012537b72c5d0e6acfb1d7627767",
+	"libflux/flux/FLUXDOC.md":                                                       "295bbb2c9230880283aadc476a49451f4d54fe8e94f360a578b40300c8e5de7c",
+>>>>>>> 5e84d030 (chore: minor edits and rewording)
 	"libflux/flux/benches/basic.rs":                                                 "f6b1d133a4edaa38b0ab6e2b63de1bbd62a489e39b77c62d0df6fa8e5462da0e",
 	"libflux/flux/benches/builtins.rs":                                              "625b3de708d49a3cb758f331a01f41805ac59d22bbadfee417922504f2d5797e",
 	"libflux/flux/benches/everything.flux":                                          "39134841113ac5e8437e29c5ac379f54a9bef8d84ef761799e6ffefcee2cb9b4",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -61,6 +61,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/walk/walk_mut.rs":                               "845e0b706c90fd84b1f7ef08ab85d86a5af24392d7973415ed6d1c778a67e012",
 	"libflux/flux-core/tests/analyze_test.rs":                                       "537fcf7722f940794646d5916e3484262769fd90a7fa5e74e8095fb732136be6",
 	"libflux/flux/Cargo.toml":                                                       "8275ea00b53d2825ae65cf85c0f6ba9c1df1135ad6615d762796538256d74085",
+	"libflux/flux/FLUXDOC.md":                                                       "c325dd30aecc0b3d8fff76c43b5af83729e8c76e5d91406281e2a00caf6ec783",
 	"libflux/flux/benches/basic.rs":                                                 "f6b1d133a4edaa38b0ab6e2b63de1bbd62a489e39b77c62d0df6fa8e5462da0e",
 	"libflux/flux/benches/builtins.rs":                                              "625b3de708d49a3cb758f331a01f41805ac59d22bbadfee417922504f2d5797e",
 	"libflux/flux/benches/everything.flux":                                          "39134841113ac5e8437e29c5ac379f54a9bef8d84ef761799e6ffefcee2cb9b4",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -61,7 +61,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/walk/walk_mut.rs":                               "845e0b706c90fd84b1f7ef08ab85d86a5af24392d7973415ed6d1c778a67e012",
 	"libflux/flux-core/tests/analyze_test.rs":                                       "537fcf7722f940794646d5916e3484262769fd90a7fa5e74e8095fb732136be6",
 	"libflux/flux/Cargo.toml":                                                       "8275ea00b53d2825ae65cf85c0f6ba9c1df1135ad6615d762796538256d74085",
-	"libflux/flux/FLUXDOC.md":                                                       "5f64dbe8ae9957c6431c5c3b0f986844a63a0e8106d53597e5596c9502e4b259",
+	"libflux/flux/FLUXDOC.md":                                                       "dc1f872a0fbb7537f7e274caea2eb8015ef589e54fd17ac6c398c6c46371bd5a",
 	"libflux/flux/benches/basic.rs":                                                 "f6b1d133a4edaa38b0ab6e2b63de1bbd62a489e39b77c62d0df6fa8e5462da0e",
 	"libflux/flux/benches/builtins.rs":                                              "625b3de708d49a3cb758f331a01f41805ac59d22bbadfee417922504f2d5797e",
 	"libflux/flux/benches/everything.flux":                                          "39134841113ac5e8437e29c5ac379f54a9bef8d84ef761799e6ffefcee2cb9b4",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -60,13 +60,8 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/walk/test_utils.rs":                             "ffec273fc2e54c640ba5f2ce5c1faa1516a3d98b1365d6f4cab762f582102650",
 	"libflux/flux-core/src/semantic/walk/walk_mut.rs":                               "845e0b706c90fd84b1f7ef08ab85d86a5af24392d7973415ed6d1c778a67e012",
 	"libflux/flux-core/tests/analyze_test.rs":                                       "537fcf7722f940794646d5916e3484262769fd90a7fa5e74e8095fb732136be6",
-<<<<<<< HEAD
 	"libflux/flux/Cargo.toml":                                                       "8275ea00b53d2825ae65cf85c0f6ba9c1df1135ad6615d762796538256d74085",
-	"libflux/flux/FLUXDOC.md":                                                       "c325dd30aecc0b3d8fff76c43b5af83729e8c76e5d91406281e2a00caf6ec783",
-=======
-	"libflux/flux/Cargo.toml":                                                       "175b344e3f74684a63bbbfc934cdfee3e4fe012537b72c5d0e6acfb1d7627767",
-	"libflux/flux/FLUXDOC.md":                                                       "295bbb2c9230880283aadc476a49451f4d54fe8e94f360a578b40300c8e5de7c",
->>>>>>> 5e84d030 (chore: minor edits and rewording)
+	"libflux/flux/FLUXDOC.md":                                                       "5f64dbe8ae9957c6431c5c3b0f986844a63a0e8106d53597e5596c9502e4b259",
 	"libflux/flux/benches/basic.rs":                                                 "f6b1d133a4edaa38b0ab6e2b63de1bbd62a489e39b77c62d0df6fa8e5462da0e",
 	"libflux/flux/benches/builtins.rs":                                              "625b3de708d49a3cb758f331a01f41805ac59d22bbadfee417922504f2d5797e",
 	"libflux/flux/benches/everything.flux":                                          "39134841113ac5e8437e29c5ac379f54a9bef8d84ef761799e6ffefcee2cb9b4",


### PR DESCRIPTION
Adds a document containing the specification for the new Flux doc comments, as per #3770

There were a lot of comments on the PR with the rough draft of this document. I opened this new PR with the updated version to make any future conversations in the comments easier to follow.

[Original PR here.](https://github.com/influxdata/flux/pull/3786)