### PR TITLE
feat(execute): add disposable interface for transformations

### DIFF
--- a/execute/disposable.go
+++ b/execute/disposable.go
@@ -1,0 +1,8 @@
+package execute
+
+// Disposable is an interface to be implemented for a resource
+// that will be disposed of at a defined time.
+type Disposable interface {
+	// Dispose is invoked when the resource will no longer be used.
+	Dispose()
+}

--- a/execute/group_transformation.go
+++ b/execute/group_transformation.go
@@ -14,6 +14,8 @@ import (
 // and GroupTransformation will swallow this Message.
 type GroupTransformation interface {
 	Process(chunk table.Chunk, d *TransportDataset, mem memory.Allocator) error
+
+	Disposable
 }
 
 var _ Transport = (*groupTransformation)(nil)
@@ -77,6 +79,7 @@ func (g *groupTransformation) Process(id DatasetID, tbl flux.Table) error {
 
 func (g *groupTransformation) Finish(id DatasetID, err error) {
 	g.d.Finish(err)
+	g.t.Dispose()
 }
 
 func (g *groupTransformation) RetractTable(id DatasetID, key flux.GroupKey) error {

--- a/execute/group_transformation_test.go
+++ b/execute/group_transformation_test.go
@@ -202,9 +202,14 @@ func TestGroupTransformation_Finish(t *testing.T) {
 
 	want := errors.New(codes.Internal, "expected")
 
+	isDisposed := false
 	tr, d, err := execute.NewGroupTransformation(
 		executetest.RandomDatasetID(),
-		&mock.GroupTransformation{},
+		&mock.GroupTransformation{
+			DisposeFn: func() {
+				isDisposed = true
+			},
+		},
 		memory.DefaultAllocator,
 	)
 	if err != nil {
@@ -248,11 +253,14 @@ func TestGroupTransformation_Finish(t *testing.T) {
 
 	d.Finish(want)
 
+	if !isDisposed {
+		t.Error("transformation was not disposed")
+	}
 	if !isFinished[0] {
-		t.Error("transport did not receive finish message")
+		t.Error("downstream transport did not receive finish message")
 	}
 	if !isFinished[1] {
-		t.Error("transformation did not receive finish message")
+		t.Error("downstream transformation did not receive finish message")
 	}
 }
 

--- a/execute/narrow_transformation.go
+++ b/execute/narrow_transformation.go
@@ -11,6 +11,8 @@ import (
 type NarrowTransformation interface {
 	// Process will process the table.Chunk and send any output to the TransportDataset.
 	Process(chunk table.Chunk, d *TransportDataset, mem memory.Allocator) error
+
+	Disposable
 }
 
 var _ Transport = (*narrowTransformation)(nil)
@@ -74,6 +76,7 @@ func (n *narrowTransformation) Process(id DatasetID, tbl flux.Table) error {
 // Finish is implemented to remain compatible with legacy upstreams.
 func (n *narrowTransformation) Finish(id DatasetID, err error) {
 	n.d.Finish(err)
+	n.t.Dispose()
 }
 
 func (n *narrowTransformation) OperationType() string {

--- a/execute/narrow_transformation_test.go
+++ b/execute/narrow_transformation_test.go
@@ -215,9 +215,14 @@ func TestNarrowTransformation_Finish(t *testing.T) {
 
 	want := errors.New(codes.Internal, "expected")
 
+	isDisposed := false
 	tr, d, err := execute.NewNarrowTransformation(
 		executetest.RandomDatasetID(),
-		&mock.NarrowTransformation{},
+		&mock.NarrowTransformation{
+			DisposeFn: func() {
+				isDisposed = true
+			},
+		},
 		memory.DefaultAllocator,
 	)
 	if err != nil {
@@ -261,11 +266,14 @@ func TestNarrowTransformation_Finish(t *testing.T) {
 
 	d.Finish(want)
 
+	if !isDisposed {
+		t.Error("transformation was not disposed")
+	}
 	if !isFinished[0] {
-		t.Error("transport did not receive finish message")
+		t.Error("downstream transport did not receive finish message")
 	}
 	if !isFinished[1] {
-		t.Error("transformation did not receive finish message")
+		t.Error("downstream transformation did not receive finish message")
 	}
 }
 

--- a/mock/transformation.go
+++ b/mock/transformation.go
@@ -34,31 +34,53 @@ func (t *Transformation) Finish(id execute.DatasetID, err error) {
 
 type GroupTransformation struct {
 	ProcessFn func(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error
+	DisposeFn func()
 }
 
 func (n *GroupTransformation) Process(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error {
 	return n.ProcessFn(chunk, d, mem)
 }
 
+func (a *GroupTransformation) Dispose() {
+	if a.DisposeFn != nil {
+		a.DisposeFn()
+	}
+}
+
 type NarrowTransformation struct {
 	ProcessFn func(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error
+	DisposeFn func()
 }
 
 func (n *NarrowTransformation) Process(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error {
 	return n.ProcessFn(chunk, d, mem)
 }
 
+func (a *NarrowTransformation) Dispose() {
+	if a.DisposeFn != nil {
+		a.DisposeFn()
+	}
+}
+
 type NarrowStateTransformation struct {
 	ProcessFn func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error)
+	DisposeFn func()
 }
 
 func (n *NarrowStateTransformation) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
 	return n.ProcessFn(chunk, state, d, mem)
 }
 
+func (a *NarrowStateTransformation) Dispose() {
+	if a.DisposeFn != nil {
+		a.DisposeFn()
+	}
+}
+
 type AggregateTransformation struct {
 	AggregateFn func(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error)
 	ComputeFn   func(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error
+	DisposeFn   func()
 }
 
 func (a *AggregateTransformation) Aggregate(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error) {
@@ -67,4 +89,10 @@ func (a *AggregateTransformation) Aggregate(chunk table.Chunk, state interface{}
 
 func (a *AggregateTransformation) Compute(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error {
 	return a.ComputeFn(key, state, d, mem)
+}
+
+func (a *AggregateTransformation) Dispose() {
+	if a.DisposeFn != nil {
+		a.DisposeFn()
+	}
 }

--- a/stdlib/universe/derivative2.go
+++ b/stdlib/universe/derivative2.go
@@ -291,6 +291,8 @@ func (t *derivativeTransformation2) derivativeStateFor(col flux.ColMeta, state *
 	}, nil
 }
 
+func (t *derivativeTransformation2) Dispose() {}
+
 type derivativeState struct {
 	cols        []flux.ColMeta
 	data        []*derivativeColumn

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -405,6 +405,8 @@ func (t *filterTransformationAdapter) Process(chunk table.Chunk, d *execute.Tran
 	return d.Process(out)
 }
 
+func (t *filterTransformationAdapter) Dispose() {}
+
 // RemoveTrivialFilterRule removes Filter nodes whose predicate always evaluates to true.
 type RemoveTrivialFilterRule struct{}
 

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -175,6 +175,8 @@ func (a *groupTransformationAdapter) Process(chunk table.Chunk, d *execute.Trans
 	return a.t.groupChunkByRow(chunk, d, mem)
 }
 
+func (a *groupTransformationAdapter) Dispose() {}
+
 type groupTransformation struct {
 	execute.ExecutionNode
 	d     execute.Dataset


### PR DESCRIPTION
This adds a `Disposable` interface to each of the new transformation
types and implements the usage of that interface.

The `Dispose` method signals that a resource is unused and can be
disposed of. An implementation of this can also use the method to signal
that it should be reused.

All transformations now require this method to be implemented.

The `Dispose` method is also utilized by stateful transformations to
dispose of the state if the interface is implemented. This includes both
the aggregate and narrow state transformations.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written