### PR TITLE
feat(dependency): add dependency hooks to the dependency subsystem

### DIFF
--- a/cmd/flux/cmd/repl.go
+++ b/cmd/flux/cmd/repl.go
@@ -15,8 +15,10 @@ var replCmd = &cobra.Command{
 	Long:  "Launch a Flux REPL (Read-Eval-Print-Loop)",
 	Run: func(cmd *cobra.Command, args []string) {
 		fluxinit.FluxInit()
-		ctx, deps := injectDependencies(context.Background())
-		r := repl.New(ctx, deps)
+		ctx, span := injectDependencies(context.Background())
+		defer span.Finish()
+
+		r := repl.New(ctx)
 		r.Run()
 	},
 }

--- a/dependencies.go
+++ b/dependencies.go
@@ -11,17 +11,13 @@ import (
 	"github.com/influxdata/flux/dependencies/http"
 	"github.com/influxdata/flux/dependencies/secret"
 	"github.com/influxdata/flux/dependencies/url"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/errors"
 )
 
 var _ Dependencies = (*Deps)(nil)
 
-// Dependency is an interface that must be implemented by every injectable dependency.
-// On Inject, the dependency is injected into the context and the resulting one is returned.
-// Every dependency must provide a function to extract it from the context.
-type Dependency interface {
-	Inject(ctx context.Context) context.Context
-}
+type Dependency = dependency.Interface
 
 type key int
 

--- a/dependencies/mqtt/dialer_test.go
+++ b/dependencies/mqtt/dialer_test.go
@@ -4,8 +4,32 @@ import (
 	"context"
 	"testing"
 
+	"github.com/influxdata/flux/dependencies/feature"
 	"github.com/influxdata/flux/dependencies/mqtt"
+	"github.com/influxdata/flux/dependency"
+	"github.com/influxdata/flux/execute/executetest"
 )
