### PR TITLE
chore: factor testcase transformation out of edit package

### DIFF
--- a/ast/edit/forward.go
+++ b/ast/edit/forward.go
@@ -1,0 +1,69 @@
+// Package edit provides support for editing AST trees.
+//
+// It's a thin wrapper over the editlite and testcase packages,
+// maintained to keep API compatibility.
+//
+// See those packages for documentation.
+package edit
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/ast/editlite"
+	"github.com/influxdata/flux/ast/testcase"
+)
+
+func TestcaseTransform(ctx context.Context, pkg *ast.Package, modules testcase.TestModules) ([]string, []*ast.Package, error) {
+	return testcase.Transform(ctx, pkg, modules)
+}
+
+type TestModules = testcase.TestModules
+
+var OptionNotFoundError = editlite.OptionNotFoundError
+
+func DeleteOption(file *ast.File, name string) {
+	editlite.DeleteOption(file, name)
+}
+
+func DeleteProperty(obj *ast.ObjectExpression, key string) {
+	editlite.DeleteProperty(obj, key)
+}
+
+func GetOption(file *ast.File, name string) (ast.Expression, error) {
+	return editlite.GetOption(file, name)
+}
+
+func GetProperty(obj *ast.ObjectExpression, key string) (ast.Expression, error) {
+	return editlite.GetProperty(obj, key)
+}
+
+func HasDuplicateOptions(file *ast.File, name string) bool {
+	return editlite.HasDuplicateOptions(file, name)
+}
+
+func Match(node ast.Node, pattern ast.Node, matchSlicesFuzzy bool) []ast.Node {
+	return editlite.Match(node, pattern, matchSlicesFuzzy)
+}
+
+func Option(node ast.Node, optionIdentifier string, fn OptionFn) (bool, error) {
+	return editlite.Option(node, optionIdentifier, fn)
+}
+
+func SetOption(file *ast.File, name string, expr ast.Expression) {
+	editlite.SetOption(file, name, expr)
+}
+
+func SetProperty(obj *ast.ObjectExpression, key string, value ast.Expression) {
+	editlite.SetProperty(obj, key, value)
+}
+
+type OptionFn = editlite.OptionFn
+
+func OptionObjectFn(keyMap map[string]ast.Expression) OptionFn {
+	return editlite.OptionObjectFn(keyMap)
+}
+
+func OptionValueFn(expr ast.Expression) OptionFn {
+	return editlite.OptionValueFn(expr)
+}

