### PR TITLE
chore: factor testcase transformation out of edit package

### DIFF
--- a/ast/testcase/testcase.go
+++ b/ast/testcase/testcase.go
@@ -1,4 +1,4 @@
-package edit
+package testcase
 
 import (
 	"context"
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/flux/parser"
 )
 
-// TestcaseTransform will transform an *ast.Package into a set of *ast.Package values
+// Transform will transform an *ast.Package into a set of *ast.Package values
 // that represent each testcase defined within the original package.
 //
 // A testcase is defined with the testcase statement such as below.
@@ -66,7 +66,7 @@ import (
 // It is allowed for an imported testcase to have an option, but no attempt is made
 // to remove duplicate options. If there is a duplicate option, this will likely
 // cause an error when the test is actually run.
-func TestcaseTransform(ctx context.Context, pkg *ast.Package, modules TestModules) ([]string, []*ast.Package, error) {
+func Transform(ctx context.Context, pkg *ast.Package, modules TestModules) ([]string, []*ast.Package, error) {
 	if len(pkg.Files) != 1 {
 		return nil, nil, errors.Newf(codes.FailedPrecondition, "unsupported number of files in test case package, got %d", len(pkg.Files))
 	}

--- a/ast/testcase/testcase_test.go
+++ b/ast/testcase/testcase_test.go
@@ -1,4 +1,4 @@
-package edit_test
+package testcase_test
 
 import (
 	"context"
@@ -12,12 +12,12 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/asttest"
 	"github.com/influxdata/flux/ast/astutil"
-	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/ast/testcase"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/parser"
 )
 
-func TestTestcaseTransform(t *testing.T) {
+func TestTransform(t *testing.T) {
 	expected := []*ast.Package{
 		parser.ParseSource(`package main
 
@@ -27,7 +27,7 @@ myVar = 4
 
 testing.assertEqual(got: 2 + 2, want: 4)`),
 		parser.ParseSource(`package main
-		
+
 import "testing"
 
 myVar = 4
@@ -51,7 +51,7 @@ testcase test_subtraction {
 
 	d := parser.ParseSource(testFile)
 
-	names, transformed, err := edit.TestcaseTransform(context.Background(), d, nil)
+	names, transformed, err := testcase.Transform(context.Background(), d, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ testcase test_subtraction {
 	}
 }
 
-func TestTestcaseTransformNoTestcase(t *testing.T) {
+func TestTransformNoTestcase(t *testing.T) {
 	testFile := `package an_test
 
 import "testing"
@@ -73,7 +73,7 @@ myVar = 4`
 
 	d := parser.ParseSource(testFile)
 
-	_, transformed, err := edit.TestcaseTransform(context.Background(), d, nil)
+	_, transformed, err := testcase.Transform(context.Background(), d, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ myVar = 4`
 	}
 }
 
-func TestTestcaseTransformImport(t *testing.T) {
+func TestTransformImport(t *testing.T) {
 	fs := &memoryFilesystem{
 		files: map[string]string{
 			"a/a_test.flux": `package a_test
@@ -114,7 +114,7 @@ testcase b extends "flux/a/a_test" {
 	}
 	pkg.Files[0].Name = "b/b_test.flux"
 
-	names, pkgs, err := edit.TestcaseTransform(ctx, pkg, edit.TestModules{
+	names, pkgs, err := testcase.Transform(ctx, pkg, testcase.TestModules{
 		"flux": fs,
 	})
 	if err != nil {

--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
-	"github.com/influxdata/flux/ast/edit"
+	"github.com/influxdata/flux/ast/testcase"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/testing"
@@ -140,12 +140,12 @@ func NewTestRunner(reporter TestReporter) TestRunner {
 	}
 }
 
-type gatherFunc func(filename string) ([]string, fs, edit.TestModules, error)
+type gatherFunc func(filename string) ([]string, fs, testcase.TestModules, error)
 
 // Gather gathers all tests from the filesystem and creates Test instances
 // from that info.
 func (t *TestRunner) Gather(roots []string, names []string) error {
-	var modules edit.TestModules
+	var modules testcase.TestModules
 	for _, root := range roots {
 		var gatherFrom gatherFunc
 		if strings.HasSuffix(root, ".tar.gz") || strings.HasSuffix(root, ".tar") {
@@ -181,7 +181,7 @@ func (t *TestRunner) Gather(roots []string, names []string) error {
 			if len(baseAST.Files) > 0 {
 				baseAST.Files[0].Name = file
 			}
-			tcnames, asts, err := edit.TestcaseTransform(ctx, baseAST, modules)
+			tcnames, asts, err := testcase.Transform(ctx, baseAST, modules)
 			if err != nil {
 				return err
 			}
@@ -196,7 +196,7 @@ func (t *TestRunner) Gather(roots []string, names []string) error {
 	return nil
 }
 
-func gatherFromTarArchive(filename string) ([]string, fs, edit.TestModules, error) {
+func gatherFromTarArchive(filename string) ([]string, fs, testcase.TestModules, error) {
 	var f io.ReadCloser
 	f, err := os.Open(filename)
 	if err != nil {
@@ -218,7 +218,7 @@ func gatherFromTarArchive(filename string) ([]string, fs, edit.TestModules, erro
 		tfs   = &tarfs{
 			files: make(map[string]*tarfile),
 		}
-		modules edit.TestModules
+		modules testcase.TestModules
 	)
 	archive := tar.NewReader(f)
 	for {
@@ -297,8 +297,8 @@ func (t *tarfile) Stat() (os.FileInfo, error) {
 	return t.info, nil
 }
 
-func gatherFromZipArchive(filename string) ([]string, fs, edit.TestModules, error) {
-	var modules edit.TestModules
+func gatherFromZipArchive(filename string) ([]string, fs, testcase.TestModules, error) {
+	var modules testcase.TestModules
 
 	f, err := os.Open(filename)
 	if err != nil {
@@ -413,10 +413,10 @@ func (s prefixfs) Open(fpath string) (filesystem.File, error) {
 	return s.fs.Open(fpath)
 }
 
-func gatherFromDir(filename string) ([]string, fs, edit.TestModules, error) {
+func gatherFromDir(filename string) ([]string, fs, testcase.TestModules, error) {
 	var (
 		files   []string
-		modules edit.TestModules
+		modules testcase.TestModules
 	)
 
 	// Find a test root above the root if it exists.
@@ -453,8 +453,8 @@ func gatherFromDir(filename string) ([]string, fs, edit.TestModules, error) {
 	return files, systemfs{}, modules, nil
 }
 
-func gatherFromFile(filename string) ([]string, fs, edit.TestModules, error) {
-	var modules edit.TestModules
+func gatherFromFile(filename string) ([]string, fs, testcase.TestModules, error) {
+	var modules testcase.TestModules
 
 	// Find a test root above the root if it exists.
 	if name, fs, ok, err := findParentTestRoot(filename); err != nil {


### PR DESCRIPTION
The testcase code is the only part of the edit package that depends on
the Flux parser. We'd like to be able to import it without depending on
the parser, so split it out into its own `testcase` package.

Note: this breaks backward compatibility for the `edit` package.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
