### PR TITLE
fix(stdlib): change the default epsilon for testing.diff to 1e-6

### DIFF
--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -2,11 +2,10 @@ package executetest
 
 import (
 	"math"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"testing"
-
-	"runtime/debug"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -23,7 +22,7 @@ import (
 
 // Two floating point values are considered
 // equal if they are within tol of each other.
-const tol float64 = 1e-25
+const tol float64 = 1e-6
 
 // The maximum number of floating point values that are allowed
 // to lie between two float64s and still be considered equal.

--- a/stdlib/testing/diff.go
+++ b/stdlib/testing/diff.go
@@ -17,7 +17,7 @@ import (
 )
 
 const DiffKind = "diff"
-const DefaultEpsilon = 1e-9
+const DefaultEpsilon = 1e-6
 const DefaultNaNsEqual = false
 
 type DiffOpSpec struct {


### PR DESCRIPTION
The default epsilon was too precise for our test cases. Changing the
epsilon to `1e-6` from `1e-9` to allow for the tests to pass on both
amd64 and arm64.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written