### PR TITLE
fix: update to rust 1.58.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.58"
+channel = "1.58.1"
 components = [ "rustfmt", "clippy" ]
 targets = [
 	"wasm32-unknown-unknown",


### PR DESCRIPTION
With [CVE-2022-21658](https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html), rust 1.58 is no longer safe. This patch updates to use 1.58.1