### PR TITLE
fix(stdlib): panic unknown type in query with difference function

### DIFF
--- a/stdlib/universe/difference.go
+++ b/stdlib/universe/difference.go
@@ -175,6 +175,8 @@ func (t *differenceTransformation) Process(id execute.DatasetID, tbl flux.Table)
 			typ = flux.TFloat
 		case flux.TTime:
 			return errors.New(codes.FailedPrecondition, "difference does not support time columns. Try the elapsed function")
+		default:
+			return errors.Newf(codes.Invalid, `difference does not support column "%s" of type "%v"`, c.Label, c.Type)
 		}
 		if _, err := builder.AddCol(flux.ColMeta{
 			Label: c.Label,


### PR DESCRIPTION
Issue -
The issue is with the `columns` type which is used to compute the
difference. If the column is anything else then int, float or time the
flux.ColType stayed unassigned causing builder.AddCol to fail.

Fix -
The fix is to add a default case for the ColType, generating a user error.


