### PR TITLE
fix: add targets to rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.56"
 components = [ "rustfmt", "clippy" ]
+targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-musl" ]


### PR DESCRIPTION
As we're using `rust-toolchain.toml` to manage our toolchain, there's
some implicit changes that come along with it. In the case of cloud, the
build system is set up for rust 1.55, but when `rustup` sees the
toolchain file, it opts to use `1.56`, which doesn't have the components
needed in it. This patch specifically adds the targets for which we need
to fetch the stdlib.