### PR TITLE
feat(plan): allow the query concurrency to be set to the number of nodes in the graph

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -53,6 +53,18 @@ func GroupTransformationGroup() BoolFlag {
 	return groupTransformationGroup
 }
 
+var queryConcurrencyLimit = feature.MakeIntFlag(
+	"Query Concurrency Limit",
+	"queryConcurrencyLimit",
+	"Jonathan Sternberg",
+	0,
+)
+
+// QueryConcurrencyLimit - Sets the query concurrency limit for the planner
+func QueryConcurrencyLimit() IntFlag {
+	return queryConcurrencyLimit
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -62,12 +74,14 @@ var all = []Flag{
 	narrowTransformationFilter,
 	aggregateTransformationTransport,
 	groupTransformationGroup,
+	queryConcurrencyLimit,
 }
 
 var byKey = map[string]Flag{
 	"narrowTransformationFilter":       narrowTransformationFilter,
 	"aggregateTransformationTransport": aggregateTransformationTransport,
 	"groupTransformationGroup":         groupTransformationGroup,
+	"queryConcurrencyLimit":            queryConcurrencyLimit,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -27,3 +27,9 @@
   key: groupTransformationGroup
   default: false
   contact: Sean Brickley
+
+- name: Query Concurrency Limit
+  description: Sets the query concurrency limit for the planner
+  key: queryConcurrencyLimit
+  default: 0
+  contact: Jonathan Sternberg


### PR DESCRIPTION
This adds a feature flag to allow the concurrency quota to be equal to
the number of transformation nodes in the graph instead of equal to the
number of roots. This functionality gets enabled when the
`queryConcurrencyLimit` is set to a value higher than zero. This number
limits the maximum concurrency too.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written