### PR TITLE
fix(sql): disallow setting allowAllFiles parameter in MySQL DSNs

### DIFF
--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -151,6 +151,14 @@ func TestFromSqlUrlValidation(t *testing.T) {
 			},
 			V:      url.PrivateIPValidator{},
 			ErrMsg: "data source did not pass url validation",
+		}, {
+			Name: "invalid mysql allowAllFiles parameter",
+			Spec: &FromSQLProcedureSpec{
+				DriverName:     "mysql",
+				DataSourceName: "username:password@tcp(localhost:3306)/dbname?allowAllFiles=true",
+				Query:          "",
+			},
+			ErrMsg: "invalid data source dsn: may not set allowAllFiles",
 		},
 	}
 	testCases.Run(t, createFromSQLSource)

--- a/stdlib/sql/source_validator.go
+++ b/stdlib/sql/source_validator.go
@@ -4,7 +4,7 @@ import (
 	neturl "net/url"
 	"strings"
 
-	"github.com/bonitoo-io/go-sql-bigquery"
+	bigquery "github.com/bonitoo-io/go-sql-bigquery"
 	"github.com/go-sql-driver/mysql"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/url"
@@ -32,6 +32,9 @@ func validateDataSource(validator url.Validator, driverName string, dataSourceNa
 		cfg, err := mysql.ParseDSN(dataSourceName)
 		if err != nil {
 			return errors.Newf(codes.Invalid, "invalid data source dsn: %v", err)
+		}
+		if cfg.AllowAllFiles {
+			return errors.New(codes.Invalid, "invalid data source dsn: may not set allowAllFiles")
 		}
 		u = &neturl.URL{
 			Scheme: cfg.Net,


### PR DESCRIPTION
By abusing support for MySQL's LOAD DATA LOCAL INFILE statement in the golang MySQL driver we use, an attacker can use Flux's sql.from() to leak the contents of local files on Cloud 2's queryd-pull-external pods.

The golang MySQL driver we use has no specific facility for disabling INFILE support in code. We can, however, reject connection strings that set allowAllFiles=true in stdlib/sql/source_validator.go#L30 since we already parse it into a configuration struct.

fixes: https://github.com/influxdata/idpe/issues/11716

