### PR TITLE
chore: update to rust 1.55

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,7 +4,7 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-FROM rust:1.54 as RUSTBUILD
+FROM rust:1.55 as RUSTBUILD
 
 FROM golang:1.16
 


### PR DESCRIPTION
This patch updates the required rust to 1.55. This update did not
require code changes in libflux, so we can safely bump the required
docker rust tooling without issue.