### PR TITLE
fix(stdlib): optimized derivative attempted to replicate a bug that didn't exist

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -441,7 +441,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/cumulative_sum_default_test.flux":                                            "b0255c385793d5789f0195d4a99eb3f8603c762f4a21612131b2783ef0fdf6ac",
 	"stdlib/universe/cumulative_sum_noop_test.flux":                                               "978fb401a07208ec88ed4dd1b579a9d94b0a25da4fa535fdf943ed43629d3b64",
 	"stdlib/universe/cumulative_sum_test.flux":                                                    "6b784279023c0724aa616e8676f83dfaf7675fb942294a89871234b568afcb66",
-	"stdlib/universe/derivative_test.flux":                                                        "a835bf4c7d7b13c54feaf2837c91b7d60b0899203fb824a9b04b24c52b1743e1",
+	"stdlib/universe/derivative_test.flux":                                                        "9c54f8c419296b873a0e481711004cce2729cd4ecef96e3c6b486604e6ee2b96",
 	"stdlib/universe/difference_columns_test.flux":                                                "6d71a13c5ca1a6a48b459401844c3e8e677e8363f86afbc95917db91364d4eaf",
 	"stdlib/universe/difference_keepfirst_test.flux":                                              "42b501c425f0486694735e7fe0cfb23fe5ae0c8018571ebb4b3b1a17699ade49",
 	"stdlib/universe/difference_nonnegative_test.flux":                                            "d68ec7c37768dae7829da8210e7441e02e44280cf619f28a069b8353d3bdb736",

--- a/stdlib/universe/derivative2.go
+++ b/stdlib/universe/derivative2.go
@@ -281,10 +281,7 @@ func (t *derivativeTransformation2) derivativeStateFor(col flux.ColMeta, state *
 				initialized: state.initialized,
 			}, nil
 		default:
-			// TODO(jsternberg): This is the fix for issue #914.
-			// To add this code is a breaking change so it is commented
-			// out until we decide to pull the trigger.
-			// return nil, errors.Newf(codes.FailedPrecondition, "attempted to perform derivative over non-numeric column %q of type %s", col.Label, col.Type)
+			return nil, errors.Newf(codes.FailedPrecondition, "unsupported derivative column type %s:%s", col.Label, col.Type)
 		}
 	}
 

--- a/stdlib/universe/derivative_test.flux
+++ b/stdlib/universe/derivative_test.flux
@@ -62,48 +62,6 @@ testcase non_negative {
     testing.diff(want: want, got: got) |> yield()
 }
 
-// This test ensures that non-numeric types that go through derivative get
-// passed through. That's the current behavior, but it's also likely a bug.
-// Remove this if we choose to fix https://github.com/influxdata/flux/issues/914.
-testcase passthrough {
-    input = array.from(
-        rows: [
-            {_time: 2018-05-22T20:00:00Z, _value: "a", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:10Z, _value: "b", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:20Z, _value: "c", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:30Z, _value: "d", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:40Z, _value: "e", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:00Z, _value: "f", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:10Z, _value: "g", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:20Z, _value: "h", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:30Z, _value: "i", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:40Z, _value: "j", _measurement: "m0", _field: "f0", t0: "b"},
-        ]
-    )
-        |> group(columns: ["_measurement", "_field", "t0"])
-
-    want = array.from(
-        rows: [
-            {_time: 2018-05-22T20:00:10Z, _value: "b", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:20Z, _value: "c", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:30Z, _value: "d", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:40Z, _value: "e", _measurement: "m0", _field: "f0", t0: "a"},
-            {_time: 2018-05-22T20:00:10Z, _value: "g", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:20Z, _value: "h", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:30Z, _value: "i", _measurement: "m0", _field: "f0", t0: "b"},
-            {_time: 2018-05-22T20:00:40Z, _value: "j", _measurement: "m0", _field: "f0", t0: "b"},
-        ]
-    )
-        |> group(columns: ["_measurement", "_field", "t0"])
-
-    got = input
-        |> range(start: 2018-05-22T20:00:00Z, stop: 2018-05-22T20:01:00Z)
-        |> derivative()
-        |> drop(columns: ["_start", "_stop"])
-
-    testing.diff(want: want, got: got) |> yield()
-}
-
 testcase duplicate_times {
     want = array.from(
         rows: [


### PR DESCRIPTION
The optimized derivative attempted to replicate a bug with the existing
derivative where it wouldn't error if the column was not a compatible
type with derivative. This is because I saw an issue detailing this and
I did not see where the check was.

A test was created to verify the bad behavior with a note to fix it in
the future with the issue.

After seeing this test fail when used with the older derivative, it came
to my attention that the bug had already been fixed and so the newer
derivative didn't have to replicate the bug.

This removes the test and adds the necessary code to mark the condition
with the same error.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written