### PR TITLE
fix(stdlib): change die error code to invalid

### DIFF
--- a/stdlib/universe/die.go
+++ b/stdlib/universe/die.go
@@ -2,6 +2,7 @@ package universe
 
 import (
 	"context"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/interpreter"
@@ -26,7 +27,7 @@ func Die() values.Function {
 					return nil, err
 				} else {
 					return nil, &flux.Error{
-						Code: codes.Internal,
+						Code: codes.Invalid,
 						Msg:  msg,
 					}
 				}

--- a/stdlib/universe/die_test.go
+++ b/stdlib/universe/die_test.go
@@ -25,7 +25,7 @@ func TestDie(t *testing.T) {
 		}
 
 		want := &flux.Error{
-			Code: codes.Internal,
+			Code: codes.Invalid,
 			Msg:  "this is an error message",
 		}
 


### PR DESCRIPTION
Previously the error code returned from the "die" function was
"Internal". Internal errors represent a bad state or system failure,
since a user can call the die function it is not indicative of an
internal error rather a user error as the system is behaving
appropriately when it returns the error. The change make the error code
"Invalid" instead of "Internal".


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
