### PR TITLE
test: add acceptance tests for group with first and last

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -286,6 +286,7 @@ var sourceHashes = map[string]string{
 	"stdlib/planner/group_agg_uneven_keys_test.flux":                                "f2022ea25d81c30fb7371213a7731164372b7a3c9260d85c9bf9d52673609397",
 	"stdlib/planner/group_count_eval_test.flux":                                     "7b31ca39e4b3591ee92028ef1a4a76debbd9740a0d6a22ee726a5549f31c470d",
 	"stdlib/planner/group_count_push_test.flux":                                     "c00f2e4e1450e8173e51f37e8ea260366eb9003735f66d6cfe889617939f948f",
+	"stdlib/planner/group_first_last_test.flux":                                     "c8f449b05e61c165921fcb089f7bee070ca76913914985918be80c6032680ef8",
 	"stdlib/planner/group_max_eval_test.flux":                                       "abf9fa533a0f3da221662c2de1261ac5d4202a844b53713c5d386453a0715411",
 	"stdlib/planner/group_max_push_test.flux":                                       "37124c059cffbe1f73e362ab5bb3867db388eac7d22096b6c42ea5bd533c906c",
 	"stdlib/planner/group_max_test.flux":                                            "83af33674bbae440a26073884ba84c4282728ae16c844fc127255eb956407dd4",

--- a/stdlib/planner/group_first_last_test.flux
+++ b/stdlib/planner/group_first_last_test.flux
@@ -1,0 +1,182 @@
+package planner_test
+
+
+import "array"
+import "testing"
+import "csv"
+
+// two fields, two tags keys, with three rows in each combo
+inData = array.from(
+    rows: [
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 3},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 1},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 0},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 4},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 3},
+        {_field: "f0", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 1},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 1},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 4},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 4},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f0", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 4},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 4},
+        {_field: "f1", _measurement: "m0", t0: "t0v0", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 3},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:30Z, _value: 3},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:40Z, _value: 2},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v0", _time: 2021-07-06T23:06:50Z, _value: 1},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:30Z, _value: 1},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:40Z, _value: 0},
+        {_field: "f1", _measurement: "m0", t0: "t0v1", t1: "t1v1", _time: 2021-07-06T23:06:50Z, _value: 2},
+    ],
+)
+    |> group(columns: ["_measurement", "_field", "t0", "t1"])
+
+// Group + first test
+// Group on one tag across fields
+testcase group_one_tag_first {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v0", "_value": 3, _time: 2021-07-06T23:06:30Z},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v0", "_value": 1, _time: 2021-07-06T23:06:30Z},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> group(columns: ["t0"])
+        |> first()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_all_filter_field_first {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v0", "_value": 3, _time: 2021-07-06T23:06:30Z},
+        ],
+    )
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group()
+        |> first()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_one_tag_filter_field_first {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v0", "_value": 3, _time: 2021-07-06T23:06:30Z},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v0", "_value": 1, _time: 2021-07-06T23:06:30Z},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group(columns: ["t0"])
+        |> first()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_two_tag_filter_field_first {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v0", "_value": 3, _time: 2021-07-06T23:06:30Z},
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v1", "_value": 4, _time: 2021-07-06T23:06:30Z},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v0", "_value": 1, _time: 2021-07-06T23:06:30Z},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v1", "_value": 4, _time: 2021-07-06T23:06:30Z},
+        ],
+    )
+        |> group(columns: ["t0", "t1"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group(columns: ["t0", "t1"])
+        |> first()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+// Group + last tests
+testcase group_one_tag_last {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f1", "t0": "t0v0", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 3},
+            {_measurement: "m0", _field: "f1", "t0": "t0v1", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 2},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> group(columns: ["t0"])
+        |> last()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_all_filter_field_last {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 4},
+        ],
+    )
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group()
+        |> last()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_one_tag_filter_field_last {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 1},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 4},
+        ],
+    )
+        |> group(columns: ["t0"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group(columns: ["t0"])
+        |> last()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase group_two_tag_filter_field_last {
+    want = array.from(
+        rows: [
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v0", _time: 2021-07-06T23:06:50Z, _value: 0},
+            {_measurement: "m0", _field: "f0", "t0": "t0v0", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 1},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v0", _time: 2021-07-06T23:06:50Z, _value: 4},
+            {_measurement: "m0", _field: "f0", "t0": "t0v1", "t1": "t1v1", _time: 2021-07-06T23:06:50Z, _value: 4},
+        ],
+    )
+        |> group(columns: ["t0", "t1"])
+    got = testing.load(tables: inData)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r._field == "f0")
+        |> group(columns: ["t0", "t1"])
+        |> last()
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}


### PR DESCRIPTION
This PR adds some tests for `group` with `first` and `last` selectors. These tests will be extended in OSS in order to provide test coverage for push downs.