### PR TITLE
chore(libflux): support rust 1.54

### DIFF
--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -21,7 +21,6 @@ pub fn parse_string(name: &str, s: &str) -> File {
 }
 
 struct TokenError {
-    pub message: String,
     pub token: Token,
 }
 
@@ -1387,7 +1386,7 @@ impl Parser {
                                 value,
                             }));
                         }
-                        Err(message) => return Err(TokenError { token: t, message }),
+                        Err(_) => return Err(TokenError { token: t }),
                     }
                 }
                 TokenType::StringExpr => {
@@ -1462,10 +1461,7 @@ impl Parser {
                 base: self.base_node_from_token(&t),
                 value,
             }),
-            Err(_) => Err(TokenError {
-                token: t,
-                message: String::from("failed to parse float literal"),
-            }),
+            Err(_) => Err(TokenError { token: t }),
         }
     }
     fn parse_string_literal(&mut self) -> StringLit {
@@ -1509,7 +1505,7 @@ impl Parser {
                 base: self.base_node_from_token(&t),
                 value,
             }),
-            Err(message) => Err(TokenError { token: t, message }),
+            Err(_message) => Err(TokenError { token: t }),
         }
     }
     fn parse_duration_literal(&mut self) -> Result<DurationLit, TokenError> {
@@ -1521,7 +1517,7 @@ impl Parser {
                 base: self.base_node_from_token(&t),
                 values,
             }),
-            Err(message) => Err(TokenError { token: t, message }),
+            Err(_message) => Err(TokenError { token: t }),
         }
     }
     fn parse_pipe_literal(&mut self) -> PipeLit {

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -29,7 +29,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/formatter/mod.rs":                                        "74a790a1061c8ba0f75d16ad62a653685faed561ed55d5be01c0fe67a8dd9df4",
 	"libflux/flux-core/src/formatter/tests.rs":                                      "b0a10998a65fc4b54a8f68b3a0ed186d8548ba3d7638f911eb188d2ce485206f",
 	"libflux/flux-core/src/lib.rs":                                                  "d19b7054e07f234c107d457030a0031374c123fe14a84a5b8e35537d138bac7a",
-	"libflux/flux-core/src/parser/mod.rs":                                           "ba2fcbf7a8b011ec395b77db2c19c5d175c96059e2fbabe98a7891884b56e958",
+	"libflux/flux-core/src/parser/mod.rs":                                           "f9aa2891ebbc3bad27f0f509987bcca67303255df3794b967dd61a86bf571f25",
 	"libflux/flux-core/src/parser/strconv.rs":                                       "748c82f6efc2eafaafb872db5b4185ce29aafa8f03ba02c4b84f4a9614e832d2",
 	"libflux/flux-core/src/parser/tests.rs":                                         "e3a7c9222f90323a7ea9b319bd84f96f66c6f115af6d199a0da332c894713ae4",
 	"libflux/flux-core/src/scanner/mod.rs":                                          "2e15c9e0a73d0936d2eaeec030b636786db6dbe7aab673045de3a3e815c49f8a",


### PR DESCRIPTION
This patch enables libflux to build on rust 1.54. The detection of
`dead_code` has gotten better, and discovered a struct property that we
set but never read. This patch removes it.

This patch specifically doesn't update the rust version in CI, as I
think these updates can and should be independent of each other.