### PR TITLE
feat(stdlib): port experimental.to() and adapt to use the influxdb provider

### DIFF
--- a/stdlib/experimental/to.go
+++ b/stdlib/experimental/to.go
@@ -1,15 +1,327 @@
 package experimental
 
 import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
+	"github.com/influxdata/flux/values"
+	lp "github.com/influxdata/line-protocol"
 )
 
-// ToKind is the kind for the experimental `to` flux function
-const ExperimentalToKind = "experimental-to"
-
-var ToSignature = runtime.MustLookupBuiltinType("experimental", "to")
+const ToKind = "experimental-to"
 
 func init() {
-	runtime.RegisterPackageValue("experimental", "to", flux.MustValue(flux.FunctionValueWithSideEffect("to", nil, ToSignature)))
+	toSignature := runtime.MustLookupBuiltinType("experimental", "to")
+	runtime.RegisterPackageValue("experimental", "to", flux.MustValue(flux.FunctionValueWithSideEffect("to", createToOpSpec, toSignature)))
+	plan.RegisterProcedureSpecWithSideEffect(ToKind, newToProcedure, ToKind)
+	execute.RegisterTransformation(ToKind, createToTransformation)
+}
+
+// ToOpSpec is the flux.OperationSpec for the `to` flux function.
+type ToOpSpec struct {
+	Org    influxdb.NameOrID
+	Bucket influxdb.NameOrID
+	Host   string
+	Token  string
+}
+
+// ReadArgs reads the args from flux.Arguments into the op spec
+func (s *ToOpSpec) ReadArgs(args flux.Arguments) error {
+	if b, ok, err := influxdb.GetNameOrID(args, "bucket", "bucketID"); err != nil {
+		return err
+	} else if !ok {
+		return errors.New(codes.Invalid, "must specify bucket or bucketID")
+	} else {
+		s.Bucket = b
+	}
+
+	if o, ok, err := influxdb.GetNameOrID(args, "org", "orgID"); err != nil {
+		return err
+	} else if ok {
+		s.Org = o
+	}
+
+	if host, ok, err := args.GetString("host"); err != nil {
+		return err
+	} else if ok {
+		s.Host = host
+	}
+
+	if token, ok, err := args.GetString("token"); err != nil {
+		return err
+	} else if ok {
+		s.Token = token
+	}
+	return nil
+}
+
+func createToOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	if err := a.AddParentFromArgs(args); err != nil {
+		return nil, err
+	}
+
+	s := &ToOpSpec{}
+	if err := s.ReadArgs(args); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Kind returns the kind for the ToOpSpec function.
+func (ToOpSpec) Kind() flux.OperationKind {
+	return ToKind
+}
+
+// ToProcedureSpec is the procedure spec for the `to` flux function.
+type ToProcedureSpec struct {
+	plan.DefaultCost
+	Config influxdb.Config
+}
+
+// Kind returns the kind for the procedure spec for the `to` flux function.
+func (o *ToProcedureSpec) Kind() plan.ProcedureKind {
+	return ToKind
+}
+
+// Copy clones the procedure spec for `to` flux function.
+func (o *ToProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := *o
+	return &ns
+}
+
+func newToProcedure(qs flux.OperationSpec, a plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*ToOpSpec)
+	if !ok {
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
+	}
+	return &ToProcedureSpec{
+		Config: influxdb.Config{
+			Org:    spec.Org,
+			Bucket: spec.Bucket,
+			Host:   spec.Host,
+			Token:  spec.Token,
+		},
+	}, nil
+}
+
+func createToTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*ToProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+	}
+	cache := execute.NewTableBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, cache)
+
+	t, err := NewToTransformation(a.Context(), d, cache, s)
+	if err != nil {
+		return nil, nil, err
+	}
+	return t, d, nil
+}
+
+// ToTransformation is the transformation for the `to` flux function.
+type ToTransformation struct {
+	execute.ExecutionNode
+	ctx    context.Context
+	d      execute.Dataset
+	cache  execute.TableBuilderCache
+	writer influxdb.Writer
+}
+
+// RetractTable retracts the table for the transformation for the `to` flux function.
+func (t *ToTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	return t.d.RetractTable(key)
+}
+
+// NewToTransformation returns a new *ToTransformation with the appropriate fields set.
+func NewToTransformation(ctx context.Context, d execute.Dataset, cache execute.TableBuilderCache, s *ToProcedureSpec) (*ToTransformation, error) {
+	provider := influxdb.GetProvider(ctx)
+	writer, err := provider.WriterFor(ctx, s.Config)
+	if err != nil {
+		return nil, err
+	}
+	return &ToTransformation{
+		ctx:    ctx,
+		d:      d,
+		cache:  cache,
+		writer: writer,
+	}, nil
+}
+
+// Process does the actual work for the ToTransformation.
+func (t *ToTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	return t.writeTable(tbl)
+}
+
+// UpdateWatermark updates the watermark for the transformation for the `to` flux function.
+func (t *ToTransformation) UpdateWatermark(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateWatermark(pt)
+}
+
+// UpdateProcessingTime updates the processing time for the transformation for the `to` flux function.
+func (t *ToTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return t.d.UpdateProcessingTime(pt)
+}
+
+// Finish is called after the `to` flux function's transformation is done processing.
+func (t *ToTransformation) Finish(id execute.DatasetID, err error) {
+	if err != nil {
+		t.d.Finish(err)
+		return
+	}
+	err = t.writer.Close()
+	t.d.Finish(err)
+}
+
+const (
+	defaultFieldColLabel       = influxdb.DefaultFieldColLabel
+	defaultMeasurementColLabel = influxdb.DefaultMeasurementColLabel
+	defaultTimeColLabel        = execute.DefaultTimeColLabel
+	defaultStartColLabel       = execute.DefaultStartColLabel
+	defaultStopColLabel        = execute.DefaultStopColLabel
+)
+
+type LabelAndOffset struct {
+	Label  string
+	Offset int
+}
+
+// tablePointsMetadata stores state needed to write the points from one table.
+type tablePointsMetadata struct {
+	// Name is the measurement name for this table.
+	Name string
+	// Tags holds the tags in the table excluding the measurement.
+	Tags []*lp.Tag
+	// The column offset in the input table where the _time column is stored
+	TimestampOffset int
+	// The labels and offsets of all the fields in the table
+	Fields []LabelAndOffset
+}
+
+func getTablePointsMetadata(tbl flux.Table) (md tablePointsMetadata, err error) {
+	// Find measurement, tags
+	foundMeasurement := false
+	md.Tags = make([]*lp.Tag, 0, len(tbl.Key().Cols()))
+	isTag := make(map[string]bool)
+	for j, col := range tbl.Key().Cols() {
+		switch col.Label {
+		case defaultStartColLabel:
+			continue
+		case defaultStopColLabel:
+			continue
+		case defaultFieldColLabel:
+			return md, errors.Newf(codes.FailedPrecondition, "found column %q in the group key; experimental.to() expects pivoted data", col.Label)
+		case defaultMeasurementColLabel:
+			foundMeasurement = true
+			if col.Type != flux.TString {
+				return md, errors.Newf(codes.FailedPrecondition, "group key column %q has type %v; type %v is required", col.Label, col.Type, flux.TString)
+			}
+			md.Name = tbl.Key().ValueString(j)
+		default:
+			if col.Type != flux.TString {
+				return md, errors.Newf(codes.FailedPrecondition, "group key column %q has type %v; type %v is required", col.Label, col.Type, flux.TString)
+			}
+			isTag[col.Label] = true
+			md.Tags = append(md.Tags, &lp.Tag{
+				Key:   col.Label,
+				Value: tbl.Key().ValueString(j),
+			})
+		}
+	}
+	sort.SliceStable(md.Tags, func(i, j int) bool {
+		return md.Tags[i].Key < md.Tags[j].Key
+	})
+	if !foundMeasurement {
+		return md, errors.Newf(codes.FailedPrecondition, "required column %q not in group key", defaultMeasurementColLabel)
+	}
+
+	// Find the time column as it is required.
+	md.TimestampOffset = execute.ColIdx(defaultTimeColLabel, tbl.Cols())
+	if md.TimestampOffset < 0 {
+		return md, errors.Newf(codes.FailedPrecondition, "input table is missing required column %q", defaultTimeColLabel)
+	} else if col := tbl.Cols()[md.TimestampOffset]; col.Type != flux.TTime {
+		return md, errors.Newf(codes.FailedPrecondition, "column %q has type %s; type %s is required", defaultTimeColLabel, col.Type, flux.TTime)
+	}
+
+	// Loop over all of the remaining columns to find the fields.
+	// By this point, we know all of the tags and we can exclude the time
+	// column from the list of fields so we can allocate an appropriate size.
+	md.Fields = make([]LabelAndOffset, 0, len(tbl.Cols())-len(md.Tags)-1)
+	for j, col := range tbl.Cols() {
+		switch col.Label {
+		case defaultStartColLabel, defaultStopColLabel, defaultMeasurementColLabel, defaultTimeColLabel:
+			continue
+		default:
+			if !isTag[col.Label] {
+				md.Fields = append(md.Fields, LabelAndOffset{
+					Label:  col.Label,
+					Offset: j,
+				})
+			}
+		}
+	}
+	return md, nil
+}
+
+func (t *ToTransformation) writeTable(tbl flux.Table) error {
+	builder, new := t.cache.TableBuilder(tbl.Key())
+	if new {
+		if err := execute.AddTableCols(tbl, builder); err != nil {
+			return err
+		}
+	}
+
+	tmd, err := getTablePointsMetadata(tbl)
+	if err != nil {
+		return err
+	}
+
+	return tbl.Do(func(cr flux.ColReader) error {
+		if cr.Len() == 0 {
+			// Nothing to do
+			return nil
+		}
+
+		metrics := make([]lp.Metric, 0, cr.Len())
+		for i := 0; i < cr.Len(); i++ {
+			timestamp := cr.Times(tmd.TimestampOffset).Value(i)
+			metric := &influxdb.RowMetric{
+				NameStr: tmd.Name,
+				TS:      time.Unix(0, timestamp),
+				Tags:    tmd.Tags,
+				Fields:  make([]*lp.Field, 0, len(tmd.Fields)),
+			}
+			for _, lao := range tmd.Fields {
+				fieldVal := execute.ValueForRow(cr, i, lao.Offset)
+
+				// Skip this iteration if field value is null
+				if fieldVal.IsNull() {
+					continue
+				}
+
+				metric.Fields = append(metric.Fields, &lp.Field{
+					Key:   lao.Label,
+					Value: values.Unwrap(fieldVal),
+				})
+			}
+
+			if len(metric.Fields) > 0 {
+				metrics = append(metrics, metric)
+			}
+
+			if err := execute.AppendRecord(i, cr, builder); err != nil {
+				return err
+			}
+		}
+		return t.writer.Write(metrics...)
+	})
 }

