### PR TITLE
fix(stdlib): limit now resets the offset after processing a partial buffer

### DIFF
--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -151,7 +151,12 @@ func (t *limitTransformation) limitTable(ctx context.Context, w *table.StreamWri
 			count = n
 			stop = start + count
 		}
+
+		// Reduce the number of rows we will keep from the
+		// next buffer and set the offset to zero as it has been
+		// entirely consumed.
 		n -= count
+		offset = 0
 
 		vs := make([]array.Interface, len(cr.Cols()))
 		for j := range vs {


### PR DESCRIPTION
The `limit()` function had two code paths. One path would decrement the
offset if the offset was greater than the length of the buffer so it
could track when it should stop discarding data. The second path would
process a partial buffer when the offset was less than the length of the
buffer.

Unfortunately, the second case had an error where it would not reset the
offset to zero after processing a partial buffer. It was supposed to
reset it to zero so that future buffers would be processed starting from
index zero.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written