### PR TITLE
feat: Add erroring versions for each dependency

### DIFF
--- a/dependencies/bigtable/bigtable.go
+++ b/dependencies/bigtable/bigtable.go
@@ -7,6 +7,8 @@ import (
 
 	"cloud.google.com/go/bigtable"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 )
@@ -60,6 +62,13 @@ func (d DefaultProvider) NewClient(ctx context.Context, project, instance string
 		})),
 	}, opts...)
 	return bigtable.NewClient(ctx, project, instance, opts...)
+}
+
+// DefaultProvider is the default provider that uses the default bigtable client.
+type ErrorProvider struct{}
+
+func (ErrorProvider) NewClient(ctx context.Context, project, instance string, opts ...option.ClientOption) (*bigtable.Client, error) {
+	return nil, errors.New(codes.Invalid, "Provider.NewClient called on an error dependency")
 }
 
 // Forwarding types and functions for convenience.

--- a/dependencies/influxdb/provider.go
+++ b/dependencies/influxdb/provider.go
@@ -132,6 +132,23 @@ func (u UnimplementedProvider) WriterFor(ctx context.Context, conf Config) (Writ
 	return nil, errors.New(codes.Unimplemented, "influxdb writer has not been implemented")
 }
 
+// ErrorProvider provides default implementations for a Provider.
+// This implements all of the Provider methods by returning an error
+// with the code codes.Unimplemented.
+type ErrorProvider struct{}
+
+func (u ErrorProvider) ReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error) {
+	return nil, errors.New(codes.Invalid, "Provider.ReaderFor called on an error dependency")
+}
+
+func (u ErrorProvider) SeriesCardinalityReaderFor(ctx context.Context, conf Config, bounds flux.Bounds, predicateSet PredicateSet) (Reader, error) {
+	return nil, errors.New(codes.Invalid, "Provider.SeriesCardinalityReaderFor called on an error dependency")
+}
+
+func (u ErrorProvider) WriterFor(ctx context.Context, conf Config) (Writer, error) {
+	return nil, errors.New(codes.Invalid, "Provider.WriterFor called on an error dependency")
+}
+
 // NameOrID signifies the name of an organization/bucket
 // or an ID for an organization/bucket.
 type NameOrID struct {

--- a/dependencies/mqtt/mqtt.go
+++ b/dependencies/mqtt/mqtt.go
@@ -139,3 +139,10 @@ func (d *defaultClient) Close() error {
 	d.client.Disconnect(250)
 	return nil
 }
+
+// ErrorDialer is the default dialer that uses the default mqtt client.
+type ErrorDialer struct{}
+
+func (d ErrorDialer) Dial(ctx context.Context, brokers []string, options Options) (Client, error) {
+	return nil, errors.New(codes.Invalid, "Dialer.Dial called on an error dependency")
+}

--- a/dependencies/url/validator.go
+++ b/dependencies/url/validator.go
@@ -82,3 +82,13 @@ func isPrivateIP(ip net.IP) bool {
 	}
 	return false
 }
+
+type ErrorValidator struct{}
+
+func (ErrorValidator) Validate(*url.URL) error {
+	return errors.New(codes.Invalid, "Validator.Validate called on an error dependency")
+}
+
+func (ErrorValidator) ValidateIP(net.IP) error {
+	return errors.New(codes.Invalid, "Validator.ValidateIP called on an error dependency")
+}


### PR DESCRIPTION
Trying to wrap my head around how dependencies work and I think I added these as #4147 prescribes.

I am a bit worried about how dependencies are provided/accessed however. It seems that the `func GetProvider` (or equivalent) defaults to returning the default implementation that has side effects. So if you forget to specify these added error versions you will unwittingly run with side effects. We may want to change this to return erroring dependencies by default or we could change the `func init` for these packages such that they take the `Provider`  explicitly as an argument instead so that callers have to be explicit about what they need. (On another, but similiar note, I would argue that we should also remove the `Default` runtime and instead take that as an argument to all of the `init` functions.)

Closes #4147

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
