### PR TITLE
fix: Split the entire pipe chain on multiple if necessary

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -832,9 +832,9 @@ checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "pretty"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a4b252933306dc53486fa81ab3358588af32fb78f26244b6c4a4c9d58e1804"
+checksum = "29afd15870fab34b2a8884481a68f052b3d720cfb29666d7ae0ac2a42ea10289"
 dependencies = [
  "arrayvec",
  "log",

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -35,7 +35,7 @@ fnv = "1.0.7"
 derive_more = { version = "0.99.11", default-features = false, features = [
     "display"
 ] }
-pretty = "0.11.1"
+pretty = "0.11.2"
 serde = { version = "^1.0.59", features = ["rc"] }
 serde_derive = "^1.0.59"
 serde_json = "1.0"

--- a/libflux/flux-core/src/formatter/mod.rs
+++ b/libflux/flux-core/src/formatter/mod.rs
@@ -1399,21 +1399,10 @@ impl<'doc> Formatter<'doc> {
         loop {
             match (operators.next(), arguments.next()) {
                 (Some(operator), Some(arg)) => {
-                    doc = docs![
-                        arena,
-                        doc,
-                        docs![
-                            arena,
-                            operator,
-                            arg,
-                            if arguments.peek().is_some() {
-                                line.clone()
-                            } else {
-                                arena.nil()
-                            }
-                        ]
-                        .group(),
-                    ];
+                    doc += docs![arena, operator, arg].group();
+                    if arguments.peek().is_some() {
+                        doc += line.clone();
+                    }
                 }
                 _ => return docs![arena, first, doc.nest(INDENT)].group(),
             }

--- a/libflux/flux-core/src/formatter/tests.rs
+++ b/libflux/flux-core/src/formatter/tests.rs
@@ -1918,10 +1918,13 @@ fn astutil_test_format_with_comments() {
 #[test]
 fn format_long_single_line_pipe_expression() {
     let src = r#"from(bucket: "foo") |> range(start: -1d, stop: now()) |> filter(fn: (r) => r._field == "usage_user") |> aggregateWindow(every: 1m, fn: mean) |> yield()"#;
-    expect_format(src, expect![[r#"
+    expect_format(
+        src,
+        expect![[r#"
         from(bucket: "foo")
             |> range(start: -1d, stop: now())
             |> filter(fn: (r) => r._field == "usage_user")
             |> aggregateWindow(every: 1m, fn: mean)
-            |> yield()"#]]);
+            |> yield()"#]],
+    );
 }

--- a/libflux/flux-core/src/formatter/tests.rs
+++ b/libflux/flux-core/src/formatter/tests.rs
@@ -3,7 +3,7 @@ use std::str;
 // This gives us a colorful diff.
 use pretty_assertions::assert_eq;
 
-use expect_test::expect;
+use expect_test::{expect, Expect};
 
 use super::*;
 
@@ -27,6 +27,11 @@ fn assert_format(script: &str, expected: &str) {
         "\n EXPECTED: \n {} \n OUTPUT: \n {} \n",
         expected, output
     );
+}
+
+#[track_caller]
+fn expect_format(script: &str, expect: Expect) {
+    expect.assert_eq(&format(script).unwrap());
 }
 
 #[test]
@@ -1908,4 +1913,15 @@ fn astutil_test_format_with_comments() {
         // comments
         j// not lost"#]]
     .assert_eq(&format(src).unwrap());
+}
+
+#[test]
+fn format_long_single_line_pipe_expression() {
+    let src = r#"from(bucket: "foo") |> range(start: -1d, stop: now()) |> filter(fn: (r) => r._field == "usage_user") |> aggregateWindow(every: 1m, fn: mean) |> yield()"#;
+    expect_format(src, expect![[r#"
+        from(bucket: "foo")
+            |> range(start: -1d, stop: now())
+            |> filter(fn: (r) => r._field == "usage_user")
+            |> aggregateWindow(every: 1m, fn: mean)
+            |> yield()"#]]);
 }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,9 +12,9 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "94f35b565d2dc6ff0df3e57cd991d12f4b67061fb6121220ce5b49f8ff85d765",
+	"libflux/Cargo.lock":                                                                          "3016140a3ab2e16ad75a710d0a44d196b9bf158da8f7e845168b789cf66f562b",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "d517be278b990ba95c0365a48f1faed2f2ad685f9ef6347237201b15dd89e2a6",
+	"libflux/flux-core/Cargo.toml":                                                                "b862c6250262b7eab2c99cbd9fa38a870f790051612958d4b2d58e2ac9d01bb4",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "047e68cdcbe6a490bab51991e1131b22cbdda880774296d71ac4f7f2cfd146d1",
 	"libflux/flux-core/src/ast/flatbuffers/ast_generated.rs":                                      "895e09284030a8ea05883fbb71d67282a6b567678126f2e2aadfc5bca72ed47d",
 	"libflux/flux-core/src/ast/flatbuffers/mod.rs":                                                "b02d316decf95ec20cd98bf7cb4b015be32b0d087399d9a35d9b9349a2cb4e6c",
@@ -27,7 +27,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/doc/example.rs":                                                        "a90658dd3cf6d983aa2b59c1174dd32df9eee8d35756667b393bd1873f120398",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "fbf58c52a57be72c910232db9ab26189f6da0cad4f22c88f6f8e29181b51e9f1",
 	"libflux/flux-core/src/errors.rs":                                                             "4944f1b71bbc6499b3d11a3b8afdb7c993f14b5be6bf7189ad066ddf5a6c6203",
-	"libflux/flux-core/src/formatter/mod.rs":                                                      "73b2da1f0376e208b555f59651df4800f708cc5417497bc28b671239103c00ca",
+	"libflux/flux-core/src/formatter/mod.rs":                                                      "ce5a9cc62729d03de253d97acf62b6ee385190a4acdcf14c75f4735e2c122ad1",
 	"libflux/flux-core/src/lib.rs":                                                                "f247ea5b4bf05bdbaf8463f7b6ca1b3de7702f98915adc3fdde9fd5a1a7f0743",
 	"libflux/flux-core/src/parser/mod.rs":                                                         "637a3db9d2abc0a44fb9956dc8828a95acbc931e26cafec7d7e39ec76fefe686",
 	"libflux/flux-core/src/parser/strconv.rs":                                                     "09b6089d3293d7722c2dbf94e3fb0146b3c056fb2803c2bcb3cda343b2849667",

--- a/stdlib/influxdata/influxdb/from_test.go
+++ b/stdlib/influxdata/influxdb/from_test.go
@@ -276,7 +276,8 @@ from(bucket: "telegraf") |> range(start: 2018-05-30T09:00:00Z, stop: 2018-05-30T
 
 
 from(bucket: "telegraf")
-    |> range(start: 2020-10-22T09:29:00Z, stop: 2020-10-22T09:30:00Z) |> filter(
+    |> range(start: 2020-10-22T09:29:00Z, stop: 2020-10-22T09:30:00Z)
+    |> filter(
         fn: (r) => {
             return r["_value"] >= 0.0
         },
@@ -318,7 +319,8 @@ from(bucket: "telegraf")
 
 
 from(bucket: "telegraf")
-    |> range(start: 2020-10-22T09:29:00Z, stop: 2020-10-22T09:30:00Z) |> filter(
+    |> range(start: 2020-10-22T09:29:00Z, stop: 2020-10-22T09:30:00Z)
+    |> filter(
         fn: (r) => {
             return r["_value"] >= 0.0
         },
@@ -380,7 +382,8 @@ import "math"
 import math "math"
 
 from(bucket: "telegraf")
-    |> range(start: 2020-10-22T09:29:00Z, stop: 2020-10-22T09:30:00Z) |> filter(
+    |> range(start: 2020-10-22T09:29:00Z, stop: 2020-10-22T09:30:00Z)
+    |> filter(
         fn: (r) => {
             return r["_value"] >= math["pi"]
         },


### PR DESCRIPTION
This wasn't noticed before as the code will keep any already multiline pipe chain on multiple lines, so this only occured if the entire chain was on a single line, but couldn't actually fit.


### Done checklist
- [x] Test cases written
