### PR TITLE
chore(circleci): add step to merge PR with parent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,10 +141,7 @@ jobs:
             # Cargo's built-in support for fetching dependencies from GitHub requires
             # an ssh agent to be set up, which doesn't work on Circle's Windows executors.
             # See https://github.com/rust-lang/cargo/issues/1851#issuecomment-450130685
-            cat <<EOF >> ~/.cargo/config
-            [net]
-            git-fetch-with-cli = true
-            EOF
+            echo -e "\n[net]\ngit-fetch-with-cli = true\n">> ~/.cargo/config
       - run:
           name: Install pkg-config wrapper
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
-version: 2
+version: 2.1
+orbs:
+  build-tools: circleci/build-tools@2.9.1
 jobs:
   test:
     docker:
@@ -12,6 +14,10 @@ jobs:
       SCCACHE_CACHE_SIZE: 1G
     steps:
       - checkout
+      # Merge the current branch with its parent (in most cases this should be master)
+      # Then run tests etc in that merged commit. This helps catch issues due to a
+      # branch that hasn't recently been rebased off master.
+      - build-tools/merge-with-parent
       # Populate GOPATH/pkg.
       - restore_cache:
           name: Restoring GOPATH/pkg/mod
@@ -53,6 +59,10 @@ jobs:
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
     steps:
       - checkout
+      # Merge the current branch with its parent (in most cases this should be master)
+      # Then run tests etc in that merged commit. This helps catch issues due to a
+      # branch that hasn't recently been rebased off master.
+      - build-tools/merge-with-parent
       # Building go with -race does not use the cache
       # Populate GOPATH/pkg.
       - restore_cache:
@@ -71,6 +81,10 @@ jobs:
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
     steps:
       - checkout
+      # Merge the current branch with its parent (in most cases this should be master)
+      # Then run tests etc in that merged commit. This helps catch issues due to a
+      # branch that hasn't recently been rebased off master.
+      - build-tools/merge-with-parent
       - restore_cache:
           name: Restoring GOPATH/pkg/mod
           keys:
@@ -83,6 +97,10 @@ jobs:
       - image: quay.io/influxdb/flux-build:latest
     steps:
       - checkout
+      # Merge the current branch with its parent (in most cases this should be master)
+      # Then run tests etc in that merged commit. This helps catch issues due to a
+      # branch that hasn't recently been rebased off master.
+      - build-tools/merge-with-parent
       - run: make test-valgrind
   build-windows:
     machine:
@@ -106,6 +124,10 @@ jobs:
 
             echo 'export PATH="${HOME}/.cargo/bin:/c/Program Files/Go/bin:${PATH}"' >> $BASH_ENV
       - checkout
+      # Merge the current branch with its parent (in most cases this should be master)
+      # Then run tests etc in that merged commit. This helps catch issues due to a
+      # branch that hasn't recently been rebased off master.
+      - build-tools/merge-with-parent
       - run:
           name: Pin rust version and install mingw rustup target
           command: |


### PR DESCRIPTION
This will help to prevent in most cases CI failures against master that
arise because two PRs merge that are in conflict with one another and
one PR is based off an older master commit.

This will not solve all cases. This change assumes that the branch's
parent is the master branch, this is true most of the time but not
always. In cases where its not true its still valuable to test but we
loose the safeguard of testing against master.

In other cases where the CI for both PR runs and passes before either PR
merges we would not catch potential conflicts.

Alternatively we could require that branches are up-to-date with master
before merging but that puts a lot of onus on the PR author to
constantly rebase. This change seems like a good balance in that is
should catch most cases at little cost to the development cycle.

See https://github.com/influxdata/flux/pull/4090#discussion_r717668829
