### PR TITLE
refactor: change the plan window spec to use a basic data struct instead of the location struct

### DIFF
--- a/interval/window.go
+++ b/interval/window.go
@@ -81,10 +81,6 @@ func (w Window) Period() values.Duration {
 	return w.period
 }
 
-func (w Window) Location() *zoneinfo.Location {
-	return w.loc
-}
-
 func (w Window) isValid() error {
 	if w.every.IsZero() {
 		return errors.New(codes.Invalid, "duration used as an interval cannot be zero")

--- a/plan/types.go
+++ b/plan/types.go
@@ -341,5 +341,35 @@ type WindowSpec struct {
 	Every    flux.Duration
 	Period   flux.Duration
 	Offset   flux.Duration
-	Location interval.Location
+	Location Location
+}
+
+func (w WindowSpec) LoadLocation() (interval.Location, error) {
+	return w.Location.Load()
+}
+
+type Location struct {
+	Name   string
+	Offset flux.Duration
+}
+
+func (l Location) IsUTC() bool {
+	name := l.Name
+	if name == "" {
+		name = "UTC"
+	}
+	return name == "UTC" && l.Offset.IsZero()
+}
+
+func (l Location) Load() (interval.Location, error) {
+	name := l.Name
+	if name == "" {
+		name = "UTC"
+	}
+	loc, err := interval.LoadLocation(name)
+	if err != nil {
+		return interval.Location{}, err
+	}
+	loc.Offset = l.Offset
+	return loc, nil
 }

--- a/stdlib/universe/window2.go
+++ b/stdlib/universe/window2.go
@@ -33,11 +33,16 @@ type windowTransformation2 struct {
 }
 
 func newWindowTransformation2(id execute.DatasetID, spec *WindowProcedureSpec, bounds *execute.Bounds, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	loc, err := spec.Window.LoadLocation()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	window, err := interval.NewWindowInLocation(
 		spec.Window.Every,
 		spec.Window.Period,
 		spec.Window.Offset,
-		spec.Window.Location,
+		loc,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -36,10 +36,12 @@ func TestWindow_NewQuery(t *testing.T) {
 					{
 						ID: "window1",
 						Spec: &universe.WindowOpSpec{
-							Every:       flux.ConvertDuration(time.Hour),
-							Period:      flux.ConvertDuration(time.Hour),
-							Offset:      flux.ConvertDuration(time.Minute * -5),
-							Location:    interval.UTC,
+							Every:  flux.ConvertDuration(time.Hour),
+							Period: flux.ConvertDuration(time.Hour),
+							Offset: flux.ConvertDuration(time.Minute * -5),
+							Location: plan.Location{
+								Name: "UTC",
+							},
 							TimeColumn:  execute.DefaultTimeColLabel,
 							StartColumn: execute.DefaultStartColLabel,
 							StopColumn:  execute.DefaultStopColLabel,


### PR DESCRIPTION
This changes the `plan.WindowSpec` to use a basic data struct for the
location definition instead of loading the location and including the
struct.

Loading the location was convenient for flux, but it was less convenient
for planner rules which needed to interact with basic data types. This
specifically caused a problem with window related pushdowns. While we
could check that the location was proper because of exposed types, it
relied on Go comparison mechanisms that made me uncomfortable.

This causes the loading of a location to again be moved into the
creation of the transformation. This shouldn't cause any kind of real
change because we already validate the loaded location in the timezone
package.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written