### PR TITLE
fix(join): Compare sorted join keys

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -528,7 +528,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/join_panic_test.flux":                                                        "165809f897023f15cf8cd9499e83e9ed9f2c63b330f984a418f2588c1606707f",
 	"stdlib/universe/join_test.flux":                                                              "e5d894f43ba93b0cf56b010a9797be99ed938a403673c1ada627e46a500dc8eb",
 	"stdlib/universe/join_two_same_sources_test.flux":                                             "e5679c7111377d04ed76394e14c8ad06a693aa2fa68cebe227c7b13156e47fe1",
-	"stdlib/universe/join_unsorted_columns_test.flux":                                             "1c4199b469a1e64d1742a7649dfa890250292b35736b8dac9f79bd728fd709bc",
+	"stdlib/universe/join_unsorted_columns_test.flux":                                             "f05ca43211a3688acf554ba8678bcbefcff32ec25edfdc22f0a7e332c79ea2ea",
 	"stdlib/universe/join_use_previous_test.flux":                                                 "b161efc97bf77fb7fea4f25c69408132c7e34e2b2fa6cc3b1d203c85f3d47801",
 	"stdlib/universe/kama_test.flux":                                                              "6e8b63bf2a3dcfb797b96dcf2eeff3857740d8e8cf1b8ee56de7fc9a8af819b6",
 	"stdlib/universe/kama_v2_test.flux":                                                           "49251c487c9957b724c83543d2c93a57b9a8efc82c69ebbc1a3f4196d7bdfef1",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -528,6 +528,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/join_panic_test.flux":                                                        "165809f897023f15cf8cd9499e83e9ed9f2c63b330f984a418f2588c1606707f",
 	"stdlib/universe/join_test.flux":                                                              "e5d894f43ba93b0cf56b010a9797be99ed938a403673c1ada627e46a500dc8eb",
 	"stdlib/universe/join_two_same_sources_test.flux":                                             "e5679c7111377d04ed76394e14c8ad06a693aa2fa68cebe227c7b13156e47fe1",
+	"stdlib/universe/join_unsorted_columns_test.flux":                                             "1c4199b469a1e64d1742a7649dfa890250292b35736b8dac9f79bd728fd709bc",
 	"stdlib/universe/join_use_previous_test.flux":                                                 "b161efc97bf77fb7fea4f25c69408132c7e34e2b2fa6cc3b1d203c85f3d47801",
 	"stdlib/universe/kama_test.flux":                                                              "6e8b63bf2a3dcfb797b96dcf2eeff3857740d8e8cf1b8ee56de7fc9a8af819b6",
 	"stdlib/universe/kama_v2_test.flux":                                                           "49251c487c9957b724c83543d2c93a57b9a8efc82c69ebbc1a3f4196d7bdfef1",

