### PR TITLE
refactor(execute): refactor the disposable interface to closer

### DIFF
--- a/execute/aggregate_test.go
+++ b/execute/aggregate_test.go
@@ -318,8 +318,9 @@ func TestAggregateTransformation_Finish(t *testing.T) {
 				isComputed = true
 				return nil
 			},
-			DisposeFn: func() {
+			CloseFn: func() error {
 				isDisposed = true
+				return nil
 			},
 		},
 		mem,
@@ -986,8 +987,9 @@ type mockState struct {
 	disposeCount *int
 }
 
-func (s *mockState) Dispose() {
+func (s *mockState) Close() error {
 	if s.disposeCount != nil {
 		*s.disposeCount++
 	}
+	return nil
 }

--- a/execute/closer.go
+++ b/execute/closer.go
@@ -1,0 +1,19 @@
+package execute
+
+// Closer is an interface to be implemented for a resource
+// that will be closed at a defined time.
+type Closer interface {
+	// Close is invoked when the resource will no longer be used.
+	Close() error
+}
+
+// Close is a convenience method that will take an error and a
+// Closer. This will call the Close method on the Closer. If the
+// error is nil, it will return any error from the Close method.
+// If the error was not nil, it will return the error.
+func Close(err error, c Closer) error {
+	if e := c.Close(); e != nil && err == nil {
+		err = e
+	}
+	return err
+}

--- a/execute/disposable.go
+++ b/execute/disposable.go
@@ -1,8 +1,0 @@
-package execute
-
-// Disposable is an interface to be implemented for a resource
-// that will be disposed of at a defined time.
-type Disposable interface {
-	// Dispose is invoked when the resource will no longer be used.
-	Dispose()
-}

--- a/execute/group_transformation.go
+++ b/execute/group_transformation.go
@@ -14,7 +14,7 @@ import (
 type GroupTransformation interface {
 	Process(chunk table.Chunk, d *TransportDataset, mem memory.Allocator) error
 
-	Disposable
+	Closer
 }
 
 var _ Transport = (*groupTransformation)(nil)
@@ -56,6 +56,6 @@ func (g *groupTransformation) ProcessMessage(m Message) error {
 }
 
 func (g *groupTransformation) Finish(id DatasetID, err error) {
+	err = Close(err, g.t)
 	g.d.Finish(err)
-	g.t.Dispose()
 }

--- a/execute/group_transformation_test.go
+++ b/execute/group_transformation_test.go
@@ -206,8 +206,9 @@ func TestGroupTransformation_Finish(t *testing.T) {
 	tr, d, err := execute.NewGroupTransformation(
 		executetest.RandomDatasetID(),
 		&mock.GroupTransformation{
-			DisposeFn: func() {
+			CloseFn: func() error {
 				isDisposed = true
+				return nil
 			},
 		},
 		memory.DefaultAllocator,

--- a/execute/narrow_state_transformation_test.go
+++ b/execute/narrow_state_transformation_test.go
@@ -270,8 +270,9 @@ func TestNarrowStateTransformation_Finish(t *testing.T) {
 					disposeCount: &disposeCount,
 				}, true, nil
 			},
-			DisposeFn: func() {
+			CloseFn: func() error {
 				isDisposed = true
+				return nil
 			},
 		},
 		memory.DefaultAllocator,

--- a/execute/narrow_transformation.go
+++ b/execute/narrow_transformation.go
@@ -11,7 +11,7 @@ type NarrowTransformation interface {
 	// Process will process the table.Chunk and send any output to the TransportDataset.
 	Process(chunk table.Chunk, d *TransportDataset, mem memory.Allocator) error
 
-	Disposable
+	Closer
 }
 
 var _ Transport = (*narrowTransformation)(nil)
@@ -51,8 +51,8 @@ func (n *narrowTransformation) ProcessMessage(m Message) error {
 
 // Finish is implemented to remain compatible with legacy upstreams.
 func (n *narrowTransformation) Finish(id DatasetID, err error) {
+	err = Close(err, n.t)
 	n.d.Finish(err)
-	n.t.Dispose()
 }
 
 func (n *narrowTransformation) OperationType() string {

--- a/execute/narrow_transformation_test.go
+++ b/execute/narrow_transformation_test.go
@@ -219,8 +219,9 @@ func TestNarrowTransformation_Finish(t *testing.T) {
 	tr, d, err := execute.NewNarrowTransformation(
 		executetest.RandomDatasetID(),
 		&mock.NarrowTransformation{
-			DisposeFn: func() {
+			CloseFn: func() error {
 				isDisposed = true
+				return nil
 			},
 		},
 		memory.DefaultAllocator,

--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -132,7 +132,7 @@ func (p *Analyzer) Analyze(src string, astPkg *ASTPkg) (*SemanticPkg, *FluxError
 		astPkg.ptr = nil
 	}()
 	if err := C.flux_analyze_with(p.ptr, csrc, astPkg.ptr, &semPkg); err != nil {
-		err := &FluxError { ptr: err }
+		err := &FluxError{ptr: err}
 		runtime.SetFinalizer(err, free)
 		return nil, err
 	}
@@ -164,7 +164,6 @@ func EnvStdlib() []byte {
 	return C.GoBytes(unsafe.Pointer(buf.data), C.int(buf.len))
 }
 
-
 type FluxError struct {
 	ptr *C.struct_flux_error_t
 }
@@ -187,5 +186,5 @@ func (p *FluxError) Print() {
 func (p *FluxError) GoError() error {
 	cstr := C.flux_error_str(p.ptr)
 	str := C.GoString(cstr)
-	return  errors.New(codes.Invalid, str)
+	return errors.New(codes.Invalid, str)
 }

--- a/mock/transformation.go
+++ b/mock/transformation.go
@@ -34,53 +34,56 @@ func (t *Transformation) Finish(id execute.DatasetID, err error) {
 
 type GroupTransformation struct {
 	ProcessFn func(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error
-	DisposeFn func()
+	CloseFn   func() error
 }
 
 func (n *GroupTransformation) Process(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error {
 	return n.ProcessFn(chunk, d, mem)
 }
 
-func (a *GroupTransformation) Dispose() {
-	if a.DisposeFn != nil {
-		a.DisposeFn()
+func (a *GroupTransformation) Close() error {
+	if a.CloseFn != nil {
+		return a.CloseFn()
 	}
+	return nil
 }
 
 type NarrowTransformation struct {
 	ProcessFn func(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error
-	DisposeFn func()
+	CloseFn   func() error
 }
 
 func (n *NarrowTransformation) Process(chunk table.Chunk, d *execute.TransportDataset, mem memory.Allocator) error {
 	return n.ProcessFn(chunk, d, mem)
 }
 
-func (a *NarrowTransformation) Dispose() {
-	if a.DisposeFn != nil {
-		a.DisposeFn()
+func (a *NarrowTransformation) Close() error {
+	if a.CloseFn != nil {
+		return a.CloseFn()
 	}
+	return nil
 }
 
 type NarrowStateTransformation struct {
 	ProcessFn func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error)
-	DisposeFn func()
+	CloseFn   func() error
 }
 
 func (n *NarrowStateTransformation) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
 	return n.ProcessFn(chunk, state, d, mem)
 }
 
-func (a *NarrowStateTransformation) Dispose() {
-	if a.DisposeFn != nil {
-		a.DisposeFn()
+func (a *NarrowStateTransformation) Close() error {
+	if a.CloseFn != nil {
+		return a.CloseFn()
 	}
+	return nil
 }
 
 type AggregateTransformation struct {
 	AggregateFn func(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error)
 	ComputeFn   func(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error
-	DisposeFn   func()
+	CloseFn     func() error
 }
 
 func (a *AggregateTransformation) Aggregate(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error) {
@@ -91,8 +94,9 @@ func (a *AggregateTransformation) Compute(key flux.GroupKey, state interface{}, 
 	return a.ComputeFn(key, state, d, mem)
 }
 
-func (a *AggregateTransformation) Dispose() {
-	if a.DisposeFn != nil {
-		a.DisposeFn()
+func (a *AggregateTransformation) Close() error {
+	if a.CloseFn != nil {
+		return a.CloseFn()
 	}
+	return nil
 }

--- a/stdlib/universe/derivative.go
+++ b/stdlib/universe/derivative.go
@@ -415,7 +415,7 @@ func (t *derivativeTransformation) derivativeStateFor(col flux.ColMeta, state *d
 	}, nil
 }
 
-func (t *derivativeTransformation) Dispose() {}
+func (t *derivativeTransformation) Close() error { return nil }
 
 const derivativeUnsortedTimeErr = "derivative found out-of-order times in time column"
 

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -406,7 +406,7 @@ func (t *filterTransformationAdapter) Process(chunk table.Chunk, d *execute.Tran
 	return d.Process(out)
 }
 
-func (t *filterTransformationAdapter) Dispose() {}
+func (t *filterTransformationAdapter) Close() error { return nil }
 
 // RemoveTrivialFilterRule removes Filter nodes whose predicate always evaluates to true.
 type RemoveTrivialFilterRule struct{}
@@ -464,7 +464,7 @@ func (MergeFiltersRule) Rewrite(ctx context.Context, filterNode plan.Node) (plan
 		// Not an expression.
 		return filterNode, false, nil
 	}
-	//checks if the fields of KeepEmptyTables are different and only allows merge if 1) they are the same 2) keep is the Predecessors field
+	// checks if the fields of KeepEmptyTables are different and only allows merge if 1) they are the same 2) keep is the Predecessors field
 	if filterSpec1.KeepEmptyTables != filterSpec2.KeepEmptyTables && !filterSpec2.KeepEmptyTables {
 		return filterNode, false, nil
 	}

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -175,7 +175,7 @@ func (a *groupTransformationAdapter) Process(chunk table.Chunk, d *execute.Trans
 	return a.t.groupChunkByRow(chunk, d, mem)
 }
 
-func (a *groupTransformationAdapter) Dispose() {}
+func (a *groupTransformationAdapter) Close() error { return nil }
 
 type groupTransformation struct {
 	execute.ExecutionNode

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -274,11 +274,12 @@ func (a *QuantileAgg) NewStringAgg() execute.DoStringAgg {
 	return nil
 }
 
-func (a *QuantileAgg) Dispose() {
+func (a *QuantileAgg) Close() error {
 	for i := 0; i < len(a.freeDigests); i++ {
 		a.mem.Account(tdigest.ByteSizeForCompression(a.Compression) * -1)
 	}
 	a.freeDigests = nil
+	return nil
 }
 
 type QuantileAggState struct {
@@ -308,9 +309,10 @@ func (s *QuantileAggState) IsNull() bool {
 	return !s.ok
 }
 
-func (s *QuantileAggState) Dispose() {
+func (s *QuantileAggState) Close() error {
 	s.parent.pushFreeDigest(s.digest)
 	s.digest = nil
+	return nil
 }
 
 type ExactQuantileAgg struct {

--- a/stdlib/universe/shift2.go
+++ b/stdlib/universe/shift2.go
@@ -91,4 +91,4 @@ func (s *shiftTransformation2) shiftTimes(vs *array.Int, mem memory.Allocator) *
 	return b.NewIntArray()
 }
 
-func (s *shiftTransformation2) Dispose() {}
+func (s *shiftTransformation2) Close() error { return nil }

--- a/stdlib/universe/union2.go
+++ b/stdlib/universe/union2.go
@@ -114,7 +114,7 @@ func (u *unionTransformation2) UpdateProcessingTime(id execute.DatasetID, t exec
 	return nil
 }
 
-func (u *unionTransformation2) Dispose() {}
+func (u *unionTransformation2) Close() error { return nil }
 
 type unionSchema struct {
 	cols  []flux.ColMeta


### PR DESCRIPTION
We will need the ability to return an error from places where dispose
would have been called so renaming this to `Closer` to match `io.Closer`
and changing the signature to return an error.

This does not use `io.Closer` to differentiate the interface from the
one in the standard library, but it is identical.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written