### PR TITLE
docs: SPEC.md - added missing parameter names in regexp

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4493,43 +4493,43 @@ Example: `compile(v: "abcd")` returns the regular expression value `abcd`.
 
 Return a string holding the text of the leftmost match in v of the regular expression.
 
-Example: `findString(r: regexp.compile("foo.?"), v: "seafood fool")` returns the string `food`.
+Example: `findString(r: regexp.compile(v: "foo.?"), v: "seafood fool")` returns the string `food`.
 
 ##### findStringIndex
 
 Returns a two-element slice of integers defining the location of the leftmost match in v of the regular expression.
 
-Example: `findStringIndex(r: regexp.compile("ab?"), v: "tablett")` returns the int array `[1 3]`.
+Example: `findStringIndex(r: regexp.compile(v: "ab?"), v: "tablett")` returns the int array `[1 3]`.
 
 ##### getString
 
 Return the source text used to compile the regular expression.
 
-Example: `getString(v: regexp.compile("abcd"))` returns the regular expression value `abcd`.
+Example: `getString(v: regexp.compile(v: "abcd"))` returns the regular expression value `abcd`.
 
 ##### matchRegexString
 
 Report whether the string v contains any match of the regular expression r.
 
-Example: `matchString(r: regexp.compile("(gopher){2}"), v: "gophergophergopher")` returns boolean `true`
+Example: `matchString(r: regexp.compile(v: "(gopher){2}"), v: "gophergophergopher")` returns boolean `true`
 
 ##### replaceAllString
 
 Returns a copy of v, replacing matches of the Regexp r with the replacement string t.
 
-Example: `replaceAllString(r: regexp.compile("a(x*)b"), v: "-ab-axxb-", t: "T")` returns string `-T-T-`.
+Example: `replaceAllString(r: regexp.compile(v: "a(x*)b"), v: "-ab-axxb-", t: "T")` returns string `-T-T-`.
 
 ##### quoteMeta
 
 Return a string that escapes all regular expression metacharacters inside the argument text; the returned string is a regular expression matching the literal text.
 
-Example: `quoteMeta("Escaping symbols like: .+*?()|[]{}^$")` returns string `Escaping symbols like: \.\+\*\?\(\)\|\[\]\{\}\^\$`.
+Example: `quoteMeta(v: "Escaping symbols like: .+*?()|[]{}^$")` returns string `Escaping symbols like: \.\+\*\?\(\)\|\[\]\{\}\^\$`.
 
 ##### splitRegexp
 
 Slices v into substrings separated by the expression and returns a slice of the substrings between those expression matches.
 
-Example: `splitRegex(r: regexp.compile("a*"), v: "abaabaccadaaae", i: 5)` returns string array `["", "b", "b", "c", "cadaaae"]`.
+Example: `splitRegex(r: regexp.compile(v: "a*"), v: "abaabaccadaaae", i: 5)` returns string array `["", "b", "b", "c", "cadaaae"]`.
 
 ### Composite data types
 


### PR DESCRIPTION
Code examples were invalid.

Perhaps instead of calling `regexp.compile(v: "asdf")`, these should just be Regular Expression literals `/asdf/`?

Also -- this section and the strings section before it might benefit from having a note that `strings` and `regexp` both need to be imported before use. It's also a bit awkward to have the code examples call the functions directly as identifiers in scope, when in practice they need to be referenced from the imported package (`regexp.splitRegexp`) -- unless there's a way around that I'm not aware of.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
