### PR TITLE
feat(execute): add two additional message types

### DIFF
--- a/execute/table/chunk.go
+++ b/execute/table/chunk.go
@@ -1,0 +1,107 @@
+package table
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/arrow"
+)
+
+// Chunk is a horizontal partition of a Table. It is a subset of rows
+// and contains a set of columns known as the group key.
+// It may not contain all columns that have been seen associated with
+// that group key so transformations should verify the existence of columns
+// for each chunk independently.
+type Chunk struct {
+	buf arrow.TableBuffer
+}
+
+// ChunkFromBuffer will create a Chunk from the TableBuffer.
+//
+// This function takes ownership of the arrow.TableBuffer
+// and the Chunk goes out of scope at the same time
+// as the arrow.TableBuffer unless Retain is called.
+func ChunkFromBuffer(buf arrow.TableBuffer) Chunk {
+	return Chunk{buf: buf}
+}
+
+// ChunkFromReader will create a Chunk from the ColReader.
+//
+// This function borrows a reference to the data in the ColReader
+// and will go out of scope at the same time as the ColReader
+// unless Retain is called.
+func ChunkFromReader(cr flux.ColReader) Chunk {
+	buf := arrow.TableBuffer{
+		GroupKey: cr.Key(),
+		Columns:  cr.Cols(),
+		Values:   make([]array.Interface, len(cr.Cols())),
+	}
+	for j := range buf.Values {
+		buf.Values[j] = Values(cr, j)
+	}
+	return ChunkFromBuffer(buf)
+}
+
+// Key returns the columns which are common for each row this view.
+func (v Chunk) Key() flux.GroupKey {
+	return v.buf.Key()
+}
+
+// Buffer returns the underlying TableBuffer used for this Chunk.
+// This is exposed for use by another package, but this method
+// should never be invoked in normal code.
+func (v Chunk) Buffer() arrow.TableBuffer {
+	return v.buf
+}
+
+// NCols returns the number of columns in this Chunk.
+func (v Chunk) NCols() int {
+	return len(v.buf.Columns)
+}
+
+// Len returns the number of rows.
+func (v Chunk) Len() int {
+	return v.buf.Len()
+}
+
+// Cols returns the columns as a slice.
+func (v Chunk) Cols() []flux.ColMeta {
+	return v.buf.Columns
+}
+
+// Col returns the metadata associated with the column.
+func (v Chunk) Col(j int) flux.ColMeta {
+	return v.buf.Columns[j]
+}
+
+// Index returns the index of the column with the given name.
+func (v Chunk) Index(label string) int {
+	for j, c := range v.buf.Columns {
+		if c.Label == label {
+			return j
+		}
+	}
+	return -1
+}
+
+// HasCol returns whether a column with the given name exists.
+func (v Chunk) HasCol(label string) bool {
+	return v.Index(label) >= 0
+}
+
+// Values returns a reference to the array of values in this Chunk.
+// The returned array is a borrowed reference and the caller can
+// call Retain on the returned array to retain its own reference
+// to the array.
+func (v Chunk) Values(j int) array.Interface {
+	return v.buf.Values[j]
+}
+
+// Retain will retain a reference to this Chunk.
+func (v Chunk) Retain() {
+	v.buf.Retain()
+}
+
+// Release will release a reference to this buffer.
+func (v Chunk) Release() {
+	v.buf.Release()
+}

--- a/execute/transport_internal_test.go
+++ b/execute/transport_internal_test.go
@@ -1,7 +1,14 @@
 package execute
 
-import "github.com/influxdata/flux"
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute/table"
+)
 
 func NewProcessMsg(tbl flux.Table) ProcessMsg {
 	return &processMsg{table: tbl}
+}
+
+func NewProcessChunkMsg(chunk table.Chunk) ProcessChunkMsg {
+	return &processChunkMsg{chunk: chunk}
 }

--- a/execute/transport_test.go
+++ b/execute/transport_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/table"
 	"github.com/influxdata/flux/execute/table/static"
 )
 
@@ -78,6 +79,84 @@ func TestProcessMsg(t *testing.T) {
 		}
 		dup2.Ack()
 		return nil
+	}); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	mem.AssertSize(t, 0)
+}
+
+func TestProcessChunkMsg(t *testing.T) {
+	fromTableChunk := func(chunk table.Chunk) flux.Table {
+		buffer := chunk.Buffer()
+		buffer.Retain()
+		return table.FromBuffer(&buffer)
+	}
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	// Create a set of tables, wrap them in a process message,
+	// and then ack it.
+	ti := static.Table{
+		static.StringKey("_measurement", "m0"),
+		static.Times("_time", 0, 10, 20),
+		static.Floats("_value", 0, 1, 2),
+	}
+	if err := ti.Do(func(tbl flux.Table) error {
+		return tbl.Do(func(cr flux.ColReader) error {
+			chunk := table.ChunkFromReader(cr)
+			chunk.Retain()
+			m := execute.NewProcessChunkMsg(chunk)
+
+			cr.Retain()
+			want := table.Iterator{table.FromBuffer(cr)}
+			got := table.Iterator{fromTableChunk(m.TableChunk())}
+			if diff := table.Diff(want, got); diff != "" {
+				t.Errorf("unexpected table data -want/+got:\n%s", diff)
+			}
+			m.Ack()
+			return nil
+		})
+	}); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	mem.AssertSize(t, 0)
+
+	// Create the same set of tables, but this time we are
+	// going to use dup and acknowledge the duplications.
+	// This should similarly work.
+	if err := ti.Do(func(tbl flux.Table) error {
+		return tbl.Do(func(cr flux.ColReader) error {
+			chunk := table.ChunkFromReader(cr)
+			chunk.Retain()
+			m := execute.NewProcessChunkMsg(chunk)
+			dup1, dup2 := m.Dup(), m.Dup()
+			m.Ack()
+
+			// Dup contents should be identical.
+			if diff := table.Diff(
+				table.Iterator{fromTableChunk(dup1.(execute.ProcessChunkMsg).TableChunk())},
+				table.Iterator{fromTableChunk(dup2.(execute.ProcessChunkMsg).TableChunk())},
+			); diff != "" {
+				t.Errorf("unexpected table data:\n%s", diff)
+			}
+
+			// Acknowledge the original message multiple times.
+			// This should not affect the dup'd messages.
+			for i := 0; i < 10; i++ {
+				m.Ack()
+			}
+			mem.AssertSize(t, 0)
+
+			if diff := table.Diff(
+				table.Iterator{fromTableChunk(dup1.(execute.ProcessChunkMsg).TableChunk())},
+				table.Iterator{fromTableChunk(dup2.(execute.ProcessChunkMsg).TableChunk())},
+			); diff != "" {
+				t.Errorf("unexpected table data:\n%s", diff)
+			}
+			dup1.Ack()
+			dup2.Ack()
+			return nil
+		})
 	}); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}


### PR DESCRIPTION
This adds two additional message types: `ProcessTableChunk` and `FlushKey`.

The `ProcessTableChunk` message represents that a chunk of a table is
ready to be processed by the transformation. It contains a reference to
the table chunk which is an arrow table buffer.

The `FlushKey` message represents that a group key has been finished and
is ready to flush any data stored in an associated dataset.

Closes #3885.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written