### PR TITLE
feat(stdlib): create an optimized sort limit

### DIFF
--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -32,6 +32,7 @@ var testFlags = map[string]interface{}{
 	"groupTransformationGroup":         true,
 	"optimizeShiftTransformation":      true,
 	"optimizeUnionTransformation":      true,
+	"optimizeSortLimit":                true,
 }
 
 type testFlagger struct{}

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -89,6 +89,18 @@ func OptimizeUnionTransformation() BoolFlag {
 	return optimizeUnionTransformation
 }
 
+var optimizeSortLimit = feature.MakeBoolFlag(
+	"Optimize Sort Limit",
+	"optimizeSortLimit",
+	"Jonathan Sternberg",
+	false,
+)
+
+// OptimizeSortLimit - Optimize sort limit
+func OptimizeSortLimit() BoolFlag {
+	return optimizeSortLimit
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -101,6 +113,7 @@ var all = []Flag{
 	queryConcurrencyLimit,
 	optimizeShiftTransformation,
 	optimizeUnionTransformation,
+	optimizeSortLimit,
 }
 
 var byKey = map[string]Flag{
@@ -110,6 +123,7 @@ var byKey = map[string]Flag{
 	"queryConcurrencyLimit":            queryConcurrencyLimit,
 	"optimizeShiftTransformation":      optimizeShiftTransformation,
 	"optimizeUnionTransformation":      optimizeUnionTransformation,
+	"optimizeSortLimit":                optimizeSortLimit,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -45,3 +45,9 @@
   key: optimizeUnionTransformation
   default: false
   contact: Jonathan Sternberg
+
+- name: Optimize Sort Limit
+  description: Optimize sort limit
+  key: optimizeSortLimit
+  default: false
+  contact: Jonathan Sternberg

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -591,6 +591,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/simple_max_test.flux":                                                        "1196fa76e5f603b53f3ab78980d8810ca94e690b5585fec7c0f5725d7b16518b",
 	"stdlib/universe/skew_test.flux":                                                              "7530c2fc2e84e508749e3a05f97eebf592e7070ae1290a0103cbd0da54271f07",
 	"stdlib/universe/sort2_test.flux":                                                             "3b31fa92a30fafb5ef80e1e24697aa7b62e9385a5174ec255c98cdd5eac3ee1c",
+	"stdlib/universe/sort_limit_test.flux":                                                        "dcce25b63df7f2a2ca40deda79e356b52aec4ecbbd9bc0d73238baa926aec60a",
 	"stdlib/universe/sort_test.flux":                                                              "d0481f200fdd35c4644c86a18215e5256825859a4900fc96bf7cf1a5bcdba846",
 	"stdlib/universe/spread_test.flux":                                                            "3e327ba0a1118f327964a581ac0c557b362d2a564ef1f1d14dbaa5640e085c04",
 	"stdlib/universe/state_count_test.flux":                                                       "b83e62d1e1cc16ce3b18b9c0a033f869912b41eaec381256e9abf1306671f561",

--- a/stdlib/universe/sort_limit.go
+++ b/stdlib/universe/sort_limit.go
@@ -1,0 +1,225 @@
+package universe
+
+import (
+	"context"
+
+	"github.com/apache/arrow/go/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/table"
+	"github.com/influxdata/flux/internal/arrowutil"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/internal/feature"
+	"github.com/influxdata/flux/plan"
+)
+
+func init() {
+	plan.RegisterPhysicalRules(SortLimitRule{})
+	execute.RegisterTransformation(SortLimitKind, createSortLimitTransformation)
+}
+
+const SortLimitKind = "sortLimit"
+
+type SortLimitProcedureSpec struct {
+	*SortProcedureSpec
+	N int64
+}
+
+func (s *SortLimitProcedureSpec) Kind() plan.ProcedureKind {
+	return SortLimitKind
+}
+
+func (s *SortLimitProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := *s
+	ns.SortProcedureSpec = s.SortProcedureSpec.Copy().(*SortProcedureSpec)
+	return &ns
+}
+
+func createSortLimitTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*SortLimitProcedureSpec)
+	if !ok {
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
+	}
+	return NewSortLimitTransformation(id, s, a.Allocator())
+}
+
+type sortLimitTransformation struct {
+	sortTransformation
+	limit int64
+}
+
+func NewSortLimitTransformation(id execute.DatasetID, spec *SortLimitProcedureSpec, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+	t := sortLimitTransformation{
+		sortTransformation: sortTransformation{
+			mem:     mem,
+			cols:    spec.Columns,
+			compare: arrowutil.Compare,
+		},
+		limit: spec.N,
+	}
+	if spec.Desc {
+		// If descending, use the descending comparison.
+		t.compare = arrowutil.CompareDesc
+	}
+	return execute.NewAggregateTransformation(id, &t, mem)
+}
+
+func (s *sortLimitTransformation) Aggregate(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error) {
+	var mh *sortTableMergeHeap
+	if state != nil {
+		mh = state.(*sortTableMergeHeap)
+	} else {
+		mh = &sortTableMergeHeap{
+			cols:     chunk.Cols(),
+			key:      chunk.Key(),
+			sortCols: s.sortCols(chunk.Key(), chunk.Cols()),
+			compare:  s.compare,
+		}
+
+	}
+
+	if err := s.appendChunk(mh, chunk, mem); err != nil {
+		return nil, false, err
+	}
+
+	tbl, err := mh.Table(int(s.limit), mem)
+	if err != nil {
+		return nil, false, err
+	}
+
+	mh.items = mh.items[:0]
+	if err := tbl.Do(func(cr flux.ColReader) error {
+		cr.Retain()
+		mh.items = append(mh.items, &sortTableMergeHeapItem{cr: cr})
+		return nil
+	}); err != nil {
+		return nil, false, err
+	}
+	return mh, true, nil
+}
+
+func (s *sortLimitTransformation) appendChunk(mh *sortTableMergeHeap, chunk table.Chunk, mem memory.Allocator) error {
+	buffer := chunk.Buffer()
+	buffer.Retain()
+	s.reconcileSchema(mh, &buffer, mem)
+
+	item := &sortTableMergeHeapItem{cr: &buffer}
+	if !s.isSorted(&buffer, mh.sortCols) {
+		item.indices = s.sort(&buffer, mh.sortCols)
+		item.offset = int(item.indices.Value(0))
+	}
+	mh.items = append(mh.items, item)
+	return nil
+}
+
+func (s *sortLimitTransformation) reconcileSchema(mh *sortTableMergeHeap, buffer *arrow.TableBuffer, mem memory.Allocator) {
+	if len(buffer.Columns) == len(mh.cols) {
+		equivalent := true
+		for i, col := range mh.cols {
+			if buffer.Columns[i] != col {
+				equivalent = false
+				break
+			}
+		}
+
+		if equivalent {
+			return
+		}
+	}
+
+	vals := make([]array.Interface, len(mh.cols))
+	for i, col := range buffer.Columns {
+		idx := execute.ColIdx(col.Label, mh.cols)
+		if idx < 0 {
+			// This column was not previously seen.
+			// Backfill the schema and add null columns
+			// in the relevant locations.
+			mh.cols = append(mh.cols, col)
+			if execute.ContainsStr(s.cols, col.Label) {
+				mh.sortCols = append(mh.sortCols, len(mh.cols)-1)
+			}
+			s.backfillColumn(mh, len(mh.cols)-1, mem)
+			vals = append(vals, buffer.Values[i])
+			continue
+		}
+		vals[idx] = buffer.Values[i]
+	}
+
+	// If a previous column existed but doesn't exist in the current buffer,
+	// we need to also backfill it.
+	for i := range vals {
+		if vals[i] == nil {
+			vals[i] = arrow.Nulls(mh.cols[i].Type, buffer.Len(), mem)
+		}
+	}
+	buffer.Columns = mh.cols
+	buffer.Values = vals
+}
+
+func (s *sortLimitTransformation) backfillColumn(mh *sortTableMergeHeap, i int, mem memory.Allocator) {
+	for _, item := range mh.items {
+		cpy := &arrow.TableBuffer{
+			GroupKey: item.cr.Key(),
+			Columns:  mh.cols,
+			Values:   make([]array.Interface, len(mh.cols)),
+		}
+		for j := range item.cr.Cols() {
+			cpy.Values[j] = table.Values(item.cr, j)
+		}
+		cpy.Values[i] = arrow.Nulls(mh.cols[i].Type, item.cr.Len(), mem)
+		item.cr = cpy
+	}
+}
+
+func (s *sortLimitTransformation) Compute(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error {
+	// The chunks are in sorted order already and already chunked.
+	mh := state.(*sortTableMergeHeap)
+	for _, item := range mh.items {
+		chunk := table.ChunkFromReader(item.cr)
+		if err := d.Process(chunk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *sortLimitTransformation) Close() error {
+	return nil
+}
+
+type SortLimitRule struct{}
+
+func (s SortLimitRule) Name() string {
+	return "SortLimitRule"
+}
+
+func (s SortLimitRule) Pattern() plan.Pattern {
+	return plan.Pat(LimitKind, plan.Pat(SortKind, plan.Any()))
+}
+
+func (s SortLimitRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
+	if !feature.OptimizeSortLimit().Enabled(ctx) {
+		return node, false, nil
+	}
+
+	limitSpec := node.ProcedureSpec().(*LimitProcedureSpec)
+	if limitSpec.Offset != 0 {
+		return node, false, nil
+	}
+	sortNode := node.Predecessors()[0]
+	sortSpec := sortNode.ProcedureSpec().(*SortProcedureSpec)
+
+	sortLimitSpec := &SortLimitProcedureSpec{
+		SortProcedureSpec: sortSpec,
+		N:                 limitSpec.N,
+	}
+
+	n, err := plan.MergeToPhysicalNode(node, sortNode, sortLimitSpec)
+	if err != nil {
+		return nil, false, err
+	}
+	return n, true, nil
+}

--- a/stdlib/universe/sort_limit_test.flux
+++ b/stdlib/universe/sort_limit_test.flux
@@ -1,0 +1,126 @@
+package universe_test
+
+
+import "array"
+import "csv"
+import "testing"
+
+testcase sort_limit {
+    got =
+        array.from(
+            rows: [
+                {_time: 2022-01-11T00:00:00Z, _value: 10.0},
+                {_time: 2022-01-11T01:00:00Z, _value: 12.0},
+                {_time: 2022-01-11T02:00:00Z, _value: 18.0},
+                {_time: 2022-01-11T03:00:00Z, _value: 4.0},
+                {_time: 2022-01-11T04:00:00Z, _value: 8.0},
+            ],
+        )
+            |> sort()
+            |> limit(n: 3)
+
+    want =
+        array.from(
+            rows: [
+                {_time: 2022-01-11T03:00:00Z, _value: 4.0},
+                {_time: 2022-01-11T04:00:00Z, _value: 8.0},
+                {_time: 2022-01-11T00:00:00Z, _value: 10.0},
+            ],
+        )
+
+    testing.diff(got: got, want: want)
+}
+
+testcase sort_limit_divergent_schemas {
+        got =
+            csv.from(
+                csv:
+                    "
+#datatype,string,long,dateTime:RFC3339,double,long
+#group,false,false,false,false,true
+#default,_result,,,,
+,result,table,_time,_value,t0
+,,0,2022-01-11T00:00:00Z,10.0,0
+,,0,2022-01-11T01:00:00Z,12.0,0
+
+#datatype,string,long,dateTime:RFC3339,double,long
+#group,false,false,false,false,true
+#default,_result,,,,
+,result,table,_time,_value,t1
+,,1,2022-01-11T00:00:00Z,18.0,1
+,,1,2022-01-11T01:00:00Z,4.0,1
+
+#datatype,string,long,dateTime:RFC3339,double,long
+#group,false,false,false,false,true
+#default,_result,,,,
+,result,table,_time,_value,t2
+,,2,2022-01-11T00:00:00Z,8.0,2
+",
+            )
+                |> group()
+                |> sort()
+                |> limit(n: 3)
+
+        want =
+            csv.from(
+                csv:
+                    "
+#datatype,string,long,dateTime:RFC3339,double,long,long,long
+#group,false,false,false,false,false,false,false
+#default,_result,,,,,,
+,result,table,_time,_value,t0,t1,t2
+,,0,2022-01-11T01:00:00Z,4.0,,1,
+,,0,2022-01-11T00:00:00Z,8.0,,,2
+,,0,2022-01-11T00:00:00Z,10.0,0,,
+",
+            )
+
+        testing.diff(got: got, want: want)
+    }
+
+testcase sort_limit_unordered_columns {
+        got =
+            csv.from(
+                csv:
+                    "
+#datatype,string,long,dateTime:RFC3339,double,string
+#group,false,false,false,false,true
+#default,_result,,,,
+,result,table,_time,_value,t0
+,,0,2022-01-11T00:00:00Z,10.0,a
+,,0,2022-01-11T01:00:00Z,12.0,a
+
+#datatype,string,long,dateTime:RFC3339,string,double
+#group,false,false,false,true,false
+#default,_result,,,,
+,result,table,_time,t0,_value
+,,1,2022-01-11T00:00:00Z,b,18.0
+,,1,2022-01-11T01:00:00Z,b,4.0
+
+#datatype,string,long,string,double,dateTime:RFC3339
+#group,false,false,true,false,false
+#default,_result,,,,
+,result,table,t0,_value,_time
+,,2,c,8.0,2022-01-11T00:00:00Z
+",
+            )
+                |> group()
+                |> sort()
+                |> limit(n: 3)
+
+        want =
+            csv.from(
+                csv:
+                    "
+#datatype,string,long,dateTime:RFC3339,double,string
+#group,false,false,false,false,false
+#default,_result,,,,
+,result,table,_time,_value,t0
+,,0,2022-01-11T01:00:00Z,4.0,b
+,,0,2022-01-11T00:00:00Z,8.0,c
+,,0,2022-01-11T00:00:00Z,10.0,a
+",
+            )
+
+        testing.diff(got: got, want: want)
+    }

--- a/stdlib/universe/sort_limit_test.go
+++ b/stdlib/universe/sort_limit_test.go
@@ -1,0 +1,85 @@
+package universe_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
+	"github.com/influxdata/flux/stdlib/universe"
+)
+
+func TestSortLimitRule(t *testing.T) {
+	deps := executetest.NewTestExecuteDependencies()
+	ctx := deps.Inject(context.Background())
+
+	from := &influxdb.FromProcedureSpec{
+		Bucket: influxdb.NameOrID{Name: "testbucket"},
+	}
+	sort := &universe.SortProcedureSpec{
+		Columns: []string{execute.DefaultValueColLabel},
+	}
+	limit0 := &universe.LimitProcedureSpec{N: 5}
+	limit1 := &universe.LimitProcedureSpec{N: 1, Offset: 5}
+
+	tests := []plantest.RuleTestCase{
+		{
+			Name:    "Default",
+			Context: ctx,
+			Rules: []plan.Rule{
+				universe.SortLimitRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("from0", from),
+					plan.CreatePhysicalNode("sort1", sort),
+					plan.CreatePhysicalNode("limit2", limit0),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			After: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("from0", from),
+					plan.CreatePhysicalNode("merged_sort1_limit2", &universe.SortLimitProcedureSpec{
+						SortProcedureSpec: sort,
+						N:                 5,
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+		},
+		{
+			Name:    "WithOffset",
+			Context: ctx,
+			Rules: []plan.Rule{
+				universe.SortLimitRule{},
+			},
+			Before: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plan.CreatePhysicalNode("from0", from),
+					plan.CreatePhysicalNode("sort1", sort),
+					plan.CreatePhysicalNode("limit2", limit1),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			NoChange: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			plantest.PhysicalRuleTestHelper(t, &tc)
+		})
+	}
+}


### PR DESCRIPTION
The optimized sort limit will take the pattern `sort |> limit` when
limit has no offset and will replace it with an optimized version that
performs the sorting continuously as data comes in rather than
performing a sort on all of the data and then doing the limit.

This is most analogous to performing a merge sort on each incoming
chunk of data.

Fixes #4397.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written