--- a/result.go
+++ b/result.go
@@ -199,6 +199,16 @@ type GroupKey interface {
 	Equal(o GroupKey) bool
 	Less(o GroupKey) bool
 	String() string
+
+	// EqualTrueNulls should be functionally identical to Equal,
+	// with the exception that two nulls should never be treated
+	// as equal - the idea being that, by strict technical definition,
+	// null should not equal null. Therefore, this implementation is
+	// closer to the `true` null behavior.
+	//
+	// This is useful for transformations like join()
+	// that repurpose group keys for something other than grouping.
+	EqualTrueNulls(o GroupKey) bool
 }
 
 // GroupKeys provides a sortable collection of group keys.

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -748,9 +748,7 @@ func (c *MergeJoinCache) registerKey(id execute.DatasetID, key flux.GroupKey) {
 	switch id {
 
 	case c.leftID:
-
 		c.buffers[c.rightID].iterate(func(groupKey flux.GroupKey) {
-
 			keys := map[execute.DatasetID]flux.GroupKey{
 				c.leftID:  key,
 				c.rightID: groupKey,
@@ -772,9 +770,7 @@ func (c *MergeJoinCache) registerKey(id execute.DatasetID, key flux.GroupKey) {
 		})
 
 	case c.rightID:
-
 		c.buffers[c.leftID].iterate(func(groupKey flux.GroupKey) {
-
 			keys := map[execute.DatasetID]flux.GroupKey{
 				c.leftID:  groupKey,
 				c.rightID: key,
@@ -841,19 +837,6 @@ func (c *MergeJoinCache) buildPostJoinSchema() {
 	for j, column := range c.schema.columns {
 		c.colIndex[column] = j
 	}
-}
-
-// equalJoinKeys compares two keys for equality.
-// Null values are not considered equal when joining (unlike when grouping).
-func equalJoinkeys(left, right flux.GroupKey) bool {
-
-	for j, v := range left.Values() {
-		// value.Equal will return false if both sides are null
-		if !v.Equal(right.Value(j)) {
-			return false
-		}
-	}
-	return true
 }
 
 // Find indexes of column names missing between the two tables
@@ -928,8 +911,7 @@ func (c *MergeJoinCache) join(left, right *execute.ColListTableBuilder) (flux.Ta
 
 	// Perform sort merge join
 	for !leftSet.Empty() && !rightSet.Empty() {
-		if equalJoinkeys(leftKey, rightKey) {
-
+		if leftKey.EqualTrueNulls(rightKey) {
 			for l := leftSet.Start; l < leftSet.Stop; l++ {
 				for r := rightSet.Start; r < rightSet.Stop; r++ {
 

--- a/stdlib/universe/join_unsorted_columns_test.flux
+++ b/stdlib/universe/join_unsorted_columns_test.flux
@@ -4,43 +4,15 @@ package universe_test
 import "array"
 import "testing"
 
-lhs = array.from(
-    rows: [
-        {interface: "port1", router: "router1", _value: 123},
-        {interface: "port1", router: "router2", _value: 855},
-        {interface: "port2", router: "router1", _value: 1235},
-        {interface: "port2", router: "router2", _value: 2432},
-    ],
-)
+lhs = array.from(rows: [{interface: "port1", router: "router1", _value: 123}, {interface: "port1", router: "router2", _value: 855}, {interface: "port2", router: "router1", _value: 1235}, {interface: "port2", router: "router2", _value: 2432}])
 
-rhs = array.from(
-    rows: [
-        {router: "router1", interface: "port1", data: "acme corp"},
-        {router: "router1", interface: "port2", data: "foo corp"},
-        {router: "router2", interface: "port2", data: "foo corp"},
-        {router: "router2", interface: "port1", data: "bar corp"},
-    ],
-)
+rhs = array.from(rows: [{router: "router1", interface: "port1", data: "acme corp"}, {router: "router1", interface: "port2", data: "foo corp"}, {router: "router2", interface: "port2", data: "foo corp"}, {router: "router2", interface: "port1", data: "bar corp"}])
 
 testcase join_many_groups_to_one {
-    want = array.from(
-        rows: [
-            {interface: "port1", router: "router1", _value: 123, data: "acme corp"},
-            {interface: "port1", router: "router2", _value: 855, data: "bar corp"},
-            {interface: "port2", router: "router1", _value: 1235, data: "foo corp"},
-            {interface: "port2", router: "router2", _value: 2432, data: "foo corp"},
-        ],
-    )
+    want = array.from(rows: [{interface: "port1", router: "router1", _value: 123, data: "acme corp"}, {interface: "port1", router: "router2", _value: 855, data: "bar corp"}, {interface: "port2", router: "router1", _value: 1235, data: "foo corp"}, {interface: "port2", router: "router2", _value: 2432, data: "foo corp"}])
         |> group(columns: ["interface", "router"])
 
-    left = lhs
-        |> group(
-            columns: [
-                "interface",
-                "router",
-            ],
-        )
-
+    left = lhs |> group(columns: ["interface", "router"])
     right = rhs |> group(columns: [])
 
     got = join(tables: {left: left, right: right}, on: ["router", "interface"])
@@ -49,14 +21,7 @@ testcase join_many_groups_to_one {
 }
 
 testcase join_one_to_one {
-    want = array.from(
-        rows: [
-            {interface: "port1", router: "router1", _value: 123, data: "acme corp"},
-            {interface: "port1", router: "router2", _value: 855, data: "bar corp"},
-            {interface: "port2", router: "router1", _value: 1235, data: "foo corp"},
-            {interface: "port2", router: "router2", _value: 2432, data: "foo corp"},
-        ],
-    )
+    want = array.from(rows: [{interface: "port1", router: "router1", _value: 123, data: "acme corp"}, {interface: "port1", router: "router2", _value: 855, data: "bar corp"}, {interface: "port2", router: "router1", _value: 1235, data: "foo corp"}, {interface: "port2", router: "router2", _value: 2432, data: "foo corp"}])
         |> group(columns: [])
 
     left = lhs |> group(columns: [])

--- a/stdlib/universe/join_unsorted_columns_test.flux
+++ b/stdlib/universe/join_unsorted_columns_test.flux
@@ -1,0 +1,68 @@
+package universe_test
+
+
+import "array"
+import "testing"
+
+lhs = array.from(
+    rows: [
+        {interface: "port1", router: "router1", _value: 123},
+        {interface: "port1", router: "router2", _value: 855},
+        {interface: "port2", router: "router1", _value: 1235},
+        {interface: "port2", router: "router2", _value: 2432},
+    ],
+)
+
+rhs = array.from(
+    rows: [
+        {router: "router1", interface: "port1", data: "acme corp"},
+        {router: "router1", interface: "port2", data: "foo corp"},
+        {router: "router2", interface: "port2", data: "foo corp"},
+        {router: "router2", interface: "port1", data: "bar corp"},
+    ],
+)
+
+testcase join_many_groups_to_one {
+    want = array.from(
+        rows: [
+            {interface: "port1", router: "router1", _value: 123, data: "acme corp"},
+            {interface: "port1", router: "router2", _value: 855, data: "bar corp"},
+            {interface: "port2", router: "router1", _value: 1235, data: "foo corp"},
+            {interface: "port2", router: "router2", _value: 2432, data: "foo corp"},
+        ],
+    )
+        |> group(columns: ["interface", "router"])
+
+    left = lhs
+        |> group(
+            columns: [
+                "interface",
+                "router",
+            ],
+        )
+
+    right = rhs |> group(columns: [])
+
+    got = join(tables: {left: left, right: right}, on: ["router", "interface"])
+
+    testing.diff(want: want, got: got)
+}
+
+testcase join_one_to_one {
+    want = array.from(
+        rows: [
+            {interface: "port1", router: "router1", _value: 123, data: "acme corp"},
+            {interface: "port1", router: "router2", _value: 855, data: "bar corp"},
+            {interface: "port2", router: "router1", _value: 1235, data: "foo corp"},
+            {interface: "port2", router: "router2", _value: 2432, data: "foo corp"},
+        ],
+    )
+        |> group(columns: [])
+
+    left = lhs |> group(columns: [])
+    right = rhs |> group(columns: [])
+
+    got = join(tables: {left: left, right: right}, on: ["router", "interface"])
+
+    testing.diff(want: want, got: got)
+}


### PR DESCRIPTION
Fixes #4150

~This patch takes advantage of the fact that `execute.groupKey` already has a list of sorted indices that can be used to access its elements in lexicographical order, without altering the underlying contents. It introduces a new `SortedGroupKey` interface, which functions much like the normal `GroupKey` interface, except that its public methods always operate on sorted columns.~

EDIT: This patch adds a new method to the `GroupKey` interface called `EqualTrueNulls`, which should be functionally identical to `Equal`, except that it never counts two nulls as equal. This new method is then used to compare the join keys for `universe.join` (thereby replacing the problematic `equalJoinkeys` function) as a solution to #4150.

The key to reproducing the original bug is to pay attention to the order in which columns are arranged in a table. If the columns are sorted in lexicographical order, there is no problem. If they are not, we get no output.

As an example, consider the following two flux scripts. They are almost identical, but only the first one yields a table.

Script 1:
```
import "array"

lhs = array.from(
    rows: [
        {interface: "port1", router: "router1", _value: 123},
        {interface: "port1", router: "router2", _value: 855},
        {interface: "port2", router: "router1", _value: 1235},
        {interface: "port2", router: "router2", _value: 2432},
    ],
)
    |> group(
        columns: [
            "interface",
            "router",
        ],
    )

rhs = array.from(
    rows: [
        {interface: "port1", router: "router1", data: "acme corp"},
        {interface: "port2", router: "router1", data: "foo corp"},
        {interface: "port2", router: "router2", data: "foo corp"},
        {interface: "port1", router: "router2", data: "bar corp"},
    ],
)

join(tables: {left: lhs, right: rhs}, on: ["router", "interface"])
```

Script 2:
```
import "array"

lhs = array.from(
    rows: [
        {interface: "port1", router: "router1", _value: 123},
        {interface: "port1", router: "router2", _value: 855},
        {interface: "port2", router: "router1", _value: 1235},
        {interface: "port2", router: "router2", _value: 2432},
    ],
)
    |> group(
        columns: [
            "interface",
            "router",
        ],
    )

rhs = array.from(
    rows: [
        {router: "router1", interface: "port1", data: "acme corp"},
        {router: "router1", interface: "port2", data: "foo corp"},
        {router: "router2", interface: "port2", data: "foo corp"},
        {router: "router2", interface: "port1", data: "bar corp"},
    ],
)

join(tables: {left: lhs, right: rhs}, on: ["router", "interface"])
```

The problem was that some parts of the join transformation operated on join keys with sorted columns, and others operated on join keys with unsorted columns. This caused some strange behavior when comparing or checking for equality between two join keys, since `[port1 router1] != [router1 port1]`.

This patch makes both of these scripts produce the same output.