### PR TITLE
chore(codeowners): use glob instead of root dir

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Automatically request review from a Flux team member for all changes
-/ @influxdata/flux-team
+* @influxdata/flux-team
 
 # Automatically request review from Flux and Docs teams for stdlib source changes
 *.flux @influxdata/flux-team @influxdata/docs-team


### PR DESCRIPTION
The `/` syntax didn't work using `*` as the examples show should work.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
