### PR TITLE
fix(array): add null support to optimized repeat function

### DIFF
--- a/array/repeat.gen.go
+++ b/array/repeat.gen.go
@@ -8,65 +8,64 @@ package array
 
 import (
 	"github.com/apache/arrow/go/arrow/memory"
-	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/internal/errors"
 )
 
-func Repeat(v interface{}, n int, mem memory.Allocator) Interface {
-	switch v := v.(type) {
-
-	case int64:
-		return IntRepeat(v, n, mem)
-
-	case uint64:
-		return UintRepeat(v, n, mem)
-
-	case float64:
-		return FloatRepeat(v, n, mem)
-
-	case string:
-		return StringRepeat(v, n, mem)
-
-	case bool:
-		return BooleanRepeat(v, n, mem)
-
-	default:
-		panic(errors.Newf(codes.Internal, "invalid arrow primitive type: %T", v))
-	}
-}
-
-func IntRepeat(v int64, n int, mem memory.Allocator) *Int {
+func IntRepeat(v int64, isNull bool, n int, mem memory.Allocator) *Int {
 	b := NewIntBuilder(mem)
 	b.Resize(n)
-	for i := 0; i < n; i++ {
-		b.Append(v)
+	if isNull {
+		for i := 0; i < n; i++ {
+			b.AppendNull()
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
 	}
 	return b.NewIntArray()
 }
 
-func UintRepeat(v uint64, n int, mem memory.Allocator) *Uint {
+func UintRepeat(v uint64, isNull bool, n int, mem memory.Allocator) *Uint {
 	b := NewUintBuilder(mem)
 	b.Resize(n)
-	for i := 0; i < n; i++ {
-		b.Append(v)
+	if isNull {
+		for i := 0; i < n; i++ {
+			b.AppendNull()
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
 	}
 	return b.NewUintArray()
 }
 
-func FloatRepeat(v float64, n int, mem memory.Allocator) *Float {
+func FloatRepeat(v float64, isNull bool, n int, mem memory.Allocator) *Float {
 	b := NewFloatBuilder(mem)
 	b.Resize(n)
-	for i := 0; i < n; i++ {
-		b.Append(v)
+	if isNull {
+		for i := 0; i < n; i++ {
+			b.AppendNull()
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
 	}
 	return b.NewFloatArray()
 }
 
-func BooleanRepeat(v bool, n int, mem memory.Allocator) *Boolean {
+func BooleanRepeat(v bool, isNull bool, n int, mem memory.Allocator) *Boolean {
 	b := NewBooleanBuilder(mem)
 	b.Resize(n)
-	for i := 0; i < n; i++ {
-		b.Append(v)
+	if isNull {
+		for i := 0; i < n; i++ {
+			b.AppendNull()
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			b.Append(v)
+		}
 	}
 	return b.NewBooleanArray()
 }

--- a/array/repeat.gen.go.tmpl
+++ b/array/repeat.gen.go.tmpl
@@ -2,27 +2,20 @@ package array
 
 import (
     "github.com/apache/arrow/go/arrow/memory"
-    "github.com/influxdata/flux/codes"
-    "github.com/influxdata/flux/internal/errors"
 )
 
-func Repeat(v interface{}, n int, mem memory.Allocator) Interface {
-    switch v := v.(type) {
-    {{range .}}
-    case {{.PrimitiveType}}:
-        return {{.Name}}Repeat(v, n, mem)
-    {{end}}
-    default:
-        panic(errors.Newf(codes.Internal, "invalid arrow primitive type: %T", v))
-    }
-}
-
 {{range .}}{{if .ArrowType}}
-func {{.Name}}Repeat(v {{.PrimitiveType}}, n int, mem memory.Allocator) *{{.Name}} {
+func {{.Name}}Repeat(v {{.PrimitiveType}}, isNull bool, n int, mem memory.Allocator) *{{.Name}} {
     b := New{{.Name}}Builder(mem)
     b.Resize(n)
-    for i := 0; i < n; i++ {
-        b.Append(v)
+    if isNull {
+        for i := 0; i < n; i++ {
+			b.AppendNull()
+		}
+    } else {
+        for i := 0; i < n; i++ {
+            b.Append(v)
+        }
     }
     return b.New{{.Name}}Array()
 }

--- a/array/repeat_test.go
+++ b/array/repeat_test.go
@@ -4,38 +4,46 @@ import (
 	"testing"
 
 	"github.com/apache/arrow/go/arrow/memory"
-	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/values"
 )
 
 func TestRepeat(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		v    interface{}
+		t    flux.ColType
+		v    values.Value
 		sz   int
 	}{
 		{
 			name: "Int",
-			v:    int64(4),
+			t:    flux.TInt,
+			v:    values.NewInt(4),
 			sz:   192, // 128 bytes (ints), 64 bytes (nulls)
 		},
 		{
 			name: "Uint",
-			v:    uint64(4),
+			t:    flux.TUInt,
+			v:    values.NewUInt(4),
 			sz:   192, // 128 bytes (ints), 64 bytes (nulls)
 		},
 		{
 			name: "Float",
-			v:    float64(4),
+			t:    flux.TFloat,
+			v:    values.NewFloat(4),
 			sz:   192, // 128 bytes (ints), 64 bytes (nulls)
 		},
 		{
 			name: "String",
-			v:    "a",
+			t:    flux.TString,
+			v:    values.NewString("a"),
 			sz:   0, // optimized away
 		},
 		{
 			name: "Boolean",
-			v:    true,
+			t:    flux.TBool,
+			v:    values.NewBool(true),
 			sz:   128, // 64 bytes (bools), 64 bytes (nulls)
 		},
 	} {
@@ -43,7 +51,7 @@ func TestRepeat(t *testing.T) {
 			mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 			defer mem.AssertSize(t, 0)
 
-			arr := array.Repeat(tc.v, 10, mem)
+			arr := arrow.Repeat(tc.t, tc.v, 10, mem)
 			mem.AssertSize(t, tc.sz)
 			arr.Release()
 		})

--- a/arrow/repeat.go
+++ b/arrow/repeat.go
@@ -2,17 +2,54 @@ package arrow
 
 import (
 	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/values"
 )
 
 // Repeat will construct an arrow array that repeats
 // the value n times.
-func Repeat(v values.Value, n int, mem memory.Allocator) array.Interface {
-	switch v := values.Unwrap(v).(type) {
-	case values.Time:
-		return array.IntRepeat(int64(v), n, mem)
+func Repeat(colType flux.ColType, v values.Value, n int, mem memory.Allocator) array.Interface {
+	switch colType {
+	case flux.TInt:
+		var ival int64
+		if !v.IsNull() {
+			ival = v.Int()
+		}
+		return array.IntRepeat(ival, v.IsNull(), n, mem)
+	case flux.TUInt:
+		var uival uint64
+		if !v.IsNull() {
+			uival = v.UInt()
+		}
+		return array.UintRepeat(uival, v.IsNull(), n, mem)
+	case flux.TFloat:
+		var fval float64
+		if !v.IsNull() {
+			fval = v.Float()
+		}
+		return array.FloatRepeat(fval, v.IsNull(), n, mem)
+	case flux.TBool:
+		var bval bool
+		if !v.IsNull() {
+			bval = v.Bool()
+		}
+		return array.BooleanRepeat(bval, v.IsNull(), n, mem)
+	case flux.TString:
+		var sval string
+		if !v.IsNull() {
+			sval = v.Str()
+		}
+		return array.StringRepeat(sval, n, mem)
+	case flux.TTime:
+		var tval values.Time
+		if !v.IsNull() {
+			tval = v.Time()
+		}
+		return array.IntRepeat(int64(tval), v.IsNull(), n, mem)
 	default:
-		return array.Repeat(v, n, mem)
+		panic(errors.Newf(codes.Internal, "invalid arrow primitive type: %T", colType))
 	}
 }

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -458,31 +458,28 @@ func (t *simpleAggregateTransformation2) Compute(key flux.GroupKey, state interf
 
 	buffer.Values = make([]array.Interface, len(key.Cols()), len(buffer.Columns))
 	for j := range key.Cols() {
-		buffer.Values[j] = arrow.Repeat(key.Value(j), 1, mem)
+		buffer.Values[j] = arrow.Repeat(key.Cols()[j].Type, key.Value(j), 1, mem)
 	}
 
 	for _, s := range aggregates {
 		var arr array.Interface
-		if !s.agg.IsNull() {
-			switch s.agg.Type() {
-			case flux.TBool:
-				v := s.agg.(BoolValueFunc).ValueBool()
-				arr = array.BooleanRepeat(v, 1, mem)
-			case flux.TInt:
-				v := s.agg.(IntValueFunc).ValueInt()
-				arr = array.IntRepeat(v, 1, mem)
-			case flux.TUInt:
-				v := s.agg.(UIntValueFunc).ValueUInt()
-				arr = array.UintRepeat(v, 1, mem)
-			case flux.TFloat:
-				v := s.agg.(FloatValueFunc).ValueFloat()
-				arr = array.FloatRepeat(v, 1, mem)
-			case flux.TString:
-				v := s.agg.(StringValueFunc).ValueString()
-				arr = array.StringRepeat(v, 1, mem)
-			}
-		} else {
-			arr = arrow.Nulls(s.agg.Type(), 1, mem)
+		isNull := s.agg.IsNull()
+		switch s.agg.Type() {
+		case flux.TBool:
+			v := s.agg.(BoolValueFunc).ValueBool()
+			arr = array.BooleanRepeat(v, isNull, 1, mem)
+		case flux.TInt:
+			v := s.agg.(IntValueFunc).ValueInt()
+			arr = array.IntRepeat(v, isNull, 1, mem)
+		case flux.TUInt:
+			v := s.agg.(UIntValueFunc).ValueUInt()
+			arr = array.UintRepeat(v, isNull, 1, mem)
+		case flux.TFloat:
+			v := s.agg.(FloatValueFunc).ValueFloat()
+			arr = array.FloatRepeat(v, isNull, 1, mem)
+		case flux.TString:
+			v := s.agg.(StringValueFunc).ValueString()
+			arr = array.StringRepeat(v, 1, mem)
 		}
 		buffer.Values = append(buffer.Values, arr)
 	}

--- a/execute/table/buffered_test.go
+++ b/execute/table/buffered_test.go
@@ -36,8 +36,8 @@ func TestBufferedTable(t *testing.T) {
 							flux.ColMeta{Label: "_value", Type: flux.TFloat},
 						)
 						vs := make([]array.Interface, len(cols))
-						vs[0] = arrow.Repeat(key.Value(0), 3, alloc)
-						vs[1] = arrow.Repeat(key.Value(1), 3, alloc)
+						vs[0] = arrow.Repeat(key.Cols()[0].Type, key.Value(0), 3, alloc)
+						vs[1] = arrow.Repeat(key.Cols()[1].Type, key.Value(1), 3, alloc)
 						vs[2] = arrow.NewInt([]int64{0, 1, 2}, alloc)
 						vs[3] = arrow.NewFloat([]float64{4, 8, 7}, alloc)
 						return &arrow.TableBuffer{
@@ -69,8 +69,8 @@ func TestBufferedTable(t *testing.T) {
 						Columns:  cols,
 					}
 					vs := make([]array.Interface, len(cols))
-					vs[0] = arrow.Repeat(key.Value(0), 3, alloc)
-					vs[1] = arrow.Repeat(key.Value(1), 3, alloc)
+					vs[0] = arrow.Repeat(key.Cols()[0].Type, key.Value(0), 3, alloc)
+					vs[1] = arrow.Repeat(key.Cols()[1].Type, key.Value(1), 3, alloc)
 					vs[2] = arrow.NewInt([]int64{0, 1, 2}, alloc)
 					vs[3] = arrow.NewFloat([]float64{4, 8, 7}, alloc)
 					table.Buffers = append(table.Buffers, &arrow.TableBuffer{
@@ -80,8 +80,8 @@ func TestBufferedTable(t *testing.T) {
 					})
 
 					vs = make([]array.Interface, len(cols))
-					vs[0] = arrow.Repeat(key.Value(0), 5, alloc)
-					vs[1] = arrow.Repeat(key.Value(1), 5, alloc)
+					vs[0] = arrow.Repeat(key.Cols()[0].Type, key.Value(0), 5, alloc)
+					vs[1] = arrow.Repeat(key.Cols()[1].Type, key.Value(1), 5, alloc)
 					vs[2] = arrow.NewInt([]int64{3, 4, 5, 6, 7}, alloc)
 					vs[3] = arrow.NewFloat([]float64{2, 9, 4, 6, 2}, alloc)
 					table.Buffers = append(table.Buffers, &arrow.TableBuffer{

--- a/execute/table/static/static.go
+++ b/execute/table/static/static.go
@@ -196,7 +196,7 @@ type KeyColumn struct {
 }
 
 func (s KeyColumn) Make(n int, mem memory.Allocator) array.Interface {
-	return arrow.Repeat(s.KeyValue(), n, mem)
+	return arrow.Repeat(s.Type(), s.KeyValue(), n, mem)
 }
 
 func (s KeyColumn) Label() string          { return s.k }

--- a/internal/execute/table/stream_test.go
+++ b/internal/execute/table/stream_test.go
@@ -35,8 +35,8 @@ func TestStream(t *testing.T) {
 				)
 				tbl1 := MustStreamContext(ctx, key1, cols1, func(ctx context.Context, w *table.StreamWriter) error {
 					vs := make([]array.Interface, len(w.Cols()))
-					vs[0] = arrow.Repeat(w.Key().Value(0), 3, alloc)
-					vs[1] = arrow.Repeat(w.Key().Value(1), 3, alloc)
+					vs[0] = arrow.Repeat(w.Key().Cols()[0].Type, w.Key().Value(0), 3, alloc)
+					vs[1] = arrow.Repeat(w.Key().Cols()[1].Type, w.Key().Value(1), 3, alloc)
 					vs[2] = arrow.NewInt([]int64{0, 1, 2}, alloc)
 					vs[3] = arrow.NewFloat([]float64{4, 8, 7}, alloc)
 					return w.Write(vs)
@@ -58,8 +58,8 @@ func TestStream(t *testing.T) {
 				)
 				tbl2 := MustStreamContext(ctx, key2, cols2, func(ctx context.Context, w *table.StreamWriter) error {
 					vs := make([]array.Interface, len(w.Cols()))
-					vs[0] = arrow.Repeat(w.Key().Value(0), 3, alloc)
-					vs[1] = arrow.Repeat(w.Key().Value(1), 3, alloc)
+					vs[0] = arrow.Repeat(w.Key().Cols()[0].Type, w.Key().Value(0), 3, alloc)
+					vs[1] = arrow.Repeat(w.Key().Cols()[1].Type, w.Key().Value(1), 3, alloc)
 					vs[2] = arrow.NewInt([]int64{0, 1, 2}, alloc)
 					vs[3] = arrow.NewFloat([]float64{4, 8, 7}, alloc)
 					if err := w.Write(vs); err != nil {
@@ -67,8 +67,8 @@ func TestStream(t *testing.T) {
 					}
 
 					vs = make([]array.Interface, len(w.Cols()))
-					vs[0] = arrow.Repeat(w.Key().Value(0), 5, alloc)
-					vs[1] = arrow.Repeat(w.Key().Value(1), 5, alloc)
+					vs[0] = arrow.Repeat(w.Key().Cols()[0].Type, w.Key().Value(0), 5, alloc)
+					vs[1] = arrow.Repeat(w.Key().Cols()[1].Type, w.Key().Value(1), 5, alloc)
 					vs[2] = arrow.NewInt([]int64{3, 4, 5, 6, 7}, alloc)
 					vs[3] = arrow.NewFloat([]float64{2, 9, 4, 6, 2}, alloc)
 					return w.Write(vs)

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -410,7 +410,7 @@ func (dg *dataGenerator) Do(f func(tbl flux.Table) error) error {
 					ts, start, n = dg.generateBufferTimes(start, n)
 					for i, v := range s.Values() {
 						if keyValues[i] == nil {
-							keyValues[i] = arrow.Repeat(v, ts.Len(), dg.Allocator)
+							keyValues[i] = arrow.Repeat(s.Cols()[i].Type, v, ts.Len(), dg.Allocator)
 						}
 						vs := keyValues[i]
 						if vs.Len() == ts.Len() {

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -581,6 +581,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/show_all_tag_keys_test.flux":                                                 "809b35913149fd7a1c00f7b995ff5541054e9736d0700233d83646f77dafe86d",
 	"stdlib/universe/simple_max_test.flux":                                                        "4425e3033c0db63f273a852011accae0ffa68169b391807e54ec7339947acc60",
 	"stdlib/universe/skew_test.flux":                                                              "aa790e67511f21c2eecc957656bcb7604970276fa0433d2f78b84da97097e4c9",
+	"stdlib/universe/sort2_test.flux":                                                             "8555a673a0a9f33986ede6cb6a86097e37d410585e37d93169d8c6cea261f628",
 	"stdlib/universe/sort_test.flux":                                                              "231121ef03f52827ee1231035159d8c8585a0f5a3f1e4325b6798f16a143d437",
 	"stdlib/universe/spread_test.flux":                                                            "320dde43106a0011b3305e7cf29838ac6a6209e69826c11fa67b2cc37eb7bc7e",
 	"stdlib/universe/state_count_test.flux":                                                       "cb3e418a1f7407b824401e028897ad605e2ec653c10379ea83af44ac155bd8a7",

--- a/stdlib/contrib/jsternberg/aggregate/table.go
+++ b/stdlib/contrib/jsternberg/aggregate/table.go
@@ -330,7 +330,7 @@ func (t *tableTransformation) buildTable(key flux.GroupKey, cols []flux.ColMeta,
 	// Copy over the group key columns.
 	for i, c := range key.Cols() {
 		buffer.Columns[i] = c
-		buffer.Values[i] = arrow.Repeat(key.Value(i), n, t.mem)
+		buffer.Values[i] = arrow.Repeat(key.Cols()[i].Type, key.Value(i), n, t.mem)
 	}
 
 	if err := buffer.Validate(); err != nil {

--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -744,7 +744,7 @@ func (gr *pivotTableGroup) doPivot(key flux.GroupKey, mem arrowmemory.Allocator)
 	// Add the group key columns to the table.
 	for j, col := range key.Cols() {
 		tb.Columns = append(tb.Columns, col)
-		tb.Values = append(tb.Values, arrow.Repeat(key.Value(j), keys.Len(), mem))
+		tb.Values = append(tb.Values, arrow.Repeat(key.Cols()[j].Type, key.Value(j), keys.Len(), mem))
 	}
 
 	// Build each column by appending a value when it matches

--- a/stdlib/universe/sort2.go
+++ b/stdlib/universe/sort2.go
@@ -319,7 +319,7 @@ func (s *sortTableMergeHeap) NextBuffer(builders []array.Builder, keys []array.I
 	// Initialize the key buffers if they need to be.
 	for i := range keys {
 		if keys[i] == nil {
-			keys[i] = arrow.Repeat(s.key.Value(i), n, mem)
+			keys[i] = arrow.Repeat(s.key.Cols()[i].Type, s.key.Value(i), n, mem)
 		}
 	}
 

--- a/stdlib/universe/sort2_test.flux
+++ b/stdlib/universe/sort2_test.flux
@@ -1,0 +1,41 @@
+package universe_test
+
+
+import "csv"
+import "testing"
+
+option now = () => 2030-01-01T00:00:00Z
+
+testcase sort_with_null_columns {
+    got = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,double,string,string,string
+#group,false,false,false,false,true,true,true
+#default,_result,,,,,,
+,result,table,_time,_value,_field,_measurement,host
+,,0,2018-05-22T19:53:26Z,1.83,load1,system,host.local
+,,0,2018-05-22T19:53:36Z,1.7,load1,system,host.local
+,,0,2018-05-22T19:53:46Z,1.74,load1,system,host.local
+,,0,2018-05-22T19:53:56Z,1.63,load1,system,host.local
+,,0,2018-05-22T19:54:06Z,1.91,load1,system,host.local
+,,0,2018-05-22T19:54:16Z,1.84,load1,system,host.local
+",
+    )
+        |> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:58:00Z)
+        |> aggregateWindow(every: 5m, fn: mean)
+        |> group(mode: "except", columns: ["_time", "_value"])
+        |> sort(columns: ["_value"])
+
+    want = csv.from(
+        csv: "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string
+#group,false,false,true,true,false,false,true,true,true
+#default,_result,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,host
+,,0,2018-05-22T19:53:00Z,2018-05-22T19:58:00Z,2018-05-22T19:58:00Z,,load1,system,host.local
+,,0,2018-05-22T19:53:00Z,2018-05-22T19:58:00Z,2018-05-22T19:55:00Z,1.775,load1,system,host.local
+",
+    )
+
+    testing.diff(got: got, want: want)
+}


### PR DESCRIPTION
This change is to add null support to optimized repeat function for arrow arrays
Also did some refactoring of the existing code

This was caught with the bug linked to this issue, aggregateWindow()
function with 'createEmpty: true' was returning empty tables which were
generating rows with null values when piped with group and sort(test
case added)

fixes: https://github.com/influxdata/idpe/issues/11589

