### PR TITLE
fix: Propagate the element type through array constructors

### DIFF
--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -517,7 +517,13 @@ func (itrp *Interpreter) doArray(ctx context.Context, a *semantic.ArrayExpressio
 		}
 		elements[i] = v
 	}
-	return values.NewArrayWithBacking(a.TypeOf(), elements), nil
+	arrayType := semantic.MonoType{}
+	if len(elements) > 0 {
+		arrayType = semantic.NewArrayType(elements[0].Type())
+	} else {
+		arrayType = a.TypeOf()
+	}
+	return values.NewArrayWithBacking(arrayType, elements), nil
 }
 
 func (itrp *Interpreter) doDict(ctx context.Context, e *semantic.DictExpression, scope values.Scope) (values.Value, error) {

--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -891,9 +891,10 @@ map(fn: (r) => ({ r with _value: if true and false then 1}) )
 "#,
     );
     let parsed = p.parse_file("".to_string());
-    expect_test::expect![[r#"error at @2:34-2:59: expected ELSE, got RBRACE (}) at 2:58"#]].assert_eq(
-        &ast::check::check(ast::walk::Node::File(&parsed))
-            .unwrap_err()
-            .to_string(),
-    );
+    expect_test::expect![[r#"error at @2:34-2:59: expected ELSE, got RBRACE (}) at 2:58"#]]
+        .assert_eq(
+            &ast::check::check(ast::walk::Node::File(&parsed))
+                .unwrap_err()
+                .to_string(),
+        );
 }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -67,6 +67,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/templates/value.html":                                                           "2af699af2535f83635acbc75c92d2ee941c2335350fc7e82ceb2dccf479360bf",
 	"libflux/include/influxdata/flux.h":                                                           "dc9556757c40e2a8557d535e8132e8bc0c88e371f2ac5eb2b7b1c0b236e92653",
 	"stdlib/array/array.flux":                                                                     "d06a0415f5f7999310675c433bd3f6a638e27bedf2efe4eab7bf7be76acaea8a",
+	"stdlib/array/array_test.flux":                                                                "649c3e017bca32c1cdbfef81288f84226dc5cac73be9975cb6b1286cd3637775",
 	"stdlib/array/from_group_test.flux":                                                           "029a60a7f16efd370bc0ff85f37a7d638d450903f143be83072bbc6c574c6e68",
 	"stdlib/array/from_test.flux":                                                                 "7876a2321474fa670bb81a2ab209e5ffab89dc0fd93f670f270bddbf99c1a071",
 	"stdlib/contrib/RohanSreerama5/naiveBayesClassifier/bayes_test.flux":                          "719b4d5b7d7edef97b4769ad797748a06dfb7a4ef321d0b320263441ae06bc79",

--- a/stdlib/array/array_test.flux
+++ b/stdlib/array/array_test.flux
@@ -1,0 +1,15 @@
+package array_test
+
+
+import "testing"
+import "array"
+
+fromElement = (v) => array.from(rows: [{v: v}])
+
+testcase fromElementTest {
+    want = fromElement(v: 123)
+    got = fromElement(v: 123)
+
+    testing.diff(want, got)
+        |> yield()
+}


### PR DESCRIPTION
Before it was just using the statically determined type which causes functions like `array.from` to fail as they would see the type variable from the generic function instead of the actual type.

Fixes #3858


### Done checklist
- [x] Test cases written
