### PR TITLE
test: fix group_agg_test to yield data and use array.from for input

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -282,7 +282,7 @@ var sourceHashes = map[string]string{
 	"stdlib/planner/bare_min_push_test.flux":                                        "1acac982cc0813569449ecf24afa1ea493d1d3dc8ed4f326d30f702ff40d9882",
 	"stdlib/planner/bare_sum_eval_test.flux":                                        "0c1e1267a57d5466f8e6ab20fd969a774058e859e1a9f76a1af6248f83c41cd6",
 	"stdlib/planner/bare_sum_push_test.flux":                                        "4d2d43bcdcf50e99568b89fa40c57de9673bdf90570bbb9ec46dcc7f67b19c90",
-	"stdlib/planner/group_agg_test.flux":                                            "81fdd6739902a3bce1b24acea39d8b02e30c0c59d4f315a4220e52ba990b44a3",
+	"stdlib/planner/group_agg_test.flux":                                            "3f20b928e1c6efd0030041c6d0994a2f9eb09727dd9f226c5d4380360a53b33f",
 	"stdlib/planner/group_agg_uneven_keys_test.flux":                                "f2022ea25d81c30fb7371213a7731164372b7a3c9260d85c9bf9d52673609397",
 	"stdlib/planner/group_count_eval_test.flux":                                     "7b31ca39e4b3591ee92028ef1a4a76debbd9740a0d6a22ee726a5549f31c470d",
 	"stdlib/planner/group_count_push_test.flux":                                     "c00f2e4e1450e8173e51f37e8ea260366eb9003735f66d6cfe889617939f948f",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -282,7 +282,7 @@ var sourceHashes = map[string]string{
 	"stdlib/planner/bare_min_push_test.flux":                                        "1acac982cc0813569449ecf24afa1ea493d1d3dc8ed4f326d30f702ff40d9882",
 	"stdlib/planner/bare_sum_eval_test.flux":                                        "0c1e1267a57d5466f8e6ab20fd969a774058e859e1a9f76a1af6248f83c41cd6",
 	"stdlib/planner/bare_sum_push_test.flux":                                        "4d2d43bcdcf50e99568b89fa40c57de9673bdf90570bbb9ec46dcc7f67b19c90",
-	"stdlib/planner/group_agg_test.flux":                                            "3f20b928e1c6efd0030041c6d0994a2f9eb09727dd9f226c5d4380360a53b33f",
+	"stdlib/planner/group_agg_test.flux":                                            "cc75ddbaa436a81a92c5fe4bbc0791f9d2b0c581c9303b443e9569e77bc6c64f",
 	"stdlib/planner/group_agg_uneven_keys_test.flux":                                "f2022ea25d81c30fb7371213a7731164372b7a3c9260d85c9bf9d52673609397",
 	"stdlib/planner/group_count_eval_test.flux":                                     "7b31ca39e4b3591ee92028ef1a4a76debbd9740a0d6a22ee726a5549f31c470d",
 	"stdlib/planner/group_count_push_test.flux":                                     "c00f2e4e1450e8173e51f37e8ea260366eb9003735f66d6cfe889617939f948f",

--- a/stdlib/planner/group_agg_test.flux
+++ b/stdlib/planner/group_agg_test.flux
@@ -85,6 +85,26 @@ testcase group_one_tag_filter_field_count {
     testing.diff(got, want) |> yield()
 }
 
+testcase group_two_tag_filter_field_count {
+    want = array.from(
+        rows: [
+            {"t0": "t0v0", "t1": "t1v0", "_value": 3},
+            {"t0": "t0v0", "t1": "t1v1", "_value": 3},
+            {"t0": "t0v1", "t1": "t1v0", "_value": 3},
+            {"t0": "t0v1", "t1": "t1v1", "_value": 3},
+        ],
+    )
+        |> group(columns: ["t0", "t1"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group(columns: ["t0", "t1"])
+        |> count()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
 // Group + sum tests
 testcase group_one_tag_sum {
     want = array.from(
@@ -127,6 +147,26 @@ testcase group_one_tag_filter_field_sum {
         |> range(start: -100y)
         |> filter(fn: (r) => r._field == "f0")
         |> group(columns: ["t0"])
+        |> sum()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_two_tag_filter_field_sum {
+    want = array.from(
+        rows: [
+            {"t0": "t0v0", "t1": "t1v0", "_value": 4},
+            {"t0": "t0v0", "t1": "t1v1", "_value": 8},
+            {"t0": "t0v1", "t1": "t1v0", "_value": 5},
+            {"t0": "t0v1", "t1": "t1v1", "_value": 8},
+        ],
+    )
+        |> group(columns: ["t0", "t1"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group(columns: ["t0", "t1"])
         |> sum()
         |> drop(columns: ["_start", "_stop"])
 

--- a/stdlib/planner/group_agg_test.flux
+++ b/stdlib/planner/group_agg_test.flux
@@ -1,338 +1,134 @@
 package planner_test
 
+
 import "array"
 import "testing"
 import "csv"
 
 // two fields, two tags keys, with three rows in each combo
-input = "
-#group,false,false,true,true,false,false,true,true
-#datatype,string,long,string,string,dateTime:RFC3339,long,string,string
-#default,_result,,,,,,,
-,result,table,_field,_measurement,_time,_value,t0,t1
-,,0,f0,m0,2021-07-06T23:06:30Z,3,t0v0,t1v0
-,,0,f0,m0,2021-07-06T23:06:40Z,1,t0v0,t1v0
-,,0,f0,m0,2021-07-06T23:06:50Z,0,t0v0,t1v0
-,,1,f0,m0,2021-07-06T23:06:30Z,4,t0v0,t1v1
-,,1,f0,m0,2021-07-06T23:06:40Z,3,t0v0,t1v1
-,,1,f0,m0,2021-07-06T23:06:50Z,1,t0v0,t1v1
-,,2,f0,m0,2021-07-06T23:06:30Z,1,t0v1,t1v0
-,,2,f0,m0,2021-07-06T23:06:40Z,0,t0v1,t1v0
-,,2,f0,m0,2021-07-06T23:06:50Z,4,t0v1,t1v0
-,,3,f0,m0,2021-07-06T23:06:30Z,4,t0v1,t1v1
-,,3,f0,m0,2021-07-06T23:06:40Z,0,t0v1,t1v1
-,,3,f0,m0,2021-07-06T23:06:50Z,4,t0v1,t1v1
-
-,,4,f1,m0,2021-07-06T23:06:30Z,0,t0v0,t1v0
-,,4,f1,m0,2021-07-06T23:06:40Z,0,t0v0,t1v0
-,,4,f1,m0,2021-07-06T23:06:50Z,0,t0v0,t1v0
-,,5,f1,m0,2021-07-06T23:06:30Z,0,t0v0,t1v1
-,,5,f1,m0,2021-07-06T23:06:40Z,4,t0v0,t1v1
-,,5,f1,m0,2021-07-06T23:06:50Z,3,t0v0,t1v1
-,,6,f1,m0,2021-07-06T23:06:30Z,3,t0v1,t1v0
-,,6,f1,m0,2021-07-06T23:06:40Z,2,t0v1,t1v0
-,,6,f1,m0,2021-07-06T23:06:50Z,1,t0v1,t1v0
-,,7,f1,m0,2021-07-06T23:06:30Z,1,t0v1,t1v1
-,,7,f1,m0,2021-07-06T23:06:40Z,0,t0v1,t1v1
-,,7,f1,m0,2021-07-06T23:06:50Z,2,t0v1,t1v1
-"
+inData = array.from(
+    rows: [
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 3},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 1},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 0},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 4},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 3},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 1},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 1},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 4},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 4},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 4},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 4},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 3},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 3},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 2},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 1},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 1},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 2},
+    ],
+)
+    |> group(columns: ["_measurement", "_field", "t0", "t1"])
 
 // Group + count test
