### PR TITLE
chore: Add rust toolchain file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,9 +111,9 @@ jobs:
       - run:
           name: Pin rust version and install mingw rustup target
           command: |
-            RUST_VERSION=$(grep -Eo 'rust:[^ ]+' Dockerfile_build | cut -d: -f2)
+            RUST_VERSION=$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml)
             if [ -z "$RUST_VERSION" ]; then
-              echo "Error: couldn't parse Rust version from Dockerfile_build!"
+              echo "Error: couldn't parse Rust version from rust-toolchain.toml!"
               exit 1
             fi
             rustup default ${RUST_VERSION}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.55"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Per <https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file>
`rustup` will check cargo projects for a toolchain file and will fetch
the specified toolchain version if it isn't already present in
`$CARGO_HOME`.

In this, the toolchain file provides a _project-specific_ toolchain
override, allowing individual projects to be pinned to different
versions (if desired).

The intent here is to help unify the standards (lints) applied between
local dev and CI and also signal when a toolchain bump is expected.

Unlike the [earlier PR for flux-lsp](https://github.com/influxdata/flux-lsp/pull/332),
this diff pins to rust toolchain that is not currently "latest."
The project sources currently fail clippy lints added in 1.56, so this diff
pins to the version specified by the Dockerfile (which previously drove
toolchain selection).

A follow-up PR will bump the toolchain up to the 1.56 line and include fixes
for the new lints.