### PR TITLE
feat(fluxdoc): Allow reporting unlimited diagnostics

### DIFF
--- a/libflux/flux-core/src/bin/fluxdoc.rs
+++ b/libflux/flux-core/src/bin/fluxdoc.rs
@@ -49,7 +49,7 @@ enum FluxDoc {
         dir: PathBuf,
         /// Limit the number of diagnostics to report. Default 10. 0 means no limit.
         #[structopt(short, long)]
-        limit: Option<isize>,
+        limit: Option<i64>,
         /// Honor the exception list.
         #[structopt(long)]
         allow_exceptions: bool,
@@ -156,7 +156,7 @@ fn dump(
 fn lint(
     stdlib_dir: Option<&Path>,
     dir: &Path,
-    limit: Option<isize>,
+    limit: Option<i64>,
     allow_exceptions: bool,
 ) -> Result<()> {
     let stdlib_dir = match stdlib_dir {
@@ -164,7 +164,7 @@ fn lint(
         None => Path::new(DEFAULT_STDLIB_PATH),
     };
     let limit = match limit {
-        Some(limit) if limit == 0 => isize::MAX,
+        Some(limit) if limit == 0 => i64::MAX,
         Some(limit) => limit,
         None => 10,
     };
@@ -175,9 +175,9 @@ fn lint(
     };
     let (_, mut diagnostics) = parse_docs(stdlib_dir, dir, exceptions)?;
     if !diagnostics.is_empty() {
-        let rest = diagnostics.len() - limit as usize;
+        let rest = diagnostics.len() as i64 - limit;
         println!("Found {} diagnostics", diagnostics.len());
-        diagnostics.truncate(limit);
+        diagnostics.truncate(limit as usize);
         for d in diagnostics {
             println!("{}", d);
         }

--- a/libflux/flux-core/src/bin/fluxdoc.rs
+++ b/libflux/flux-core/src/bin/fluxdoc.rs
@@ -49,7 +49,7 @@ enum FluxDoc {
         dir: PathBuf,
         /// Limit the number of diagnostics to report. Default 10. 0 means no limit.
         #[structopt(short, long)]
-        limit: Option<usize>,
+        limit: Option<isize>,
         /// Honor the exception list.
         #[structopt(long)]
         allow_exceptions: bool,
@@ -156,7 +156,7 @@ fn dump(
 fn lint(
     stdlib_dir: Option<&Path>,
     dir: &Path,
-    limit: Option<usize>,
+    limit: Option<isize>,
     allow_exceptions: bool,
 ) -> Result<()> {
     let stdlib_dir = match stdlib_dir {
@@ -164,7 +164,7 @@ fn lint(
         None => Path::new(DEFAULT_STDLIB_PATH),
     };
     let limit = match limit {
-        Some(limit) if limit == 0 => usize::MAX,
+        Some(limit) if limit == 0 => isize::MAX,
         Some(limit) => limit,
         None => 10,
     };
@@ -175,16 +175,13 @@ fn lint(
     };
     let (_, mut diagnostics) = parse_docs(stdlib_dir, dir, exceptions)?;
     if !diagnostics.is_empty() {
-        let rest = match limit {
-            usize::MAX => 0,
-            _ => diagnostics.len() - limit,
-        };
+        let rest = diagnostics.len() - limit as usize;
         println!("Found {} diagnostics", diagnostics.len());
         diagnostics.truncate(limit);
         for d in diagnostics {
             println!("{}", d);
         }
-        if rest > 0 && limit != usize::MAX {
+        if rest > 0 {
             println!("Hiding the remaining {} diagnostics", rest);
         }
         bail!("docs do not pass lint");

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -28,7 +28,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/walk/tests.rs":                                                     "f1570e25863b7aa4087549eadf37e6c04114c7a8b74a31e360cef0d6097b46b8",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "68d16ddef3a6c6f6db04a969cef91a0e22ee74ecc52e5f57905fde88ae2da87b",
-	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "c33717edde3027cc77a921b5e6d030255793eea8f50fb8afce3b154c7805eda5",
+	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "fa576747f8752bf2dc25d187da11c0b5e6bb015878263191b74711de2fd60d89",
 	"libflux/flux-core/src/doc/example.rs":                                                        "358eb2d5459b741e19f900cc35aba01098f78a6c75c3ffe60ef001632d49df02",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "6c528347f211c8393b45eb698b350258f14c9866e0f6bf3c85ea64b0e7603cd5",
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "b788647bd8472b62eb0c25f7f37295a76e5fb8f5ec94c9f1f39fa439e819c79d",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -28,7 +28,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/walk/tests.rs":                                                     "f1570e25863b7aa4087549eadf37e6c04114c7a8b74a31e360cef0d6097b46b8",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "68d16ddef3a6c6f6db04a969cef91a0e22ee74ecc52e5f57905fde88ae2da87b",
-	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "fa576747f8752bf2dc25d187da11c0b5e6bb015878263191b74711de2fd60d89",
+	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "3a350f6e9039445cfd58b27d1f79d386957e01e0e3c739b210e60f0535267779",
 	"libflux/flux-core/src/doc/example.rs":                                                        "358eb2d5459b741e19f900cc35aba01098f78a6c75c3ffe60ef001632d49df02",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "6c528347f211c8393b45eb698b350258f14c9866e0f6bf3c85ea64b0e7603cd5",
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "b788647bd8472b62eb0c25f7f37295a76e5fb8f5ec94c9f1f39fa439e819c79d",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -28,7 +28,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/walk/tests.rs":                                                     "f1570e25863b7aa4087549eadf37e6c04114c7a8b74a31e360cef0d6097b46b8",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "68d16ddef3a6c6f6db04a969cef91a0e22ee74ecc52e5f57905fde88ae2da87b",
-	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "34f755629bdf8d16aa5422afa39f77def72ed649704f701771b9018c8f69f335",
+	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "c33717edde3027cc77a921b5e6d030255793eea8f50fb8afce3b154c7805eda5",
 	"libflux/flux-core/src/doc/example.rs":                                                        "358eb2d5459b741e19f900cc35aba01098f78a6c75c3ffe60ef001632d49df02",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "6c528347f211c8393b45eb698b350258f14c9866e0f6bf3c85ea64b0e7603cd5",
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "b788647bd8472b62eb0c25f7f37295a76e5fb8f5ec94c9f1f39fa439e819c79d",


### PR DESCRIPTION
User can pass `--limit=0` to display all errors.