### PR TITLE
feat: Add optional types

### DIFF
--- a/libflux/flux-core/src/ast/mod.rs
+++ b/libflux/flux-core/src/ast/mod.rs
@@ -610,6 +610,8 @@ pub enum MonoType {
     Record(RecordType),
     #[serde(rename = "FunctionType")]
     Function(Box<FunctionType>),
+    #[serde(rename = "OptionalType")]
+    Optional(Box<OptionalType>),
 }
 
 impl MonoType {
@@ -623,6 +625,7 @@ impl MonoType {
             MonoType::Dict(t) => &t.base,
             MonoType::Record(t) => &t.base,
             MonoType::Function(t) => &t.base,
+            MonoType::Optional(t) => &t.base,
         }
     }
 }
@@ -686,6 +689,16 @@ pub struct FunctionType {
     #[serde(flatten)]
     pub base: BaseNode,
     pub parameters: Vec<ParameterType>,
+    pub monotype: MonoType,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
+pub struct OptionalType {
+    #[serde(skip_serializing_if = "BaseNode::is_empty")]
+    #[serde(default)]
+    #[serde(flatten)]
+    pub base: BaseNode,
     pub monotype: MonoType,
 }
 

--- a/libflux/flux-core/src/ast/walk/mod.rs
+++ b/libflux/flux-core/src/ast/walk/mod.rs
@@ -466,6 +466,9 @@ where
 
                     walk(v, Node::MonoType(&f.monotype));
                 }
+                MonoType::Optional(o) => {
+                    walk(&w, Node::MonoType(&o.monotype));
+                }
             },
             Node::PropertyType(n) => {
                 walk(v, Node::from_property_key(&n.name));

--- a/libflux/flux-core/src/ast/walk/mod.rs
+++ b/libflux/flux-core/src/ast/walk/mod.rs
@@ -467,7 +467,7 @@ where
                     walk(v, Node::MonoType(&f.monotype));
                 }
                 MonoType::Optional(o) => {
-                    walk(&w, Node::MonoType(&o.monotype));
+                    walk(v, Node::MonoType(&o.monotype));
                 }
             },
             Node::PropertyType(n) => {

--- a/libflux/flux-core/src/formatter/mod.rs
+++ b/libflux/flux-core/src/formatter/mod.rs
@@ -488,6 +488,7 @@ impl<'doc> Formatter<'doc> {
                     self.format_monotype(&n.monotype),
                 ]
             }
+            ast::MonoType::Optional(opt) => docs![arena, self.format_monotype(&opt.monotype), "?"],
         }
         .group()
     }

--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -535,8 +535,8 @@ impl<'input> Parser<'input> {
     /// Parses a mono type
     pub fn parse_monotype(&mut self) -> MonoType {
         // Tvar | Basic | Array | Dict | Record | Function
-        let t = self.peek();
-        match t.tok {
+        let t = self.peek().clone();
+        let mut typ = match t.tok {
             TokenType::LBrack => {
                 let start = self.open(TokenType::LBrack, TokenType::RBrack);
                 let ty = self.parse_monotype();
@@ -579,7 +579,16 @@ impl<'input> Parser<'input> {
                     self.parse_basic_type()
                 }
             }
+        };
+        let question = self.peek();
+        if let TokenType::QuestionMark = question.tok {
+            let question = self.scan();
+            typ = MonoType::Optional(Box::new(OptionalType {
+                base: self.base_node_from_tokens(&t, &question),
+                monotype: typ,
+            }));
         }
+        typ
     }
 
     fn parse_basic_type(&mut self) -> MonoType {

--- a/libflux/flux-core/src/semantic/convert.rs
+++ b/libflux/flux-core/src/semantic/convert.rs
@@ -603,6 +603,9 @@ impl<'a> Converter<'a> {
                 }
                 r
             }
+            ast::MonoType::Optional(opt) => Ok(MonoType::from(types::Optional(
+                self.convert_monotype(opt.monotype, tvars)?,
+            ))),
         }
     }
 

--- a/libflux/flux-core/src/semantic/convert.rs
+++ b/libflux/flux-core/src/semantic/convert.rs
@@ -603,9 +603,9 @@ impl<'a> Converter<'a> {
                 }
                 r
             }
