### PR TITLE
refactor(execute): create a non-recover version of recovery methods for debugging

### DIFF
--- a/execute/recover.go
+++ b/execute/recover.go
@@ -1,0 +1,57 @@
+//go:build !debug
+// +build !debug
+
+package execute
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func (es *executionState) recover() {
+	if e := recover(); e != nil {
+		// We had a panic, abort the entire execution.
+		err, ok := e.(error)
+		if !ok {
+			err = fmt.Errorf("%v", e)
+		}
+
+		if errors.Code(err) == codes.ResourceExhausted {
+			es.abort(err)
+			return
+		}
+
+		err = errors.Wrap(err, codes.Internal, "panic")
+		es.abort(err)
+		if entry := es.logger.Check(zapcore.InfoLevel, "Execute source panic"); entry != nil {
+			entry.Stack = string(debug.Stack())
+			entry.Write(zap.Error(err))
+		}
+	}
+}
+
+func (d *poolDispatcher) recover() {
+	if e := recover(); e != nil {
+		err, ok := e.(error)
+		if !ok {
+			err = fmt.Errorf("%v", e)
+		}
+
+		if errors.Code(err) == codes.ResourceExhausted {
+			d.setErr(err)
+			return
+		}
+
+		err = errors.Wrap(err, codes.Internal, "panic")
+		d.setErr(err)
+		if entry := d.logger.Check(zapcore.InfoLevel, "Dispatcher panic"); entry != nil {
+			entry.Stack = string(debug.Stack())
+			entry.Write(zap.Error(err))
+		}
+	}
+}

--- a/execute/recover_debug.go
+++ b/execute/recover_debug.go
@@ -1,0 +1,7 @@
+//go:build debug
+// +build debug
+
+package execute
+
+func (es *executionState) recover() {}
+func (d *poolDispatcher) recover()  {}


### PR DESCRIPTION
When there's a panic in a transformation, it's sometimes useful to
either get a stack trace or have the panic bubble up so it can be seen
in the debugger. I very commonly end up deleting the recover from the
dispatcher so I can see what the panic was without guessing where it
might have happened based on the message.

This change moves the recover methods into its own file with a build tag
that changes whether recover is used at all. In order to get a version
of flux that panics, the `debug` tag can be used.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written