### PR TITLE
fix(stdlib): panic with unknown type invalid in reduce function

### DIFF
--- a/stdlib/universe/reduce.go
+++ b/stdlib/universe/reduce.go
@@ -183,6 +183,9 @@ func (t *reduceTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 
 	for _, label := range columns {
 		v, _ := m.Get(label)
+		if v.IsNull() {
+			return errors.Newf(codes.Invalid, `reduce object property "%s" is "%v" type which is not supported in a flux table`, label, v.Type())
+		}
 		if _, err := builder.AddCol(flux.ColMeta{
 			Label: label,
 			Type:  flux.ColumnType(v.Type()),


### PR DESCRIPTION
if the reduce function has null value, the query is panicking with unkonown type.
So check has been added for nulls and if it exists, return the appropriate error message to the user.

fixes: #3976 