-            ast::MonoType::Optional(opt) => Ok(MonoType::from(types::Optional(
-                self.convert_monotype(opt.monotype, tvars)?,
-            ))),
+            ast::MonoType::Optional(opt) => {
+                MonoType::from(types::Optional(self.convert_monotype(&opt.monotype, tvars)))
+            }
         }
     }
 

--- a/libflux/flux-core/src/semantic/flatbuffers/types.rs
+++ b/libflux/flux-core/src/semantic/flatbuffers/types.rs
@@ -517,6 +517,9 @@ pub fn build_type(
             let offset = build_fun(builder, fun);
             (offset.as_union_value(), fb::MonoType::Fun)
         }
+        MonoType::Optional(_) => {
+            todo!()
+        }
     }
 }
 

--- a/libflux/flux-core/src/semantic/flatbuffers/types.rs
+++ b/libflux/flux-core/src/semantic/flatbuffers/types.rs
@@ -517,9 +517,7 @@ pub fn build_type(
             let offset = build_fun(builder, fun);
             (offset.as_union_value(), fb::MonoType::Fun)
         }
-        MonoType::Optional(_) => {
-            todo!()
-        }
+        MonoType::Optional(typ) => build_type(builder, &typ.0),
     }
 }
 

--- a/libflux/flux-core/src/semantic/fresh.rs
+++ b/libflux/flux-core/src/semantic/fresh.rs
@@ -6,8 +6,8 @@ use crate::semantic::{
     nodes::Symbol,
     sub::{merge, merge3, merge4, merge_collect},
     types::{
-        Collection, Dictionary, Function, Kind, Label, MonoType, MonoTypeVecMap, PolyType,
-        Property, Record, RecordLabel, SemanticMap, Tvar, TvarMap,
+        Collection, Dictionary, Function, Kind, Label, MonoType, MonoTypeVecMap, Optional,
+        PolyType, Property, Record, RecordLabel, SemanticMap, Tvar, TvarMap,
     },
 };
 
@@ -162,6 +162,7 @@ impl Fresh for MonoType {
             MonoType::Record(obj) => obj.fresh_ref(f, sub).map(MonoType::record),
             MonoType::Fun(fun) => fun.fresh_ref(f, sub).map(MonoType::fun),
             MonoType::Dict(dict) => dict.fresh_ref(f, sub).map(MonoType::dict),
+            MonoType::Optional(dict) => dict.fresh_ref(f, sub).map(MonoType::optional),
         }
     }
 }
@@ -172,6 +173,12 @@ impl Fresh for Tvar {
     }
     fn fresh_ref(&self, f: &mut Fresher, sub: &mut TvarMap) -> Option<Self> {
         Some(*sub.entry(*self).or_insert_with(|| f.fresh()))
+    }
+}
+
+impl Fresh for Optional {
+    fn fresh_ref(&self, f: &mut Fresher, sub: &mut TvarMap) -> Option<Self> {
+        self.0.fresh_ref(f, sub).map(Self)
     }
 }
 

