### PR TITLE
chore: Add more targets to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,9 @@
 [toolchain]
 channel = "1.56"
 components = [ "rustfmt", "clippy" ]
-targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]
+targets = [
+	"wasm32-unknown-unknown",
+	"x86_64-unknown-linux-musl",
+	"aarch64-unknown-linux-musl"
+	"x86_64-pc-windows-gnu",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,6 +4,6 @@ components = [ "rustfmt", "clippy" ]
 targets = [
 	"wasm32-unknown-unknown",
 	"x86_64-unknown-linux-musl",
-	"aarch64-unknown-linux-musl"
+	"aarch64-unknown-linux-musl",
 	"x86_64-pc-windows-gnu",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.56"
 components = [ "rustfmt", "clippy" ]
-targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-musl" ]
+targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,4 +6,5 @@ targets = [
 	"x86_64-unknown-linux-musl",
 	"aarch64-unknown-linux-musl",
 	"x86_64-pc-windows-gnu",
+	"x86_64-apple-darwin",
 ]


### PR DESCRIPTION
~Attempting to address CI failures for the `v0.143.1` release in OSS: https://github.com/influxdata/influxdb/pull/22916~

This solves some of the CI failures we were seeing for the `v0.145.0` flux release.

PR here: https://github.com/influxdata/influxdb/pull/22972
Previous CI failures: https://app.circleci.com/pipelines/github/influxdata/influxdb/26288/workflows/97f36a33-418c-4622-b0eb-0e45831fe709