### PR TITLE
fix(csv): make csv report error for bad annotations

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -407,14 +407,15 @@ func readMetadata(r *bufferedCSVReader, c ResultDecoderConfig) (tableMetadata, e
 				if !strings.HasPrefix(line[annotationIdx], commentPrefix) {
 					switch {
 					case datatypes == nil:
-						return tableMetadata{}, fmt.Errorf("missing expected annotation datatype")
+						return tableMetadata{}, errors.New(codes.Invalid, "missing expected annotation datatype")
 					case groups == nil:
-						return tableMetadata{}, fmt.Errorf("missing expected annotation group")
+						return tableMetadata{}, errors.New(codes.Invalid, "missing expected annotation group")
 					case defaults == nil:
-						return tableMetadata{}, fmt.Errorf("missing expected annotation default")
+						return tableMetadata{}, errors.New(codes.Invalid, "missing expected annotation default")
 					}
+				} else {
+					return tableMetadata{}, errors.Newf(codes.Invalid, "unsupported annotation %q", line[annotationIdx])
 				}
-				// Ignore unsupported/unknown annotations.
 			}
 		}
 	}

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -1522,6 +1522,19 @@ data1,data2,data3
 				Err: errors.New("failed to read metadata: failed to read \"default\" annotation: wrong number of fields"),
 			},
 		},
+		{
+			name:          "error on bad annoations",
+			encoderConfig: csv.DefaultEncoderConfig(),
+			encoded: toCRLF(`#datatype measurement,tag,double,dateTime:RFC3339
+m,host,used_percent,time
+mem,host1,64.23,2020-01-01T00:00:00Z
+mem,host2,72.01,2020-01-01T00:00:00Z
+`),
+			result: &executetest.Result{
+				Nm:  "_result",
+				Err: errors.New("failed to read metadata: unsupported annotation \"#datatype measurement\""),
+			},
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4761,6 +4761,9 @@ It is not possible to encode/decode a non-null string value that is the same as 
 
 When the `default` annotation value of a column is the same as the `null` annotation value of a column, it is interpreted as the column's default value is null.
 
+Only the specified annotations may be present. Any extra annotations will result in an error.
+This strick handling of annotations allows for clear error messages during decoding.
+
 ##### Errors
 
 When an error occurs during execution a table will be returned with the first column label as `error` and the second column label as `reference`.


### PR DESCRIPTION
Prior to this change extra or misspelled annotations would be ignored.
Now those kinds of annotations produce an error. This might be a
breaking change in that previously extra annotations were simply
ignored. The SPEC didn't clarify if extra annotations are allowed. It
has now been updated.


### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
