### PR TITLE
fix(execute): allow work queue to be resized when work exceeds queue length

### DIFF
--- a/execute/dispatcher_test.go
+++ b/execute/dispatcher_test.go
@@ -2,7 +2,9 @@ package execute
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"go.uber.org/zap/zaptest"
 )
@@ -35,4 +37,47 @@ func TestDispatcher_MultipleStops(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		_ = d.Stop()
 	}
+}
+
+func TestDispatcher_ScheduleMany(t *testing.T) {
+	// Continuously schedule jobs that schedule other jobs.
+	// The schedule method should not block the dispatcher but
+	// instead grow continously.
+	d := newPoolDispatcher(10, zaptest.NewLogger(t))
+
+	// This test should finish by the timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	d.Start(1, ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		_ = d.Stop()
+	}()
+
+	// The default ring size is 100.
+	// A size of 200 should trigger any deadlock from scheduling
+	// too many times.
+	for i := 0; i < 200; i++ {
+		d.Schedule(func(ctx context.Context, throughput int) {
+			for i := 0; i < throughput; i++ {
+				// Attempt to schedule another job.
+				// If the dispatcher doesn't expand correctly,
+				// this should deadlock.
+				d.Schedule(func(ctx context.Context, throughput int) {
+					// Do nothing here.
+				})
+			}
+		})
+	}
+
+	// Check for the context error.
+	if err := ctx.Err(); err != nil {
+		t.Errorf("timeout reached: %s", err)
+	}
+	cancel()
+	wg.Wait()
 }

--- a/execute/ring.go
+++ b/execute/ring.go
@@ -1,0 +1,56 @@
+package execute
+
+type ring struct {
+	buf []interface{}
+	i   int
+	sz  int
+}
+
+func newRing(sz int) *ring {
+	return &ring{
+		buf: make([]interface{}, sz),
+	}
+}
+
+func (r *ring) Next() interface{} {
+	if r.sz == 0 {
+		return nil
+	}
+
+	v := r.buf[r.i]
+	r.buf[r.i] = nil
+	r.i++
+	if r.i >= len(r.buf) {
+		r.i = 0
+	}
+	r.sz--
+	return v
+}
+
+func (r *ring) Len() int {
+	return r.sz
+}
+
+func (r *ring) Append(v interface{}) {
+	if r.sz == len(r.buf) {
+		// The number of elements in the ring is equal
+		// to the buffer size so we need to dynamically
+		// resize it.
+		//
+		// Do this by copying the existing buffer from
+		// the current index, which may be in the middle,
+		// and copy that section of the array first.
+		// Then copy the previous buffer from the zero index
+		// to the current index which is the end of the ring.
+		buf := make([]interface{}, 0, r.sz*2)
+		buf = append(buf, r.buf[r.i:]...)
+		buf = append(buf, r.buf[:r.i]...)
+		// Resize the length of the buffer to its capacity
+		// now that we have finished the appends.
+		r.i, r.buf = 0, buf[:cap(buf)]
+	}
+
+	i := (r.i + r.sz) % len(r.buf)
+	r.buf[i] = v
+	r.sz++
+}

--- a/execute/ring_test.go
+++ b/execute/ring_test.go
@@ -1,0 +1,49 @@
+package execute
+
+import "testing"
+
+func TestRing(t *testing.T) {
+	// Ensure that the ring works properly when we append exactly
+	// the correct number of elements to it.
+	r := newRing(4)
+	for i := 0; i < 4; i++ {
+		r.Append(i)
+	}
+
+	// Now we will check the length, pop the next value, and append another
+	// value in succession and check the ring is working properly.
+	for i := 0; i < 6; i++ {
+		if want, got := 4, r.Len(); want != got {
+			t.Fatalf("unexpected ring length -want/+got:\n\t- %d\n\t+ %d", want, got)
+		}
+		if want, got := i, r.Next().(int); want != got {
+			t.Fatalf("unexpected value -want/+got:\n\t- %d\n\t+ %d", want, got)
+		}
+		r.Append(i + 4)
+	}
+
+	// Append a value to ensure expansion works.
+	// Do not fill the resized queue as we also want to verify that a non-filled
+	// ring will continue to work properly.
+	r.Append(10)
+	for i := 0; i < 6; i++ {
+		if want, got := 5, r.Len(); want != got {
+			t.Fatalf("unexpected ring length -want/+got:\n\t- %d\n\t+ %d", want, got)
+		}
+		if want, got := i+6, r.Next().(int); want != got {
+			t.Fatalf("unexpected value -want/+got:\n\t- %d\n\t+ %d", want, got)
+		}
+		r.Append(i + 11)
+	}
+
+	// If we take the remainder, we will continue to get values and the
+	// length goes down to zero.
+	for i := 0; i < 5; i++ {
+		if want, got := 5-i, r.Len(); want != got {
+			t.Fatalf("unexpected ring length -want/+got:\n\t- %d\n\t+ %d", want, got)
+		}
+		if want, got := i+12, r.Next().(int); want != got {
+			t.Fatalf("unexpected value -want/+got:\n\t- %d\n\t+ %d", want, got)
+		}
+	}
+}


### PR DESCRIPTION
This modifies the dispatcher to make the work queue dynamically increase
when the amount of work exceeds the default size.

Previously, the work queue was implemented with a channel. Channels have
a static size and it was possible for a worker, which reads from the
work queue, to also attempt to add to the work queue and this resulted
in a deadlock.

This updates the work queue to be a dynamically sized ring to avoid a
deadlock when the amount of work exceeds the size of the work queue.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written