### PR TITLE
chore: Install nodejs and npm in dockerfile

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     openssl libtinfo5 ruby \
     ca-certificates curl file gnupg \
-    build-essential cmake \
+    build-essential cmake nodejs npm \
     libxml2-dev libssl-dev zlib1g-dev \
     autoconf automake autotools-dev libtool xutils-dev valgrind && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In order to run the wasm tests for the new flux-doc generator in CI, our docker container needs to have node installed. Otherwise, we get failures like this: https://app.circleci.com/pipelines/github/influxdata/flux/9788/workflows/8ee4530f-6899-467a-98c9-ec6a93217e33/jobs/28634 
