### PR TITLE
chore: remove redundant env vars from circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,7 @@ jobs:
       - image: quay.io/influxdb/flux-build:latest
     resource_class: large
     environment:
-      GOCACHE: /tmp/go-cache
       GOFLAGS: -p=8
-      GOPATH: /tmp/go
       GO111MODULE: 'on' # must be quoted to force string type instead of boolean type
       SCCACHE_CACHE_SIZE: 1G
     steps:


### PR DESCRIPTION
In #4298, `GOPATH` is set in the build dockerfile so that the logged in user has permissions to the Go cache.

In this PR, I'm removing the now redundant `GOPATH` and `GOCACHE` environment variables from the CircleCI config, since they are already set by `Dockerfile_build`. (By default, the Go cache seems to be put under `GOPATH`)