### PR TITLE
fix: added FormatDuration method which can be exported in other repo

### DIFF
--- a/parser/strconv.go
+++ b/parser/strconv.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/influxdata/flux/ast"
@@ -46,6 +48,16 @@ func ParseDuration(lit string) (*ast.DurationLiteral, error) {
 		Values:   d,
 		BaseNode: ast.BaseNode{Loc: &ast.SourceLocation{Source: lit}},
 	}, nil
+}
+
+// FormatDuration will convert DurationLiteral into formatted string representation
+func FormatDuration(n *ast.DurationLiteral) string {
+	builder := strings.Builder{}
+	for _, d := range n.Values {
+		builder.WriteString(strconv.FormatInt(d.Magnitude, 10))
+		builder.WriteString(d.Unit)
+	}
+	return builder.String()
 }
 
 // ParseString removes quotes and unescapes the string literal.

--- a/parser/strconv_test.go
+++ b/parser/strconv_test.go
@@ -57,3 +57,59 @@ func TestParseSignedDuration(t *testing.T) {
 	})
 
 }
+
+func TestFormatDuration(t *testing.T) {
+	t.Run("format negative duration", func(t *testing.T) {
+		node := &ast.DurationLiteral{
+			Values: []ast.Duration{
+				{
+					Magnitude: -1,
+					Unit:      "d",
+				},
+				{
+					Magnitude: -2,
+					Unit:      "h",
+				},
+				{
+					Magnitude: -1,
+					Unit:      "m",
+				},
+				{
+					Magnitude: -3,
+					Unit:      "s",
+				},
+			},
+		}
+		durs := parser.FormatDuration(node)
+		if diff := cmp.Diff("-1d-2h-1m-3s", durs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("format duration", func(t *testing.T) {
+		node := &ast.DurationLiteral{
+			Values: []ast.Duration{
+				{
+					Magnitude: 1,
+					Unit:      "d",
+				},
+				{
+					Magnitude: 2,
+					Unit:      "h",
+				},
+				{
+					Magnitude: 1,
+					Unit:      "m",
+				},
+				{
+					Magnitude: 3,
+					Unit:      "s",
+				},
+			},
+		}
+		durs := parser.FormatDuration(node)
+		if diff := cmp.Diff("1d2h1m3s", durs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}


### PR DESCRIPTION
Added FormatDuration method which can be exported from other repo. 