--- a/stdlib/experimental/to_test.go
+++ b/stdlib/experimental/to_test.go
@@ -1,0 +1,266 @@
+package experimental_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/andreyvit/diff"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/execute/table/static"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/querytest"
+	"github.com/influxdata/flux/stdlib/experimental"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
+	"github.com/influxdata/flux/stdlib/universe"
+)
+
+func TestTo_Query(t *testing.T) {
+	tests := []querytest.NewQueryTestCase{
+		{
+			Name: "from range pivot experimental to",
+			Raw: `import "experimental"
+import "influxdata/influxdb/v1"
+from(bucket:"mydb")
+  |> range(start: -1h)
+  |> v1.fieldsAsCols()
+  |> experimental.to(bucket:"series1", org:"fred", host:"localhost", token:"auth-token")`,
+			Want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{
+						ID: "from0",
+						Spec: &influxdb.FromOpSpec{
+							Bucket: influxdb.NameOrID{Name: "mydb"},
+						},
+					},
+					{
+						ID: "range1",
+						Spec: &universe.RangeOpSpec{
+							Start:       flux.Time{IsRelative: true, Relative: -time.Hour},
+							Stop:        flux.Time{IsRelative: true},
+							TimeColumn:  "_time",
+							StartColumn: "_start",
+							StopColumn:  "_stop",
+						},
+					},
+					{
+						ID: "pivot2",
+						Spec: &universe.PivotOpSpec{
+							RowKey:      []string{"_time"},
+							ColumnKey:   []string{"_field"},
+							ValueColumn: "_value"},
+					},
+					{
+						ID: "experimental-to3",
+						Spec: &experimental.ToOpSpec{
+							Bucket: influxdb.NameOrID{Name: "series1"},
+							Org:    influxdb.NameOrID{Name: "fred"},
+							Host:   "localhost",
+							Token:  "auth-token",
+						},
+					},
+				},
+				Edges: []flux.Edge{
+					{Parent: "from0", Child: "range1"},
+					{Parent: "range1", Child: "pivot2"},
+					{Parent: "pivot2", Child: "experimental-to3"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			querytest.NewQueryTestHelper(t, tc)
+		})
+	}
+}
+
+func TestToTransformation(t *testing.T) {
+	var written bytes.Buffer
+	deps := dependenciestest.Default()
+	deps.Deps.HTTPClient = &http.Client{
+		Transport: dependenciestest.RoundTripFunc(func(req *http.Request) *http.Response {
+			if _, err := io.Copy(&written, req.Body); err != nil {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Status:     http.StatusText(http.StatusInternalServerError),
+					Body:       ioutil.NopCloser(strings.NewReader(err.Error())),
+					Header:     make(http.Header),
+				}
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusNoContent,
+				Status:     http.StatusText(http.StatusNoContent),
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+				Header:     make(http.Header),
+			}
+		}),
+	}
+
+	cache := execute.NewTableBuilderCache(&memory.Allocator{})
+	d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
+	d.SetTriggerSpec(plan.DefaultTriggerSpec)
+
+	ctx := deps.Inject(context.Background())
+	spec := &experimental.ToProcedureSpec{
+		Config: influxdb.Config{
+			Bucket: influxdb.NameOrID{Name: "mybucket"},
+			Host:   "http://localhost:8086",
+		},
+	}
+	tr, err := experimental.NewToTransformation(ctx, d, cache, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parentID := executetest.RandomDatasetID()
+	input := static.TableGroup{
+		static.Times("_time", 0, 10, 20, 30),
+		static.Floats("f0", 1.0, 2.0, 3.0, nil),
+		static.Ints("f1", 1, nil, 3, nil),
+		static.StringKey("_measurement", "m0"),
+		static.TableList{
+			static.StringKeys("t0", "a", "b"),
+		},
+	}
+	if err := input.Do(func(tbl flux.Table) error {
+		return tr.Process(parentID, tbl)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tr.Finish(parentID, nil)
+
+	want := `m0,t0=a f0=1,f1=1i 0
+m0,t0=a f0=2 10000000000
+m0,t0=a f0=3,f1=3i 20000000000
+m0,t0=b f0=1,f1=1i 0
+m0,t0=b f0=2 10000000000
+m0,t0=b f0=3,f1=3i 20000000000
+`
+	if got := written.String(); got != want {
+		t.Errorf("unexpected line protocol -want/+got:\n%s", diff.LineDiff(want, got))
+	}
+}
+
+func TestToTransformation_Errors(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input flux.TableIterator
+		want  string
+	}{
+		{
+			name: "FieldKeyPresent",
+			input: static.Table{
+				static.Times("_time", 0, 10, 20),
+				static.StringKey("_measurement", "m0"),
+				static.StringKey("_field", "f0"),
+				static.Floats("_value", 1.0, 2.0, 3.0),
+			},
+			want: `found column "_field" in the group key; experimental.to() expects pivoted data`,
+		},
+		{
+			name: "MeasurementWrongType",
+			input: static.Table{
+				static.Times("_time", 0, 10, 20),
+				static.IntKey("_measurement", 0),
+				static.Floats("f0", 1.0, 2.0, 3.0),
+			},
+			want: `group key column "_measurement" has type int; type string is required`,
+		},
+		{
+			name: "NonStringGroupKey",
+			input: static.Table{
+				static.Times("_time", 0, 10, 20),
+				static.StringKey("_measurement", "m0"),
+				static.IntKey("t0", 0),
+				static.Floats("f0", 1.0, 2.0, 3.0),
+			},
+			want: `group key column "t0" has type int; type string is required`,
+		},
+		{
+			name: "MeasurementColumnMissing",
+			input: static.Table{
+				static.Times("_time", 0, 10, 20),
+				static.Floats("f0", 1.0, 2.0, 3.0),
+			},
+			want: `required column "_measurement" not in group key`,
+		},
+		{
+			name: "MeasurementNotInGroupKey",
+			input: static.Table{
+				static.Times("_time", 0, 10, 20),
+				static.Strings("_measurement", "m0", "m0", "m0"),
+				static.Floats("f0", 1.0, 2.0, 3.0),
+			},
+			want: `required column "_measurement" not in group key`,
+		},
+		{
+			name: "TimeColumnMissing",
+			input: static.Table{
+				static.StringKey("_measurement", "m0"),
+				static.Floats("f0", 1.0, 2.0, 3.0),
+			},
+			want: `input table is missing required column "_time"`,
+		},
+		{
+			name: "TimeColumnWrongType",
+			input: static.Table{
+				static.Ints("_time", 0, 10, 20),
+				static.StringKey("_measurement", "m0"),
+				static.Floats("f0", 1.0, 2.0, 3.0),
+			},
+			want: `column "_time" has type int; type time is required`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := dependenciestest.Default()
+			deps.Deps.HTTPClient = &http.Client{
+				Transport: dependenciestest.RoundTripFunc(func(req *http.Request) *http.Response {
+					return &http.Response{
+						StatusCode: http.StatusNoContent,
+						Status:     http.StatusText(http.StatusNoContent),
+						Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+						Header:     make(http.Header),
+					}
+				}),
+			}
+
+			cache := execute.NewTableBuilderCache(&memory.Allocator{})
+			d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
+			d.SetTriggerSpec(plan.DefaultTriggerSpec)
+
+			ctx := deps.Inject(context.Background())
+			spec := &experimental.ToProcedureSpec{
+				Config: influxdb.Config{
+					Bucket: influxdb.NameOrID{Name: "mybucket"},
+					Host:   "http://localhost:8086",
+				},
+			}
+			tr, err := experimental.NewToTransformation(ctx, d, cache, spec)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			parentID := executetest.RandomDatasetID()
+			got := tc.input.Do(func(tbl flux.Table) error {
+				return tr.Process(parentID, tbl)
+			})
+			if got == nil {
+				t.Fatal("expected error")
+			} else if got.Error() != tc.want {
+				t.Fatalf("unexpected error -want/+got:\n\t- %s\n\t+ %s", tc.want, got.Error())
+			}
+		})
+	}
+}

