### PR TITLE
ci: upgrade to go 1.17 for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Install system dependencies
           command: |
-            choco upgrade golang --version=1.16.6
+            choco upgrade golang --version=1.17 --allow-downgrade
 
             choco install \
               grep \

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -6,7 +6,7 @@
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
 FROM rust:1.55 as RUSTBUILD
 
-FROM golang:1.16
+FROM golang:1.17
 
 # Install common packages
 RUN apt-get update && \


### PR DESCRIPTION
This upgrades to go 1.17 for ci but does not modify the base `go.mod`
version as `go 1.16` can still be used with flux.

It also modifies the windows build to use `--allow-downgrade` with choco
so that upstream releases don't cause our builds to break.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written