### PR TITLE
fix: `int`/`uint` widen to `int64`/`uint64` in `values.New()`

### DIFF
--- a/values/values.go
+++ b/values/values.go
@@ -223,8 +223,12 @@ func New(v interface{}) Value {
 		return NewString(v)
 	case []byte:
 		return NewBytes(v)
+	case int:
+		return NewInt(int64(v))
 	case int64:
 		return NewInt(v)
+	case uint:
+		return NewUInt(uint64(v))
 	case uint64:
 		return NewUInt(v)
 	case float64:


### PR DESCRIPTION
The vertica database driver (and perhaps others) will generate values of
`int` and `uint` which would previously be converted to `InvalidValue`
when passed to `values.New()`.

This patch handles arguments of these smaller types by casting them up
to the wider version when encountered.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
