### PR TITLE
revert: update to rust 1.55 (#4027)

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,7 +4,7 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-FROM rust:1.55 as RUSTBUILD
+FROM rust:1.54 as RUSTBUILD
 
 FROM golang:1.17
 


### PR DESCRIPTION
This reverts commit b899d8bd6a35797d52964c71a21d192ceda40611.

The upgrade to rust 1.55 was causing build errors in the flux release for influxdb. We've confirmed that downgrading to rust 1.54 resolves the issues: https://app.circleci.com/pipelines/github/influxdata/influxdb/24024/workflows/09396d1f-5b38-4c4c-ba55-a62006c9cfe8
