### PR TITLE
perf: Avoid cloning in Parser::peek

### DIFF
--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -74,7 +74,7 @@ impl Parser {
     }
 
     // peek_with_regex is the same as peek, except that the scan step will allow scanning regexp tokens.
-    fn peek_with_regex(&mut self) -> Token {
+    fn peek_with_regex(&mut self) -> &Token {
         if let Some(token) = &mut self.t {
             if let Token {
                 tok: TokenType::Div,
@@ -86,12 +86,12 @@ impl Parser {
                 self.s.unread();
             }
         }
-        match self.t.clone() {
-            Some(t) => t,
+        match self.t {
+            Some(ref t) => t,
             None => {
                 let t = self.s.scan_with_regex();
-                self.t = Some(t.clone());
-                t
+                self.t = Some(t);
+                self.t.as_ref().unwrap()
             }
         }
     }
@@ -1368,7 +1368,10 @@ impl Parser {
             TokenType::LParen => self.parse_paren_expression(),
             // We got a bad token, do not consume it, but use it in the message.
             // Other methods will match BadExpr and consume the token if needed.
-            _ => self.create_bad_expression(t),
+            _ => {
+                let t = t.clone();
+                self.create_bad_expression(t)
+            }
         }
     }
     fn parse_string_expression(&mut self) -> Result<StringExpr, TokenError> {

--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -54,11 +54,8 @@ impl Parser {
     // scan will read the next token from the Scanner. If peek has been used,
     // this will return the peeked token and consume it.
     fn scan(&mut self) -> Token {
-        match self.t.clone() {
-            Some(t) => {
-                self.t = None;
-                t
-            }
+        match self.t.take() {
+            Some(t) => t,
             None => self.s.scan(),
         }
     }
@@ -102,8 +99,8 @@ impl Parser {
     // consume will consume a token that has been retrieve using peek.
     // This will panic if a token has not been buffered with peek.
     fn consume(&mut self) {
-        match self.t.clone() {
-            Some(_) => self.t = None,
+        match self.t.take() {
+            Some(_) => (),
             None => panic!("called consume on an unbuffered input"),
         }
     }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -29,7 +29,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "945736a4ad87adb6a3f359b6f2da6e5492b3cb0efd282e277303e2acae137763",
 	"libflux/flux-core/src/formatter/tests.rs":                                                    "b0a10998a65fc4b54a8f68b3a0ed186d8548ba3d7638f911eb188d2ce485206f",
 	"libflux/flux-core/src/lib.rs":                                                                "d19b7054e07f234c107d457030a0031374c123fe14a84a5b8e35537d138bac7a",
-	"libflux/flux-core/src/parser/mod.rs":                                                         "ea475a7975794b298fef8bb2953bd9aca53f8568bfec8882eed9f9fcb0d51c0b",
+	"libflux/flux-core/src/parser/mod.rs":                                                         "e3f11fe29f47271b5c04accc2d7efa35e1dc62c6de036bf0cc0cccda5e4742e8",
 	"libflux/flux-core/src/parser/strconv.rs":                                                     "748c82f6efc2eafaafb872db5b4185ce29aafa8f03ba02c4b84f4a9614e832d2",
 	"libflux/flux-core/src/parser/tests.rs":                                                       "e3a7c9222f90323a7ea9b319bd84f96f66c6f115af6d199a0da332c894713ae4",
 	"libflux/flux-core/src/scanner/mod.rs":                                                        "2e15c9e0a73d0936d2eaeec030b636786db6dbe7aab673045de3a3e815c49f8a",


### PR DESCRIPTION
Reduces the runtime of the benchmark on `everything.flux` by ~25%.

Just poking around trying to understand the structure of the project(s), noticed that a lot of time were spent cloning `Token` (which is a rather large and expensive to clone struct).

Seeing some (unrelated) test failures locally but haven't understood why those happen yet