### PR TITLE
perf(execute): Avoid recompiling types for every Process call

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -63,7 +63,7 @@ func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) 
 		return nil, errors.Wrapf(err, codes.Inherit, "cannot compile @ %v", f.Location())
 	}
 	return compiledFn{
-		root:       root,
+		root:        root,
 		parentScope: scope,
 	}, nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -64,7 +64,7 @@ func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) 
 	}
 	return compiledFn{
 		root:       root,
-		inputScope: nestScope(scope),
+		parentScope: scope,
 	}, nil
 }
 

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -26,7 +26,7 @@ type Evaluator interface {
 }
 
 type compiledFn struct {
-	root       Evaluator
+	root        Evaluator
 	parentScope Scope
 }
 
@@ -85,8 +85,8 @@ func eval(ctx context.Context, e Evaluator, scope Scope) (values.Value, error) {
 }
 
 type blockEvaluator struct {
-	t     semantic.MonoType
-	body  []Evaluator
+	t    semantic.MonoType
+	body []Evaluator
 }
 
 func (e *blockEvaluator) Type() semantic.MonoType {

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -87,7 +87,6 @@ func eval(ctx context.Context, e Evaluator, scope Scope) (values.Value, error) {
 type blockEvaluator struct {
 	t     semantic.MonoType
 	body  []Evaluator
-	value values.Value
 }
 
 func (e *blockEvaluator) Type() semantic.MonoType {
@@ -96,13 +95,14 @@ func (e *blockEvaluator) Type() semantic.MonoType {
 
 func (e *blockEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
 	var err error
+	var value values.Value
 	for _, b := range e.body {
-		e.value, err = eval(ctx, b, scope)
+		value, err = eval(ctx, b, scope)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return e.value, nil
+	return value, nil
 }
 
 type returnEvaluator struct {

--- a/execute/row_fn.go
+++ b/execute/row_fn.go
@@ -23,9 +23,9 @@ type dynamicFn struct {
 
 type compiledFn struct {
 	fn         compiler.Func
-	inType semantic.MonoType
+	inType     semantic.MonoType
 	recordType semantic.MonoType
-	cols []flux.ColMeta
+	cols       []flux.ColMeta
 	extraTypes map[string]semantic.MonoType
 }
 
@@ -78,13 +78,13 @@ func (f *dynamicFn) prepare(cols []flux.ColMeta, extraTypes map[string]semantic.
 		if err != nil {
 			return preparedFn{}, err
 		}
-		f.compiledFn = &compiledFn {
-			fn: fn,
-			inType: inType,
+		f.compiledFn = &compiledFn{
+			fn:         fn,
+			inType:     inType,
 			recordType: recordType,
-			cols: cols,
+			cols:       cols,
 			extraTypes: extraTypes,
-		};
+		}
 	}
 
 	// Construct the arguments that will be used when evaluating the function.

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -344,6 +344,7 @@ func (t *filterTransformation) filterChunk(fn *execute.RowPredicatePreparedFn, c
 
 func (t *filterTransformation) filter(fn *execute.RowPredicatePreparedFn, cr flux.ColReader, record values.Object, indices []int, mem arrowmem.Allocator) (*arrowmem.Buffer, error) {
 	cols, l := cr.Cols(), cr.Len()
+
 	bitset := arrowmem.NewResizableBuffer(mem)
 	bitset.Resize(l)
 	for i := 0; i < l; i++ {


### PR DESCRIPTION
When executing `Process` on a table with few rows the time to `Compile`
the function before execution ends up dominating the total execution
time. This is an issue for data produced by `csv.from` which creates one
`Table` per row and might be for other sources as well though I have no
idea how common it would be.

For running the following query on a file with 500k lines this change
reduces the runtime from ~38s to ~16s.

```
import "csv"

csv.from(file: "../indata_dup.csv")
    |> filter(fn: (r) => r.Animal_name == "crow")
    |> count()
```

To make `compileFn` immutable after compilation (at least as far as I
and `make test` understands) I changed it to only hold the parent scope
and only construct the scope used during evaluation when `Eval` is
actually called.