--- a/stdlib/influxdata/influxdb/consts.go
+++ b/stdlib/influxdata/influxdb/consts.go
@@ -1,0 +1,6 @@
+package influxdb
+
+const (
+	DefaultMeasurementColLabel = "_measurement"
+	DefaultFieldColLabel       = "_field"
+)

--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -63,7 +63,7 @@ func createFromOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	if b, ok, err := GetNameOrID(args, "bucket", "bucketID"); err != nil {
 		return nil, err
 	} else if !ok {
-		return nil, errors.New(codes.Invalid, "must specify only one of bucket or bucketID")
+		return nil, errors.New(codes.Invalid, "must specify bucket or bucketID")
 	} else {
 		spec.Bucket = b
 	}
@@ -100,7 +100,7 @@ func GetNameOrID(args flux.Arguments, nameParam, idParam string) (NameOrID, bool
 	}
 
 	if nameOk && idOk {
-		return NameOrID{}, false, errors.Newf(codes.Invalid, "must specify one of %s or %s", nameParam, idParam)
+		return NameOrID{}, false, errors.Newf(codes.Invalid, "must specify only one of %s or %s", nameParam, idParam)
 	}
 	return NameOrID{Name: name, ID: id}, nameOk || idOk, nil
 }

--- a/stdlib/influxdata/influxdb/provider.go
+++ b/stdlib/influxdata/influxdb/provider.go
@@ -1,0 +1,13 @@
+package influxdb
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/dependencies/influxdb"
+)
+
+type Provider = influxdb.Provider
+
+func GetProvider(ctx context.Context) Provider {
+	return influxdb.GetProvider(ctx)
+}

