### PR TITLE
test: add a table stream test for is_type, to test push downs

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -420,7 +420,7 @@ var sourceHashes = map[string]string{
 	"stdlib/testing/usage/storage_test.flux":                                                      "11360536a5023809df4ee2fdeb7404cc8286abc6e2b59485c6bdb05c0d8a9af5",
 	"stdlib/testing/usage/writes_test.flux":                                                       "88ddcba45de796c2794e93483f1dbc425873df979f9881c92dc6339a5dad07ac",
 	"stdlib/timezone/timezone.flux":                                                               "27f1fb30b0474168c9861d585752c9dafc1500f44f9c6afc16882fc2b7210063",
-	"stdlib/types/is_type_test.flux":                                                              "102f61e8c8116b44bb6352c04e9014e738b05de99fbc6d4f5ac1dc54ffdffc3e",
+	"stdlib/types/is_type_test.flux":                                                              "66daa27dea82fff1325bd6823274a2946ce75e4e27c9b6068c2f2c82677f7257",
 	"stdlib/types/types.flux":                                                                     "1e04dba942e7b03f84271bc27854ac1e8654d4e537ab9bc7c91d70179ca1aff7",
 	"stdlib/universe/aggregate_empty_window_count_test.flux":                                      "39ac3741edab42fc471bcee92c70db37ad62c23ed3cb5574c238235d9bd9f9a0",
 	"stdlib/universe/aggregate_empty_window_first_test.flux":                                      "9aead8a23604ed2337dfffbd49e2429c80a5f6ba92ae71f96ad7fe6d91f1a23f",

--- a/stdlib/types/is_type_test.flux
+++ b/stdlib/types/is_type_test.flux
@@ -1,6 +1,8 @@
 package types_test
 
 
+import "array"
+import "internal/debug"
 import "testing"
 import "types"
 
@@ -21,4 +23,135 @@ testcase isType5 {
 }
 testcase isType6 {
     testing.assertEqualValues(want: false, got: types.isType(v: 2030-01-01T00:00:00Z, type: "int"))
+}
+
+tableDataF0 =
+    array.from(
+        rows: [
+            {_measurement: "m", _field: "f0", _value: "cat", _time: 2021-12-16T00:00:00Z},
+            {_measurement: "m", _field: "f0", _value: "dog", _time: 2021-12-16T00:01:00Z},
+            {_measurement: "m", _field: "f0", _value: "emu", _time: 2021-12-16T00:02:00Z},
+            {_measurement: "m", _field: "f0", _value: "rat", _time: 2021-12-16T00:03:00Z},
+            {_measurement: "m", _field: "f0", _value: "bird", _time: 2021-12-16T00:04:00Z},
+        ],
+    )
+        |> group(columns: ["_measurement", "_field"])
+        |> debug.opaque()
+
+tableDataF1 =
+    array.from(
+        rows: [
+            {_measurement: "m", _field: "f1", _value: 10, _time: 2021-12-16T00:00:00Z},
+            {_measurement: "m", _field: "f1", _value: 11, _time: 2021-12-16T00:01:00Z},
+            {_measurement: "m", _field: "f1", _value: 12, _time: 2021-12-16T00:02:00Z},
+            {_measurement: "m", _field: "f1", _value: 13, _time: 2021-12-16T00:03:00Z},
+            {_measurement: "m", _field: "f1", _value: 14, _time: 2021-12-16T00:04:00Z},
+        ],
+    )
+        |> group(columns: ["_measurement", "_field"])
+        |> debug.opaque()
+
+tableDataF2 =
+    array.from(
+        rows: [
+            {_measurement: "m", _field: "f2", _value: uint(v: 10), _time: 2021-12-16T00:00:00Z},
+            {_measurement: "m", _field: "f2", _value: uint(v: 11), _time: 2021-12-16T00:01:00Z},
+            {_measurement: "m", _field: "f2", _value: uint(v: 12), _time: 2021-12-16T00:02:00Z},
+            {_measurement: "m", _field: "f2", _value: uint(v: 13), _time: 2021-12-16T00:03:00Z},
+            {_measurement: "m", _field: "f2", _value: uint(v: 14), _time: 2021-12-16T00:04:00Z},
+        ],
+    )
+        |> group(columns: ["_measurement", "_field"])
+        |> debug.opaque()
+
+tableDataF3 =
+    array.from(
+        rows: [
+            {_measurement: "m", _field: "f3", _value: 10.0, _time: 2021-12-16T00:00:00Z},
+            {_measurement: "m", _field: "f3", _value: 11.0, _time: 2021-12-16T00:01:00Z},
+            {_measurement: "m", _field: "f3", _value: 12.0, _time: 2021-12-16T00:02:00Z},
+            {_measurement: "m", _field: "f3", _value: 13.0, _time: 2021-12-16T00:03:00Z},
+            {_measurement: "m", _field: "f3", _value: 14.0, _time: 2021-12-16T00:04:00Z},
+        ],
+    )
+        |> group(columns: ["_measurement", "_field"])
+        |> debug.opaque()
+
+tableDataF4 =
+    array.from(
+        rows: [
+            {_measurement: "m", _field: "f4", _value: true, _time: 2021-12-16T00:00:00Z},
+            {_measurement: "m", _field: "f4", _value: false, _time: 2021-12-16T00:01:00Z},
+            {_measurement: "m", _field: "f4", _value: true, _time: 2021-12-16T00:02:00Z},
+            {_measurement: "m", _field: "f4", _value: false, _time: 2021-12-16T00:03:00Z},
+            {_measurement: "m", _field: "f4", _value: true, _time: 2021-12-16T00:04:00Z},
+        ],
+    )
+        |> group(columns: ["_measurement", "_field"])
+        |> debug.opaque()
+
+tableData =
+    union(
+        tables: [
+            tableDataF0,
+            tableDataF1,
+            tableDataF2,
+            tableDataF3,
+            tableDataF4,
+        ],
+    )
+
+testcase isTypeTableString {
+    want = tableDataF0
+    got =
+        testing.load(tables: tableData)
+            |> range(start: -100)
+            |> filter(fn: (r) => types.isType(v: r._value, type: "string"))
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase isTypeTableInt {
+    want = tableDataF1
+    got =
+        testing.load(tables: tableData)
+            |> range(start: -100)
+            |> filter(fn: (r) => types.isType(v: r._value, type: "int"))
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase isTypeTableUint {
+    want = tableDataF2
+    got =
+        testing.load(tables: tableData)
+            |> range(start: -100)
+            |> filter(fn: (r) => types.isType(v: r._value, type: "uint"))
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase isTypeTableFloat {
+    want = tableDataF3
+    got =
+        testing.load(tables: tableData)
+            |> range(start: -100)
+            |> filter(fn: (r) => types.isType(v: r._value, type: "float"))
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
+}
+
+testcase isTypeTableBool {
+    want = tableDataF4
+    got =
+        testing.load(tables: tableData)
+            |> range(start: -100)
+            |> filter(fn: (r) => types.isType(v: r._value, type: "bool"))
+            |> drop(columns: ["_start", "_stop"])
+
+    testing.diff(got, want) |> yield()
 }


### PR DESCRIPTION
These new tests will be extended to test out pushing down type predicates into the storage tier.

Part of #2159.