### PR TITLE
chore(libflux/fluxdocs): add script to generate flux docs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - run: make checkgenerate
       - run: make checkfmt
       - run: make checktidy
+      - run: make checkdocs
       - run: make vet
       - run: GOGC=50 make staticcheck
       - run: make libflux-wasm
@@ -158,6 +159,8 @@ jobs:
       - run:
           name: Install pkg-config
           command: go build -o /go/bin/pkg-config github.com/influxdata/pkg-config
+      # Make the flux documentation JSON archives to add to the release
+      - run: make fluxdocs
       - run:
           # Parallelism for goreleaser must be set to 1 so it doesn't
           # attempt to invoke pkg-config, which invokes cargo,

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /libflux/go/libflux/hack.gen.go
 /release-notes.txt
 cmake-build-debug
+/generated_docs
 
 # exclude any files with the name flux but
 # include any directories that share the same name.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,4 +27,6 @@ archive:
 release:
   prerelease: auto
   name_template: "v{{.Version}}"
+  extra_files:
+    - glob: ./generated_docs/*.json
 

--- a/Makefile
+++ b/Makefile
@@ -170,30 +170,45 @@ test-release: Dockerfile_build
 	    go build -o /go/bin/pkg-config github.com/influxdata/pkg-config &&\
 		./gotool.sh github.com/goreleaser/goreleaser release --rm-dist --snapshot"
 
-.PHONY: generate \
-	clean \
-	cleangenerate \
+
+libflux/target/release/fluxc: libflux
+	cd libflux && $(CARGO) build $(CARGO_ARGS) --release --bin fluxc
+
+libflux/target/release/fluxdoc: libflux
+	cd libflux && $(CARGO) build $(CARGO_ARGS) --release --bin fluxdoc
+
+fluxdocs: $(STDLIB_SOURCES) libflux/target/release/fluxc libflux/target/release/fluxdoc
+	FLUXC=./libflux/target/release/fluxc FLUXDOC=./libflux/target/release/fluxdoc ./etc/gen_docs.sh
+
+checkdocs: $(STDLIB_SOURCES) libflux/target/release/fluxc libflux/target/release/fluxdoc
+	FLUXC=./libflux/target/release/fluxc FLUXDOC=./libflux/target/release/fluxdoc ./etc/checkdocs.sh
+
+# This list is sorted for easy inspection
+.PHONY: bench \
 	build \
+	build-wasm \
+	checkdocs \
+	checkfmt \
+	checkgenerate \
+	checktidy \
+	clean \
+	clean-wasm \
+	cleangenerate \
 	default \
+	fluxdocs \
+	fmt \
+	generate \
 	libflux \
 	libflux-go \
 	libflux-wasm \
-	clean-wasm \
-	build-wasm \
 	publish-wasm \
-	fmt \
-	checkfmt \
-	tidy \
-	checktidy \
-	checkgenerate \
+	release \
 	staticcheck \
 	test \
-	test-go \
-	test-rust \
-	test-race \
 	test-bench \
+	test-go \
+	test-race \
+	test-rust \
 	test-valgrind \
-	vet \
-	bench \
-	checkfmt \
-	release
+	tidy \
+	vet

--- a/etc/checkdocs.sh
+++ b/etc/checkdocs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+stdlib=${FLUX_STDLIB_DIR-./stdlib}
+fluxc=${FLUXC-fluxc}
+fluxdoc=${FLUXDOC-fluxdoc}
+
+dir=$(mktemp -d)
+stdlib_compiled="${dir}/stdlib"
+
+# Compile stdlib to a temporary dir
+mkdir -p $stdlib_compiled
+$fluxc stdlib --srcdir "${stdlib}" --outdir "${stdlib_compiled}"
+
+# Lint the docs to ensure they are valid
+# TODO(nathanielc): Remove allow_exceptions option once all exceptions have been removed
+$fluxdoc lint --dir ${stdlib} --stdlib-dir "${stdlib_compiled}" --allow-exceptions
+
+rm -rf "$dir"

--- a/etc/gen_docs.sh
+++ b/etc/gen_docs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+stdlib=${FLUX_STDLIB_SRC-./stdlib}
+fluxc=${FLUXC-fluxc}
+fluxdoc=${FLUXDOC-fluxdoc}
+gendir=${DOCS_GEN_DIR-./generated_docs}
+full_docs="${gendir}/flux-docs-full.json"
+short_docs="${gendir}/flux-docs-short.json"
+
+dir=$(mktemp -d)
+stdlib_compiled="${dir}/stdlib"
+
+# Compile stdlib to a temporary dir
+mkdir -p $stdlib_compiled
+$fluxc stdlib --srcdir "${stdlib}" --outdir "${stdlib_compiled}"
+
+# Generate docs JSON files
+mkdir -p "${gendir}"
+$fluxdoc dump --dir ${stdlib} --stdlib-dir "${stdlib_compiled}" --allow-exceptions --output ${full_docs} --nested
+$fluxdoc dump --dir ${stdlib} --stdlib-dir "${stdlib_compiled}" --allow-exceptions --output ${short_docs} --short
+
+rm -rf "${dir}"
+

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -27,7 +27,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "e8a03023d7426bcf6dfdb1a61ac3263f5cf9194a595a1584dff7c899d06562f1",
 	"libflux/flux-core/src/ast/walk/tests.rs":                                                     "54e417affc95ef9887860c54f65b6d8fd7f41ccc13e2a5fa9d7452296364d629",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "68d16ddef3a6c6f6db04a969cef91a0e22ee74ecc52e5f57905fde88ae2da87b",
-	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "eab5746aaf0b8c4fe577cd909f991c17c0ccd2184b1ab9f65b8fa9b6c9385451",
+	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "7ba332669631f85bea5682018782c0d7e1ae53933d8cfbde7e76771494a8fa6d",
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "ce8396fb867a5bc361fec99c36d36d70d2e1f3a6ec12de714f7257e4d4eef57f",
 	"libflux/flux-core/src/formatter/tests.rs":                                                    "b0a10998a65fc4b54a8f68b3a0ed186d8548ba3d7638f911eb188d2ce485206f",
 	"libflux/flux-core/src/lib.rs":                                                                "8bea09103be65b527a0e86b5861d598e9bd971e2225e2fbc7946e1cfcc7d8624",


### PR DESCRIPTION
This change add a script  to generate Flux docs and adds those docs to the Flux release archives.

Additionally a `checkdocs` step was added to CI to ensure docs pass lint before merging. However every package in the Flux stdlib is currently marked as an exception that does not need to pass. We will incrementally get the packages passing lint and remove them from the list.

Based off https://github.com/influxdata/flux/pull/4138

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
