### PR TITLE
fix(stdlib): `length()` should not panic given a table stream

### DIFF
--- a/stdlib/universe/length.go
+++ b/stdlib/universe/length.go
@@ -2,8 +2,8 @@ package universe
 
 import (
 	"context"
-	"github.com/influxdata/flux"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"

--- a/stdlib/universe/length_test.go
+++ b/stdlib/universe/length_test.go
@@ -2,10 +2,10 @@ package universe_test
 
 import (
 	"context"
-	"github.com/influxdata/flux/runtime"
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"

--- a/stdlib/universe/length_test.go
+++ b/stdlib/universe/length_test.go
@@ -2,6 +2,7 @@ package universe_test
 
 import (
 	"context"
+	"github.com/influxdata/flux/runtime"
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
@@ -78,5 +79,18 @@ func lengthTestHelper(t *testing.T, tc lengthCase) {
 		t.Error(err.Error())
 	} else if result.Int() != int64(tc.expected) {
 		t.Error("expected %i, got %i", result.Int(), int64(tc.expected))
+	}
+}
+
+func TestLength_ReceiveTableObjectIsError(t *testing.T) {
+	src := `import "array"
+			length(arr: array.from(rows: [{}]))`
+	_, _, err := runtime.Eval(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+
+	if want, got := "error calling function \"length\" @2:4-2:39: arr must be an array, got table stream", err.Error(); want != got {
+		t.Errorf("wanted error %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
Avoid panicking when an array-like table stream is passed to the `length()` function. Instead emit a Flux error.

### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [x] Test cases written