-
-// Group + count tests with no filter on field
-
-testcase group_all_count {
-    want = array.from(rows: [{"_value": 24}])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group()
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
+// Group on one tag across fields
 testcase group_one_tag_count {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_value": 12},
-        {"t0": "t0v1", "_value": 12},
-    ]) |> group(columns: ["t0"])
-    got = testing.loadStorage(csv: input)
+    want = array.from(
+        rows: [
+            {"t0": "t0v0", "_value": 12},
+            {"t0": "t0v1", "_value": 12},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
         |> range(start: -100y)
         |> group(columns: ["t0"])
         |> count()
         |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
+
+    testing.diff(got, want) |> yield()
 }
-
-testcase group_one_tag_and_field_count {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_field": "f0", "_value": 6},
-        {"t0": "t0v1", "_field": "f0", "_value": 6},
-        {"t0": "t0v0", "_field": "f1", "_value": 6},
-        {"t0": "t0v1", "_field": "f1", "_value": 6},
-    ]) |> group(columns: ["t0", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group(columns: ["t0", "_field"])
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_count {
-    want = array.from(rows: [
-        {"t0": "t0v0", "t1": "t1v0", "_value": 6},
-        {"t0": "t0v1", "t1": "t1v0", "_value": 6},
-        {"t0": "t0v0", "t1": "t1v1", "_value": 6},
-        {"t0": "t0v1", "t1": "t1v1", "_value": 6},
-    ]) |> group(columns: ["t0", "t1"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group(columns: ["t0", "t1"])
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_and_field_count {
-    want = array.from(rows: [
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v0", "_value": 3},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v0", "_value": 3},
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v1", "_value": 3},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v1", "_value": 3},
-        {"_field": "f1", "t0": "t0v0", "t1": "t1v0", "_value": 3},
-        {"_field": "f1", "t0": "t0v1", "t1": "t1v0", "_value": 3},
-        {"_field": "f1", "t0": "t0v0", "t1": "t1v1", "_value": 3},
-        {"_field": "f1", "t0": "t0v1", "t1": "t1v1", "_value": 3},
-    ]) |> group(columns: ["t0", "t1", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group(columns: ["t0", "t1", "_field"])
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-
-// Group + count tests with filter on field
 
 testcase group_all_filter_field_count {
     want = array.from(rows: [{"_value": 12}])
-    got = testing.loadStorage(csv: input)
+    got = testing.load(tables: inData)
         |> range(start: -100y)
         |> filter(fn: (r) => r._field == "f0")
         |> group()
         |> count()
         |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
+
+    testing.diff(got, want) |> yield()
 }
 
 testcase group_one_tag_filter_field_count {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_value": 6},
-        {"t0": "t0v1", "_value": 6},
-    ]) |> group(columns: ["t0"])
-    got = testing.loadStorage(csv: input)
+    want = array.from(
+        rows: [
+            {"t0": "t0v0", "_value": 6},
+            {"t0": "t0v1", "_value": 6},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
         |> range(start: -100y)
         |> filter(fn: (r) => r._field == "f0")
         |> group(columns: ["t0"])
         |> count()
         |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
 
-testcase group_one_tag_and_field_filter_field_count {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_field": "f0", "_value": 6},
-        {"t0": "t0v1", "_field": "f0", "_value": 6},
-    ]) |> group(columns: ["t0", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> filter(fn: (r) => r._field == "f0")
-        |> group(columns: ["t0", "_field"])
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_filter_field_count {
-    want = array.from(rows: [
-        {"t0": "t0v0", "t1": "t1v0", "_value": 3},
-        {"t0": "t0v1", "t1": "t1v0", "_value": 3},
-        {"t0": "t0v0", "t1": "t1v1", "_value": 3},
-        {"t0": "t0v1", "t1": "t1v1", "_value": 3},
-    ]) |> group(columns: ["t0", "t1"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> filter(fn: (r) => r._field == "f0")
-        |> group(columns: ["t0", "t1"])
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_and_field_filter_field_count {
-    want = array.from(rows: [
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v0", "_value": 3},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v0", "_value": 3},
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v1", "_value": 3},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v1", "_value": 3},
-    ]) |> group(columns: ["t0", "t1", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> filter(fn: (r) => r._field == "f0")
-        |> group(columns: ["t0", "t1", "_field"])
-        |> count()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
+    testing.diff(got, want) |> yield()
 }
 
 // Group + sum tests
-
-// Group + sum tests with no filter on field
-
-testcase group_all_sum {
-    want = array.from(rows: [{"_value": 41}])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group()
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
 testcase group_one_tag_sum {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_value": 19},
-        {"t0": "t0v1", "_value": 22},
-    ]) |> group(columns: ["t0"])
-    got = testing.loadStorage(csv: input)
+    want = array.from(
+        rows: [
+            {"t0": "t0v0", "_value": 19},
+            {"t0": "t0v1", "_value": 22},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
         |> range(start: -100y)
         |> group(columns: ["t0"])
         |> sum()
         |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
+
+    testing.diff(got, want) |> yield()
 }
-
-testcase group_one_tag_and_field_sum {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_field": "f0", "_value": 12},
-        {"t0": "t0v1", "_field": "f0", "_value": 13},
-        {"t0": "t0v0", "_field": "f1", "_value": 7},
-        {"t0": "t0v1", "_field": "f1", "_value": 9},
-    ]) |> group(columns: ["t0", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group(columns: ["t0", "_field"])
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_sum {
-    want = array.from(rows: [
-        {"t0": "t0v0", "t1": "t1v0", "_value": 4},
-        {"t0": "t0v1", "t1": "t1v0", "_value": 11},
-        {"t0": "t0v0", "t1": "t1v1", "_value": 15},
-        {"t0": "t0v1", "t1": "t1v1", "_value": 11},
-    ]) |> group(columns: ["t0", "t1"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group(columns: ["t0", "t1"])
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_and_field_sum {
-    want = array.from(rows: [
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v0", "_value": 4},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v0", "_value": 5},
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v1", "_value": 8},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v1", "_value": 8},
-        {"_field": "f1", "t0": "t0v0", "t1": "t1v0", "_value": 0},
-        {"_field": "f1", "t0": "t0v1", "t1": "t1v0", "_value": 6},
-        {"_field": "f1", "t0": "t0v0", "t1": "t1v1", "_value": 7},
-        {"_field": "f1", "t0": "t0v1", "t1": "t1v1", "_value": 3},
-    ]) |> group(columns: ["t0", "t1", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> group(columns: ["t0", "t1", "_field"])
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-
-// Group + sum tests with filter on field
 
 testcase group_all_filter_field_sum {
     want = array.from(rows: [{"_value": 25}])
-    got = testing.loadStorage(csv: input)
+    got = testing.load(tables: inData)
         |> range(start: -100y)
         |> filter(fn: (r) => r._field == "f0")
         |> group()
         |> sum()
         |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
+
+    testing.diff(got, want) |> yield()
 }
 
 testcase group_one_tag_filter_field_sum {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_value": 12},
-        {"t0": "t0v1", "_value": 13},
-    ]) |> group(columns: ["t0"])
-    got = testing.loadStorage(csv: input)
+    want = array.from(
+        rows: [
+            {"t0": "t0v0", "_value": 12},
+            {"t0": "t0v1", "_value": 13},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
         |> range(start: -100y)
         |> filter(fn: (r) => r._field == "f0")
         |> group(columns: ["t0"])
         |> sum()
         |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
 
-testcase group_one_tag_and_field_filter_field_sum {
-    want = array.from(rows: [
-        {"t0": "t0v0", "_field": "f0", "_value": 12},
-        {"t0": "t0v1", "_field": "f0", "_value": 13},
-    ]) |> group(columns: ["t0", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> filter(fn: (r) => r._field == "f0")
-        |> group(columns: ["t0", "_field"])
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_filter_field_sum {
-    want = array.from(rows: [
-        {"t0": "t0v0", "t1": "t1v0", "_value": 4},
-        {"t0": "t0v0", "t1": "t1v1", "_value": 8},
-        {"t0": "t0v1", "t1": "t1v0", "_value": 5},
-        {"t0": "t0v1", "t1": "t1v1", "_value": 8},
-    ]) |> group(columns: ["t0", "t1"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> filter(fn: (r) => r._field == "f0")
-        |> group(columns: ["t0", "t1"])
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
-}
-
-testcase group_all_tags_and_field_filter_field_sum {
-    want = array.from(rows: [
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v0", "_value": 4},
-        {"_field": "f0", "t0": "t0v0", "t1": "t1v1", "_value": 8},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v0", "_value": 5},
-        {"_field": "f0", "t0": "t0v1", "t1": "t1v1", "_value": 8},
-    ]) |> group(columns: ["t0", "t1", "_field"])
-    got = testing.loadStorage(csv: input)
-        |> range(start: -100y)
-        |> filter(fn: (r) => r._field == "f0")
-        |> group(columns: ["t0", "t1", "_field"])
-        |> sum()
-        |> drop(columns: ["_start", "_stop"])
-    testing.diff(got, want)
+    testing.diff(got, want) |> yield()
 }


### PR DESCRIPTION
This PR removes some of the tests that I added yesterday in #3860 since they took too long to run in `influxdb`.

I also added `|> yield()` to each test query, since extending the test in `influxdb` seems to require it.

Finally I used `array.from()` to create the input data since that is possible to do now, and it's more readable.