### PR TITLE
test: add test cases for show tag values

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -249,6 +249,7 @@ var sourceHashes = map[string]string{
 	"stdlib/influxdata/influxdb/schema/show_tag_keys_test.flux":                                   "e7fbc9b2a51539bde61153f81c1dd090f72d14d9a3f064d276984c5c818987e1",
 	"stdlib/influxdata/influxdb/schema/show_tag_keys_with_pred_test.flux":                         "ec81c53de89e57af7ac1a5147a3805db2b6e8fed77c0fb608c8f49ade0fde967",
 	"stdlib/influxdata/influxdb/schema/show_tag_values_empty_test.flux":                           "93baa172562c75ed21bc6eb1780341844233ccac3cb09d09ed0c18c81b988c95",
+	"stdlib/influxdata/influxdb/schema/show_tag_values_measurement_or_predicate_test.flux":        "c9acc9c5838c146bb72b1a0806143003a539bdb877bf2dbb2662fadc5fe5d970",
 	"stdlib/influxdata/influxdb/schema/show_tag_values_test.flux":                                 "1c0f7b42dbfd86ce00eff863ed8c66d15a735127e37ca9fd8a86ec14fe8c5555",
 	"stdlib/influxdata/influxdb/schema/show_tag_values_with_pred_test.flux":                       "ec643b6c1b149c18a9a17a6025245a80e8fb076dfd38acd65558d4c879358d4f",
 	"stdlib/influxdata/influxdb/secrets/secrets.flux":                                             "d4aca3c5ff3186665d37ba487e8de0ed13235b3c7802912b34e5502f6dff76e5",

--- a/stdlib/influxdata/influxdb/schema/show_tag_values_measurement_or_predicate_test.flux
+++ b/stdlib/influxdata/influxdb/schema/show_tag_values_measurement_or_predicate_test.flux
@@ -1,0 +1,124 @@
+package schema_test
+
+
+import "csv"
+import "testing"
+
+option now = () => 2030-01-01T00:00:00Z
+
+input = "
+#group,false,false,false,false,true,true,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#default,_result,,,,,,,,,,
+,result,table,_time,_value,_field,_measurement,device,fstype,host,mode,path
+,,0,2020-10-21T20:48:30Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:40Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,0,2020-10-21T20:48:50Z,4881964326,inodes_free,disk,disk1s5,apfs,euterpe.local,ro,/
+,,1,2020-10-21T20:48:30Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:40Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,1,2020-10-21T20:48:50Z,4294963701,inodes_free,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,2,2020-10-21T20:48:30Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:40Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,2,2020-10-21T20:48:50Z,488514,inodes_used,disk,disk1s5,apfs,euterpe.local,ro,/
+,,3,2020-10-21T20:48:30Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:40Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+,,3,2020-10-21T20:48:50Z,3578,inodes_used,disk,disk2s1,hfs,euterpe.local,ro,/Volumes/IntelliJ IDEA CE
+
+#group,false,false,false,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string
+#default,_result,,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host,region
+,,4,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,euterpe.local,south
+,,4,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,euterpe.local,south
+,,4,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,euterpe.local,south
+,,5,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,euterpe.local,south
+,,5,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,euterpe.local,south
+,,5,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,euterpe.local,south
+
+#group,false,false,false,false,true,true,true,true,true
+#datatype,string,long,dateTime:RFC3339,double,string,string,string,string,string
+#default,_result,,,,,,,,
+,result,table,_time,_value,_field,_measurement,cpu,host,region
+,,6,2020-10-21T20:48:30Z,69.30000000167638,usage_idle,cpu,cpu0,mnemosyne.local,east
+,,6,2020-10-21T20:48:40Z,67.36736736724372,usage_idle,cpu,cpu0,mnemosyne.local,east
+,,6,2020-10-21T20:48:50Z,69.23076923005354,usage_idle,cpu,cpu0,mnemosyne.local,east
+,,7,2020-10-21T20:48:30Z,96.10000000102445,usage_idle,cpu,cpu1,mnemosyne.local,east
+,,7,2020-10-21T20:48:40Z,95.70000000055181,usage_idle,cpu,cpu1,mnemosyne.local,east
+,,7,2020-10-21T20:48:50Z,95.89999999860534,usage_idle,cpu,cpu1,mnemosyne.local,east
+
+#group,false,false,true,true,false,false,true,true,true
+#datatype,string,long,string,string,dateTime:RFC3339,double,string,string,string
+#default,_result,,,,,,,,
+,result,table,_field,_measurement,_time,_value,cpu,host,region
+,,8,usage_user,cpu,2020-10-21T20:48:30Z,19.30000000007567,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:40Z,20.020020020038682,cpu0,euterpe.local,north
+,,8,usage_user,cpu,2020-10-21T20:48:50Z,18.581418581407107,cpu0,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:30Z,2.3000000000138243,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:40Z,2.4000000000536965,cpu1,euterpe.local,north
+,,9,usage_user,cpu,2020-10-21T20:48:50Z,2.0999999999423746,cpu1,euterpe.local,north
+"
+
+testcase show_tag_values_measurement_or_predicate {
+    got = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r["_measurement"] == "cpu")
+        |> filter(fn: (r) => r["_measurement"] == "someOtherThing" or r["host"] == "euterpe.local")
+        |> keep(columns: ["region"])
+        |> group()
+        |> distinct(column: "region")
+        |> limit(n: 200)
+        |> sort()
+
+    want = csv.from(csv: "#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,north
+,,0,south
+")
+
+    testing.diff(got, want)
+}
+
+testcase show_tag_values_measurement_or_negation {
+    got = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r["_measurement"] != "cpu")
+        |> filter(fn: (r) => r["_measurement"] == "someOtherThing" or r["fstype"] != "apfs")
+        |> keep(columns: ["fstype"])
+        |> group()
+        |> distinct(column: "fstype")
+        |> limit(n: 200)
+        |> sort()
+
+    want = csv.from(csv: "#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,hfs
+")
+
+    testing.diff(got, want)
+}
+
+testcase show_tag_values_measurement_or_regex {
+    got = testing.loadStorage(csv: input)
+        |> range(start: -100y)
+        |> filter(fn: (r) => r["_measurement"] =~ /cp.*/)
+        |> filter(fn: (r) => r["_measurement"] == "someOtherThing" or r["host"] !~ /mnemo.*/)
+        |> keep(columns: ["region"])
+        |> group()
+        |> distinct(column: "region")
+        |> limit(n: 200)
+        |> sort()
+
+    want = csv.from(csv: "#datatype,string,long,string
+#group,false,false,false
+#default,0,,
+,result,table,_value
+,,0,north
+,,0,south
+")
+
+    testing.diff(got, want)
+}


### PR DESCRIPTION
This adds test cases to cover the bug described by https://github.com/influxdata/influxdb/issues/22385, which was closed in OSS PR https://github.com/influxdata/influxdb/pull/22500 and did not exist on cloud. It involved some more complex predicates for a "show tag values" type of metaquery. I am opening a PR to add these tests here since they seem like they would be useful to catch regressions more broadly outside of OSS only.