### PR TITLE
fix: reject usePrevious when column doesn't exist

### DIFF
--- a/stdlib/universe/fill.go
+++ b/stdlib/universe/fill.go
@@ -229,6 +229,9 @@ func (t *fillTransformation) Process(id execute.DatasetID, tbl flux.Table) error
 	// In case of missing fill column, add it to the existing columns
 	tableCols := tbl.Cols()
 	if colIdx < 0 {
+		if t.spec.UsePrevious {
+			return errors.New(codes.Invalid, "fill column does not exist; cannot usePrevious")
+		}
 		newCols := make([]flux.ColMeta, len(tableCols), len(tableCols)+1)
 		copy(newCols, tableCols)
 		c := flux.ColMeta{


### PR DESCRIPTION
This patch addresses an issue where one might do
`fill(column: "a-nonexistent-column" usePrevious: true)`. Why would
someone do that, you might ask. In the current bug being chased, it was
because the table was a result of a `union` of two different schemas,
and sometimes the fill happened when the other schema was the first
record in the `union`.