### PR TITLE
fix: Mitigate risk of SQL injection in table/column identifiers

### DIFF
--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -487,7 +487,7 @@ func validateIdent(ident string) error {
 	}
 	for _, x := range denied {
 		if strings.Contains(ident, x) {
-			return errors.Newf(codes.Invalid, "encountered invalid identifier (%s)", ident)
+			return errors.Newf(codes.Invalid, "encountered invalid identifier: %s", ident)
 		}
 	}
 	return nil


### PR DESCRIPTION
While any values written to databases via `sql.to()` will be escaped
appropriately via parameter binding, table and column identifiers would not.

It's debatable if we should consider these identifiers a security risk
since the developer (i.e. the author of the flux program) should really
take steps to ensure they can trust their own inputs, especially when it
comes to identifiers.

Still, we can take some naive steps in `sql.to()` to catch elements of
SQL injection techniques by checking for `;` and comments. If these
patterns are found in table or column names, `sql.to()` will now give an
error.

The big downside is this may error even if the identifier was properly
(manually) escaped by the caller. Better to err on the side of caution,
I suppose.

### Done checklist
- [ ] ~~docs/SPEC.md updated~~
- [x] Test cases written
