### PR TITLE
fix(semantic): properly copy record types with no extends parameter

### DIFF
--- a/semantic/monotype.go
+++ b/semantic/monotype.go
@@ -794,12 +794,12 @@ func copyMonoType(builder *flatbuffers.Builder, t MonoType) flatbuffers.UOffsetT
 				Value: monoTypeFromFunc(prop.V, prop.VType()),
 			}
 		}
-		extends := record.Extends(nil)
-		var tv uint64
-		if extends != nil {
-			tv = extends.I()
+
+		var tv *uint64
+		if extends := record.Extends(nil); extends != nil {
+			tv = func(v uint64) *uint64 { return &v }(extends.I())
 		}
-		return buildObjectType(builder, properties, &tv)
+		return buildObjectType(builder, properties, tv)
 	case fbsemantic.MonoTypeFun:
 		var fun fbsemantic.Fun
 		fun.Init(table.Bytes, table.Pos)

--- a/semantic/monotype_test.go
+++ b/semantic/monotype_test.go
@@ -59,4 +59,14 @@ func TestNewObjectType(t *testing.T) {
 	if want, got := objectType.String(), "{a: int, b: string}"; want != got {
 		t.Errorf("unexpected monotype -want/+got:\n\t- %s\n\t+ %s", want, got)
 	}
+
+	// Nest the object type in another object.
+	objectType = semantic.NewObjectType(
+		[]semantic.PropertyType{
+			{Key: []byte("r"), Value: objectType},
+		},
+	)
+	if want, got := objectType.String(), "{r: {a: int, b: string}}"; want != got {
+		t.Errorf("unexpected monotype -want/+got:\n\t- %s\n\t+ %s", want, got)
+	}
 }


### PR DESCRIPTION
It seems that the code to copy a monotype did not copy the monotype
properly when the type was a record and it did not extend another
record. This causes compiler substitution to mark itself as extending
`t0` when the original was a fully qualified type with no record
extension.

This may have affected the `map()` call which could possibly heavily
rely on this code or it could have affected some other part of the
compiler infrastructure.

This was found while testing some code for an experiment so I don't have
a reproducer for how this would affect a live system.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written