--- a/stdlib/influxdata/influxdb/rowmetric.go
+++ b/stdlib/influxdata/influxdb/rowmetric.go
@@ -1,4 +1,4 @@
-package internal
+package influxdb
 
 import (
 	"time"

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -15,7 +15,6 @@ import (
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
-	"github.com/influxdata/flux/stdlib/influxdata/influxdb/internal"
 	"github.com/influxdata/flux/values"
 	lp "github.com/influxdata/line-protocol"
 	"github.com/opentracing/opentracing-go"
@@ -23,6 +22,8 @@ import (
 
 // ToKind is the kind for the `to` flux function
 const ToKind = "to"
+
+type Writer = influxdb.Writer
 
 func init() {
 	toSignature := runtime.MustLookupBuiltinType("influxdata/influxdb", "to")
@@ -231,7 +232,7 @@ func writeTableToAPI(ctx context.Context, t *ToTransformation, tbl flux.Table) (
 
 	outer:
 		for i := 0; i < er.Len(); i++ {
-			metric := &internal.RowMetric{
+			metric := &RowMetric{
 				Tags: make([]*lp.Tag, 0, len(spec.TagColumns)),
 			}
 

--- a/stdlib/influxdata/influxdb/to_test.go
+++ b/stdlib/influxdata/influxdb/to_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/mock"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
-	"github.com/influxdata/flux/stdlib/influxdata/influxdb/internal"
 	"github.com/influxdata/flux/values/valuestest"
 	protocol "github.com/influxdata/line-protocol"
 )
@@ -34,8 +33,8 @@ func (t *pointsWriter) Write(metric ...protocol.Metric) error {
 	return nil
 }
 
-func rowMetric(m string, tags [][2]string, fields [][2]interface{}, ts time.Time) *internal.RowMetric {
-	metric := &internal.RowMetric{
+func rowMetric(m string, tags [][2]string, fields [][2]interface{}, ts time.Time) *influxdb.RowMetric {
+	metric := &influxdb.RowMetric{
 		NameStr: m,
 		Tags:    make([]*protocol.Tag, 0, len(tags)),
 		Fields:  make([]*protocol.Field, 0, len(fields)),
@@ -772,7 +771,7 @@ func TestTo_Process(t *testing.T) {
 				},
 			)
 			for _, m := range writer.writes {
-				rm := m.(*internal.RowMetric)
+				rm := m.(*influxdb.RowMetric)
 				sort.Slice(rm.Fields, func(i, j int) bool {
 					return rm.Fields[i].Key < rm.Fields[j].Key
 				})


### PR DESCRIPTION
This ports `experimental.to()` from its home in influxdb OSS and the
cloud product to being included within the flux repository. The flux
version will use the `influxdb.Provider` that is in the dependencies.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written