### PR TITLE
feat(interval): add location functionality to interval package

### DIFF
--- a/interval/bounds.go
+++ b/interval/bounds.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/influxdata/flux/internal/zoneinfo"
 	"github.com/influxdata/flux/values"
 )
 
@@ -118,4 +119,20 @@ func (b Bounds) Union(o Bounds) Bounds {
 	}
 
 	return *u
+}
+
+// in translates the start and stop time for this Bounds
+// into one where the times are transposed to their equivalent
+// clock time in the zoneinfo.Location.
+//
+// This method is not idempotent. It expects the Bounds to have
+// been created with the utc location.
+func (b Bounds) in(loc *zoneinfo.Location) Bounds {
+	start := loc.ToLocalClock(int64(b.start))
+	stop := loc.ToLocalClock(int64(b.stop))
+	return Bounds{
+		start: values.Time(start),
+		stop:  values.Time(stop),
+		index: b.index,
+	}
 }


### PR DESCRIPTION
This adds the location functionality to the interval package using the
`zoneinfo.Location` struct from the `zoneinfo` package.

The interval package now translates an input time from the local clock
time to the utc clock time if a location has been specified. It performs
the same time math it previously did and then it will convert the times
back to the local clock time before returning them.

If the default `NewWindow` is used or the location is nil, it continues
to use the old behavior which does not translate for zone offsets.

Fixes #4059.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written