### PR TITLE
feat: update flatc in flux-build image

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -56,13 +56,16 @@ RUN curl https://www.colm.net/files/thurston.asc | gpg --import - && \
     make && \
     make install && \
     cd .. && rm -rf ragel-${RAGEL7_VERSION}*
-ENV FLATBUFFERS_VERSION=1.11.0
-RUN curl -LS https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.tar.gz | gunzip -c | tar x && \
+ENV FLATBUFFERS_VERSION=2.0.0 \
+    FLATBUFFERS_CHECKSUM=9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4
+RUN curl -LS https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.tar.gz -O && \
+    echo "${FLATBUFFERS_CHECKSUM} v${FLATBUFFERS_VERSION}.tar.gz" | sha256sum --check -- && \
+    tar xvzf v${FLATBUFFERS_VERSION}.tar.gz && \
     mkdir flatbuffers-${FLATBUFFERS_VERSION}/build && \
     cd flatbuffers-${FLATBUFFERS_VERSION}/build && \
     cmake -G "Unix Makefiles" .. && \
     make && make install && \
-    cd ../.. && rm -rf flatbuffers-${FLATBUFFERS_VERSION}
+    cd ../.. && rm -rf flatbuffers-${FLATBUFFERS_VERSION} v${FLATBUFFERS_VERSION}.tar.gz
 
 # Add builder user
 ENV UNAME=builder


### PR DESCRIPTION
This patch updates the version of `flatc` availabale in the flux-build
docker image.



### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written