### PR TITLE
fix(stdlib): Join does not produce columns of equivalent length when …

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -494,6 +494,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/integral_test.flux":                                            "439ce6fb39d8e214445fc0e87963846af91efe0ca67300cd924a896423f6b96b",
 	"stdlib/universe/join_across_measurements_test.flux":                            "f56e51db608f1b04f01215279d21affd83b5802068794cfd3730272306e5b5d6",
 	"stdlib/universe/join_agg_test.flux":                                            "bf89dbe3c400418488af058e8e5a56c7171678ee2028607a6310ddb7f0a76625",
+	"stdlib/universe/join_mismatched_schema_test.flux":                              "78c5c1b3da6fa074122641b38166cfa6f06d8f3005fd2c28a4749c7721c6957c",
 	"stdlib/universe/join_missing_on_col_test.flux":                                 "66d8b8f0f9c4c02bf76af1424a8a03b0bbbda2cb06542c205ceafc564851ab16",
 	"stdlib/universe/join_panic_test.flux":                                          "165809f897023f15cf8cd9499e83e9ed9f2c63b330f984a418f2588c1606707f",
 	"stdlib/universe/join_test.flux":                                                "e5d894f43ba93b0cf56b010a9797be99ed938a403673c1ada627e46a500dc8eb",

--- a/stdlib/universe/join_mismatched_schema_test.flux
+++ b/stdlib/universe/join_mismatched_schema_test.flux
@@ -1,0 +1,60 @@
+package universe_test
+
+
+import "csv"
+import "testing"
+import "internal/debug"
+
+a = csv.from(
+    csv: "
+#datatype,string,long,dateTime:RFC3339,double,string
+#group,false,false,false,false,true
+#default,_result,,,,
+,result,table,_time,_value,key
+,,0,2021-01-01T00:00:00Z,1.0,foo
+,,0,2021-01-01T00:01:00Z,2.0,foo
+
+#datatype,string,long,dateTime:RFC3339,double
+#group,false,false,false,false
+#default,_result,,,
+,result,table,_time,_value
+,,1,2021-01-01T00:00:00Z,1.5
+,,1,2021-01-01T00:01:00Z,2.5
+",
+)
+
+b = csv.from(
+    csv: "
+#datatype,string,long,dateTime:RFC3339,double,string
+#group,false,false,false,false,true
+#default,_result,,,,
+,result,table,_time,_value,key
+,,0,2021-01-01T00:00:00Z,10.0,
+,,0,2021-01-01T00:01:00Z,20.0,
+",
+)
+
+testcase normal {
+    got = join(tables: {a, b}, on: ["_time"])
+        |> debug.slurp()
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,double,double,string,string
+#group,false,false,false,false,false,true,true
+#default,_result,,,,,,
+,result,table,_time,_value_a,_value_b,key_a,key_b
+,,0,2021-01-01T00:00:00Z,1.0,10.0,foo,
+,,0,2021-01-01T00:01:00Z,2.0,20.0,foo,
+
+#datatype,string,long,dateTime:RFC3339,double,double,string,string
+#group,false,false,false,false,false,false,true
+#default,_result,,,,,,
+,result,table,_time,_value_a,_value_b,key_a,key_b
+,,1,2021-01-01T00:00:00Z,1.5,10.0,,
+,,1,2021-01-01T00:01:00Z,2.5,20.0,,
+",
+    )
+
+    testing.diff(got, want) |> yield()
+}