--- a/libflux/flux-core/src/semantic/nodes.rs
+++ b/libflux/flux-core/src/semantic/nodes.rs
@@ -1394,7 +1394,9 @@ impl ConditionalExpr {
                 if let Expression::Identifier(record_ident) = &mut member.object {
                     record_ident.infer(infer)?;
 
+                    unary.typ = MonoType::BOOL;
                     member.typ = MonoType::Var(infer.sub.fresh());
+
                     infer.equal(
                         &MonoType::from(types::Record::new(
                             [types::Property {

--- a/libflux/flux-core/src/semantic/nodes.rs
+++ b/libflux/flux-core/src/semantic/nodes.rs
@@ -1435,7 +1435,7 @@ impl ConditionalExpr {
                     // the full record
                     infer.equal(&record_rest, &record_ident.typ, &record_ident.loc);
 
-                    infer.equal(
+                    self.typ = infer.equal(
                         &self.consequent.type_of(),
                         &self.alternate.type_of(),
                         &self.alternate.loc(),

--- a/libflux/flux-core/src/semantic/nodes.rs
+++ b/libflux/flux-core/src/semantic/nodes.rs
@@ -1398,7 +1398,7 @@ impl ConditionalExpr {
                     infer.equal(
                         &MonoType::from(types::Record::new(
                             [types::Property {
-                                k: Label::from(member.property.clone()),
+                                k: Label::from(member.property.clone()).into(),
                                 v: MonoType::from(types::Optional(member.typ.clone())),
                             }],
                             Some(MonoType::Var(infer.sub.fresh())),
@@ -1417,7 +1417,7 @@ impl ConditionalExpr {
                         record_ident.name.clone(),
                         MonoType::from(types::Record::new(
                             [types::Property {
-                                k: Label::from(member.property.clone()),
+                                k: Label::from(member.property.clone()).into(),
                                 v: member.typ.clone(),
                             }],
                             Some(record_rest.clone()),

--- a/libflux/flux-core/src/semantic/tests.rs
+++ b/libflux/flux-core/src/semantic/tests.rs
@@ -4146,4 +4146,14 @@ fn exists_operator() {
         "#,
         err: "error @3:45-3:46: record is missing label a",
     }
+
+    // Should be an error as `a` exists, but has the wrong type (or it should fail the exists check
+    // at runtime at least)
+    test_error_msg! {
+        src: r#"
+            f = (r) => if exists r.a then r.a else 0
+            x = f(r: { a: "" })
+        "#,
+        err: "error @3:45-3:46: TODO",
+    }
 }

--- a/libflux/flux-core/src/semantic/tests.rs
+++ b/libflux/flux-core/src/semantic/tests.rs
@@ -4170,7 +4170,13 @@ fn exists_operator_errors() {
             x = if exists r.a then r.a else r.a
         "#,
         expect: expect![[r#"
-            error @3:45-3:46: record is missing label a"#]],
+            error: record is missing label a
+              ┌─ main:3:45
+              │
+            3 │             x = if exists r.a then r.a else r.a
+              │                                             ^
+
+        "#]],
     }
 
     // Should be an error as `a` exists, but has the wrong type (or it should fail the exists check
@@ -4180,6 +4186,13 @@ fn exists_operator_errors() {
             f = (r) => if exists r.a then r.a else 0
             x = f(r: { a: "" })
         "#,
-        expect: expect![[r#"error @3:17-3:32: expected int? but found string (argument r)"#]]
+        expect: expect![[r#"
+            error: expected int but found string (argument r)
+              ┌─ main:3:22
+              │
+            3 │             x = f(r: { a: "" })
+              │                      ^^^^^^^^^
+
+        "#]]
     }
 }

--- a/libflux/flux-core/src/semantic/types.rs
+++ b/libflux/flux-core/src/semantic/types.rs
@@ -188,6 +188,16 @@ pub struct PolyType {
     pub expr: MonoType,
 }
 
+impl From<MonoType> for PolyType {
+    fn from(expr: MonoType) -> Self {
+        PolyType {
+            vars: Vec::new(),
+            cons: TvarKinds::new(),
+            expr,
+        }
+    }
+}
+
 /// Map of identifier to a polytype that preserves a sorted order when iterating.
 pub type PolyTypeMap<T = String> = SemanticMap<T, PolyType>;
 /// Nested map of polytypes that preserves a sorted order when iterating


### PR DESCRIPTION
Continued prototype of https://github.com/influxdata/flux/issues/4073#issuecomment-951892648 to try and visualize the scope.

This adds the optional type to the typesystem (`A?`, `{ A with b: B? }`), primarily to represent fields that may or may not exist. Instead of representing this directly on the record fields I represent it on `MonoType` which will complicate things a bit now, but should avoid the complexity of a potential `{ a with a?: int? }` if optional types were added later.

* We should probably prevent `A??` etc from being valid.
* Unification will need to handle subsumption (subtyping) which is added in a bit of a hacky way currently. But the short of it is that `unify` only checks that two types are equal, but under optional types (fields) we must allow `int` to be passed in place of `int?`, but not the other way around.
* I believe nulls may be generated from sources today(?). If we know whether a column of a source is strictly null/non-null, perhaps this can be used to be more precise about that. It runs the risk of increased verbosity though. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
