### PR TITLE
build: re-enable build-windows, pin rust version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,52 +84,56 @@ jobs:
     steps:
       - checkout
       - run: make test-valgrind
-#  build-windows:
-#    machine:
-#      image: windows-server-2019-vs2019:stable
-#    resource_class: windows.medium
-#    shell: bash.exe -eo pipefail
-#    steps:
-#      - run:
-#          name: Install system dependencies
-#          command: |
-#            choco upgrade golang --version=1.16.6
-#
-#            choco install \
-#              llvm \
-#              pkgconfiglite \
-#              rustup.install
-#
-#            # rustc depends on a version of libgcc_eh that isn't present in the latest mingw.
-#            choco install mingw --version=8.1.0
-#
-#            echo 'export PATH="${HOME}/.cargo/bin:/c/Program Files/Go/bin:${PATH}"' >> $BASH_ENV
-#      - run:
-#          name: Install mingw rustup target
-#          command: |
-#            rustup target add x86_64-pc-windows-gnu
-#            # Cargo's built-in support for fetching dependencies from GitHub requires
-#            # an ssh agent to be set up, which doesn't work on Circle's Windows executors.
-#            # See https://github.com/rust-lang/cargo/issues/1851#issuecomment-450130685
-#            cat <<EOF >> ~/.cargo/config
-#            [net]
-#            git-fetch-with-cli = true
-#            EOF
-#      - checkout
-#      - run:
-#          name: Install pkg-config wrapper
-#          command: |
-#            export GOPATH="${HOME}/go"
-#            echo "export GOPATH='${GOPATH}'" >> $BASH_ENV
-#            mkdir -p "${GOPATH}/bin"
-#            echo 'export PATH="${GOPATH}/bin:${PATH}"' >> $BASH_ENV
-#            go install github.com/influxdata/pkg-config
-#      - run:
-#          name: Generate libflux
-#          command: go generate ./libflux/go/libflux
-#      - run:
-#          name: Build flux
-#          command: go build ./...
+  build-windows:
+    environment:
+      # NOTE: If you change this, you must also change the version in the `FROM` line in `Dockerfile_build`.
+      RUST_VERSION: 1.53
+    machine:
+      image: windows-server-2019-vs2019:stable
+    resource_class: windows.medium
+    shell: bash.exe -eo pipefail
+    steps:
+      - run:
+          name: Install system dependencies
+          command: |
+            choco upgrade golang --version=1.16.6
+
+            choco install \
+              llvm \
+              pkgconfiglite \
+              rustup.install
+
+            # rustc depends on a version of libgcc_eh that isn't present in the latest mingw.
+            choco install mingw --version=8.1.0
+
+            echo 'export PATH="${HOME}/.cargo/bin:/c/Program Files/Go/bin:${PATH}"' >> $BASH_ENV
+      - run:
+          name: Pin rust version and install mingw rustup target
+          command: |
+            rustup default ${RUST_VERSION}
+            rustup target add x86_64-pc-windows-gnu
+            # Cargo's built-in support for fetching dependencies from GitHub requires
+            # an ssh agent to be set up, which doesn't work on Circle's Windows executors.
+            # See https://github.com/rust-lang/cargo/issues/1851#issuecomment-450130685
+            cat <<EOF >> ~/.cargo/config
+            [net]
+            git-fetch-with-cli = true
+            EOF
+      - checkout
+      - run:
+          name: Install pkg-config wrapper
+          command: |
+            export GOPATH="${HOME}/go"
+            echo "export GOPATH='${GOPATH}'" >> $BASH_ENV
+            mkdir -p "${GOPATH}/bin"
+            echo 'export PATH="${GOPATH}/bin:${PATH}"' >> $BASH_ENV
+            go install github.com/influxdata/pkg-config
+      - run:
+          name: Generate libflux
+          command: go generate ./libflux/go/libflux
+      - run:
+          name: Build flux
+          command: go build ./...
 
   release:
     docker:
@@ -168,7 +172,7 @@ workflows:
       - test-race
       - test-bench
       - test-valgrind
-#      - build-windows
+      - build-windows
 
   release:
     jobs:

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,6 +4,9 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minory releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
+#
+# NOTE: If you change this, you must also change `RUST_VERSION` in the `build-windows`
+# job in `.circleci/config.yml`.
 FROM rust:1.53 as RUSTBUILD
 
 FROM golang:1.16


### PR DESCRIPTION
Add an explicit `rustup default` call to the Windows CI logic, to ensure new versions aren't used accidentally.

I couldn't think of a way to declare the `RUST_VERSION` constant in a single place without significantly refactoring the existing docker-based environment setup, so I settled for adding a comment above each spot the version appears referring to the other location.