### PR TITLE
feat(zoneinfo): copy over location related code from the Go time package

### DIFF
--- a/internal/zoneinfo/LICENSE
+++ b/internal/zoneinfo/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/internal/zoneinfo/export_test.go
+++ b/internal/zoneinfo/export_test.go
@@ -1,0 +1,55 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zoneinfo
+
+import (
+	"sync"
+)
+
+func ZoneinfoForTesting() *string {
+	return zoneinfo
+}
+
+func ResetZoneinfoForTesting() {
+	zoneinfo = nil
+	zoneinfoOnce = sync.Once{}
+}
+
+var (
+	ForceZipFileForTesting = forceZipFileForTesting
+	ErrLocation            = errLocation
+	LoadTzinfo             = loadTzinfo
+	Tzset                  = tzset
+	TzsetName              = tzsetName
+	TzsetOffset            = tzsetOffset
+)
+
+type RuleKind int
+
+const (
+	RuleJulian       = RuleKind(ruleJulian)
+	RuleDOY          = RuleKind(ruleDOY)
+	RuleMonthWeekDay = RuleKind(ruleMonthWeekDay)
+)
+
+type Rule struct {
+	Kind RuleKind
+	Day  int
+	Week int
+	Mon  int
+	Time int
+}
+
+func TzsetRule(s string) (Rule, string, bool) {
+	r, rs, ok := tzsetRule(s)
+	rr := Rule{
+		Kind: RuleKind(r.kind),
+		Day:  r.day,
+		Week: r.week,
+		Mon:  r.mon,
+		Time: r.time,
+	}
+	return rr, rs, ok
+}

--- a/internal/zoneinfo/internal_test.go
+++ b/internal/zoneinfo/internal_test.go
@@ -1,0 +1,19 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zoneinfo
+
+var OrigZoneSources = zoneSources
+
+func forceZipFileForTesting(zipOnly bool) {
+	zoneSources = make([]string, len(OrigZoneSources))
+	copy(zoneSources, OrigZoneSources)
+	if zipOnly {
+		zoneSources = zoneSources[len(zoneSources)-1:]
+	}
+}
+
+func (l *Location) Lookup(sec int64) (name string, offset int, start, end int64, isDST bool) {
+	return l.lookup(sec)
+}

