### PR TITLE
fix(execute): transformation adapter does not error when receiving a flush key for a table that is not present

### DIFF
--- a/execute/table/builder_cache.go
+++ b/execute/table/builder_cache.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/execute/groupkey"
 )
 
@@ -91,12 +89,16 @@ func (d *BuilderCache) Get(key flux.GroupKey, b interface{}) bool {
 
 // Table will remove a builder from the cache and construct a flux.Table
 // from the buffered contents.
-func (d *BuilderCache) Table(key flux.GroupKey) (flux.Table, error) {
+func (d *BuilderCache) Table(key flux.GroupKey) (flux.Table, bool, error) {
 	builder, ok := d.lookupState(key)
 	if !ok {
-		return nil, errors.Newf(codes.Internal, "table not found with key %v", key)
+		return nil, false, nil
 	}
-	return builder.Table()
+	tbl, err := builder.Table()
+	if err != nil {
+		return nil, false, err
+	}
+	return tbl, true, nil
 }
 
 func (d *BuilderCache) ForEach(f func(key flux.GroupKey, builder Builder) error) error {

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -654,8 +654,8 @@ func (t *transformationTransportAdapter) ProcessMessage(m Message) error {
 
 		// Retrieve the buffered builder for the given key
 		// and send the data to the next transformation.
-		tbl, err := t.cache.Table(m.Key())
-		if err != nil {
+		tbl, ok, err := t.cache.Table(m.Key())
+		if err != nil || !ok {
 			return err
 		}
 		t.cache.ExpireTable(m.Key())

--- a/execute/transport_test.go
+++ b/execute/transport_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/execute/table"
 	"github.com/influxdata/flux/execute/table/static"
 	"github.com/influxdata/flux/mock"
+	"github.com/influxdata/flux/values"
 )
 
 func TestProcessMsg(t *testing.T) {
@@ -229,6 +230,23 @@ func TestWrapTransformationInTransport(t *testing.T) {
 			return nil
 		}); err != nil {
 			t.Fatal(err)
+		}
+
+		// Include a group key that hasn't previously been seen.
+		// This should not cause an error and nothing should happen.
+		{
+			key := execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "_nonexistant", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("a"),
+				},
+			)
+			m := execute.NewFlushKeyMsg(key)
+			if err := tr.ProcessMessage(m); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 		}
 
 		m := execute.NewFinishMsg(nil)


### PR DESCRIPTION
The transformation adapter would respond to the flush key message by
attempting to create a table for the key. If there was no table builder
associated with the key, it would cause an error instead of just
ignoring the message.

This updates the transformation adapter to ignore flush key messages for
keys that don't correspond to an existing table builder.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written