### PR TITLE
refactor(aggregate): Allow aggregates to recycle state

### DIFF
--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -104,24 +104,6 @@ func (t *aggregateTransformation) Process(id DatasetID, tbl flux.Table) error {
 
 func (t *aggregateTransformation) processChunk(chunk table.Chunk) error {
 	state, _ := t.d.Lookup(chunk.Key())
-	// XXX: sean (Oct 7, 2021) - I am not entirely sure why, but checking `ok`
-	// here before setting `state` to the return value of `popFreeState()` avoids
-	// some major bugs. Without it, some aggregates produce wrong answers, and tests
-	// start to fail.
-	//
-	// My hunch is that while `multiState` and `aggregateState` implement
-	// `Recyclable`, the underlying aggregate may not. So we append states to
-	// `t.freeStates` (see the `flushKey` function) in all circumstances, even
-	// if the underlying aggregate cannot be recycled. This causes some aggregates
-	// (sum in particular) to re-use state erroneously.
-	//
-	// Still, I don't know why checking if it's recyclable here solves the problem.
-	// If the state wasn't recyclable, t.freeStates should be empty anyway, so this check
-	// shouldn't make a difference.
-	//
-	// Also, if `state` is nil, wouldn't `ok` always be false? In which case, the below
-	// `if` block would never trigger, which means that the fix would not work.
-	// Something strange is going on here.
 	if state == nil {
 		// If no reusable state is available, state will remain nil
 		state = t.popFreeState()
@@ -450,6 +432,11 @@ func (a *aggregateState) Drop() {
 	}
 }
 
+// multiState is an alias for []aggregateState so that we can
+// define methods on it. It is the type that's returned from
+// the group key lookup on the transport dataset inside `aggregateTransformation`.
+//
+// It contains one aggregateState for every column in the table chunk.
 type multiState []aggregateState
 
 func (m multiState) Recycle() {

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -563,6 +563,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/pivot_table_test.flux":                                                       "cd31c461f16f11fff0455f696b290aac70833eab64be99f907de15ec581aeed9",
 	"stdlib/universe/pivot_task_test_test.flux":                                                   "c835cd8c74220c3352c7540f5f5fc53b9cad14ecaedafb25f438267c65aa3666",
 	"stdlib/universe/pivot_test.flux":                                                             "4568aa37ad4d203a4c72270f851b015a4eadc9a8baf255cb6f088c7ff0dcc63e",
+	"stdlib/universe/quantile_agg_test.flux":                                                      "fb717b38c4f17525b5f0eb8aefbda1398028d1292a4061de69c91c0775ab739a",
 	"stdlib/universe/quantile_aggregate_test.flux":                                                "596256940c3a3f011f09abb322bfb6c3a666cc08cd09518e5a54b6512c6ed221",
 	"stdlib/universe/quantile_defaults_test.flux":                                                 "18bf66ecd7af89aa303c3094ad3591dc38cfee1c65729b9e646fe601e4558efe",
 	"stdlib/universe/quantile_tdigest_test.flux":                                                  "92821a1cabb67d8a0b5b72e284047792617f29d5efd9192570f7bf4bd3fd1711",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -563,7 +563,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/pivot_table_test.flux":                                                       "cd31c461f16f11fff0455f696b290aac70833eab64be99f907de15ec581aeed9",
 	"stdlib/universe/pivot_task_test_test.flux":                                                   "c835cd8c74220c3352c7540f5f5fc53b9cad14ecaedafb25f438267c65aa3666",
 	"stdlib/universe/pivot_test.flux":                                                             "4568aa37ad4d203a4c72270f851b015a4eadc9a8baf255cb6f088c7ff0dcc63e",
-	"stdlib/universe/quantile_agg_test.flux":                                                      "fb717b38c4f17525b5f0eb8aefbda1398028d1292a4061de69c91c0775ab739a",
+	"stdlib/universe/quantile_agg_test.flux":                                                      "7699e0648744f3f5252cd0f1c29be81969f9b6272a08174ad8d4c47369d8df85",
 	"stdlib/universe/quantile_aggregate_test.flux":                                                "596256940c3a3f011f09abb322bfb6c3a666cc08cd09518e5a54b6512c6ed221",
 	"stdlib/universe/quantile_defaults_test.flux":                                                 "18bf66ecd7af89aa303c3094ad3591dc38cfee1c65729b9e646fe601e4558efe",
 	"stdlib/universe/quantile_tdigest_test.flux":                                                  "92821a1cabb67d8a0b5b72e284047792617f29d5efd9192570f7bf4bd3fd1711",

--- a/stdlib/universe/quantile_agg_test.flux
+++ b/stdlib/universe/quantile_agg_test.flux
@@ -1,0 +1,65 @@
+package universe_test
+
+
+import "array"
+import "testing"
+
+inData = array.from(
+    rows: [
+        {_time: 2018-05-22T20:00:00Z, _value: 6.05, t0: "a"},
+        {_time: 2018-05-22T20:00:10Z, _value: 9.41, t0: "a"},
+        {_time: 2018-05-22T20:00:20Z, _value: 6.65, t0: "a"},
+        {_time: 2018-05-22T20:00:30Z, _value: 4.37, t0: "a"},
+        {_time: 2018-05-22T20:00:40Z, _value: 4.25, t0: "a"},
+        {_time: 2018-05-22T20:00:00Z, _value: 6.87, t0: "b"},
+        {_time: 2018-05-22T20:00:10Z, _value: 0.66, t0: "b"},
+        {_time: 2018-05-22T20:00:20Z, _value: 1.57, t0: "b"},
+        {_time: 2018-05-22T20:00:30Z, _value: 0.97, t0: "b"},
+        {_time: 2018-05-22T20:00:40Z, _value: 3.01, t0: "b"},
+        {_time: 2018-05-22T20:00:00Z, _value: 7.85, t0: "c"},
+        {_time: 2018-05-22T20:00:10Z, _value: 3.52, t0: "c"},
+        {_time: 2018-05-22T20:00:20Z, _value: 4.21, t0: "c"},
+        {_time: 2018-05-22T20:00:30Z, _value: 8.96, t0: "c"},
+        {_time: 2018-05-22T20:00:40Z, _value: 4.24, t0: "c"},
+        {_time: 2018-05-22T20:00:00Z, _value: 3.43, t0: "d"},
+        {_time: 2018-05-22T20:00:10Z, _value: 1.11, t0: "d"},
+        {_time: 2018-05-22T20:00:20Z, _value: 0.48, t0: "d"},
+        {_time: 2018-05-22T20:00:30Z, _value: 6.35, t0: "d"},
+        {_time: 2018-05-22T20:00:40Z, _value: 5.23, t0: "d"},
+    ],
+)
+
+testcase with_group {
+    want = array.from(
+        rows: [
+            {_value: 7.34, t0: "a"},
+            {_value: 3.975, t0: "b"},
+            {_value: 8.1275, t0: "c"},
+            {_value: 5.51, t0: "d"},
+        ],
+    )
+        |> group(columns: ["t0"])
+
+    got = inData
+        |> range(start: 2018-05-22T20:00:00Z, stop: 2018-05-22T20:01:00Z)
+        |> group(columns: ["t0"])
+        |> quantile(q: 0.75, method: "estimate_tdigest")
+        |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(want: want, got: got) |> yield()
+}
+
+testcase without_group {
+    want = array.from(
+        rows: [
+            {_value: 6.5},
+        ],
+    )
+
+    got = inData
+        |> range(start: 2018-05-22T20:00:00Z, stop: 2018-05-22T20:01:00Z)
+        |> quantile(q: 0.75, method: "estimate_tdigest")
+        |> drop(columns: ["_start", "_stop", "t0"])
+
+    testing.diff(want: want, got: got) |> yield()
+}

--- a/stdlib/universe/quantile_agg_test.flux
+++ b/stdlib/universe/quantile_agg_test.flux
@@ -29,7 +29,7 @@ inData = array.from(
     ],
 )
 
-testcase with_group {
+testcase quantile_with_group {
     want = array.from(
         rows: [
             {_value: 7.34, t0: "a"},
@@ -49,7 +49,7 @@ testcase with_group {
     testing.diff(want: want, got: got) |> yield()
 }
 
-testcase without_group {
+testcase quantile_without_group {
     want = array.from(
         rows: [
             {_value: 6.5},

--- a/stdlib/universe/quantile_test.go
+++ b/stdlib/universe/quantile_test.go
@@ -458,7 +458,7 @@ func TestQuantile_Process(t *testing.T) {
 			if tc.exact {
 				agg = &universe.ExactQuantileAgg{Quantile: tc.quantile}
 			} else {
-				agg = universe.NewQuantileAgg(tc.quantile, 1000.0)
+				agg = universe.NewQuantileAgg(tc.quantile, 1000.0, &memory.Allocator{})
 			}
 			executetest.AggFuncTestHelper(
 				t,
@@ -787,7 +787,7 @@ func BenchmarkQuantile(b *testing.B) {
 	data := arrow.NewFloat(NormalData, &memory.Allocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
-		universe.NewQuantileAgg(0.9, 1000.0),
+		universe.NewQuantileAgg(0.9, 1000.0, &memory.Allocator{}),
 		data,
 		13.842132136909889,
 	)


### PR DESCRIPTION
Closes #4042

This patch adds an interface called `Recyclable`, which marks an aggregate as one that can re-use state in order to reduce memory consumption. This resolves an issue with `quantile` and the new narrow aggregate transport that was causing aggregate states to be reset before a full result could be calculated.

There are still a few concerns I have with this patch.

~~First, I had to squash a bug that resulted in some aggregates reusing state erroneously. I've left a comment in the code with more details, and I could use some help diagnosing the issue and coming up with a cleaner fix.~~ Edit: a slightly better fix (better in the sense that it's easier to understand what the problem is) was added in commit daac803ee3223003a29ce68b8d5f3d06a36a8ef0 (see the `isRecyclable` method)

~~Second, state is still getting recycled for the quantile transformation when `NewFloatAgg()` is called. I'm not sure whether or not this is an issue, but it seems potentially problematic since it's a point where state is recycled outside of the code path where I included my fix. I would like a second opinion on whether or not it needs to change.~~

***Benchmarks for quantile after applying this patch***
*compare with the benchmarks found in #3497*
```
go test -bench=Quantile$ -run=^Benchmark -benchmem ./stdlib/universe
goos: linux
goarch: amd64
pkg: github.com/influxdata/flux/stdlib/universe
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
BenchmarkQuantile-12    	       7	 147663543 ns/op	   25120 B/op	       7 allocs/op
PASS
ok  	github.com/influxdata/flux/stdlib/universe	1.513s
```