### PR TITLE
fix: ensure arrays are not table streams before calling `Len()`

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -92,7 +92,7 @@ type TableObject struct {
 	Parents []*TableObject
 }
 
-// TableObject satisfies the values.ITableObject interface.
+// TableObject satisfies the values.TableObject interface.
 // This is a hacky workaround to avoid an import cycles.
 func (t *TableObject) TableObject() {}
 

--- a/compile.go
+++ b/compile.go
@@ -94,6 +94,7 @@ type TableObject struct {
 
 // TableObject satisfies the values.TableObject interface.
 // This is a hacky workaround to avoid an import cycles.
+// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 func (t *TableObject) TableObject() {}
 
 func (t *TableObject) Operation(ider IDer) *Operation {

--- a/compile.go
+++ b/compile.go
@@ -92,6 +92,10 @@ type TableObject struct {
 	Parents []*TableObject
 }
 
+// TableObject satisfies the values.ITableObject interface.
+// This is a hacky workaround to avoid an import cycles.
+func (t *TableObject) TableObject() {}
+
 func (t *TableObject) Operation(ider IDer) *Operation {
 	if iderOpSpec, ok := t.Spec.(IDerOpSpec); ok {
 		iderOpSpec.IDer(ider)

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -592,7 +592,7 @@ func (e *arrayIndexEvaluator) Eval(ctx context.Context, scope Scope) (values.Val
 	if typ := i.Type().Nature(); typ != semantic.Int {
 		return nil, errors.Newf(codes.Invalid, "cannot index into an array with value of type %s; expected an int", typ)
 	}
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := a.(values.TableObject); ok {
 		return nil, errors.Newf(codes.Invalid, "cannot index into a table stream; expected an array")
 	}

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -593,7 +593,7 @@ func (e *arrayIndexEvaluator) Eval(ctx context.Context, scope Scope) (values.Val
 		return nil, errors.Newf(codes.Invalid, "cannot index into an array with value of type %s; expected an int", typ)
 	}
 	// FIXME: needs a test
-	if _, ok := a.(values.ITableObject); ok {
+	if _, ok := a.(values.TableObject); ok {
 		return nil, errors.Newf(codes.Invalid, "cannot index into a table stream; expected an array")
 	}
 	ix := int(i.Int())

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -592,6 +592,10 @@ func (e *arrayIndexEvaluator) Eval(ctx context.Context, scope Scope) (values.Val
 	if typ := i.Type().Nature(); typ != semantic.Int {
 		return nil, errors.Newf(codes.Invalid, "cannot index into an array with value of type %s; expected an int", typ)
 	}
+	// FIXME: needs a test
+	if _, ok := a.(values.ITableObject); ok {
+		return nil, errors.Newf(codes.Invalid, "cannot index into a table stream; expected an array")
+	}
 	ix := int(i.Int())
 	l := a.Array().Len()
 	if ix < 0 || ix >= l {

--- a/compiler/runtime_test.go
+++ b/compiler/runtime_test.go
@@ -83,3 +83,19 @@ func TestFunctionValue_Resolve(t *testing.T) {
 		t.Errorf("unexpected resolved function: -want/+got\n%s", cmp.Diff(want, got, semantictest.CmpOptions...))
 	}
 }
+
+// XXX: sort of confusing but this error message is actually coming
+//      from runtime.Eval but can also be seen in interpreter...
+func TestIndexExpr_TableObjectIsError(t *testing.T) {
+	src := `
+	import "array"
+	array.from(rows: [{}])[0]`
+	_, _, err := runtime.Eval(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+
+	if want, got := "cannot index into table stream; expected an array", err.Error(); want != got {
+		t.Errorf("wanted error %q, got %q", want, got)
+	}
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -237,7 +237,7 @@ func (irtp *Interpreter) evaluateNowOption(ctx context.Context, name string, ini
 
 func convert(rules values.Array) ([]string, error) {
 	// FIXME: not sure how to test
-	if _, ok := rules.(values.ITableObject); ok {
+	if _, ok := rules.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got table stream; expected an array")
 	}
 	noRules := rules.Len()
@@ -395,7 +395,7 @@ func (itrp *Interpreter) doExpression(ctx context.Context, expr semantic.Express
 		}
 		ix := int(idx.Int())
 		// FIXME: needs a test
-		if _, ok := arr.(values.ITableObject); ok {
+		if _, ok := arr.(values.TableObject); ok {
 			return nil, errors.New(codes.Invalid, "cannot index into table stream; expected an array")
 		}
 		l := arr.Array().Len()
@@ -1265,7 +1265,7 @@ func resolveValue(v values.Value) (semantic.Node, bool, error) {
 	case semantic.Array:
 		arr := v.Array()
 		// FIXME: needs a test
-		if _, ok := arr.(values.ITableObject); ok {
+		if _, ok := arr.(values.TableObject); ok {
 			return nil, false, errors.New(codes.Invalid, "got a table stream; expected an array")
 		}
 		node := new(semantic.ArrayExpression)
@@ -1374,7 +1374,7 @@ func ToStringArray(a values.Array) ([]string, error) {
 		return nil, errors.Newf(codes.Invalid, "cannot convert array of %v to an array of strings", t)
 	}
 	// FIXME: needs a test
-	if _, ok := a.(values.ITableObject); ok {
+	if _, ok := a.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
 	strs := make([]string, a.Len())
@@ -1392,7 +1392,7 @@ func ToFloatArray(a values.Array) ([]float64, error) {
 		return nil, errors.Newf(codes.Invalid, "cannot convert array of %v to an array of floats", t)
 	}
 	// FIXME: needs a test
-	if _, ok := a.(values.ITableObject); ok {
+	if _, ok := a.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
 	vs := make([]float64, a.Len())
@@ -1571,7 +1571,7 @@ func (a *arguments) GetArrayAllowEmpty(name string, t semantic.Nature) (values.A
 	}
 	arr := v.Array()
 	// FIXME: needs a test
-	if _, ok := arr.(values.ITableObject); ok {
+	if _, ok := arr.(values.TableObject); ok {
 		return nil, false, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
 	if arr.Len() > 0 {
@@ -1610,7 +1610,7 @@ func (a *arguments) GetRequiredArrayAllowEmpty(name string, t semantic.Nature) (
 	}
 	arr := v.Array()
 	// FIXME: needs a test
-	if _, ok := arr.(values.ITableObject); ok {
+	if _, ok := arr.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
 	if arr.Array().Len() > 0 {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -236,6 +236,10 @@ func (irtp *Interpreter) evaluateNowOption(ctx context.Context, name string, ini
 }
 
 func convert(rules values.Array) ([]string, error) {
+	// FIXME: not sure how to test
+	if _, ok := rules.(values.ITableObject); ok {
+		return nil, errors.New(codes.Invalid, "got table stream; expected an array")
+	}
 	noRules := rules.Len()
 	rs := make([]string, noRules)
 	rules.Range(func(i int, v values.Value) {
@@ -390,6 +394,10 @@ func (itrp *Interpreter) doExpression(ctx context.Context, expr semantic.Express
 			return nil, err
 		}
 		ix := int(idx.Int())
+		// FIXME: needs a test
+		if _, ok := arr.(values.ITableObject); ok {
+			return nil, errors.New(codes.Invalid, "cannot index into table stream; expected an array")
+		}
 		l := arr.Array().Len()
 		if ix < 0 || ix >= l {
 			return nil, errors.Newf(codes.Invalid, "cannot access element %v of array of length %v", ix, l)
@@ -1256,6 +1264,10 @@ func resolveValue(v values.Value) (semantic.Node, bool, error) {
 		return nil, false, nil
 	case semantic.Array:
 		arr := v.Array()
+		// FIXME: needs a test
+		if _, ok := arr.(values.ITableObject); ok {
+			return nil, false, errors.New(codes.Invalid, "got a table stream; expected an array")
+		}
 		node := new(semantic.ArrayExpression)
 		node.Elements = make([]semantic.Expression, arr.Len())
 		var (
@@ -1361,6 +1373,10 @@ func ToStringArray(a values.Array) ([]string, error) {
 	if t.Nature() != semantic.String {
 		return nil, errors.Newf(codes.Invalid, "cannot convert array of %v to an array of strings", t)
 	}
+	// FIXME: needs a test
+	if _, ok := a.(values.ITableObject); ok {
+		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
+	}
 	strs := make([]string, a.Len())
 	a.Range(func(i int, v values.Value) {
 		strs[i] = v.Str()
@@ -1374,6 +1390,10 @@ func ToFloatArray(a values.Array) ([]float64, error) {
 	}
 	if t.Nature() != semantic.Float {
 		return nil, errors.Newf(codes.Invalid, "cannot convert array of %v to an array of floats", t)
+	}
+	// FIXME: needs a test
+	if _, ok := a.(values.ITableObject); ok {
+		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
 	vs := make([]float64, a.Len())
 	a.Range(func(i int, v values.Value) {
@@ -1550,6 +1570,10 @@ func (a *arguments) GetArrayAllowEmpty(name string, t semantic.Nature) (values.A
 		return nil, ok, err
 	}
 	arr := v.Array()
+	// FIXME: needs a test
+	if _, ok := arr.(values.ITableObject); ok {
+		return nil, false, errors.New(codes.Invalid, "got a table stream; expected an array")
+	}
 	if arr.Len() > 0 {
 		et, err := arr.Type().ElemType()
 		if err != nil {
@@ -1585,6 +1609,10 @@ func (a *arguments) GetRequiredArrayAllowEmpty(name string, t semantic.Nature) (
 		return nil, err
 	}
 	arr := v.Array()
+	// FIXME: needs a test
+	if _, ok := arr.(values.ITableObject); ok {
+		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
+	}
 	if arr.Array().Len() > 0 {
 		et, err := arr.Type().ElemType()
 		if err != nil {

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -236,7 +236,7 @@ func (irtp *Interpreter) evaluateNowOption(ctx context.Context, name string, ini
 }
 
 func convert(rules values.Array) ([]string, error) {
-	// FIXME: not sure how to test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := rules.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got table stream; expected an array")
 	}
@@ -394,7 +394,7 @@ func (itrp *Interpreter) doExpression(ctx context.Context, expr semantic.Express
 			return nil, err
 		}
 		ix := int(idx.Int())
-		// FIXME: needs a test
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 		if _, ok := arr.(values.TableObject); ok {
 			return nil, errors.New(codes.Invalid, "cannot index into table stream; expected an array")
 		}
@@ -1264,7 +1264,7 @@ func resolveValue(v values.Value) (semantic.Node, bool, error) {
 		return nil, false, nil
 	case semantic.Array:
 		arr := v.Array()
-		// FIXME: needs a test
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 		if _, ok := arr.(values.TableObject); ok {
 			return nil, false, errors.New(codes.Invalid, "got a table stream; expected an array")
 		}
@@ -1373,7 +1373,7 @@ func ToStringArray(a values.Array) ([]string, error) {
 	if t.Nature() != semantic.String {
 		return nil, errors.Newf(codes.Invalid, "cannot convert array of %v to an array of strings", t)
 	}
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := a.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
@@ -1391,7 +1391,7 @@ func ToFloatArray(a values.Array) ([]float64, error) {
 	if t.Nature() != semantic.Float {
 		return nil, errors.Newf(codes.Invalid, "cannot convert array of %v to an array of floats", t)
 	}
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := a.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
@@ -1570,7 +1570,7 @@ func (a *arguments) GetArrayAllowEmpty(name string, t semantic.Nature) (values.A
 		return nil, ok, err
 	}
 	arr := v.Array()
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := arr.(values.TableObject); ok {
 		return nil, false, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
@@ -1609,7 +1609,7 @@ func (a *arguments) GetRequiredArrayAllowEmpty(name string, t semantic.Nature) (
 		return nil, err
 	}
 	arr := v.Array()
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := arr.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -579,6 +579,10 @@ func getOptionValues(pkg values.Object, optionName string) ([]string, error) {
 	}
 
 	rules := value.Array()
+	// FIXME: needs a test
+	if _, ok := rules.(values.ITableObject); ok {
+		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
+	}
 	noRules := rules.Len()
 	rs := make([]string, noRules)
 	rules.Range(func(i int, v values.Value) {

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -580,7 +580,7 @@ func getOptionValues(pkg values.Object, optionName string) ([]string, error) {
 
 	rules := value.Array()
 	// FIXME: needs a test
-	if _, ok := rules.(values.ITableObject); ok {
+	if _, ok := rules.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}
 	noRules := rules.Len()

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -579,7 +579,7 @@ func getOptionValues(pkg values.Object, optionName string) ([]string, error) {
 	}
 
 	rules := value.Array()
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := rules.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
 	}

--- a/semantic/semantictest/cmp.go
+++ b/semantic/semantictest/cmp.go
@@ -150,6 +150,9 @@ func TransformValue(v values.Value) map[string]interface{} {
 			"value": v.Regexp(),
 		}
 	case semantic.Array:
+		// n.b. normally we need to check v.Array() to make sure it isn't a
+		// TableObject before calling Len(), but we can just let it panic here
+		// since this is test-related code.
 		elements := make([]map[string]interface{}, v.Array().Len())
 		for i := range elements {
 			elements[i] = TransformValue(v.Array().Get(i))

--- a/stdlib/array/from.go
+++ b/stdlib/array/from.go
@@ -42,8 +42,8 @@ func createFromOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 		}
 		spec.Rows = rows.Array()
 	}
-	// FIXME: needs a test
-	if _, ok := spec.Rows.(*flux.TableObject); ok {
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+	if _, ok := spec.Rows.(values.TableObject); ok {
 		return nil, errors.Newf(codes.Invalid, "rows cannot be a table stream; expected an array")
 	}
 	if spec.Rows.Len() == 0 {
@@ -122,10 +122,6 @@ func buildTable(rows values.Array, mem *memory.Allocator) (flux.Table, error) {
 	} else if typ.Nature() != semantic.Object {
 		return nil, errors.New(codes.Internal, "rows should have been a list of records")
 	}
-	// FIXME: needs a test
-	if _, ok := rows.(*flux.TableObject); ok {
-		return nil, errors.Newf(codes.Invalid, "rows cannot be a table stream; expected an array")
-	}
 	l, err := typ.NumProperties()
 	if err != nil {
 		return nil, err
@@ -153,6 +149,10 @@ func buildTable(rows values.Array, mem *memory.Allocator) (flux.Table, error) {
 
 	key := execute.NewGroupKey(nil, nil)
 	builder := table.NewArrowBuilder(key, mem)
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+	if _, ok := rows.(values.TableObject); ok {
+		return nil, errors.Newf(codes.Invalid, "rows cannot be a table stream; expected an array")
+	}
 	for _, col := range cols {
 		i, err := builder.AddCol(col)
 		if err != nil {

--- a/stdlib/array/from.go
+++ b/stdlib/array/from.go
@@ -42,7 +42,10 @@ func createFromOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 		}
 		spec.Rows = rows.Array()
 	}
-
+	// FIXME: needs a test
+	if _, ok := spec.Rows.(*flux.TableObject); ok {
+		return nil, errors.Newf(codes.Invalid, "rows cannot be a table stream; expected an array")
+	}
 	if spec.Rows.Len() == 0 {
 		return nil, errors.New(codes.Invalid, "rows must be non-empty")
 	}
@@ -119,7 +122,10 @@ func buildTable(rows values.Array, mem *memory.Allocator) (flux.Table, error) {
 	} else if typ.Nature() != semantic.Object {
 		return nil, errors.New(codes.Internal, "rows should have been a list of records")
 	}
-
+	// FIXME: needs a test
+	if _, ok := rows.(*flux.TableObject); ok {
+		return nil, errors.Newf(codes.Invalid, "rows cannot be a table stream; expected an array")
+	}
 	l, err := typ.NumProperties()
 	if err != nil {
 		return nil, err

--- a/stdlib/array/from_test.go
+++ b/stdlib/array/from_test.go
@@ -1,0 +1,22 @@
+package array_test
+
+import (
+	"context"
+	"testing"
+
+	_ "github.com/influxdata/flux/fluxinit/static"
+	"github.com/influxdata/flux/runtime"
+)
+
+func TestArrayFrom_ReceiveTableObjectIsError(t *testing.T) {
+	src := `import "array"
+			array.from(rows: array.from(rows: [{}]))`
+	_, _, err := runtime.Eval(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+
+	if want, got := "error calling function \"from\" @2:4-2:44: rows cannot be a table stream; expected an array", err.Error(); want != got {
+		t.Errorf("wanted error %q, got %q", want, got)
+	}
+}

--- a/stdlib/contrib/jsternberg/influxdb/influxdb.go
+++ b/stdlib/contrib/jsternberg/influxdb/influxdb.go
@@ -41,7 +41,10 @@ func createMaskOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	if err != nil {
 		return nil, err
 	}
-
+	// FIXME: needs a test
+	if _, ok := columns.(*flux.TableObject); ok {
+		return nil, errors.New(codes.Invalid, "got a table stream; expected an array")
+	}
 	spec.Columns = make([]string, columns.Len())
 	columns.Range(func(i int, v values.Value) {
 		spec.Columns[i] = v.Str()

--- a/stdlib/contrib/sranka/opsgenie/responders_to_json.go
+++ b/stdlib/contrib/sranka/opsgenie/responders_to_json.go
@@ -43,6 +43,10 @@ func RespondersToJSON(args interpreter.Arguments) (values.Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	// FIXME: needs a test
+	if _, ok := v.(values.ITableObject); ok {
+		return nil, errors.New("got a table stream; expected an array")
+	}
 	responders := make([]interface{}, v.Len())
 	for i := 0; i < v.Len(); i++ {
 		item := v.Get(i).Str()

--- a/stdlib/contrib/sranka/opsgenie/responders_to_json.go
+++ b/stdlib/contrib/sranka/opsgenie/responders_to_json.go
@@ -44,7 +44,7 @@ func RespondersToJSON(args interpreter.Arguments) (values.Value, error) {
 		return nil, err
 	}
 	// FIXME: needs a test
-	if _, ok := v.(values.ITableObject); ok {
+	if _, ok := v.(values.TableObject); ok {
 		return nil, errors.New("got a table stream; expected an array")
 	}
 	responders := make([]interface{}, v.Len())

--- a/stdlib/contrib/sranka/opsgenie/responders_to_json.go
+++ b/stdlib/contrib/sranka/opsgenie/responders_to_json.go
@@ -43,7 +43,7 @@ func RespondersToJSON(args interpreter.Arguments) (values.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	// FIXME: needs a test
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := v.(values.TableObject); ok {
 		return nil, errors.New("got a table stream; expected an array")
 	}

--- a/stdlib/experimental/geo/geo.go
+++ b/stdlib/experimental/geo/geo.go
@@ -342,6 +342,10 @@ func parseGeometryArgument(name string, arg values.Object, units *units) (geom i
 	points, polygonOk := arg.Get("points")
 	if polygonOk && arg.Len() == 1 {
 		array := points.Array()
+		// FIXME: needs a test
+		if _, ok := array.(values.ITableObject); ok {
+			return nil, errors.New(codes.Invalid, "points cannot be a table stream; expected an array")
+		}
 		if array.Len() < 3 {
 			err = errors.Newf(codes.Invalid, "polygon must have at least 3 points")
 		}

--- a/stdlib/experimental/geo/geo.go
+++ b/stdlib/experimental/geo/geo.go
@@ -343,7 +343,7 @@ func parseGeometryArgument(name string, arg values.Object, units *units) (geom i
 	if polygonOk && arg.Len() == 1 {
 		array := points.Array()
 		// FIXME: needs a test
-		if _, ok := array.(values.ITableObject); ok {
+		if _, ok := array.(values.TableObject); ok {
 			return nil, errors.New(codes.Invalid, "points cannot be a table stream; expected an array")
 		}
 		if array.Len() < 3 {

--- a/stdlib/experimental/geo/geo.go
+++ b/stdlib/experimental/geo/geo.go
@@ -342,7 +342,7 @@ func parseGeometryArgument(name string, arg values.Object, units *units) (geom i
 	points, polygonOk := arg.Get("points")
 	if polygonOk && arg.Len() == 1 {
 		array := points.Array()
-		// FIXME: needs a test
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 		if _, ok := array.(values.TableObject); ok {
 			return nil, errors.New(codes.Invalid, "points cannot be a table stream; expected an array")
 		}

--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -92,6 +92,10 @@ func (o *ToMQTTOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 	o.TagColumns = o.TagColumns[:0]
 	if ok {
+		// FIXME: needs a test
+		if _, ok := tagColumns.(*flux.TableObject); ok {
+			return errors.New(codes.Invalid, "tagColumns cannot be a table stream; expected an array")
+		}
 		for i := 0; i < tagColumns.Len(); i++ {
 			o.TagColumns = append(o.TagColumns, tagColumns.Get(i).Str())
 		}
@@ -103,7 +107,10 @@ func (o *ToMQTTOpSpec) ReadArgs(args flux.Arguments) error {
 		return err
 	}
 	o.ValueColumns = o.ValueColumns[:0]
-
+	// FIXME: needs a test
+	if _, ok := valueColumns.(*flux.TableObject); ok {
+		return errors.New(codes.Invalid, "valueColumns cannot be a table stream; expected an array")
+	}
 	if !ok || valueColumns.Len() == 0 {
 		o.ValueColumns = append(o.ValueColumns, execute.DefaultValueColLabel)
 	} else {

--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -92,8 +92,8 @@ func (o *ToMQTTOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 	o.TagColumns = o.TagColumns[:0]
 	if ok {
-		// FIXME: needs a test
-		if _, ok := tagColumns.(*flux.TableObject); ok {
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+		if _, ok := tagColumns.(values.TableObject); ok {
 			return errors.New(codes.Invalid, "tagColumns cannot be a table stream; expected an array")
 		}
 		for i := 0; i < tagColumns.Len(); i++ {
@@ -107,8 +107,8 @@ func (o *ToMQTTOpSpec) ReadArgs(args flux.Arguments) error {
 		return err
 	}
 	o.ValueColumns = o.ValueColumns[:0]
-	// FIXME: needs a test
-	if _, ok := valueColumns.(*flux.TableObject); ok {
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+	if _, ok := valueColumns.(values.TableObject); ok {
 		return errors.New(codes.Invalid, "valueColumns cannot be a table stream; expected an array")
 	}
 	if !ok || valueColumns.Len() == 0 {

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -514,8 +514,8 @@ func (o *ToOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 
 	if tags, ok, _ := args.GetArray("tagColumns", semantic.String); ok {
-		// FIXME: needs a test
-		if _, ok := tags.(*flux.TableObject); ok {
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+		if _, ok := tags.(values.TableObject); ok {
 			return errors.New(codes.Invalid, "tagColumns cannot be a table stream; expected an array")
 		}
 		o.TagColumns = make([]string, tags.Len())

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -514,6 +514,10 @@ func (o *ToOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 
 	if tags, ok, _ := args.GetArray("tagColumns", semantic.String); ok {
+		// FIXME: needs a test
+		if _, ok := tags.(*flux.TableObject); ok {
+			return errors.New(codes.Invalid, "tagColumns cannot be a table stream; expected an array")
+		}
 		o.TagColumns = make([]string, tags.Len())
 		tags.Sort(func(i, j values.Value) bool {
 			return i.Str() < j.Str()

--- a/stdlib/json/encode.go
+++ b/stdlib/json/encode.go
@@ -3,7 +3,6 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"github.com/influxdata/flux"
 	"time"
 
 	"github.com/influxdata/flux/codes"
@@ -67,10 +66,8 @@ func convertValue(v values.Value) (interface{}, error) {
 		// the Array interface. Since TableObject will currently panic
 		// if the methods provided by this interface are invoked, short-circuit
 		// by returning an error.
-		// XXX: In the future we may delineate the difference between
-		//      fully-realized and streamed collections making this unnecessary.
-		//      <https://github.com/influxdata/flux/issues/4275>
-		case *flux.TableObject:
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+		case values.TableObject:
 			return nil, errors.New(
 				codes.Invalid,
 				"got table stream instead of array. "+

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -70,6 +70,10 @@ func (o *ToKafkaOpSpec) ReadArgs(args flux.Arguments) error {
 	if err != nil {
 		return err
 	}
+	// FIXME: needs a test
+	if _, ok := brokers.(*flux.TableObject); ok {
+		return errors.New(codes.Invalid, "brokers cannot be a table stream; expected an array")
+	}
 	l := brokers.Len()
 
 	o.Brokers = make([]string, l)
@@ -119,6 +123,10 @@ func (o *ToKafkaOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 	o.TagColumns = o.TagColumns[:0]
 	if ok {
+		// FIXME: needs a test
+		if _, ok := tagColumns.(*flux.TableObject); ok {
+			return errors.New(codes.Invalid, "tagColumns cannot be a table stream; expected an array")
+		}
 		for i := 0; i < tagColumns.Len(); i++ {
 			o.TagColumns = append(o.TagColumns, tagColumns.Get(i).Str())
 		}
@@ -127,6 +135,10 @@ func (o *ToKafkaOpSpec) ReadArgs(args flux.Arguments) error {
 	valueColumns, ok, err := args.GetArray("valueColumns", semantic.String)
 	if err != nil {
 		return err
+	}
+	// FIXME: needs a test
+	if _, ok := valueColumns.(*flux.TableObject); ok {
+		return errors.New(codes.Invalid, "valueColumns cannot be a table stream; expected an array")
 	}
 	o.ValueColumns = o.ValueColumns[:0]
 	if !ok || valueColumns.Len() == 0 {

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -70,8 +70,8 @@ func (o *ToKafkaOpSpec) ReadArgs(args flux.Arguments) error {
 	if err != nil {
 		return err
 	}
-	// FIXME: needs a test
-	if _, ok := brokers.(*flux.TableObject); ok {
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+	if _, ok := brokers.(values.TableObject); ok {
 		return errors.New(codes.Invalid, "brokers cannot be a table stream; expected an array")
 	}
 	l := brokers.Len()
@@ -123,8 +123,8 @@ func (o *ToKafkaOpSpec) ReadArgs(args flux.Arguments) error {
 	}
 	o.TagColumns = o.TagColumns[:0]
 	if ok {
-		// FIXME: needs a test
-		if _, ok := tagColumns.(*flux.TableObject); ok {
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+		if _, ok := tagColumns.(values.TableObject); ok {
 			return errors.New(codes.Invalid, "tagColumns cannot be a table stream; expected an array")
 		}
 		for i := 0; i < tagColumns.Len(); i++ {
@@ -136,8 +136,8 @@ func (o *ToKafkaOpSpec) ReadArgs(args flux.Arguments) error {
 	if err != nil {
 		return err
 	}
-	// FIXME: needs a test
-	if _, ok := valueColumns.(*flux.TableObject); ok {
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+	if _, ok := valueColumns.(values.TableObject); ok {
 		return errors.New(codes.Invalid, "valueColumns cannot be a table stream; expected an array")
 	}
 	o.ValueColumns = o.ValueColumns[:0]

--- a/stdlib/pagerduty/pagerduty.go
+++ b/stdlib/pagerduty/pagerduty.go
@@ -54,8 +54,8 @@ func createDedupKeyOpSpec(args flux.Arguments, a *flux.Administration) (flux.Ope
 			},
 		)
 	}
-	// FIXME: needs a test
-	if _, ok := exclude.(*flux.TableObject); ok {
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+	if _, ok := exclude.(values.TableObject); ok {
 		return nil, errors.New(codes.Invalid, "exclude cannot be a table stream; expected an array")
 	}
 	spec := &DedupKeyOpSpec{

--- a/stdlib/pagerduty/pagerduty.go
+++ b/stdlib/pagerduty/pagerduty.go
@@ -54,7 +54,10 @@ func createDedupKeyOpSpec(args flux.Arguments, a *flux.Administration) (flux.Ope
 			},
 		)
 	}
-
+	// FIXME: needs a test
+	if _, ok := exclude.(*flux.TableObject); ok {
+		return nil, errors.New(codes.Invalid, "exclude cannot be a table stream; expected an array")
+	}
 	spec := &DedupKeyOpSpec{
 		Exclude: make([]string, exclude.Len()),
 	}

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -448,7 +448,7 @@ func init() {
 				}
 				arr := val.Array()
 				// FIXME: needs a test
-				if _, ok := arr.(values.ITableObject); ok {
+				if _, ok := arr.(values.TableObject); ok {
 					return nil, fmt.Errorf("%q cannot be a table stream; expected an array", "arr")
 				}
 				if arr.Len() >= 0 {

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -447,6 +447,10 @@ func init() {
 					return nil, fmt.Errorf("missing argument %q", "arr")
 				}
 				arr := val.Array()
+				// FIXME: needs a test
+				if _, ok := arr.(values.ITableObject); ok {
+					return nil, fmt.Errorf("%q cannot be a table stream; expected an array", "arr")
+				}
 				if arr.Len() >= 0 {
 					et, _ := arr.Type().ElemType()
 					if et.Nature() != semantic.String {
@@ -466,6 +470,8 @@ func init() {
 
 				stringArray := argVals[0].Array()
 				var newStringArray []string
+				// n.b. should already have been vetted as non-TableObject
+				// above, making the Len() call safe.
 				for i := 0; i < stringArray.Len(); i++ {
 					newStringArray = append(newStringArray, stringArray.Get(i).Str())
 				}

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -447,7 +447,7 @@ func init() {
 					return nil, fmt.Errorf("missing argument %q", "arr")
 				}
 				arr := val.Array()
-				// FIXME: needs a test
+				// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 				if _, ok := arr.(values.TableObject); ok {
 					return nil, fmt.Errorf("%q cannot be a table stream; expected an array", "arr")
 				}

--- a/stdlib/strings/strings__test.go
+++ b/stdlib/strings/strings__test.go
@@ -1,0 +1,29 @@
+package strings_test
+
+// n.b. strings_test.go belongs to the "strings" package so it can access
+// private functions from the implementation.
+// Importing "flux/fluxinit/static" in there causes a cyclical import.
+// This is why we have a strings__test.go in addition to strings_test.go.
+
+import (
+	"context"
+
+	_ "github.com/influxdata/flux/fluxinit/static"
+	"github.com/influxdata/flux/runtime"
+	"testing"
+)
+
+func TestJoinStr_ReceiveTableObjectIsError(t *testing.T) {
+	src := `
+	import "array"
+	import "strings"
+	strings.joinStr(arr: array.from(rows: [{_value: ""}]) |> map(fn: (r) => r._value), v: ",")`
+	_, _, err := runtime.Eval(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+
+	if want, got := "error calling function \"joinStr\" @4:2-4:92: \"arr\" cannot be a table stream; expected an array", err.Error(); want != got {
+		t.Errorf("wanted error %q, got %q", want, got)
+	}
+}

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -32,7 +32,7 @@ func MakeContainsFunc() values.Function {
 			set := setarg.Array()
 			found := false
 			// FIXME: needs a test
-			if _, ok := set.(values.ITableObject); ok {
+			if _, ok := set.(values.TableObject); ok {
 				return nil, errors.New(codes.Invalid, "set cannot be a table stream; expected an array")
 			}
 			if set.Len() > 0 {

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -31,7 +31,7 @@ func MakeContainsFunc() values.Function {
 
 			set := setarg.Array()
 			found := false
-			// FIXME: needs a test
+			// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 			if _, ok := set.(values.TableObject); ok {
 				return nil, errors.New(codes.Invalid, "set cannot be a table stream; expected an array")
 			}

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -31,6 +31,10 @@ func MakeContainsFunc() values.Function {
 
 			set := setarg.Array()
 			found := false
+			// FIXME: needs a test
+			if _, ok := set.(values.ITableObject); ok {
+				return nil, errors.New(codes.Invalid, "set cannot be a table stream; expected an array")
+			}
 			if set.Len() > 0 {
 				if set.Get(0).Type() != v.Type() {
 					err = errors.Newf(codes.Invalid, "value type %T does not match set type %T", v.Type(), set.Get(0).Type())

--- a/stdlib/universe/contains_test.go
+++ b/stdlib/universe/contains_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
@@ -130,5 +131,19 @@ func TestContains_Empty(t *testing.T) {
 
 	if !mustLookup(s, "ok").Bool() {
 		t.Errorf("ok was not OK indeed")
+	}
+}
+
+func TestContains_ReceiveTableObjectIsError(t *testing.T) {
+	src := `
+	import "array"
+	contains(value: 1, set: array.from(rows: [{_value: 1}]) |> map(fn: (r) => r._value ))`
+	_, _, err := runtime.Eval(context.Background(), src)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+
+	if want, got := "error calling function \"contains\" @3:2-3:87: got a table stream; expected an array", err.Error(); want != got {
+		t.Errorf("wanted error %q, got %q", want, got)
 	}
 }

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -80,6 +80,8 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	// On specifies the columns to join on, and is required.
 	if array, err := args.GetRequiredArray("on", semantic.String); err != nil {
 		return nil, err
+	} else if _, ok := array.(*flux.TableObject); ok { // FIXME: needs a test
+		return nil, errors.New(codes.Invalid, "exclude cannot be a table stream; expected an array")
 	} else if array.Len() == 0 {
 		return nil, errors.New(codes.Invalid, "at least one column in 'on' column list is required")
 	} else {

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -80,8 +80,9 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 	// On specifies the columns to join on, and is required.
 	if array, err := args.GetRequiredArray("on", semantic.String); err != nil {
 		return nil, err
-	} else if _, ok := array.(*flux.TableObject); ok { // FIXME: needs a test
-		return nil, errors.New(codes.Invalid, "exclude cannot be a table stream; expected an array")
+	} else if _, ok := array.(values.TableObject); ok {
+		// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+		return nil, errors.New(codes.Invalid, "on cannot be a table stream; expected an array")
 	} else if array.Len() == 0 {
 		return nil, errors.New(codes.Invalid, "at least one column in 'on' column list is required")
 	} else {

--- a/stdlib/universe/length.go
+++ b/stdlib/universe/length.go
@@ -3,7 +3,6 @@ package universe
 import (
 	"context"
 
-	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
@@ -35,10 +34,8 @@ func MakeLengthFunc() values.Function {
 			// the Array interface. Since TableObject will currently panic
 			// if the methods provided by this interface are invoked, short-circuit
 			// by returning an error.
-			// XXX: In the future we may delineate the difference between
-			//      fully-realized and streamed collections making this unnecessary.
-			//      <https://github.com/influxdata/flux/issues/4275>
-			case *flux.TableObject:
+			// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
+			case values.TableObject:
 				return nil, errors.New(codes.Invalid, "arr must be an array, got table stream")
 			default:
 				l := maybeArr.Len()

--- a/values/array.go
+++ b/values/array.go
@@ -126,7 +126,7 @@ func (a *array) Equal(rhs Value) bool {
 	}
 	r := rhs.Array()
 	// When RHS is a table stream, mark it false
-	if _, ok := r.(ITableObject); ok {
+	if _, ok := r.(TableObject); ok {
 		return false
 	}
 	if a.Len() != r.Len() {

--- a/values/array.go
+++ b/values/array.go
@@ -125,8 +125,11 @@ func (a *array) Equal(rhs Value) bool {
 		return false
 	}
 	r := rhs.Array()
-	// When RHS is a table stream, mark it false
+	// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 	if _, ok := r.(TableObject); ok {
+		// When RHS is a table stream instead of array, mark it false.
+		// This short-circuits the invalid `Len()` call below that would
+		// otherwise panic.
 		return false
 	}
 	if a.Len() != r.Len() {

--- a/values/array.go
+++ b/values/array.go
@@ -125,6 +125,10 @@ func (a *array) Equal(rhs Value) bool {
 		return false
 	}
 	r := rhs.Array()
+	// When RHS is a table stream, mark it false
+	if _, ok := r.(ITableObject); ok {
+		return false
+	}
 	if a.Len() != r.Len() {
 		return false
 	}

--- a/values/display.go
+++ b/values/display.go
@@ -68,6 +68,11 @@ func display(w *bufio.Writer, v Value, indent int) (err error) {
 		return
 	case semantic.Array:
 		a := v.Array()
+		// FIXME: needs a test
+		if _, ok := a.(ITableObject); ok {
+			_, err = w.WriteString("<table stream>")
+			return
+		}
 		multiline := a.Len() > 3
 		_, err = w.WriteString("[")
 		if err != nil {

--- a/values/display.go
+++ b/values/display.go
@@ -31,6 +31,9 @@ func display(w *bufio.Writer, v Value, indent int) (err error) {
 	if v.IsNull() {
 		_, err = w.WriteString("<null>")
 		return
+	} else if _, ok := v.(TableObject); ok {
+		_, err = w.WriteString("<table stream>")
+		return
 	}
 	switch v.Type().Nature() {
 	default:
@@ -68,11 +71,7 @@ func display(w *bufio.Writer, v Value, indent int) (err error) {
 		return
 	case semantic.Array:
 		a := v.Array()
-		// FIXME: needs a test
-		if _, ok := a.(TableObject); ok {
-			_, err = w.WriteString("<table stream>")
-			return
-		}
+		// XXX: vetted as a non-TableObject at the top of the function; Len() should be safe.
 		multiline := a.Len() > 3
 		_, err = w.WriteString("[")
 		if err != nil {

--- a/values/display.go
+++ b/values/display.go
@@ -69,7 +69,7 @@ func display(w *bufio.Writer, v Value, indent int) (err error) {
 	case semantic.Array:
 		a := v.Array()
 		// FIXME: needs a test
-		if _, ok := a.(ITableObject); ok {
+		if _, ok := a.(TableObject); ok {
 			_, err = w.WriteString("<table stream>")
 			return
 		}

--- a/values/display_test.go
+++ b/values/display_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -17,6 +18,10 @@ func TestDisplay(t *testing.T) {
 		value   values.Value
 		display string
 	}{
+		{
+			value:   &flux.TableObject{},
+			display: "<table stream>",
+		},
 		{
 			value:   values.NewNull(semantic.BasicInt),
 			display: "<null>",

--- a/values/values.go
+++ b/values/values.go
@@ -20,6 +20,7 @@ type Typer interface {
 // TableObject serves as sort of a "marker trait" to allow us to check if a
 // value is a flux.TableObject without having to import the flux package which
 // in many cases will cause a cyclical import.
+// XXX: remove when array/stream are different types <https://github.com/influxdata/flux/issues/4343>
 type TableObject interface {
 	TableObject()
 }
@@ -188,7 +189,6 @@ func Unwrap(v Value) interface{} {
 		return v.Regexp()
 	case semantic.Array:
 		arr := v.Array()
-		// FIXME: needs a test
 		if _, ok := arr.(TableObject); ok {
 			panic(errors.New(codes.Invalid, "cannot unwrap a table stream"))
 		}

--- a/values/values.go
+++ b/values/values.go
@@ -17,12 +17,10 @@ type Typer interface {
 	Type() semantic.MonoType
 }
 
-// ITableObject serves as sort of a "marker trait" to allow us to check if a
-// value is a TableObject without having to import TableObject which would be a
-// cyclical import.
-// Identical purpose to the interface in the interpreter package, but sadly we
-// can't import it here because of yet another potential cycle.
-type ITableObject interface {
+// TableObject serves as sort of a "marker trait" to allow us to check if a
+// value is a flux.TableObject without having to import the flux package which
+// in many cases will cause a cyclical import.
+type TableObject interface {
 	TableObject()
 }
 
@@ -191,7 +189,7 @@ func Unwrap(v Value) interface{} {
 	case semantic.Array:
 		arr := v.Array()
 		// FIXME: needs a test
-		if _, ok := arr.(ITableObject); ok {
+		if _, ok := arr.(TableObject); ok {
 			panic(errors.New(codes.Invalid, "cannot unwrap a table stream"))
 		}
 		a := make([]interface{}, arr.Len())

--- a/values/values_test.go
+++ b/values/values_test.go
@@ -60,6 +60,19 @@ func TestUnexpectedKind(t *testing.T) {
 	}
 }
 
+func TestUnwrap_ArrayIsOk(t *testing.T) {
+	values.Unwrap(values.NewArray(semantic.NewArrayType(semantic.BasicInt)))
+}
+
+func TestUnwrap_TableObjectIsPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("Expected panic, but there was none")
+		}
+	}()
+	values.Unwrap(&flux.TableObject{})
+}
+
 // result stores results from the benchmark at the package level.
 // Assigning to a global value prevents the optimizer from removing
 // the assignment as it cannot determine whether the value will


### PR DESCRIPTION
`TableObject` currently implements the `Array` interface but all the
methods panic, explaining they are unsupported.

This change aims to avoid panicking and instead give an error message
suited to each case.

A new interface is introduced, `values.TableObject,` which allows type
assertions to be made without importing `flux` (to get access to
`flux.TableObject`). This is a tactic to avoid cyclical imports. For
cases where the module already had access to `flux.TableObject`, it's
used directly. For most other cases, `values` was already imported
making the interface available. For other cases, `values.TableObject`
is favored to avoid more contention on `flux`.

Each place where we make a type assertion, there's a link to #4343 which hopes to help track down all these checks for removal later. They should become redundant once we're typing the difference between array and table stream more strongly, preventing one of either type to "sneak through" in situations where it isn't appropriate.

New tests have been added for many, but not all, of the new branches. The omitted ones fall into a few categories:

- side effects that would otherwise look to contact some remote service
- private functions that can't be tested because cyclical imports would need to be introduced to do so
- I couldn't figure out how to build a `TableObject` suited for the situation (nil defaults technically leave these "invalid" for many purposes)

---

Earlier patches targeted specific callsites that appeared in logs:

- <https://github.com/influxdata/flux/pull/4272>
- <https://github.com/influxdata/flux/pull/4276>


### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [x] Test cases written
