### PR TITLE
fix: Don't alter the indentation of interpolated strings

### DIFF
--- a/libflux/flux-core/src/formatter/mod.rs
+++ b/libflux/flux-core/src/formatter/mod.rs
@@ -703,6 +703,12 @@ impl Formatter {
 
     fn format_text_part(&mut self, n: &ast::TextPart) {
         let escaped_string = self.escape_string(&n.value);
+
+        if escaped_string.contains('\n') {
+            self.unindent();
+            self.safe_to_reindent = false;
+        }
+
         self.write_string(&escaped_string);
     }
 

--- a/libflux/flux-core/src/formatter/mod.rs
+++ b/libflux/flux-core/src/formatter/mod.rs
@@ -93,7 +93,7 @@ impl Formatter {
                 self.clear = true;
             }
         }
-        (&mut self.builder).push_str(s);
+        self.builder.push_str(s);
     }
 
     fn write_rune(&mut self, c: char) {
@@ -106,7 +106,7 @@ impl Formatter {
         } else if c != '\t' && c != ' ' {
             self.clear = false;
         }
-        (&mut self.builder).push(c);
+        self.builder.push(c);
     }
 
     fn write_indent(&mut self) {
@@ -1259,8 +1259,7 @@ impl Formatter {
         if !(s.contains('\"') || s.contains('\\')) {
             return s.to_string();
         }
-        let mut escaped: String;
-        escaped = String::with_capacity(s.len() * 2);
+        let mut escaped = String::with_capacity(s.len() * 2);
         for r in s.chars() {
             if r == '"' || r == '\\' {
                 escaped.push('\\')
@@ -1272,12 +1271,7 @@ impl Formatter {
 
     // TODO(adriandt): this code appears dead. Boolean literal is no longer a node type?
     fn format_boolean_literal(&mut self, n: &ast::BooleanLit) {
-        let s: &str;
-        if n.value {
-            s = "true"
-        } else {
-            s = "false"
-        }
+        let s = if n.value { "true" } else { "false" };
         self.write_string(s)
     }
 

--- a/libflux/flux-core/src/formatter/tests.rs
+++ b/libflux/flux-core/src/formatter/tests.rs
@@ -1598,3 +1598,12 @@ j
 "#,
     );
 }
+
+#[test]
+fn dont_alter_string_literal() {
+    let script = r#"sendSlackMessage(
+    text: "*Earthquake Alert*
+M *${string(v: r.mag)}*",
+)"#;
+    assert_unchanged(script);
+}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -27,7 +27,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/doc/example.rs":                                                        "ec887ef108ec8c78694d7feb233b61f6b480fac18b17156d202bb37a0a51f81b",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "119765f5352b282ebc5fa940284d410742ebb7a9de18361afecfccfa7d3d6362",
 	"libflux/flux-core/src/errors.rs":                                                             "4944f1b71bbc6499b3d11a3b8afdb7c993f14b5be6bf7189ad066ddf5a6c6203",
-	"libflux/flux-core/src/formatter/mod.rs":                                                      "cc66f8a9ce3c467b68e27b278165b7fc0eed53cc682b5305fd2efabf8843ece1",
+	"libflux/flux-core/src/formatter/mod.rs":                                                      "dddd3bfd504319e97137663f8f69f58cfd77db6fa61522d8ec4efc98746bfa6f",
 	"libflux/flux-core/src/lib.rs":                                                                "f247ea5b4bf05bdbaf8463f7b6ca1b3de7702f98915adc3fdde9fd5a1a7f0743",
 	"libflux/flux-core/src/parser/mod.rs":                                                         "b75f5aab5431ae11230297b20788bbb476fc28d487b5574324f35820357b5303",
 	"libflux/flux-core/src/parser/strconv.rs":                                                     "09b6089d3293d7722c2dbf94e3fb0146b3c056fb2803c2bcb3cda343b2849667",


### PR DESCRIPTION
Fixes one instance where formatting would alter a string literal (maybe the only instance?). #4261 also mentions an issue with surrounding code getting wrongly indented, however fixing this seems more complicated as the formatter works with just plain (formatted) `String` values, which do not have the information necessary to fix them after the fact.

cc #4261

### Done checklist
- [x] Test cases written
