### PR TITLE
fix(dependencies/influxdb): handle http errors from influxdb writer

### DIFF
--- a/codes/codes.go
+++ b/codes/codes.go
@@ -77,7 +77,7 @@ const (
 	PermissionDenied Code = 7
 
 	// ResourceExhausted indicates some resource has been exhausted, perhaps
-	// a per-user quota, or perhaps the the memory allocation limit has been
+	// a per-user quota, or perhaps the memory allocation limit has been
 	// reached.
 	ResourceExhausted Code = 8
 

--- a/dependencies/influxdb/http.go
+++ b/dependencies/influxdb/http.go
@@ -483,7 +483,7 @@ func newHttpWriter(writer *api.WriteAPIImpl) (*httpWriter, error) {
 		for err := range w.errChan {
 			if err != nil {
 				select {
-				case w.latestError <- err:
+				case w.latestError <- handleError(err):
 				default:
 				}
 			}


### PR DESCRIPTION
This handles http errors from the influxdb writer properly. It now
recognizes the http error type from the influxdb client library and
transforms it to an equivalent flux error using the same mechanism that
the read side uses.

It also has been expanded to handle the "too many requests" code that is
used for rate limiting and to categorize these as the equivalent code in
flux which is resource exhausted. This code gets translated back to
"invalid" when flux is run within influxdb.

Fixes #4180.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written