### PR TITLE
fix: set GOPATH in Dockerfile_build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       - image: quay.io/influxdb/flux-build:latest
     resource_class: large
     environment:
+      GOCACHE: /tmp/go-cache
       GOFLAGS: -p=8
+      GOPATH: /tmp/go
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
       SCCACHE_CACHE_SIZE: 1G
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,7 @@ jobs:
       - image: quay.io/influxdb/flux-build:latest
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
       GOFLAGS: -p=8
-      GOPATH: /tmp/go
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
       SCCACHE_CACHE_SIZE: 1G
     steps:

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -71,6 +71,7 @@ RUN groupadd -g $GID -o $UNAME
 RUN useradd -m -u $UID -g $UNAME -s /bin/bash $UNAME
 USER $UNAME
 ENV HOME=/home/$UNAME \
-    CARGO_HOME=/home/$UNAME/.cargo
+    CARGO_HOME=/home/$UNAME/.cargo \
+    GOPATH=/home/$UNAME/go
 
 WORKDIR $HOME


### PR DESCRIPTION
I think that this will address the `permission denied` failures that we've been seeing in the nightly integration tests.

It seems that the image `golang:1.17` is set up to run with user `root` and `GOPATH` set to `/go`.  However our build container creates a new user, but does not update `GOPATH`. So commands like `go get ...` will fail when they try to write with the Go cache.

I noticed that `.circleci/config.yml` sets `GOPATH` and `GOCACHE` explicitly, but it seems like just setting `GOPATH` is enough, and that we want to do that right in `Dockerfile_build` so it just works everywhere.

The only thing I can't figure out is how the nightly integration tests ever worked, since nothing seems to have changed recently to cause them to fail.