### PR TITLE
chore: ast: implement DurationLiteral.String

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -1712,6 +1713,17 @@ func (l *DurationLiteral) Copy() Node {
 		copy(nl.Values, l.Values)
 	}
 	return nl
+}
+
+// String implements fmt.Stringer by returning
+// the duration formatted as its Flux representation.
+func (n *DurationLiteral) String() string {
+	builder := strings.Builder{}
+	for _, d := range n.Values {
+		builder.WriteString(strconv.FormatInt(d.Magnitude, 10))
+		builder.WriteString(d.Unit)
+	}
+	return builder.String()
 }
 
 // Duration gives you a DurationLiteral from a time.Duration.

--- a/ast/duration_test.go
+++ b/ast/duration_test.go
@@ -1,0 +1,64 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/ast"
+)
+
+func TestDurationLiteralString(t *testing.T) {
+	t.Run("format negative duration", func(t *testing.T) {
+		node := &ast.DurationLiteral{
+			Values: []ast.Duration{
+				{
+					Magnitude: -1,
+					Unit:      "d",
+				},
+				{
+					Magnitude: -2,
+					Unit:      "h",
+				},
+				{
+					Magnitude: -1,
+					Unit:      "m",
+				},
+				{
+					Magnitude: -3,
+					Unit:      "s",
+				},
+			},
+		}
+		durs := node.String()
+		if diff := cmp.Diff("-1d-2h-1m-3s", durs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("format duration", func(t *testing.T) {
+		node := &ast.DurationLiteral{
+			Values: []ast.Duration{
+				{
+					Magnitude: 1,
+					Unit:      "d",
+				},
+				{
+					Magnitude: 2,
+					Unit:      "h",
+				},
+				{
+					Magnitude: 1,
+					Unit:      "m",
+				},
+				{
+					Magnitude: 3,
+					Unit:      "s",
+				},
+			},
+		}
+		durs := node.String()
+		if diff := cmp.Diff("1d2h1m3s", durs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}

--- a/parser/strconv.go
+++ b/parser/strconv.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"strconv"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/influxdata/flux/ast"
@@ -52,12 +50,7 @@ func ParseDuration(lit string) (*ast.DurationLiteral, error) {
 
 // FormatDuration will convert DurationLiteral into formatted string representation
 func FormatDuration(n *ast.DurationLiteral) string {
-	builder := strings.Builder{}
-	for _, d := range n.Values {
-		builder.WriteString(strconv.FormatInt(d.Magnitude, 10))
-		builder.WriteString(d.Unit)
-	}
-	return builder.String()
+	return n.String()
 }
 
 // ParseString removes quotes and unescapes the string literal.


### PR DESCRIPTION
Currently, to format a Duration, it's necessary to import the `parser`
package, which is a heavyweight dependency because it imports
the Rust Flux parser.

To avoid that necessity, move the `parser.FormatDuration` code into `DurationLiteral.String`
and implement `parser.FormatDuration` in terms of that.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
