### PR TITLE
chore: Generate fluxdocs as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       - run: GOGC=50 make staticcheck
       - run: make libflux-wasm
       - run: make test GO_TEST_FLAGS='-coverprofile=coverage.txt -covermode=atomic'
+      - run: make fluxdocs
       - save_cache:
           name: Saving GOPATH/pkg/mod
           key: flux-gomod-{{checksum "go.sum"}}


### PR DESCRIPTION
Adds another step to the `test` job in the circle ci config that runs `make fluxdocs`. This way, we can catch errors like [this](https://app.circleci.com/pipelines/github/influxdata/flux/10963/workflows/60f039bd-a309-459e-ae9b-64f412ec1d73/jobs/34502) before we attempt to cut a release.
