### PR TITLE
chore: Add coz profiling to the `execute` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To build Flux, first install the GNU `pkg-config` utility on your system, then e
 ```
 # First install GNU pkg-config.
 # On Debian/Ubuntu
-$ sudo apt-get install -y clang pkg-config
+$ sudo apt-get install -y clang pkg-config coz-profiler
 # Or on Mac OS X with Homebrew
 $ brew install pkg-config
 
@@ -107,7 +107,7 @@ Here are a few examples of the language to get an idea of the syntax.
 
     // Functions are polymorphic
     add(a: 5.5, b: 2.5) // 8.0
-    
+
     // And strongly typed
     add(a: 5, b: 2.5) // type error
 
@@ -115,12 +115,12 @@ Here are a few examples of the language to get an idea of the syntax.
     // This is only possible within the influxdb repl (at the moment).
     import "influxdata/influxdb"
     data = influxdb.from(bucket:"telegraf/autogen")
-    
+
     // When running inside of influxdb, the import isn't needed.
     data = from(bucket:"telegraf/autogen")
 
     // Chain more transformation functions to further specify the desired data
-    cpu = data 
+    cpu = data
         // only get the last 5m of data
         |> range(start: -5m)
         // only get the "usage_user" data from the _measurement "cpu"
@@ -147,7 +147,7 @@ Here are a few examples of the language to get an idea of the syntax.
         |> yield()
 
     // Gather different data
-    mem = data 
+    mem = data
         // only get the last 5m of data
         |> range(start: -5m)
         // only get the "used_percent" data from the _measurement "mem"

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/uber/athenadriver v1.1.4
 	github.com/uber/jaeger-client-go v2.28.0+incompatible
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/urjitbhatia/cozgo v0.0.0-20191206043830-8e482eb35875 // indirect
 	go.uber.org/zap v1.14.0
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,8 @@ github.com/uber/jaeger-client-go v2.28.0+incompatible h1:G4QSBfvPKvg5ZM2j9MrJFdf
 github.com/uber/jaeger-client-go v2.28.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/urjitbhatia/cozgo v0.0.0-20191206043830-8e482eb35875 h1:vmmSRcMDlrzsQHx3GZDUPzHZLM9O1W25VZTvYFqqeyc=
+github.com/urjitbhatia/cozgo v0.0.0-20191206043830-8e482eb35875/go.mod h1:mzkLCVSSBt1yhJf8LIFGul19gL6ycVMsac6+8/AF+Jg=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=


### PR DESCRIPTION
Tracing through, adding in coz at the same places as the already existing calls to opentracing seems to make sense. We probably want some option to enable/disable this at runtime (possibly at compile time as well?).

### Done checklist
- [ ] Test cases written
