### PR TITLE
fix(stdlib): fix pivot when no data left

### DIFF
--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -48,7 +48,7 @@ func init() {
 	execute.RegisterTransformation(PivotKind, createPivotTransformation)
 
 	// optimized pivot
-	execute.RegisterTransformation(SortedPivotKind, createPivotTransformation)
+	execute.RegisterTransformation(SortedPivotKind, createSortedPivotTransformation)
 }
 
 func createPivotOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
@@ -420,6 +420,7 @@ type SortedPivotProcedureSpec struct {
 func (s *SortedPivotProcedureSpec) Kind() plan.ProcedureKind {
 	return SortedPivotKind
 }
+
 func (s *SortedPivotProcedureSpec) Copy() plan.ProcedureSpec {
 	ns := new(SortedPivotProcedureSpec)
 	ns.RowKey = make([]string, len(s.RowKey))
@@ -428,6 +429,18 @@ func (s *SortedPivotProcedureSpec) Copy() plan.ProcedureSpec {
 	copy(ns.ColumnKey, s.ColumnKey)
 	ns.ValueColumn = s.ValueColumn
 	return ns
+}
+
+func createSortedPivotTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*SortedPivotProcedureSpec)
+	if !ok {
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
+	}
+	t, dataset, err := newSortedPivotTransformation(a.Context(), *s, id, a.Allocator())
+	if err != nil {
+		return nil, nil, err
+	}
+	return t, dataset, nil
 }
 
 // sortedPivotTransformation is an optimized version of pivot.
@@ -536,7 +549,7 @@ func (t *sortedPivotTransformation) Process(id execute.DatasetID, tbl flux.Table
 		colLabel := cr.Key().LabelValue(colKey)
 
 		if colLabel == nil {
-			// The column colLabel is not part of the group colLabel
+			// The column key is not part of the group key
 			// so it does not have a consistent value.
 			// This is possible for us to do, but it requires
 			// regrouping the input and that is not implemented yet.
@@ -667,14 +680,16 @@ func (t *sortedPivotTransformation) Finish(id execute.DatasetID, err error) {
 		return
 	}
 
-	var tbl flux.Table
-	gr := t.group
-	tbl, err = gr.doPivot(t.prevOutputKey, t.alloc)
-	if err != nil {
-		return
-	}
-	if err = t.d.Process(tbl); err != nil {
-		return
+	if t.group != nil {
+		var tbl flux.Table
+		gr := t.group
+		tbl, err = gr.doPivot(t.prevOutputKey, t.alloc)
+		if err != nil {
+			return
+		}
+		if err = t.d.Process(tbl); err != nil {
+			return
+		}
 	}
 
 	if err = t.d.UpdateWatermark(t.watermark); err != nil {

--- a/stdlib/universe/pivot_test.go
+++ b/stdlib/universe/pivot_test.go
@@ -1490,6 +1490,16 @@ func TestSortedPivot_Process(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pivot no data",
+			spec: &universe.SortedPivotProcedureSpec{
+				RowKey:      []string{"_time"},
+				ColumnKey:   []string{"_field"},
+				ValueColumn: "_value",
+			},
+			data: []flux.Table{},
+			want: nil,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
There's a pipeline test for this transformation that was failing because of improper registration and a logic error. This PR fixes those. 