### PR TITLE
perf: Avoid allocating temporary `Vec`s in max_tvars

### DIFF
--- a/libflux/flux-core/src/semantic/types.rs
+++ b/libflux/flux-core/src/semantic/types.rs
@@ -93,16 +93,15 @@ impl Substitutable for PolyType {
     }
 }
 
-impl MaxTvar for Vec<Tvar> {
+impl MaxTvar for [Tvar] {
     fn max_tvar(&self) -> Tvar {
-        self.iter()
-            .fold(Tvar(0), |max, tv| if *tv > max { *tv } else { max })
+        self.iter().max().cloned().unwrap_or(Tvar(0))
     }
 }
 
 impl MaxTvar for PolyType {
     fn max_tvar(&self) -> Tvar {
-        vec![self.vars.max_tvar(), self.expr.max_tvar()].max_tvar()
+        [self.vars.max_tvar(), self.expr.max_tvar()].max_tvar()
     }
 }
 
@@ -711,7 +710,7 @@ impl Substitutable for Dictionary {
 
 impl MaxTvar for Dictionary {
     fn max_tvar(&self) -> Tvar {
-        vec![self.key.max_tvar(), self.val.max_tvar()].max_tvar()
+        [self.key.max_tvar(), self.val.max_tvar()].max_tvar()
     }
 }
 
@@ -845,7 +844,7 @@ impl MaxTvar for Record {
     fn max_tvar(&self) -> Tvar {
         match self {
             Record::Empty => Tvar(0),
-            Record::Extension { head, tail } => vec![head.max_tvar(), tail.max_tvar()].max_tvar(),
+            Record::Extension { head, tail } => [head.max_tvar(), tail.max_tvar()].max_tvar(),
         }
     }
 }
@@ -1191,7 +1190,7 @@ impl<T: MaxTvar> MaxTvar for Option<T> {
 
 impl MaxTvar for Function {
     fn max_tvar(&self) -> Tvar {
-        vec![
+        [
             self.req.max_tvar(),
             self.opt.max_tvar(),
             self.pipe.max_tvar(),

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -54,7 +54,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/nodes.rs":                                                     "e19b389ffbb04915294c7faf2958afd7a71cde98a462a83d8f03139e160983a0",
 	"libflux/flux-core/src/semantic/sub.rs":                                                       "7a6300e22d1e3ff8f4263c17b9af6df806d7d214128d62a099d9b1ba209f5621",
 	"libflux/flux-core/src/semantic/tests.rs":                                                     "9c66626d17b86d5444afa745c213263f3d61663fcea7f4ca065573c0f477311a",
-	"libflux/flux-core/src/semantic/types.rs":                                                     "5e89dcabca249b98e3d39ace2db0aa321a70e8dad55d695dc737300b6f292194",
+	"libflux/flux-core/src/semantic/types.rs":                                                     "2cbc2c31a45ad41400c145d7c298cc7881ca382d15cdc43190483bbec4c7a460",
 	"libflux/flux-core/src/semantic/walk/_walk.rs":                                                "0e8739d439fc26112c654a3c90264d14cdb4f21faf69c5bd3845e70a4c925c5f",
 	"libflux/flux-core/src/semantic/walk/mod.rs":                                                  "f422c0fadd953e587096f9d72141b1fd9c76aaf7ca997e212279ee17bfc39e32",
 	"libflux/flux-core/src/semantic/walk/test_utils.rs":                                           "ffec273fc2e54c640ba5f2ce5c1faa1516a3d98b1365d6f4cab762f582102650",


### PR DESCRIPTION
Drive-by refactor