### PR TITLE
test: create a test for group performance

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -481,6 +481,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/group_by_irregular_test.flux":                                                "b74944c8d826a930fcefa1f695d2ac22f9bbaa62f6b5dcc501c3c88001131d62",
 	"stdlib/universe/group_except_test.flux":                                                      "67cd762fca4468e57b16a81119bbf6d413c3397cd841490014d25e9870dd91c1",
 	"stdlib/universe/group_nulls_test.flux":                                                       "1ffe996153793de8f3ef96f88410dda67cabd788afdb357c9420eae376aee5cc",
+	"stdlib/universe/group_perf_test.flux":                                                        "1b76b4d23da4ec6ba21160016c0ca48fc245b852c3fcee0b0d8412809a39d116",
 	"stdlib/universe/group_test.flux":                                                             "f3d583650276343c119f37628c97182e8ea90821c44262b4ee65ab5a9cfae270",
 	"stdlib/universe/group_ungroup_test.flux":                                                     "4bf56972b81aeb61e915148c00350a39873e71aa194fe2ba0823fa9f249ecd45",
 	"stdlib/universe/highestAverage_test.flux":                                                    "19493504f36aaf8fc579339f22f61940b0343848cb893d862276f1937631968e",

--- a/stdlib/universe/group_perf_test.flux
+++ b/stdlib/universe/group_perf_test.flux
@@ -1,0 +1,50 @@
+package universe_test
+
+
+import "testing"
+import "internal/gen"
+import "array"
+
+option now = () => 2030-01-01T00:00:00Z
+
+numSeries = 1000
+pointsPerSeries = 10
+
+input = gen.tables(
+    n: pointsPerSeries,
+    tags: [
+        {cardinality: 1, name: "_measurement"},
+        {cardinality: 1, name: "_field"},
+        {cardinality: numSeries, name: "orgID"},
+    ],
+)
+    |> range(start: -10y)
+    |> map(fn: (r) => ({r with _measurement: "query_log", _field: "totalDuration"}))
+
+want = array.from(rows: [{_measurement: "query_log", _value: numSeries * pointsPerSeries}])
+    |> group(columns: ["_measurement"])
+
+testcase group_perf_good {
+    result = input |> testing.load()
+        |> range(start: -10y)
+        |> filter(fn: (r) => r._measurement == "query_log" or r._measurement == "influxql_query_log")
+        |> filter(fn: (r) => r._field == "totalDuration")
+        |> group(columns: ["_measurement", "orgID"])
+        |> count()
+        |> group(columns: ["_measurement"])
+        |> sum()
+
+    testing.diff(got: result, want: want) |> yield()
+}
+
+testcase group_perf_bad {
+    result = input |> testing.load()
+        |> range(start: -10y)
+        |> filter(fn: (r) => r._measurement == "query_log" or r._measurement == "influxql_query_log")
+        |> filter(fn: (r) => r._field == "totalDuration")
+        |> count()
+        |> group(columns: ["_measurement"])
+        |> sum()
+
+    testing.diff(got: result, want: want) |> yield()
+}


### PR DESCRIPTION
Because of some formatting issues, it looks like more changed than what I did. There is just one new file:
```
stdlib/universe/group_perf_test.flux
```
This file contains a unit test that should reproduce an issue with group performance.