--- a/ast/editlite/match.go
+++ b/ast/editlite/match.go
@@ -1,4 +1,4 @@
-package edit
+package editlite
 
 import (
 	"fmt"

--- a/ast/editlite/match_test.go
+++ b/ast/editlite/match_test.go
@@ -1,4 +1,4 @@
-package edit_test
+package editlite_test
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/asttest"
-	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/ast/editlite"
 )
 
 func TestMatch(t *testing.T) {
@@ -912,7 +912,7 @@ func TestMatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ms := edit.Match(tc.in, tc.match, tc.fuzzy)
+			ms := editlite.Match(tc.in, tc.match, tc.fuzzy)
 			if !cmp.Equal(tc.result, ms, asttest.IgnoreBaseNodeOptions...) {
 				t.Errorf("unexpected match result: -want/+got:\n%s", cmp.Diff(tc.result, ms, asttest.IgnoreBaseNodeOptions...))
 			}

--- a/ast/editlite/option_editor.go
+++ b/ast/editlite/option_editor.go
@@ -1,4 +1,4 @@
-package edit
+package editlite
 
 import (
 	"fmt"

--- a/ast/editlite/option_editor_test.go
+++ b/ast/editlite/option_editor_test.go
@@ -1,11 +1,11 @@
-package edit_test
+package editlite_test
 
 import (
 	"testing"
 
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/astutil"
-	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/ast/editlite"
 	"github.com/influxdata/flux/parser"
 	"github.com/influxdata/flux/values"
 )
@@ -25,7 +25,7 @@ func TestEditor(t *testing.T) {
     |> range(start: 2018-05-23T13:09:22.885021542Z)`,
 			unchanged: true,
 			edit: func(node ast.Node) (bool, error) {
-				return edit.Option(node, "from", nil)
+				return editlite.Option(node, "from", nil)
 			},
 		},
 		{
@@ -33,7 +33,7 @@ func TestEditor(t *testing.T) {
 			in:        `option foo = 1`,
 			unchanged: true,
 			edit: func(node ast.Node) (bool, error) {
-				return edit.Option(node, "bar", nil)
+				return editlite.Option(node, "bar", nil)
 			},
 		},
 		{
@@ -42,7 +42,7 @@ func TestEditor(t *testing.T) {
 			edited: `option alert.state = 1`,
 			edit: func(node ast.Node) (bool, error) {
 				literal := &ast.IntegerLiteral{Value: int64(1)}
-				return edit.Option(node, "alert.state", edit.OptionValueFn(literal))
+				return editlite.Option(node, "alert.state", editlite.OptionValueFn(literal))
 			},
 		},
 		{
@@ -53,7 +53,7 @@ option bar = 1`,
 option bar = 42`,
 			edit: func(node ast.Node) (bool, error) {
 				literal := &ast.IntegerLiteral{Value: int64(42)}
-				return edit.Option(node, "bar", edit.OptionValueFn(literal))
+				return editlite.Option(node, "bar", editlite.OptionValueFn(literal))
 			},
 		},
 		{
@@ -83,7 +83,7 @@ option task = {
 				if err != nil {
 					t.Fatal(err)
 				}
-				return edit.Option(node, "task", edit.OptionObjectFn(map[string]ast.Expression{
+				return editlite.Option(node, "task", editlite.OptionObjectFn(map[string]ast.Expression{
 					"every": every,
 					"delay": delay,
 					"cron":  &ast.StringLiteral{Value: "buz"},
@@ -115,7 +115,7 @@ option task = {
 				if err != nil {
 					t.Fatal(err)
 				}
-				return edit.Option(node, "task", edit.OptionObjectFn(map[string]ast.Expression{
+				return editlite.Option(node, "task", editlite.OptionObjectFn(map[string]ast.Expression{
 					"foo":   &ast.StringLiteral{Value: "foo"}, // should add a foo string
 					"every": every,
 				}))
@@ -132,7 +132,7 @@ option task = {
 					&ast.IntegerLiteral{Value: 3},
 					&ast.IntegerLiteral{Value: 4},
 				}}
-				return edit.Option(node, "foo", edit.OptionValueFn(literal))
+				return editlite.Option(node, "foo", editlite.OptionValueFn(literal))
 			},
 		},
 		{
@@ -149,7 +149,7 @@ option task = {
 						Value: &ast.StringLiteral{Value: "y"},
 					},
 					}}
-				return edit.Option(node, "foo", edit.OptionValueFn(literal))
+				return editlite.Option(node, "foo", editlite.OptionValueFn(literal))
 			},
 		},
 		{
@@ -191,7 +191,7 @@ option task = {
 						Value: z,
 					},
 					}}
-				return edit.Option(node, "foo", edit.OptionValueFn(literal))
+				return editlite.Option(node, "foo", editlite.OptionValueFn(literal))
 			},
 		},
 		{
@@ -208,7 +208,7 @@ option task = {
 						},
 					}}},
 				}
-				return edit.Option(node, "location", edit.OptionValueFn(literal))
+				return editlite.Option(node, "location", editlite.OptionValueFn(literal))
 			},
 		},
 		{
@@ -225,7 +225,7 @@ option task = {
 					Params: []*ast.Property{},
 					Body:   &ast.DateTimeLiteral{Value: t.Time()},
 				}
-				return edit.Option(node, "now", edit.OptionValueFn(literal))
+				return editlite.Option(node, "now", editlite.OptionValueFn(literal))
 			},
 		},
 	}

--- a/ast/editlite/task_editor.go
+++ b/ast/editlite/task_editor.go
@@ -1,4 +1,4 @@
-package edit
+package editlite
 
 import (
 	"github.com/influxdata/flux"

--- a/ast/editlite/task_editor_test.go
+++ b/ast/editlite/task_editor_test.go
@@ -1,4 +1,4 @@
-package edit_test
+package editlite_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/asttest"
-	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/ast/editlite"
 	"github.com/influxdata/flux/parser"
 )
 
@@ -18,9 +18,9 @@ func TestGetOptionBlockMissing(t *testing.T) {
 	f := parser.ParseSource(src).Files[0]
 
 	// here GetOption will return nil, OptionNotFoundError
-	_, err := edit.GetOption(f, "task")
-	if err != edit.OptionNotFoundError {
-		t.Errorf("expected err == edit.OptionNotFoundError but found err == : %v", err)
+	_, err := editlite.GetOption(f, "task")
+	if err != editlite.OptionNotFoundError {
+		t.Errorf("expected err == editlite.OptionNotFoundError but found err == : %v", err)
 	}
 }
 
@@ -29,12 +29,12 @@ func TestGetOptionProperty(t *testing.T) {
 
 	f := parser.ParseSource(src).Files[0]
 
-	obj, err := edit.GetOption(f, "task")
+	obj, err := editlite.GetOption(f, "task")
 	if err != nil {
 		t.Fatalf("unexpected error retrieving option: %v", err)
 	}
 
-	expr, err := edit.GetProperty(obj.(*ast.ObjectExpression), "b")
+	expr, err := editlite.GetProperty(obj.(*ast.ObjectExpression), "b")
 	if err != nil {
 		t.Fatalf("unexpected error retrieving property: %v", err)
 	}
@@ -103,7 +103,7 @@ func TestGetOption(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			got, err := edit.GetOption(tc.file, tc.optionID)
+			got, err := editlite.GetOption(tc.file, tc.optionID)
 			if err != nil {
 				t.Errorf("unexpected error %s", err)
 			}
@@ -261,9 +261,9 @@ func TestSetDeleteOption(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			switch tc.testType {
 			case "setOption":
-				edit.SetOption(tc.got, tc.optionID, tc.opt)
+				editlite.SetOption(tc.got, tc.optionID, tc.opt)
 			case "deleteOption":
-				edit.DeleteOption(tc.got, tc.optionID)
+				editlite.DeleteOption(tc.got, tc.optionID)
 			default:
 				t.Fatal("Test type must be set to 'setOption' or 'deleteOption'.")
 			}
@@ -321,7 +321,7 @@ func TestGetProperty(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			got, err := edit.GetProperty(tc.obj, tc.key)
+			got, err := editlite.GetProperty(tc.obj, tc.key)
 			if err != nil {
 				t.Errorf("unexpected error %s", err)
 			}
@@ -524,9 +524,9 @@ func TestSetDeleteProperty(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			switch tc.testType {
 			case "setProperty":
-				edit.SetProperty(tc.obj, tc.key, tc.value)
+				editlite.SetProperty(tc.obj, tc.key, tc.value)
 			case "deleteProperty":
-				edit.DeleteProperty(tc.obj, tc.key)
+				editlite.DeleteProperty(tc.obj, tc.key)
 			default:
 				t.Fatal("Test type must be set to 'setProperty' or 'deleteProperty'.")
 			}
@@ -608,7 +608,7 @@ func TestHasDuplicateOptions(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			hasDuplicates := edit.HasDuplicateOptions(tc.file, tc.optionID)
+			hasDuplicates := editlite.HasDuplicateOptions(tc.file, tc.optionID)
 
 			if tc.wantDuplicates != hasDuplicates {
 				t.Errorf("Mismatch in duplicate expectation want=%t got=%t", tc.wantDuplicates, hasDuplicates)

--- a/ast/testcase/testcase.go
+++ b/ast/testcase/testcase.go
@@ -1,4 +1,4 @@
-package edit
+package testcase
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/flux/parser"
 )
 
-// TestcaseTransform will transform an *ast.Package into a set of *ast.Package values
+// Transform will transform an *ast.Package into a set of *ast.Package values
 // that represent each testcase defined within the original package.
 //
 // A testcase is defined with the testcase statement such as below.
@@ -66,7 +66,7 @@ import (
 // It is allowed for an imported testcase to have an option, but no attempt is made
 // to remove duplicate options. If there is a duplicate option, this will likely
 // cause an error when the test is actually run.
-func TestcaseTransform(ctx context.Context, pkg *ast.Package, modules TestModules) ([]string, []*ast.Package, error) {
+func Transform(ctx context.Context, pkg *ast.Package, modules TestModules) ([]string, []*ast.Package, error) {
 	if len(pkg.Files) != 1 {
 		return nil, nil, errors.Newf(codes.FailedPrecondition, "unsupported number of files in test case package, got %d", len(pkg.Files))
 	}

--- a/ast/testcase/testcase_test.go
+++ b/ast/testcase/testcase_test.go
@@ -1,4 +1,4 @@
-package edit_test
+package testcase_test
 
 import (
 	"context"
@@ -12,12 +12,12 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/asttest"
 	"github.com/influxdata/flux/ast/astutil"
-	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/ast/testcase"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/parser"
 )
 
-func TestTestcaseTransform(t *testing.T) {
+func TestTransform(t *testing.T) {
 	expected := []*ast.Package{
 		parser.ParseSource(`package main
 
@@ -27,7 +27,7 @@ myVar = 4
 
 testing.assertEqual(got: 2 + 2, want: 4)`),
 		parser.ParseSource(`package main
-		
+
 import "testing"
 
 myVar = 4
@@ -51,7 +51,7 @@ testcase test_subtraction {
 
 	d := parser.ParseSource(testFile)
 
-	names, transformed, err := edit.TestcaseTransform(context.Background(), d, nil)
+	names, transformed, err := testcase.Transform(context.Background(), d, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ testcase test_subtraction {
 	}
 }
 
-func TestTestcaseTransformNoTestcase(t *testing.T) {
+func TestTransformNoTestcase(t *testing.T) {
 	testFile := `package an_test
 
 import "testing"
@@ -73,7 +73,7 @@ myVar = 4`
 
 	d := parser.ParseSource(testFile)
 
-	_, transformed, err := edit.TestcaseTransform(context.Background(), d, nil)
+	_, transformed, err := testcase.Transform(context.Background(), d, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ myVar = 4`
 	}
 }
 
-func TestTestcaseTransformImport(t *testing.T) {
+func TestTransformImport(t *testing.T) {
 	fs := &memoryFilesystem{
 		files: map[string]string{
 			"a/a_test.flux": `package a_test
@@ -114,7 +114,7 @@ testcase b extends "flux/a/a_test" {
 	}
 	pkg.Files[0].Name = "b/b_test.flux"
 
-	names, pkgs, err := edit.TestcaseTransform(ctx, pkg, edit.TestModules{
+	names, pkgs, err := testcase.Transform(ctx, pkg, testcase.TestModules{
 		"flux": fs,
 	})
 	if err != nil {


### PR DESCRIPTION
The testcase code is the only part of the edit package that depends on
the Flux parser. We'd like to be able to import it without depending on
the parser, so split it out into its own `testcase` package.

To maintain full backward API compatibility, we move all but the
`TestcaseTransform` code into a new `editlite` package and redefine
the `edit` package as a lightweight forwarder on top of `editlite` and
`testcase`.

If it's OK to break backward compatibility for this (for example because
we're pretty sure that no external users are using the `TestcaseTransform`
function, we could just change the existing `edit` package instead.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