--- a/internal/zoneinfo/zoneinfo.go
+++ b/internal/zoneinfo/zoneinfo.go
@@ -1,0 +1,796 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zoneinfo
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// A Location maps time instants to the zone in use at that time.
+// Typically, the Location represents the collection of time offsets
+// in use in a geographical area. For many Locations the time offset varies
+// depending on whether daylight savings time is in use at the time instant.
+type Location struct {
+	name string
+	zone []zone
+	tx   []zoneTrans
+
+	// The tzdata information can be followed by a string that describes
+	// how to handle DST transitions not recorded in zoneTrans.
+	// The format is the TZ environment variable without a colon; see
+	// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html.
+	// Example string, for America/Los_Angeles: PST8PDT,M3.2.0,M11.1.0
+	extend string
+
+	// Most lookups will be for the current time.
+	// To avoid the binary search through tx, keep a
+	// static one-element cache that gives the correct
+	// zone for the time when the Location was created.
+	// if cacheStart <= t < cacheEnd,
+	// lookup can return cacheZone.
+	// The units for cacheStart and cacheEnd are seconds
+	// since January 1, 1970 UTC, to match the argument
+	// to lookup.
+	cacheStart int64
+	cacheEnd   int64
+	cacheZone  *zone
+}
+
+// A zone represents a single time zone such as CET.
+type zone struct {
+	name   string // abbreviated name, "CET"
+	offset int    // seconds east of UTC
+	isDST  bool   // is this zone Daylight Savings Time?
+}
+
+// A zoneTrans represents a single time zone transition.
+type zoneTrans struct {
+	when         int64 // transition time, in seconds since 1970 GMT
+	index        uint8 // the index of the zone that goes into effect at that time
+	isstd, isutc bool  // ignored - no idea what these mean
+}
+
+// alpha and omega are the beginning and end of time for zone
+// transitions.
+const (
+	alpha = -1 << 63  // math.MinInt64
+	omega = 1<<63 - 1 // math.MaxInt64
+)
+
+// UTC represents Universal Coordinated Time (UTC).
+var UTC *Location = &utcLoc
+
+// utcLoc is separate so that get can refer to &utcLoc
+// and ensure that it never returns a nil *Location,
+// even if a badly behaved client has changed UTC.
+var utcLoc = Location{name: "UTC"}
+
+func (l *Location) get() *Location {
+	if l == nil {
+		return &utcLoc
+	}
+	return l
+}
+
+// String returns a descriptive name for the time zone information,
+// corresponding to the name argument to LoadLocation or FixedZone.
+func (l *Location) String() string {
+	return l.get().name
+}
+
+// FixedZone returns a Location that always uses
+// the given zone name and offset (seconds east of UTC).
+func FixedZone(name string, offset int) *Location {
+	l := &Location{
+		name:       name,
+		zone:       []zone{{name, offset, false}},
+		tx:         []zoneTrans{{alpha, 0, false, false}},
+		cacheStart: alpha,
+		cacheEnd:   omega,
+	}
+	l.cacheZone = &l.zone[0]
+	return l
+}
+
+// lookup returns information about the time zone in use at an
+// instant in time expressed as seconds since January 1, 1970 00:00:00 UTC.
+//
+// The returned information gives the name of the zone (such as "CET"),
+// the start and end times bracketing sec when that zone is in effect,
+// the offset in seconds east of UTC (such as -5*60*60), and whether
+// the daylight savings is being observed at that time.
+func (l *Location) lookup(sec int64) (name string, offset int, start, end int64, isDST bool) {
+	l = l.get()
+
+	if len(l.zone) == 0 {
+		name = "UTC"
+		offset = 0
+		start = alpha
+		end = omega
+		isDST = false
+		return
+	}
+
+	if zone := l.cacheZone; zone != nil && l.cacheStart <= sec && sec < l.cacheEnd {
+		name = zone.name
+		offset = zone.offset
+		start = l.cacheStart
+		end = l.cacheEnd
+		isDST = zone.isDST
+		return
+	}
+
+	if len(l.tx) == 0 || sec < l.tx[0].when {
+		zone := &l.zone[l.lookupFirstZone()]
+		name = zone.name
+		offset = zone.offset
+		start = alpha
+		if len(l.tx) > 0 {
+			end = l.tx[0].when
+		} else {
+			end = omega
+		}
+		isDST = zone.isDST
+		return
+	}
+
+	// Binary search for entry with largest time <= sec.
+	// Not using sort.Search to avoid dependencies.
+	tx := l.tx
+	end = omega
+	lo := 0
+	hi := len(tx)
+	for hi-lo > 1 {
+		m := lo + (hi-lo)/2
+		lim := tx[m].when
+		if sec < lim {
+			end = lim
+			hi = m
+		} else {
+			lo = m
+		}
+	}
+	zone := &l.zone[tx[lo].index]
+	name = zone.name
+	offset = zone.offset
+	start = tx[lo].when
+	// end = maintained during the search
+	isDST = zone.isDST
+
+	// If we're at the end of the known zone transitions,
+	// try the extend string.
+	if lo == len(tx)-1 && l.extend != "" {
+		if ename, eoffset, estart, eend, eisDST, ok := tzset(l.extend, end, sec); ok {
+			return ename, eoffset, estart, eend, eisDST
+		}
+	}
+
+	return
+}
+
+// lookupFirstZone returns the index of the time zone to use for times
+// before the first transition time, or when there are no transition
+// times.
+//
+// The reference implementation in localtime.c from
+// https://www.iana.org/time-zones/repository/releases/tzcode2013g.tar.gz
+// implements the following algorithm for these cases:
+// 1) If the first zone is unused by the transitions, use it.
+// 2) Otherwise, if there are transition times, and the first
+//    transition is to a zone in daylight time, find the first
+//    non-daylight-time zone before and closest to the first transition
+//    zone.
+// 3) Otherwise, use the first zone that is not daylight time, if
+//    there is one.
+// 4) Otherwise, use the first zone.
+func (l *Location) lookupFirstZone() int {
+	// Case 1.
+	if !l.firstZoneUsed() {
+		return 0
+	}
+
+	// Case 2.
+	if len(l.tx) > 0 && l.zone[l.tx[0].index].isDST {
+		for zi := int(l.tx[0].index) - 1; zi >= 0; zi-- {
+			if !l.zone[zi].isDST {
+				return zi
+			}
+		}
+	}
+
+	// Case 3.
+	for zi := range l.zone {
+		if !l.zone[zi].isDST {
+			return zi
+		}
+	}
+
+	// Case 4.
+	return 0
+}
+
+// firstZoneUsed reports whether the first zone is used by some
+// transition.
+func (l *Location) firstZoneUsed() bool {
+	for _, tx := range l.tx {
+		if tx.index == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// tzset takes a timezone string like the one found in the TZ environment
+// variable, the end of the last time zone transition expressed as seconds
+// since January 1, 1970 00:00:00 UTC, and a time expressed the same way.
+// We call this a tzset string since in C the function tzset reads TZ.
+// The return values are as for lookup, plus ok which reports whether the
+// parse succeeded.
+func tzset(s string, initEnd, sec int64) (name string, offset int, start, end int64, isDST, ok bool) {
+	var (
+		stdName, dstName     string
+		stdOffset, dstOffset int
+	)
+
+	stdName, s, ok = tzsetName(s)
+	if ok {
+		stdOffset, s, ok = tzsetOffset(s)
+	}
+	if !ok {
+		return "", 0, 0, 0, false, false
+	}
+
+	// The numbers in the tzset string are added to local time to get UTC,
+	// but our offsets are added to UTC to get local time,
+	// so we negate the number we see here.
+	stdOffset = -stdOffset
+
+	if len(s) == 0 || s[0] == ',' {
+		// No daylight savings time.
+		return stdName, stdOffset, initEnd, omega, false, true
+	}
+
+	dstName, s, ok = tzsetName(s)
+	if ok {
+		if len(s) == 0 || s[0] == ',' {
+			dstOffset = stdOffset + secondsPerHour
+		} else {
+			dstOffset, s, ok = tzsetOffset(s)
+			dstOffset = -dstOffset // as with stdOffset, above
+		}
+	}
+	if !ok {
+		return "", 0, 0, 0, false, false
+	}
+
+	if len(s) == 0 {
+		// Default DST rules per tzcode.
+		s = ",M3.2.0,M11.1.0"
+	}
+	// The TZ definition does not mention ';' here but tzcode accepts it.
+	if s[0] != ',' && s[0] != ';' {
+		return "", 0, 0, 0, false, false
+	}
+	s = s[1:]
+
+	var startRule, endRule rule
+	startRule, s, ok = tzsetRule(s)
+	if !ok || len(s) == 0 || s[0] != ',' {
+		return "", 0, 0, 0, false, false
+	}
+	s = s[1:]
+	endRule, s, ok = tzsetRule(s)
+	if !ok || len(s) > 0 {
+		return "", 0, 0, 0, false, false
+	}
+
+	year, _, _, yday := absDate(uint64(sec+unixToInternal+internalToAbsolute), false)
+
+	ysec := int64(yday*secondsPerDay) + sec%secondsPerDay
+
+	// Compute start of year in seconds since Unix epoch.
+	d := daysSinceEpoch(year)
+	abs := int64(d * secondsPerDay)
+	abs += absoluteToInternal + internalToUnix
+
+	startSec := int64(tzruleTime(year, startRule, stdOffset))
+	endSec := int64(tzruleTime(year, endRule, dstOffset))
+	dstIsDST, stdIsDST := true, false
+	// Note: this is a flipping of "DST" and "STD" while retaining the labels
+	// This happens in southern hemispheres. The labelling here thus is a little
+	// inconsistent with the goal.
+	if endSec < startSec {
+		startSec, endSec = endSec, startSec
+		stdName, dstName = dstName, stdName
+		stdOffset, dstOffset = dstOffset, stdOffset
+		stdIsDST, dstIsDST = dstIsDST, stdIsDST
+	}
+
+	// The start and end values that we return are accurate
+	// close to a daylight savings transition, but are otherwise
+	// just the start and end of the year. That suffices for
+	// the only caller that cares, which is Date.
+	if ysec < startSec {
+		return stdName, stdOffset, abs, startSec + abs, stdIsDST, true
+	} else if ysec >= endSec {
+		return stdName, stdOffset, endSec + abs, abs + 365*secondsPerDay, stdIsDST, true
+	} else {
+		return dstName, dstOffset, startSec + abs, endSec + abs, dstIsDST, true
+	}
+}
+
+// tzsetName returns the timezone name at the start of the tzset string s,
+// and the remainder of s, and reports whether the parsing is OK.
+func tzsetName(s string) (string, string, bool) {
+	if len(s) == 0 {
+		return "", "", false
+	}
+	if s[0] != '<' {
+		for i, r := range s {
+			switch r {
+			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ',', '-', '+':
+				if i < 3 {
+					return "", "", false
+				}
+				return s[:i], s[i:], true
+			}
+		}
+		if len(s) < 3 {
+			return "", "", false
+		}
+		return s, "", true
+	} else {
+		for i, r := range s {
+			if r == '>' {
+				return s[1:i], s[i+1:], true
+			}
+		}
+		return "", "", false
+	}
+}
+
+// tzsetOffset returns the timezone offset at the start of the tzset string s,
+// and the remainder of s, and reports whether the parsing is OK.
+// The timezone offset is returned as a number of seconds.
+func tzsetOffset(s string) (offset int, rest string, ok bool) {
+	if len(s) == 0 {
+		return 0, "", false
+	}
+	neg := false
+	if s[0] == '+' {
+		s = s[1:]
+	} else if s[0] == '-' {
+		s = s[1:]
+		neg = true
+	}
+
+	// The tzdata code permits values up to 24 * 7 here,
+	// although POSIX does not.
+	var hours int
+	hours, s, ok = tzsetNum(s, 0, 24*7)
+	if !ok {
+		return 0, "", false
+	}
+	off := hours * secondsPerHour
+	if len(s) == 0 || s[0] != ':' {
+		if neg {
+			off = -off
+		}
+		return off, s, true
+	}
+
+	var mins int
+	mins, s, ok = tzsetNum(s[1:], 0, 59)
+	if !ok {
+		return 0, "", false
+	}
+	off += mins * secondsPerMinute
+	if len(s) == 0 || s[0] != ':' {
+		if neg {
+			off = -off
+		}
+		return off, s, true
+	}
+
+	var secs int
+	secs, s, ok = tzsetNum(s[1:], 0, 59)
+	if !ok {
+		return 0, "", false
+	}
+	off += secs
+
+	if neg {
+		off = -off
+	}
+	return off, s, true
+}
+
+// ruleKind is the kinds of rules that can be seen in a tzset string.
+type ruleKind int
+
+const (
+	ruleJulian ruleKind = iota
+	ruleDOY
+	ruleMonthWeekDay
+)
+
+// rule is a rule read from a tzset string.
+type rule struct {
+	kind ruleKind
+	day  int
+	week int
+	mon  int
+	time int // transition time
+}
+
+// tzsetRule parses a rule from a tzset string.
+// It returns the rule, and the remainder of the string, and reports success.
+func tzsetRule(s string) (rule, string, bool) {
+	var r rule
+	if len(s) == 0 {
+		return rule{}, "", false
+	}
+	ok := false
+	if s[0] == 'J' {
+		var jday int
+		jday, s, ok = tzsetNum(s[1:], 1, 365)
+		if !ok {
+			return rule{}, "", false
+		}
+		r.kind = ruleJulian
+		r.day = jday
+	} else if s[0] == 'M' {
+		var mon int
+		mon, s, ok = tzsetNum(s[1:], 1, 12)
+		if !ok || len(s) == 0 || s[0] != '.' {
+			return rule{}, "", false
+
+		}
+		var week int
+		week, s, ok = tzsetNum(s[1:], 1, 5)
+		if !ok || len(s) == 0 || s[0] != '.' {
+			return rule{}, "", false
+		}
+		var day int
+		day, s, ok = tzsetNum(s[1:], 0, 6)
+		if !ok {
+			return rule{}, "", false
+		}
+		r.kind = ruleMonthWeekDay
+		r.day = day
+		r.week = week
+		r.mon = mon
+	} else {
+		var day int
+		day, s, ok = tzsetNum(s, 0, 365)
+		if !ok {
+			return rule{}, "", false
+		}
+		r.kind = ruleDOY
+		r.day = day
+	}
+
+	if len(s) == 0 || s[0] != '/' {
+		r.time = 2 * secondsPerHour // 2am is the default
+		return r, s, true
+	}
+
+	offset, s, ok := tzsetOffset(s[1:])
+	if !ok {
+		return rule{}, "", false
+	}
+	r.time = offset
+
+	return r, s, true
+}
+
+// tzsetNum parses a number from a tzset string.
+// It returns the number, and the remainder of the string, and reports success.
+// The number must be between min and max.
+func tzsetNum(s string, min, max int) (num int, rest string, ok bool) {
+	if len(s) == 0 {
+		return 0, "", false
+	}
+	num = 0
+	for i, r := range s {
+		if r < '0' || r > '9' {
+			if i == 0 || num < min {
+				return 0, "", false
+			}
+			return num, s[i:], true
+		}
+		num *= 10
+		num += int(r) - '0'
+		if num > max {
+			return 0, "", false
+		}
+	}
+	if num < min {
+		return 0, "", false
+	}
+	return num, "", true
+}
+
+// tzruleTime takes a year, a rule, and a timezone offset,
+// and returns the number of seconds since the start of the year
+// that the rule takes effect.
+func tzruleTime(year int, r rule, off int) int {
+	var s int
+	switch r.kind {
+	case ruleJulian:
+		s = (r.day - 1) * secondsPerDay
+		if isLeap(year) && r.day >= 60 {
+			s += secondsPerDay
+		}
+	case ruleDOY:
+		s = r.day * secondsPerDay
+	case ruleMonthWeekDay:
+		// Zeller's Congruence.
+		m1 := (r.mon+9)%12 + 1
+		yy0 := year
+		if r.mon <= 2 {
+			yy0--
+		}
+		yy1 := yy0 / 100
+		yy2 := yy0 % 100
+		dow := ((26*m1-2)/10 + 1 + yy2 + yy2/4 + yy1/4 - 2*yy1) % 7
+		if dow < 0 {
+			dow += 7
+		}
+		// Now dow is the day-of-week of the first day of r.mon.
+		// Get the day-of-month of the first "dow" day.
+		d := r.day - dow
+		if d < 0 {
+			d += 7
+		}
+		for i := 1; i < r.week; i++ {
+			if d+7 >= daysIn(time.Month(r.mon), year) {
+				break
+			}
+			d += 7
+		}
+		d += int(daysBefore[r.mon-1])
+		if isLeap(year) && r.mon > 2 {
+			d++
+		}
+		s = d * secondsPerDay
+	}
+
+	return s + r.time - off
+}
+
+// NOTE(rsc): Eventually we will need to accept the POSIX TZ environment
+// syntax too, but I don't feel like implementing it today.
+
+var errLocation = errors.New("time: invalid location name")
+
+var zoneinfo *string
+var zoneinfoOnce sync.Once
+
+// LoadLocation returns the Location with the given name.
+//
+// If the name is "" or "UTC", LoadLocation returns UTC.
+// If the name is "Local", LoadLocation returns Local.
+//
+// Otherwise, the name is taken to be a location name corresponding to a file
+// in the IANA Time Zone database, such as "America/New_York".
+//
+// The time zone database needed by LoadLocation may not be
+// present on all systems, especially non-Unix systems.
+// LoadLocation looks in the directory or uncompressed zip file
+// named by the ZONEINFO environment variable, if any, then looks in
+// known installation locations on Unix systems,
+// and finally looks in $GOROOT/lib/time/zoneinfo.zip.
+func LoadLocation(name string) (*Location, error) {
+	if name == "" || name == "UTC" {
+		return UTC, nil
+	}
+	if containsDotDot(name) || name[0] == '/' || name[0] == '\\' {
+		// No valid IANA Time Zone name contains a single dot,
+		// much less dot dot. Likewise, none begin with a slash.
+		return nil, errLocation
+	}
+	zoneinfoOnce.Do(func() {
+		env, _ := syscall.Getenv("ZONEINFO")
+		zoneinfo = &env
+	})
+	var firstErr error
+	if *zoneinfo != "" {
+		if zoneData, err := loadTzinfoFromDirOrZip(*zoneinfo, name); err == nil {
+			if z, err := LoadLocationFromTZData(name, zoneData); err == nil {
+				return z, nil
+			}
+			firstErr = err
+		} else if !os.IsNotExist(err) {
+			firstErr = err
+		}
+	}
+	if z, err := loadLocation(name, zoneSources); err == nil {
+		return z, nil
+	} else if firstErr == nil {
+		firstErr = err
+	}
+	return nil, firstErr
+}
+
+// containsDotDot reports whether s contains "..".
+func containsDotDot(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == '.' && s[i+1] == '.' {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	// The unsigned zero year for internal calculations.
+	// Must be 1 mod 400, and times before it will not compute correctly,
+	// but otherwise can be changed at will.
+	absoluteZeroYear = -292277022399
+
+	// The year of the zero Time.
+	// Assumed by the unixToInternal computation below.
+	internalYear = 1
+
+	// Offsets to convert between internal and absolute or Unix times.
+	absoluteToInternal int64 = (absoluteZeroYear - internalYear) * 365.2425 * secondsPerDay
+	internalToAbsolute       = -absoluteToInternal
+
+	unixToInternal int64 = (1969*365 + 1969/4 - 1969/100 + 1969/400) * secondsPerDay
+	internalToUnix int64 = -unixToInternal
+
+	wallToInternal int64 = (1884*365 + 1884/4 - 1884/100 + 1884/400) * secondsPerDay
+	internalToWall int64 = -wallToInternal
+)
+
+const (
+	secondsPerMinute = 60
+	secondsPerHour   = 60 * secondsPerMinute
+	secondsPerDay    = 24 * secondsPerHour
+	secondsPerWeek   = 7 * secondsPerDay
+	daysPer400Years  = 365*400 + 97
+	daysPer100Years  = 365*100 + 24
+	daysPer4Years    = 365*4 + 1
+)
+
+// absDate is like date but operates on an absolute time.
+func absDate(abs uint64, full bool) (year int, month time.Month, day int, yday int) {
+	// Split into time and day.
+	d := abs / secondsPerDay
+
+	// Account for 400 year cycles.
+	n := d / daysPer400Years
+	y := 400 * n
+	d -= daysPer400Years * n
+
+	// Cut off 100-year cycles.
+	// The last cycle has one extra leap year, so on the last day
+	// of that year, day / daysPer100Years will be 4 instead of 3.
+	// Cut it back down to 3 by subtracting n>>2.
+	n = d / daysPer100Years
+	n -= n >> 2
+	y += 100 * n
+	d -= daysPer100Years * n
+
+	// Cut off 4-year cycles.
+	// The last cycle has a missing leap year, which does not
+	// affect the computation.
+	n = d / daysPer4Years
+	y += 4 * n
+	d -= daysPer4Years * n
+
+	// Cut off years within a 4-year cycle.
+	// The last year is a leap year, so on the last day of that year,
+	// day / 365 will be 4 instead of 3. Cut it back down to 3
+	// by subtracting n>>2.
+	n = d / 365
+	n -= n >> 2
+	y += n
+	d -= 365 * n
+
+	year = int(int64(y) + absoluteZeroYear)
+	yday = int(d)
+
+	if !full {
+		return
+	}
+
+	day = yday
+	if isLeap(year) {
+		// Leap year
+		switch {
+		case day > 31+29-1:
+			// After leap day; pretend it wasn't there.
+			day--
+		case day == 31+29-1:
+			// Leap day.
+			month = time.February
+			day = 29
+			return
+		}
+	}
+
+	// Estimate month on assumption that every month has 31 days.
+	// The estimate may be too low by at most one month, so adjust.
+	month = time.Month(day / 31)
+	end := int(daysBefore[month+1])
+	var begin int
+	if day >= end {
+		month++
+		begin = end
+	} else {
+		begin = int(daysBefore[month])
+	}
+
+	month++ // because January is 1
+	day = day - begin + 1
+	return
+}
+
+// daysBefore[m] counts the number of days in a non-leap year
+// before month m begins. There is an entry for m=12, counting
+// the number of days before January of next year (365).
+var daysBefore = [...]int32{
+	0,
+	31,
+	31 + 28,
+	31 + 28 + 31,
+	31 + 28 + 31 + 30,
+	31 + 28 + 31 + 30 + 31,
+	31 + 28 + 31 + 30 + 31 + 30,
+	31 + 28 + 31 + 30 + 31 + 30 + 31,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30,
+	31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31,
+}
+
+func daysIn(m time.Month, year int) int {
+	if m == time.February && isLeap(year) {
+		return 29
+	}
+	return int(daysBefore[m] - daysBefore[m-1])
+}
+
+// daysSinceEpoch takes a year and returns the number of days from
+// the absolute epoch to the start of that year.
+// This is basically (year - zeroYear) * 365, but accounting for leap days.
+func daysSinceEpoch(year int) uint64 {
+	y := uint64(int64(year) - absoluteZeroYear)
+
+	// Add in days from 400-year cycles.
+	n := y / 400
+	y -= 400 * n
+	d := daysPer400Years * n
+
+	// Add in 100-year cycles.
+	n = y / 100
+	y -= 100 * n
+	d += daysPer100Years * n
+
+	// Add in 4-year cycles.
+	n = y / 4
+	y -= 4 * n
+	d += daysPer4Years * n
+
+	// Add in non-leap years.
+	n = y
+	d += 365 * n
+
+	return d
+}
+
+func isLeap(year int) bool {
+	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
+}

--- a/internal/zoneinfo/zoneinfo_read.go
+++ b/internal/zoneinfo/zoneinfo_read.go
@@ -1,0 +1,540 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Parse "zoneinfo" time zone file.
+// This is a fairly standard file format used on OS X, Linux, BSD, Sun, and others.
+// See tzfile(5), https://en.wikipedia.org/wiki/Zoneinfo,
+// and ftp://munnari.oz.au/pub/oldtz/
+
+package zoneinfo
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"time"
+)
+
+// Simple I/O interface to binary blob of data.
+type dataIO struct {
+	p     []byte
+	error bool
+}
+
+func (d *dataIO) read(n int) []byte {
+	if len(d.p) < n {
+		d.p = nil
+		d.error = true
+		return nil
+	}
+	p := d.p[0:n]
+	d.p = d.p[n:]
+	return p
+}
+
+func (d *dataIO) big4() (n uint32, ok bool) {
+	p := d.read(4)
+	if len(p) < 4 {
+		d.error = true
+		return 0, false
+	}
+	return uint32(p[3]) | uint32(p[2])<<8 | uint32(p[1])<<16 | uint32(p[0])<<24, true
+}
+
+func (d *dataIO) big8() (n uint64, ok bool) {
+	n1, ok1 := d.big4()
+	n2, ok2 := d.big4()
+	if !ok1 || !ok2 {
+		d.error = true
+		return 0, false
+	}
+	return (uint64(n1) << 32) | uint64(n2), true
+}
+
+func (d *dataIO) byte() (n byte, ok bool) {
+	p := d.read(1)
+	if len(p) < 1 {
+		d.error = true
+		return 0, false
+	}
+	return p[0], true
+}
+
+// read returns the read of the data in the buffer.
+func (d *dataIO) rest() []byte {
+	r := d.p
+	d.p = nil
+	return r
+}
+
+// Make a string by stopping at the first NUL
+func byteString(p []byte) string {
+	for i := 0; i < len(p); i++ {
+		if p[i] == 0 {
+			return string(p[0:i])
+		}
+	}
+	return string(p)
+}
+
+//lint:ignore ST1012 go standard library code that does not conform to staticcheck
+var badData = errors.New("malformed time zone information")
+
+// LoadLocationFromTZData returns a Location with the given name
+// initialized from the IANA Time Zone database-formatted data.
+// The data should be in the format of a standard IANA time zone file
+// (for example, the content of /etc/localtime on Unix systems).
+func LoadLocationFromTZData(name string, data []byte) (*Location, error) {
+	d := dataIO{data, false}
+
+	// 4-byte magic "TZif"
+	if magic := d.read(4); string(magic) != "TZif" {
+		return nil, badData
+	}
+
+	// 1-byte version, then 15 bytes of padding
+	var version int
+	var p []byte
+	if p = d.read(16); len(p) != 16 {
+		return nil, badData
+	} else {
+		switch p[0] {
+		case 0:
+			version = 1
+		case '2':
+			version = 2
+		case '3':
+			version = 3
+		default:
+			return nil, badData
+		}
+	}
+
+	// six big-endian 32-bit integers:
+	//	number of UTC/local indicators
+	//	number of standard/wall indicators
+	//	number of leap seconds
+	//	number of transition times
+	//	number of local time zones
+	//	number of characters of time zone abbrev strings
+	const (
+		NUTCLocal = iota
+		NStdWall
+		NLeap
+		NTime
+		NZone
+		NChar
+	)
+	var n [6]int
+	for i := 0; i < 6; i++ {
+		nn, ok := d.big4()
+		if !ok {
+			return nil, badData
+		}
+		if uint32(int(nn)) != nn {
+			return nil, badData
+		}
+		n[i] = int(nn)
+	}
+
+	// If we have version 2 or 3, then the data is first written out
+	// in a 32-bit format, then written out again in a 64-bit format.
+	// Skip the 32-bit format and read the 64-bit one, as it can
+	// describe a broader range of dates.
+
+	is64 := false
+	if version > 1 {
+		// Skip the 32-bit data.
+		skip := n[NTime]*4 +
+			n[NTime] +
+			n[NZone]*6 +
+			n[NChar] +
+			n[NLeap]*8 +
+			n[NStdWall] +
+			n[NUTCLocal]
+		// Skip the version 2 header that we just read.
+		skip += 4 + 16
+		d.read(skip)
+
+		is64 = true
+
+		// Read the counts again, they can differ.
+		for i := 0; i < 6; i++ {
+			nn, ok := d.big4()
+			if !ok {
+				return nil, badData
+			}
+			if uint32(int(nn)) != nn {
+				return nil, badData
+			}
+			n[i] = int(nn)
+		}
+	}
+
+	size := 4
+	if is64 {
+		size = 8
+	}
+
+	// Transition times.
+	txtimes := dataIO{d.read(n[NTime] * size), false}
+
+	// Time zone indices for transition times.
+	txzones := d.read(n[NTime])
+
+	// Zone info structures
+	zonedata := dataIO{d.read(n[NZone] * 6), false}
+
+	// Time zone abbreviations.
+	abbrev := d.read(n[NChar])
+
+	// Leap-second time pairs
+	d.read(n[NLeap] * (size + 4))
+
+	// Whether tx times associated with local time types
+	// are specified as standard time or wall time.
+	isstd := d.read(n[NStdWall])
+
+	// Whether tx times associated with local time types
+	// are specified as UTC or local time.
+	isutc := d.read(n[NUTCLocal])
+
+	if d.error { // ran out of data
+		return nil, badData
+	}
+
+	var extend string
+	rest := d.rest()
+	if len(rest) > 2 && rest[0] == '\n' && rest[len(rest)-1] == '\n' {
+		extend = string(rest[1 : len(rest)-1])
+	}
+
+	// Now we can build up a useful data structure.
+	// First the zone information.
+	//	utcoff[4] isdst[1] nameindex[1]
+	nzone := n[NZone]
+	if nzone == 0 {
+		// Reject tzdata files with no zones. There's nothing useful in them.
+		// This also avoids a panic later when we add and then use a fake transition (golang.org/issue/29437).
+		return nil, badData
+	}
+	zones := make([]zone, nzone)
+	for i := range zones {
+		var ok bool
+		var n uint32
+		if n, ok = zonedata.big4(); !ok {
+			return nil, badData
+		}
+		if uint32(int(n)) != n {
+			return nil, badData
+		}
+		zones[i].offset = int(int32(n))
+		var b byte
+		if b, ok = zonedata.byte(); !ok {
+			return nil, badData
+		}
+		zones[i].isDST = b != 0
+		if b, ok = zonedata.byte(); !ok || int(b) >= len(abbrev) {
+			return nil, badData
+		}
+		zones[i].name = byteString(abbrev[b:])
+		if runtime.GOOS == "aix" && len(name) > 8 && (name[:8] == "Etc/GMT+" || name[:8] == "Etc/GMT-") {
+			// There is a bug with AIX 7.2 TL 0 with files in Etc,
+			// GMT+1 will return GMT-1 instead of GMT+1 or -01.
+			if name != "Etc/GMT+0" {
+				// GMT+0 is OK
+				zones[i].name = name[4:]
+			}
+		}
+	}
+
+	// Now the transition time info.
+	tx := make([]zoneTrans, n[NTime])
+	for i := range tx {
+		var n int64
+		if !is64 {
+			if n4, ok := txtimes.big4(); !ok {
+				return nil, badData
+			} else {
+				n = int64(int32(n4))
+			}
+		} else {
+			if n8, ok := txtimes.big8(); !ok {
+				return nil, badData
+			} else {
+				n = int64(n8)
+			}
+		}
+		tx[i].when = n
+		if int(txzones[i]) >= len(zones) {
+			return nil, badData
+		}
+		tx[i].index = txzones[i]
+		if i < len(isstd) {
+			tx[i].isstd = isstd[i] != 0
+		}
+		if i < len(isutc) {
+			tx[i].isutc = isutc[i] != 0
+		}
+	}
+
+	if len(tx) == 0 {
+		// Build fake transition to cover all time.
+		// This happens in fixed locations like "Etc/GMT0".
+		tx = append(tx, zoneTrans{when: alpha, index: 0})
+	}
+
+	// Committed to succeed.
+	l := &Location{zone: zones, tx: tx, name: name, extend: extend}
+
+	// Fill in the cache with information about right now,
+	// since that will be the most common lookup.
+	sec := time.Now().Unix()
+	for i := range tx {
+		if tx[i].when <= sec && (i+1 == len(tx) || sec < tx[i+1].when) {
+			l.cacheStart = tx[i].when
+			l.cacheEnd = omega
+			l.cacheZone = &l.zone[tx[i].index]
+			if i+1 < len(tx) {
+				l.cacheEnd = tx[i+1].when
+			} else if l.extend != "" {
+				// If we're at the end of the known zone transitions,
+				// try the extend string.
+				if name, offset, estart, eend, isDST, ok := tzset(l.extend, l.cacheEnd, sec); ok {
+					l.cacheStart = estart
+					l.cacheEnd = eend
+					// Find the zone that is returned by tzset to avoid allocation if possible.
+					if zoneIdx := findZone(l.zone, name, offset, isDST); zoneIdx != -1 {
+						l.cacheZone = &l.zone[zoneIdx]
+					} else {
+						l.cacheZone = &zone{
+							name:   name,
+							offset: offset,
+							isDST:  isDST,
+						}
+					}
+				}
+			}
+			break
+		}
+	}
+
+	return l, nil
+}
+
+func findZone(zones []zone, name string, offset int, isDST bool) int {
+	for i, z := range zones {
+		if z.name == name && z.offset == offset && z.isDST == isDST {
+			return i
+		}
+	}
+	return -1
+}
+
+// loadTzinfoFromDirOrZip returns the contents of the file with the given name
+// in dir. dir can either be an uncompressed zip file, or a directory.
+func loadTzinfoFromDirOrZip(dir, name string) ([]byte, error) {
+	if len(dir) > 4 && dir[len(dir)-4:] == ".zip" {
+		return loadTzinfoFromZip(dir, name)
+	}
+	if dir != "" {
+		name = dir + "/" + name
+	}
+	return ioutil.ReadFile(name)
+}
+
+// There are 500+ zoneinfo files. Rather than distribute them all
+// individually, we ship them in an uncompressed zip file.
+// Used this way, the zip file format serves as a commonly readable
+// container for the individual small files. We choose zip over tar
+// because zip files have a contiguous table of contents, making
+// individual file lookups faster, and because the per-file overhead
+// in a zip file is considerably less than tar's 512 bytes.
+
+// get4 returns the little-endian 32-bit value in b.
+func get4(b []byte) int {
+	if len(b) < 4 {
+		return 0
+	}
+	return int(b[0]) | int(b[1])<<8 | int(b[2])<<16 | int(b[3])<<24
+}
+
+// get2 returns the little-endian 16-bit value in b.
+func get2(b []byte) int {
+	if len(b) < 2 {
+		return 0
+	}
+	return int(b[0]) | int(b[1])<<8
+}
+
+// loadTzinfoFromZip returns the contents of the file with the given name
+// in the given uncompressed zip file.
+func loadTzinfoFromZip(zipfile, name string) ([]byte, error) {
+	fd, err := os.Open(zipfile)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+
+	const (
+		zecheader = 0x06054b50
+		zcheader  = 0x02014b50
+		ztailsize = 22
+
+		zheadersize = 30
+		zheader     = 0x04034b50
+	)
+
+	buf := make([]byte, ztailsize)
+	if err := preadn(fd, buf, -ztailsize); err != nil || get4(buf) != zecheader {
+		return nil, errors.New("corrupt zip file " + zipfile)
+	}
+	n := get2(buf[10:])
+	size := get4(buf[12:])
+	off := get4(buf[16:])
+
+	buf = make([]byte, size)
+	if err := preadn(fd, buf, off); err != nil {
+		return nil, errors.New("corrupt zip file " + zipfile)
+	}
+
+	for i := 0; i < n; i++ {
+		// zip entry layout:
+		//	0	magic[4]
+		//	4	madevers[1]
+		//	5	madeos[1]
+		//	6	extvers[1]
+		//	7	extos[1]
+		//	8	flags[2]
+		//	10	meth[2]
+		//	12	modtime[2]
+		//	14	moddate[2]
+		//	16	crc[4]
+		//	20	csize[4]
+		//	24	uncsize[4]
+		//	28	namelen[2]
+		//	30	xlen[2]
+		//	32	fclen[2]
+		//	34	disknum[2]
+		//	36	iattr[2]
+		//	38	eattr[4]
+		//	42	off[4]
+		//	46	name[namelen]
+		//	46+namelen+xlen+fclen - next header
+		//
+		if get4(buf) != zcheader {
+			break
+		}
+		meth := get2(buf[10:])
+		size := get4(buf[24:])
+		namelen := get2(buf[28:])
+		xlen := get2(buf[30:])
+		fclen := get2(buf[32:])
+		off := get4(buf[42:])
+		zname := buf[46 : 46+namelen]
+		buf = buf[46+namelen+xlen+fclen:]
+		if string(zname) != name {
+			continue
+		}
+		if meth != 0 {
+			return nil, errors.New("unsupported compression for " + name + " in " + zipfile)
+		}
+
+		// zip per-file header layout:
+		//	0	magic[4]
+		//	4	extvers[1]
+		//	5	extos[1]
+		//	6	flags[2]
+		//	8	meth[2]
+		//	10	modtime[2]
+		//	12	moddate[2]
+		//	14	crc[4]
+		//	18	csize[4]
+		//	22	uncsize[4]
+		//	26	namelen[2]
+		//	28	xlen[2]
+		//	30	name[namelen]
+		//	30+namelen+xlen - file data
+		//
+		buf = make([]byte, zheadersize+namelen)
+		if err := preadn(fd, buf, off); err != nil ||
+			get4(buf) != zheader ||
+			get2(buf[8:]) != meth ||
+			get2(buf[26:]) != namelen ||
+			string(buf[30:30+namelen]) != name {
+			return nil, errors.New("corrupt zip file " + zipfile)
+		}
+		xlen = get2(buf[28:])
+
+		buf = make([]byte, size)
+		if err := preadn(fd, buf, off+30+namelen+xlen); err != nil {
+			return nil, errors.New("corrupt zip file " + zipfile)
+		}
+
+		return buf, nil
+	}
+
+	return nil, os.ErrNotExist
+}
+
+// loadTzinfoFromTzdata returns the time zone information of the time zone
+// with the given name, from a tzdata database file as they are typically
+// found on android.
+var loadTzinfoFromTzdata func(file, name string) ([]byte, error)
+
+// loadTzinfo returns the time zone information of the time zone
+// with the given name, from a given source. A source may be a
+// timezone database directory, tzdata database file or an uncompressed
+// zip file, containing the contents of such a directory.
+func loadTzinfo(name string, source string) ([]byte, error) {
+	if len(source) >= 6 && source[len(source)-6:] == "tzdata" {
+		return loadTzinfoFromTzdata(source, name)
+	}
+	return loadTzinfoFromDirOrZip(source, name)
+}
+
+// loadLocation returns the Location with the given name from one of
+// the specified sources. See loadTzinfo for a list of supported sources.
+// The first timezone data matching the given name that is successfully loaded
+// and parsed is returned as a Location.
+func loadLocation(name string, sources []string) (z *Location, firstErr error) {
+	for _, source := range sources {
+		var zoneData, err = loadTzinfo(name, source)
+		if err == nil {
+			if z, err = LoadLocationFromTZData(name, zoneData); err == nil {
+				return z, nil
+			}
+		}
+		if firstErr == nil && !os.IsNotExist(err) {
+			firstErr = err
+		}
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return nil, errors.New("unknown time zone " + name)
+}
+
+func preadn(fd *os.File, buf []byte, off int) error {
+	whence := io.SeekStart
+	if off < 0 {
+		whence = io.SeekEnd
+	}
+	if _, err := fd.Seek(int64(off), whence); err != nil {
+		return err
+	}
+	for len(buf) > 0 {
+		m, err := fd.Read(buf)
+		if m <= 0 {
+			if err == nil {
+				return errors.New("short read")
+			}
+			return err
+		}
+		buf = buf[m:]
+	}
+	return nil
+}

--- a/internal/zoneinfo/zoneinfo_test.go
+++ b/internal/zoneinfo/zoneinfo_test.go
@@ -1,0 +1,254 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zoneinfo_test
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/flux/internal/zoneinfo"
+)
+
+func init() {
+	if zoneinfo.ZoneinfoForTesting() != nil {
+		panic(fmt.Errorf("zoneinfo initialized before first LoadLocation"))
+	}
+}
+
+func TestEnvVarUsage(t *testing.T) {
+	zoneinfo.ResetZoneinfoForTesting()
+
+	const testZoneinfo = "foo.zip"
+	const env = "ZONEINFO"
+
+	t.Setenv(env, testZoneinfo)
+
+	// Result isn't important, we're testing the side effect of this command
+	zoneinfo.LoadLocation("Asia/Jerusalem")
+	defer zoneinfo.ResetZoneinfoForTesting()
+
+	if zoneinfo := zoneinfo.ZoneinfoForTesting(); testZoneinfo != *zoneinfo {
+		t.Errorf("zoneinfo does not match env variable: got %q want %q", *zoneinfo, testZoneinfo)
+	}
+}
+
+func TestBadLocationErrMsg(t *testing.T) {
+	zoneinfo.ResetZoneinfoForTesting()
+	loc := "Asia/SomethingNotExist"
+	want := errors.New("unknown time zone " + loc)
+	_, err := zoneinfo.LoadLocation(loc)
+	if err.Error() != want.Error() {
+		t.Errorf("LoadLocation(%q) error = %v; want %v", loc, err, want)
+	}
+}
+
+func TestLoadLocationValidatesNames(t *testing.T) {
+	zoneinfo.ResetZoneinfoForTesting()
+	const env = "ZONEINFO"
+	t.Setenv(env, "")
+
+	bad := []string{
+		"/usr/foo/Foo",
+		"\\UNC\foo",
+		"..",
+		"a..",
+	}
+	for _, v := range bad {
+		_, err := zoneinfo.LoadLocation(v)
+		if err != zoneinfo.ErrLocation {
+			t.Errorf("LoadLocation(%q) error = %v; want ErrLocation", v, err)
+		}
+	}
+}
+
+func TestVersion3(t *testing.T) {
+	zoneinfo.ForceZipFileForTesting(true)
+	defer zoneinfo.ForceZipFileForTesting(false)
+	_, err := zoneinfo.LoadLocation("Asia/Jerusalem")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Test that we get the correct results for times before the first
+// transition time. To do this we explicitly check early dates in a
+// couple of specific timezones.
+func TestFirstZone(t *testing.T) {
+	zoneinfo.ForceZipFileForTesting(true)
+	defer zoneinfo.ForceZipFileForTesting(false)
+
+	var tests = []struct {
+		zone  string
+		unix  int64
+		want1 string
+		want2 string
+	}{
+		{
+			"PST8PDT",
+			-1633269601,
+			"-0800 (PST)",
+			"-0700 (PDT)",
+		},
+		{
+			"Pacific/Fakaofo",
+			1325242799,
+			"-1100 (-11)",
+			"+1300 (+13)",
+		},
+	}
+
+	for _, test := range tests {
+		z, err := zoneinfo.LoadLocation(test.zone)
+		if err != nil {
+			t.Fatal(err)
+		}
+		name, offset, _, _, _ := z.Lookup(test.unix)
+		if got := fmt.Sprintf("%+03d%02d (%s)", offset/3600, offset%3600, name); got != test.want1 {
+			t.Errorf("for %s %d got %q want %q", test.zone, test.unix, got, test.want1)
+		}
+		name, offset, _, _, _ = z.Lookup(test.unix + 1)
+		if got := fmt.Sprintf("%+03d%02d (%s)", offset/3600, offset%3600, name); got != test.want2 {
+			t.Errorf("for %s %d got %q want %q", test.zone, test.unix, got, test.want2)
+		}
+	}
+}
+
+func TestLocationNames(t *testing.T) {
+	if zoneinfo.UTC.String() != "UTC" {
+		t.Errorf(`invalid UTC location name: got %q want "UTC"`, zoneinfo.UTC)
+	}
+}
+
+func TestLoadLocationFromTZData(t *testing.T) {
+	zoneinfo.ForceZipFileForTesting(true)
+	defer zoneinfo.ForceZipFileForTesting(false)
+
+	const locationName = "Asia/Jerusalem"
+	reference, err := zoneinfo.LoadLocation(locationName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tzinfo, err := zoneinfo.LoadTzinfo(locationName, zoneinfo.OrigZoneSources[len(zoneinfo.OrigZoneSources)-1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sample, err := zoneinfo.LoadLocationFromTZData(locationName, tzinfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(reference, sample) {
+		t.Errorf("return values of LoadLocationFromTZData and LoadLocation don't match")
+	}
+}
+
+func TestMalformedTZData(t *testing.T) {
+	// The goal here is just that malformed tzdata results in an error, not a panic.
+	issue29437 := "TZif\x00000000000000000\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0000"
+	_, err := zoneinfo.LoadLocationFromTZData("abc", []byte(issue29437))
+	if err == nil {
+		t.Error("expected error, got none")
+	}
+}
+
+func TestTzset(t *testing.T) {
+	for _, test := range []struct {
+		inStr string
+		inEnd int64
+		inSec int64
+		name  string
+		off   int
+		start int64
+		end   int64
+		isDST bool
+		ok    bool
+	}{
+		{"", 0, 0, "", 0, 0, 0, false, false},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2159200800, "PDT", -7 * 60 * 60, 2152173600, 2172733200, true, true},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2152173599, "PST", -8 * 60 * 60, 2145916800, 2152173600, false, true},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2152173600, "PDT", -7 * 60 * 60, 2152173600, 2172733200, true, true},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2152173601, "PDT", -7 * 60 * 60, 2152173600, 2172733200, true, true},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2172733199, "PDT", -7 * 60 * 60, 2152173600, 2172733200, true, true},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2172733200, "PST", -8 * 60 * 60, 2172733200, 2177452800, false, true},
+		{"PST8PDT,M3.2.0,M11.1.0", 0, 2172733201, "PST", -8 * 60 * 60, 2172733200, 2177452800, false, true},
+	} {
+		name, off, start, end, isDST, ok := zoneinfo.Tzset(test.inStr, test.inEnd, test.inSec)
+		if name != test.name || off != test.off || start != test.start || end != test.end || isDST != test.isDST || ok != test.ok {
+			t.Errorf("tzset(%q, %d, %d) = %q, %d, %d, %d, %t, %t, want %q, %d, %d, %d, %t, %t", test.inStr, test.inEnd, test.inSec, name, off, start, end, isDST, ok, test.name, test.off, test.start, test.end, test.isDST, test.ok)
+		}
+	}
+}
+
+func TestTzsetName(t *testing.T) {
+	for _, test := range []struct {
+		in   string
+		name string
+		out  string
+		ok   bool
+	}{
+		{"", "", "", false},
+		{"X", "", "", false},
+		{"PST", "PST", "", true},
+		{"PST8PDT", "PST", "8PDT", true},
+		{"PST-08", "PST", "-08", true},
+		{"<A+B>+08", "A+B", "+08", true},
+	} {
+		name, out, ok := zoneinfo.TzsetName(test.in)
+		if name != test.name || out != test.out || ok != test.ok {
+			t.Errorf("tzsetName(%q) = %q, %q, %t, want %q, %q, %t", test.in, name, out, ok, test.name, test.out, test.ok)
+		}
+	}
+}
+
+func TestTzsetOffset(t *testing.T) {
+	for _, test := range []struct {
+		in  string
+		off int
+		out string
+		ok  bool
+	}{
+		{"", 0, "", false},
+		{"X", 0, "", false},
+		{"+", 0, "", false},
+		{"+08", 8 * 60 * 60, "", true},
+		{"-01:02:03", -1*60*60 - 2*60 - 3, "", true},
+		{"01", 1 * 60 * 60, "", true},
+		{"100", 100 * 60 * 60, "", true},
+		{"1000", 0, "", false},
+		{"8PDT", 8 * 60 * 60, "PDT", true},
+	} {
+		off, out, ok := zoneinfo.TzsetOffset(test.in)
+		if off != test.off || out != test.out || ok != test.ok {
+			t.Errorf("tzsetName(%q) = %d, %q, %t, want %d, %q, %t", test.in, off, out, ok, test.off, test.out, test.ok)
+		}
+	}
+}
+
+func TestTzsetRule(t *testing.T) {
+	for _, test := range []struct {
+		in  string
+		r   zoneinfo.Rule
+		out string
+		ok  bool
+	}{
+		{"", zoneinfo.Rule{}, "", false},
+		{"X", zoneinfo.Rule{}, "", false},
+		{"J10", zoneinfo.Rule{Kind: zoneinfo.RuleJulian, Day: 10, Time: 2 * 60 * 60}, "", true},
+		{"20", zoneinfo.Rule{Kind: zoneinfo.RuleDOY, Day: 20, Time: 2 * 60 * 60}, "", true},
+		{"M1.2.3", zoneinfo.Rule{Kind: zoneinfo.RuleMonthWeekDay, Mon: 1, Week: 2, Day: 3, Time: 2 * 60 * 60}, "", true},
+		{"30/03:00:00", zoneinfo.Rule{Kind: zoneinfo.RuleDOY, Day: 30, Time: 3 * 60 * 60}, "", true},
+		{"M4.5.6/03:00:00", zoneinfo.Rule{Kind: zoneinfo.RuleMonthWeekDay, Mon: 4, Week: 5, Day: 6, Time: 3 * 60 * 60}, "", true},
+		{"M4.5.7/03:00:00", zoneinfo.Rule{}, "", false},
+		{"M4.5.6/-04", zoneinfo.Rule{Kind: zoneinfo.RuleMonthWeekDay, Mon: 4, Week: 5, Day: 6, Time: -4 * 60 * 60}, "", true},
+	} {
+		r, out, ok := zoneinfo.TzsetRule(test.in)
+		if r != test.r || out != test.out || ok != test.ok {
+			t.Errorf("tzsetName(%q) = %#v, %q, %t, want %#v, %q, %t", test.in, r, out, ok, test.r, test.out, test.ok)
+		}
+	}
+}

--- a/internal/zoneinfo/zoneinfo_unix.go
+++ b/internal/zoneinfo/zoneinfo_unix.go
@@ -1,0 +1,26 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build aix || (darwin && !ios) || dragonfly || freebsd || (linux && !android) || netbsd || openbsd || solaris
+// +build aix darwin,!ios dragonfly freebsd linux,!android netbsd openbsd solaris
+
+// Parse "zoneinfo" time zone file.
+// This is a fairly standard file format used on OS X, Linux, BSD, Sun, and others.
+// See tzfile(5), https://en.wikipedia.org/wiki/Zoneinfo,
+// and ftp://munnari.oz.au/pub/oldtz/
+
+package zoneinfo
+
+import (
+	"runtime"
+)
+
+// Many systems use /usr/share/zoneinfo, Solaris 2 has
+// /usr/share/lib/zoneinfo, IRIX 6 has /usr/lib/locale/TZ.
+var zoneSources = []string{
+	"/usr/share/zoneinfo/",
+	"/usr/share/lib/zoneinfo/",
+	"/usr/lib/locale/TZ/",
+	runtime.GOROOT() + "/lib/time/zoneinfo.zip",
+}

--- a/internal/zoneinfo/zoneinfo_windows.go
+++ b/internal/zoneinfo/zoneinfo_windows.go
@@ -1,0 +1,13 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zoneinfo
+
+import (
+	"runtime"
+)
+
+var zoneSources = []string{
+	runtime.GOROOT() + "/lib/time/zoneinfo.zip",
+}


### PR DESCRIPTION
This copies over the location related code from the Go standard library
and removes some of the unused features from it. We remove the platforms
we do not support and remove concepts like `Local` because support for
that doesn't make sense anyway in a server context.

Fixes #4057.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written