+
+type MockDialer struct {
+	DialFn func(ctx context.Context, brokers []string, options mqtt.Options) (mqtt.Client, error)
+}
+
+func (m *MockDialer) Dial(ctx context.Context, brokers []string, options mqtt.Options) (mqtt.Client, error) {
+	return m.DialFn(ctx, brokers, options)
+}
+
+type MockClient struct {
+	PublishFn func(ctx context.Context, topic string, qos byte, retain bool, payload interface{}) error
+	CloseFn   func() error
+}
+
+func (m *MockClient) Publish(ctx context.Context, topic string, qos byte, retain bool, payload interface{}) error {
+	return m.PublishFn(ctx, topic, qos, retain, payload)
+}
+
+func (m *MockClient) Close() error {
+	return m.CloseFn()
+}
 
 func TestGetNoDialer(t *testing.T) {
 	ctx := context.Background()
@@ -13,5 +37,57 @@ func TestGetNoDialer(t *testing.T) {
 	got := mqtt.GetDialer(ctx)
 	if _, ok := got.(mqtt.ErrorDialer); !ok {
 		t.Fatalf("expected error dialer, got:\n%T", got)
+	}
+}
+
+func TestPoolDialer(t *testing.T) {
+	closed := 0
+	ctx, span := dependency.Inject(context.Background(),
+		feature.Dependency{
+			Flagger: executetest.TestFlagger{
+				"mqttPoolDialer": true,
+			},
+		},
+		mqtt.Dependency{
+			Dialer: &MockDialer{
+				DialFn: func(ctx context.Context, brokers []string, options mqtt.Options) (mqtt.Client, error) {
+					return &MockClient{
+						PublishFn: func(ctx context.Context, topic string, qos byte, retain bool, payload interface{}) error {
+							return nil
+						},
+						CloseFn: func() error {
+							closed++
+							return nil
+						},
+					}, nil
+				},
+			},
+		},
+	)
+
+	dialer := mqtt.GetDialer(ctx)
+	client, err := dialer.Dial(ctx, []string{"localhost:1234"}, mqtt.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = client.Close()
+
+	if want, got := 0, closed; want != got {
+		t.Fatalf("unexpected close count -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	client, err = dialer.Dial(ctx, []string{"localhost:1234"}, mqtt.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = client.Close()
+
+	if want, got := 0, closed; want != got {
+		t.Fatalf("unexpected close count -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+
+	span.Finish()
+	if want, got := 1, closed; want != got {
+		t.Fatalf("unexpected close count -want/+got:\n\t- %d\n\t+ %d", want, got)
 	}
 }

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -1,0 +1,68 @@
+package dependency
+
+import (
+	"context"
+	"io"
+
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// Interface is an interface that must be implemented by every injectable dependency.
+// On Inject, the dependency is injected into the context and the resulting one is returned.
+// Every dependency must provide a function to extract it from the context.
+type Interface interface {
+	Inject(ctx context.Context) context.Context
+}
+
+type List []Interface
+
+func (l List) Inject(ctx context.Context) context.Context {
+	for _, dep := range l {
+		ctx = dep.Inject(ctx)
+	}
+	return ctx
+}
+
+func Inject(ctx context.Context, deps ...Interface) (context.Context, *Span) {
+	span := &Span{}
+	ctx = context.WithValue(ctx, spanKey, span)
+	for _, dep := range deps {
+		ctx = dep.Inject(ctx)
+	}
+	return ctx, span
+}
+
+func OnFinish(ctx context.Context, c io.Closer) {
+	span := spanFromContext(ctx)
+	span.onFinish(c)
+}
+
+type contextKey int
+
+const (
+	spanKey contextKey = iota
+)
+
+type Span struct {
+	closers []io.Closer
+}
+
+func spanFromContext(ctx context.Context) *Span {
+	span := ctx.Value(spanKey)
+	if span == nil {
+		panic(errors.Newf(codes.Internal, "dependency injection requires a span but one does not exist"))
+	}
+	return span.(*Span)
+}
+
+func (s *Span) onFinish(closer io.Closer) {
+	s.closers = append(s.closers, closer)
+}
+
+func (s *Span) Finish() {
+	for _, closer := range s.closers {
+		_ = closer.Close()
+	}
+	s.closers = nil
+}

--- a/dependency/dependency_test.go
+++ b/dependency/dependency_test.go
@@ -1,0 +1,43 @@
+package dependency_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/flux/dependency"
+)
+
+type Dependency struct {
+	InjectFn func(ctx context.Context) context.Context
+}
+
+func (d *Dependency) Inject(ctx context.Context) context.Context {
+	return d.InjectFn(ctx)
+}
+
+type CloseFunc func() error
+
+func (f CloseFunc) Close() error {
+	return f()
+}
+
+func TestOnFinish(t *testing.T) {
+	closed := false
+	_, span := dependency.Inject(context.Background(), &Dependency{
+		InjectFn: func(ctx context.Context) context.Context {
+			dependency.OnFinish(ctx, CloseFunc(func() error {
+				closed = true
+				return nil
+			}))
+			return ctx
+		},
+	})
+
+	if closed {
+		t.Fatal("finish hook should not have been executed, but was")
+	}
+	span.Finish()
+	if !closed {
+		t.Fatal("finish hook did not execute")
+	}
+}

--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -21,7 +21,7 @@ func NewTestExecuteDependencies() flux.Dependency {
 	return dependencyList{
 		dependenciestest.Default(),
 		feature.Dependency{
-			Flagger: testFlagger{},
+			Flagger: TestFlagger(testFlags),
 		},
 	}
 }
@@ -32,10 +32,10 @@ var testFlags = map[string]interface{}{
 	"optimizeUnionTransformation":      true,
 }
 
-type testFlagger struct{}
+type TestFlagger map[string]interface{}
 
-func (t testFlagger) FlagValue(ctx context.Context, flag feature.Flag) interface{} {
-	v, ok := testFlags[flag.Key()]
+func (t TestFlagger) FlagValue(ctx context.Context, flag feature.Flag) interface{} {
+	v, ok := t[flag.Key()]
 	if !ok {
 		return flag.Default()
 	}

--- a/internal/cmd/flux/repl.go
+++ b/internal/cmd/flux/repl.go
@@ -3,12 +3,11 @@ package main
 import (
 	"context"
 
-	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/repl"
 )
 
-func replE(ctx context.Context, deps flux.Dependencies) error {
-	r := repl.New(ctx, deps)
+func replE(ctx context.Context) error {
+	r := repl.New(ctx)
 	r.Run()
 	return nil
 }

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -65,6 +65,18 @@ func OptimizeUnionTransformation() BoolFlag {
 	return optimizeUnionTransformation
 }
 
+var mqttPoolDialer = feature.MakeBoolFlag(
+	"MQTT Pool Dialer",
+	"mqttPoolDialer",
+	"Jonathan Sternberg",
+	false,
+)
+
+// MqttPoolDialer - MQTT pool dialer
+func MqttPoolDialer() BoolFlag {
+	return mqttPoolDialer
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -75,6 +87,7 @@ var all = []Flag{
 	groupTransformationGroup,
 	queryConcurrencyLimit,
 	optimizeUnionTransformation,
+	mqttPoolDialer,
 }
 
 var byKey = map[string]Flag{
@@ -82,6 +95,7 @@ var byKey = map[string]Flag{
 	"groupTransformationGroup":         groupTransformationGroup,
 	"queryConcurrencyLimit":            queryConcurrencyLimit,
 	"optimizeUnionTransformation":      optimizeUnionTransformation,
+	"mqttPoolDialer":                   mqttPoolDialer,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -33,3 +33,9 @@
   key: optimizeUnionTransformation
   default: false
   contact: Jonathan Sternberg
+
+- name: MQTT Pool Dialer
+  description: MQTT pool dialer
+  key: mqttPoolDialer
+  default: false
+  contact: Jonathan Sternberg

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -651,7 +651,7 @@ func TestInterpreter_MultiPhaseInterpretation(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := dependenciestest.Default().Inject(context.Background())
-			r := repl.New(ctx, dependenciestest.Default())
+			r := repl.New(ctx)
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)
 			}
@@ -763,7 +763,7 @@ func TestInterpreter_MultipleEval(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := dependenciestest.Default().Inject(context.Background())
-			r := repl.New(ctx, dependenciestest.Default())
+			r := repl.New(ctx)
 
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)


### PR DESCRIPTION
This adds hooks to the dependency subsystem to run certain actions at
certain times of the execution. At present, the only hook is the
`OnFinish` hook which runs when execution has finished.

The mqtt dependency has been modified to use a pool dialer by default.
The pool dialer will retrieve an `mqtt.Client` that has the same options
and brokers that was previously "closed" to avoid establishing a new
connection. This means repeated calls to `mqtt.publish()` will use the
same client.

Pooled clients are cleaned up when `OnFinish()` is called.

Fixes #4278.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written