--- a/stdlib/universe/join_test.go
+++ b/stdlib/universe/join_test.go
@@ -721,6 +721,158 @@ func TestMergeJoin_Process(t *testing.T) {
 			},
 		},
 		{
+			name: "join with mismatched schemas",
+			spec: &universe.MergeJoinProcedureSpec{
+				On:         []string{"_time"},
+				TableNames: tableNames,
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "key", Type: flux.TString},
+					},
+					KeyCols: []string{"key"},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0, "foo"},
+						{execute.Time(2), 2.0, "foo"},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					KeyCols: []string{},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.5},
+						{execute.Time(2), 2.5},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "key", Type: flux.TString},
+					},
+					KeyCols: []string{"key"},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0, "bar"},
+						{execute.Time(2), 20.0, "bar"},
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value_a", Type: flux.TFloat},
+						{Label: "_value_b", Type: flux.TFloat},
+						{Label: "key_a", Type: flux.TString},
+						{Label: "key_b", Type: flux.TString},
+					},
+					KeyCols: []string{"key_a", "key_b"},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0, 10.0, "foo", "bar"},
+						{execute.Time(2), 2.0, 20.0, "foo", "bar"},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value_a", Type: flux.TFloat},
+						{Label: "_value_b", Type: flux.TFloat},
+						{Label: "key_a", Type: flux.TString},
+						{Label: "key_b", Type: flux.TString},
+					},
+					KeyCols: []string{"key_b"},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.5, 10.0, nil, "bar"},
+						{execute.Time(2), 2.5, 20.0, nil, "bar"},
+					},
+				},
+			},
+		},
+		{
+			name: "join with mismatched schemas with null in group key",
+			spec: &universe.MergeJoinProcedureSpec{
+				On:         []string{"_time"},
+				TableNames: tableNames,
+			},
+			data0: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "key", Type: flux.TString},
+					},
+					KeyCols: []string{"key"},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0, "foo"},
+						{execute.Time(2), 2.0, "foo"},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+					},
+					KeyCols: []string{},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.5},
+						{execute.Time(2), 2.5},
+					},
+				},
+			},
+			data1: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "key", Type: flux.TString},
+					},
+					KeyCols: []string{"key"},
+					Data: [][]interface{}{
+						{execute.Time(1), 10.0, nil},
+						{execute.Time(2), 20.0, nil},
+					},
+				},
+			},
+			want: []*executetest.Table{
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value_a", Type: flux.TFloat},
+						{Label: "_value_b", Type: flux.TFloat},
+						{Label: "key_a", Type: flux.TString},
+						{Label: "key_b", Type: flux.TString},
+					},
+					KeyCols: []string{"key_a", "key_b"},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.0, 10.0, "foo", nil},
+						{execute.Time(2), 2.0, 20.0, "foo", nil},
+					},
+				},
+				{
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value_a", Type: flux.TFloat},
+						{Label: "_value_b", Type: flux.TFloat},
+						{Label: "key_a", Type: flux.TString},
+						{Label: "key_b", Type: flux.TString},
+					},
+					KeyCols: []string{"key_b"},
+					Data: [][]interface{}{
+						{execute.Time(1), 1.5, 10.0, nil, nil},
+						{execute.Time(2), 2.5, 20.0, nil, nil},
+					},
+				},
+			},
+		},
+		{
 			name: "inner with extra attributes",
 			spec: &universe.MergeJoinProcedureSpec{
 				On:         []string{"_time", "t1"},


### PR DESCRIPTION
…combining mismatched schemas

this PR is to fix when join is joining irregular schemas, append nulls in appropriate locations.

The query ran on REPL after my fix - 

```
import "csv"
import "testing"
import "internal/debug"

a = csv.from(csv: "
#datatype,string,long,dateTime:RFC3339,double,string,string,string
#group,false,false,false,false,true,true,true
#default,_result,,,,,,
,result,table,_time,_value,_measurement,_field,host
,,0,2021-01-01T00:00:00Z,0.0,m0,f0,a

#datatype,string,long,dateTime:RFC3339,double,string,string
#group,false,false,false,false,true,true
#default,_result,,,,,
,result,table,_time,_value,_measurement,_field
,,1,2021-01-01T00:01:00Z,0.0,m0,f0
")

b = csv.from(csv: "
#datatype,string,long,dateTime:RFC3339,double,string,string,string
#group,false,false,false,false,true,true,true
#default,_result,,,,,,
,result,table,_time,_value,_measurement,_field,host
,,0,2021-01-01T00:00:00Z,0.0,m0,f0,b
,,0,2021-01-01T00:01:00Z,0.0,m0,f0,b
")

join(tables: {a, b}, on: ["_time"])
```


![image](https://user-images.githubusercontent.com/1942366/127195683-3ceb980b-f6bc-407c-8b2f-aa68714ccfe1.png)
