### PR TITLE
chore: add a method to create a String given an existing array

### DIFF
--- a/array/array.go
+++ b/array/array.go
@@ -99,6 +99,19 @@ type String struct {
 	data   *array.Binary
 }
 
+// NewStringFromBinaryArray creates an instance of String from
+// an Arrow Binary array.
+//
+// Note: Generally client code should be using the types for arrays defined in Flux.
+// This method allows string data created outside of Flux (such as from Arrow Flight)
+// to be used in Flux.
+func NewStringFromBinaryArray(data *array.Binary) *String {
+	data.Retain()
+	return &String{
+		data: data,
+	}
+}
+
 func (a *String) DataType() DataType {
 	return StringType
 }

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -120,7 +120,7 @@ func TestString(t *testing.T) {
 	}
 }
 
-func TestNewStringFromArray(t *testing.T) {
+func TestNewStringFromBinaryArray(t *testing.T) {
 	alloc := &fluxmemory.Allocator{}
 	// Need to use the Apache binary builder to be able to create an actual
 	// Arrow Binary array.


### PR DESCRIPTION
This allows us to create a `String` (which is a wrapper around the Arrow array type that also allows for a compressed representation of arrays when all the elements are the same) from a native Arrow array. This change is necessary to bring arrays coming form Arrow Flight into Flux.