### PR TITLE
feat(execute): Add GroupTransformation transport

### DIFF
--- a/execute/group_transformation.go
+++ b/execute/group_transformation.go
@@ -13,7 +13,7 @@ import (
 // NarrowTransformation will pass the FlushKeyMsg to the Dataset
 // and GroupTransformation will swallow this Message.
 type GroupTransformation interface {
-	Process(table.Chunk, *TransportDataset, memory.Allocator) error
+	Process(chunk table.Chunk, d *TransportDataset, mem memory.Allocator) error
 }
 
 var _ Transport = (*groupTransformation)(nil)
@@ -55,11 +55,6 @@ func (g *groupTransformation) ProcessMessage(m Message) error {
 	return nil
 }
 
-// Implement the Transformation interface
-func (g *groupTransformation) RetractTable(id DatasetID, key flux.GroupKey) error {
-	return nil
-}
-
 func (g *groupTransformation) Process(id DatasetID, tbl flux.Table) error {
 	if err := tbl.Do(func(cr flux.ColReader) error {
 		chunk := table.ChunkFromReader(cr)
@@ -80,14 +75,18 @@ func (g *groupTransformation) Process(id DatasetID, tbl flux.Table) error {
 	return g.ProcessMessage(&m)
 }
 
+func (g *groupTransformation) Finish(id DatasetID, err error) {
+	g.d.Finish(err)
+}
+
+func (g *groupTransformation) RetractTable(id DatasetID, key flux.GroupKey) error {
+	return nil
+}
+
 func (g *groupTransformation) UpdateWatermark(id DatasetID, t Time) error {
 	return nil
 }
 
 func (g *groupTransformation) UpdateProcessingTime(id DatasetID, t Time) error {
 	return nil
-}
-
-func (g *groupTransformation) Finish(id DatasetID, err error) {
-	g.d.Finish(err)
 }

--- a/execute/group_transformation.go
+++ b/execute/group_transformation.go
@@ -1,0 +1,93 @@
+package execute
+
+import (
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute/table"
+)
+
+// GroupTransformation is a transformation that can modify the group key.
+// Other than modifying the group key, it is identical to a NarrowTransformation.
+//
+// The main difference between this and NarrowTransformation is that
+// NarrowTransformation will pass the FlushKeyMsg to the Dataset
+// and GroupTransformation will swallow this Message.
+type GroupTransformation interface {
+	Process(table.Chunk, *TransportDataset, memory.Allocator) error
+}
+
+var _ Transport = (*groupTransformation)(nil)
+var _ Transformation = (*groupTransformation)(nil)
+
+type groupTransformation struct {
+	t GroupTransformation
+	d *TransportDataset
+}
+
+func (g *groupTransformation) OperationType() string {
+	return OperationType(g.t)
+}
+
+func NewGroupTransformation(id DatasetID, t GroupTransformation, mem memory.Allocator) (Transformation, Dataset, error) {
+	g := &groupTransformation{
+		t: t,
+		d: NewTransportDataset(id, mem),
+	}
+
+	return g, g.d, nil
+}
+
+// Implement the Transport interface
+func (g *groupTransformation) ProcessMessage(m Message) error {
+	defer m.Ack()
+
+	switch m := m.(type) {
+	case FinishMsg:
+		g.Finish(m.SrcDatasetID(), m.Error())
+		return nil
+	case ProcessChunkMsg:
+		return g.t.Process(m.TableChunk(), g.d, g.d.mem)
+	case FlushKeyMsg:
+		return nil
+	case ProcessMsg:
+		return g.Process(m.SrcDatasetID(), m.Table())
+	}
+	return nil
+}
+
+// Implement the Transformation interface
+func (g *groupTransformation) RetractTable(id DatasetID, key flux.GroupKey) error {
+	return nil
+}
+
+func (g *groupTransformation) Process(id DatasetID, tbl flux.Table) error {
+	if err := tbl.Do(func(cr flux.ColReader) error {
+		chunk := table.ChunkFromReader(cr)
+		chunk.Retain()
+		m := processChunkMsg{
+			srcMessage: srcMessage(id),
+			chunk:      chunk,
+		}
+		return g.ProcessMessage(&m)
+	}); err != nil {
+		return err
+	}
+
+	m := flushKeyMsg{
+		srcMessage: srcMessage(id),
+		key:        tbl.Key(),
+	}
+	return g.ProcessMessage(&m)
+}
+
+func (g *groupTransformation) UpdateWatermark(id DatasetID, t Time) error {
+	return nil
+}
+
+func (g *groupTransformation) UpdateProcessingTime(id DatasetID, t Time) error {
+	return nil
+}
+
+func (g *groupTransformation) Finish(id DatasetID, err error) {
+	g.d.Finish(err)
+}

--- a/execute/group_transformation_test.go
+++ b/execute/group_transformation_test.go
@@ -1,0 +1,262 @@
+package execute_test
+
+import (
+	"testing"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/execute/table"
+	"github.com/influxdata/flux/execute/table/static"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/mock"
+	"github.com/influxdata/flux/values"
+)
+
+func TestGroupTransformation_ProcessChunk(t *testing.T) {
+	// Ensure we allocate and free all memory correctly.
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	// Generate one table chunk using static.Table.
+	// This will only produce one column reader, so we are
+	// extracting that value from the nested iterators.
+	want := static.Table{
+		static.Times("_time", 0, 10, 20),
+		static.Floats("_value", 1, 2, 3),
+	}
+
+	isProcessed := false
+	tr, _, err := execute.NewGroupTransformation(
+		executetest.RandomDatasetID(),
+		&mock.GroupTransformation{
+			ProcessFn: func(chunk table.Chunk, d *execute.TransportDataset, _ memory.Allocator) error {
+				// Memory should be allocated and should not have been improperly freed.
+				// This accounts for 64 bytes (data) + 64 bytes (null bitmap) for each column
+				// of which there are two. 64 bytes is the minimum that arrow will allocate
+				// for a particular data buffer.
+				mem.AssertSize(t, 256)
+
+				// Compare the buffer contents to the table we wanted.
+				// Because we should have produced only one table chunk,
+				// we are comparing the entirety of the chunk to the entirety
+				// of the wanted output.
+				buffer := chunk.Buffer()
+				got := table.Iterator{
+					table.FromBuffer(&buffer),
+				}
+
+				if diff := table.Diff(want, got); diff != "" {
+					t.Errorf("unexpected diff -want/+got:\n%s", diff)
+				}
+				isProcessed = true
+				return nil
+			},
+		},
+		mem,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We can use a TransportDataset as a mock source
+	// to send messages to the transformation we are testing.
+	source := execute.NewTransportDataset(executetest.RandomDatasetID(), mem)
+	source.AddTransformation(tr)
+
+	tbl := want.Table(mem)
+	if err := tbl.Do(func(cr flux.ColReader) error {
+		chunk := table.ChunkFromReader(cr)
+		chunk.Retain()
+		return source.Process(chunk)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isProcessed {
+		t.Error("message was never processed")
+	}
+}
+
+func TestGroupTransformation_FlushKey(t *testing.T) {
+	want := execute.NewGroupKey(
+		[]flux.ColMeta{
+			{Label: "t0", Type: flux.TString},
+		},
+		[]values.Value{
+			values.NewString("a"),
+		},
+	)
+
+	isProcessed := false
+	tr := &mock.Transport{
+		ProcessMessageFn: func(m execute.Message) error {
+			msg, ok := m.(execute.FlushKeyMsg)
+			if !ok {
+				t.Fatalf("expected flush key message, got %T", m)
+			}
+
+			if got := msg.Key(); !want.Equal(got) {
+				t.Fatalf("unexpected group key -want/+got:\n%s", cmp.Diff(want, got))
+			}
+			isProcessed = true
+			return nil
+		},
+	}
+
+	d := execute.NewTransportDataset(executetest.RandomDatasetID(), memory.DefaultAllocator)
+	d.AddTransformation(tr)
+	if err := d.FlushKey(want); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !isProcessed {
+		t.Error("message was never processed")
+	}
+}
+
+func TestGroupTransformation_Process(t *testing.T) {
+	// Ensure we allocate and free all memory correctly.
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	// Generate one table chunk using static.Table.
+	// This will only produce one column reader, so we are
+	// extracting that value from the nested iterators.
+	want := static.Table{
+		static.Times("_time", 0, 10, 20),
+		static.Floats("_value", 1, 2, 3),
+	}
+
+	isProcessed := false
+	tr, _, err := execute.NewGroupTransformation(
+		executetest.RandomDatasetID(),
+		&mock.GroupTransformation{
+			ProcessFn: func(chunk table.Chunk, d *execute.TransportDataset, _ memory.Allocator) error {
+				// Memory should be allocated and should not have been improperly freed.
+				// This accounts for 64 bytes (data) + 64 bytes (null bitmap) for each column
+				// of which there are two. 64 bytes is the minimum that arrow will allocate
+				// for a particular data buffer.
+				mem.AssertSize(t, 256)
+
+				// Compare the buffer contents to the table we wanted.
+				// Because we should have produced only one table chunk,
+				// we are comparing the entirety of the chunk to the entirety
+				// of the wanted output.
+				buffer := chunk.Buffer()
+				got := table.Iterator{
+					table.FromBuffer(&buffer),
+				}
+
+				if diff := table.Diff(want, got); diff != "" {
+					t.Errorf("unexpected diff -want/+got:\n%s", diff)
+				}
+				isProcessed = true
+				return nil
+			},
+		},
+		mem,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Process the table and ensure it gets converted to a table chunk,
+	// memory is still allocated for it, and the actual data is correct.
+	//
+	// Instead of using public methods, we simulate sending a process message.
+	// We want to test a transport's ability to forward the process message,
+	// but the only transport that has this capability is the consecutive transport.
+	// As we don't want to add the dispatcher or concurrency to this test, we manually
+	// construct the message and send it ourselves.
+	m := execute.NewProcessMsg(want.Table(mem))
+	if err := tr.(execute.Transport).ProcessMessage(m); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isProcessed {
+		t.Error("message was never processed")
+	}
+}
+
+func TestGroupTransformation_Finish(t *testing.T) {
+	isFinished := []bool{false, false}
+
+	want := errors.New(codes.Internal, "expected")
+
+	tr, d, err := execute.NewGroupTransformation(
+		executetest.RandomDatasetID(),
+		&mock.GroupTransformation{},
+		memory.DefaultAllocator,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d.AddTransformation(
+		&mock.Transport{
+			ProcessMessageFn: func(m execute.Message) error {
+				msg, ok := m.(execute.FinishMsg)
+				if !ok {
+					t.Fatalf("expected finish message, got %T", m)
+				}
+
+				if got := msg.Error(); !cmp.Equal(want, got) {
+					t.Fatalf("unexpected error -want/+got:\n%s", cmp.Diff(want, got))
+				}
+				isFinished[0] = true
+				return nil
+			},
+		},
+	)
+	d.AddTransformation(
+		&mock.Transformation{
+			FinishFn: func(id execute.DatasetID, err error) {
+				if got := err; !cmp.Equal(want, got) {
+					t.Fatalf("unexpected error -want/+got:\n%s", cmp.Diff(want, got))
+				}
+				isFinished[1] = true
+			},
+		},
+	)
+
+	// We want to check that finish is forwarded correctly.
+	// We construct the finish message and then send it directly
+	// to the process message method.
+	if err := tr.(execute.Transport).ProcessMessage(
+		execute.NewFinishMsg(want),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	d.Finish(want)
+
+	if !isFinished[0] {
+		t.Error("transport did not receive finish message")
+	}
+	if !isFinished[1] {
+		t.Error("transformation did not receive finish message")
+	}
+}
+
+// Ensure that we report the operation type of the type we wrap
+// and ensure that we don't report ourselves as the operation type.
+//
+// This is to prevent opentracing from showing groupTransformation
+// as the operation.
+func TestGroupTransformation_OperationType(t *testing.T) {
+	tr, _, err := execute.NewGroupTransformation(
+		executetest.RandomDatasetID(),
+		&mock.GroupTransformation{},
+		memory.DefaultAllocator,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := "*mock.GroupTransformation", execute.OperationType(tr); want != got {
+		t.Errorf("unexpected operation type -want/+got:\n\t- %s\n\t+ %s", want, got)
+	}
+}

--- a/mock/transformation.go
+++ b/mock/transformation.go
@@ -32,6 +32,14 @@ func (t *Transformation) Finish(id execute.DatasetID, err error) {
 	t.FinishFn(id, err)
 }
 
+type GroupTransformation struct {
+	ProcessFn func(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error
+}
+
+func (n *GroupTransformation) Process(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error {
+	return n.ProcessFn(chunk, d, mem)
+}
+
 type NarrowTransformation struct {
 	ProcessFn func(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error
 }


### PR DESCRIPTION
Adds a `GroupTransformation` interface as per #3928 

Spent a while trying to implement this myself before realizing that the work in https://github.com/influxdata/flux/pull/3944 is virtually identical to what needed to be done here. As a result, this PR is mostly just a copy+paste of the code for the new `NarrowTransformation` transport, with some small tweaks.
