### PR TITLE
fix(universe): return false if contains gets invalid value

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -440,7 +440,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/aggregate_window_test.flux":                                                  "11fd1f9129e309895b5bd5e9a1c4e35d724533385974157cf3266e5a0748752f",
 	"stdlib/universe/cmo_test.flux":                                                               "8356f659eaecd6af8379167c79c5324039094aa513945449300d78d27a48ebdf",
 	"stdlib/universe/columns_test.flux":                                                           "0bf0755dd73579c2f11db1f8bf9b0296beff5e9d8d9e4efc95d008fd32b5e91b",
-	"stdlib/universe/contains_test.flux":                                                          "42cd059df4dfb7d6d132ca1d4a2109a4992470826456c206e14d5536a9fa647b",
+	"stdlib/universe/contains_test.flux":                                                          "a1890287ebc1ad6d8c84561f7e0cb725048a1e287f49f5dceac196866a20ee01",
 	"stdlib/universe/count_test.flux":                                                             "35a15982eeb5c28ea9ceab719f7ddb3832eddffc0c6174c0d4c74fdbdf93307f",
 	"stdlib/universe/cov_test.flux":                                                               "31ce1909916806a4fee059a29e913de23fa6a6304dc7085ad250cb3ff7399ffc",
 	"stdlib/universe/covariance_missing_column_1_test.flux":                                       "8ed860a0f32f518eaa6a446b57a4cf264b1e00bcf80938acaab1e893fdfff28a",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -440,6 +440,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/aggregate_window_test.flux":                                                  "11fd1f9129e309895b5bd5e9a1c4e35d724533385974157cf3266e5a0748752f",
 	"stdlib/universe/cmo_test.flux":                                                               "8356f659eaecd6af8379167c79c5324039094aa513945449300d78d27a48ebdf",
 	"stdlib/universe/columns_test.flux":                                                           "0bf0755dd73579c2f11db1f8bf9b0296beff5e9d8d9e4efc95d008fd32b5e91b",
+	"stdlib/universe/contains_test.flux":                                                          "42cd059df4dfb7d6d132ca1d4a2109a4992470826456c206e14d5536a9fa647b",
 	"stdlib/universe/count_test.flux":                                                             "35a15982eeb5c28ea9ceab719f7ddb3832eddffc0c6174c0d4c74fdbdf93307f",
 	"stdlib/universe/cov_test.flux":                                                               "31ce1909916806a4fee059a29e913de23fa6a6304dc7085ad250cb3ff7399ffc",
 	"stdlib/universe/covariance_missing_column_1_test.flux":                                       "8ed860a0f32f518eaa6a446b57a4cf264b1e00bcf80938acaab1e893fdfff28a",

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -24,6 +25,14 @@ func MakeContainsFunc() values.Function {
 				return nil, err
 			}
 
+			// In situations where value `v` is "invalid" (like when it's a field that is missing from an incoming
+			// unknown record type, we give a surprising and confusing error message indicating
+			// `keyword argument "set" should be of an array of type invalid`.
+			// This error is normally produced by the `GetRequiredArrayAllowEmpty` call immediately below.
+			// To avoid the confusion and handle this case more intuitively, short-circuit with a "false" outcome.
+			if v.Type().Nature() == semantic.Invalid {
+				return values.NewBool(false), nil
+			}
 			setarg, err := a.GetRequiredArrayAllowEmpty("set", v.Type().Nature())
 			if err != nil {
 				return nil, err
@@ -35,6 +44,7 @@ func MakeContainsFunc() values.Function {
 			if _, ok := set.(values.TableObject); ok {
 				return nil, errors.New(codes.Invalid, "set cannot be a table stream; expected an array")
 			}
+
 			if set.Len() > 0 {
 				if set.Get(0).Type() != v.Type() {
 					err = errors.Newf(codes.Invalid, "value type %T does not match set type %T", v.Type(), set.Get(0).Type())

--- a/stdlib/universe/contains.go
+++ b/stdlib/universe/contains.go
@@ -46,14 +46,17 @@ func MakeContainsFunc() values.Function {
 			}
 
 			if set.Len() > 0 {
-				if set.Get(0).Type() != v.Type() {
-					err = errors.Newf(codes.Invalid, "value type %T does not match set type %T", v.Type(), set.Get(0).Type())
-				} else {
-					for i := 0; i < set.Len(); i++ {
-						if set.Get(i).Equal(v) {
-							found = true
-							break
-						}
+				for i := 0; i < set.Len(); i++ {
+					// Skip any members of the `set` array that are invalid.
+					if set.Get(i).Type().Nature() == semantic.Invalid {
+						continue
+					} else if set.Get(i).Type() != v.Type() {
+						err = errors.Newf(codes.Invalid, "value type %T does not match set type %T", v.Type(), set.Get(0).Type())
+						break
+					}
+					if set.Get(i).Equal(v) {
+						found = true
+						break
 					}
 				}
 			}

--- a/stdlib/universe/contains_test.flux
+++ b/stdlib/universe/contains_test.flux
@@ -1,0 +1,26 @@
+package universe_test
+
+
+import "array"
+import "internal/debug"
+import "testing"
+
+testcase invalid_field_is_falsy {
+    want = array.from(rows: [{}]) |> filter(fn: (r) => false) |> debug.opaque()
+    got =
+        array.from(
+            rows: [
+                {
+                    _time: 2018-05-22T20:00:10Z,
+                    _value: 0.336,
+                    _measurement: "m0",
+                    _field: "f0",
+                    t0: "a",
+                },
+            ],
+        )
+            |> debug.opaque()
+            |> filter(fn: (r) => contains(value: r.unknown, set: [1, 2, 3]))
+
+    testing.diff(want: want, got: got) |> yield()
+}

--- a/stdlib/universe/contains_test.flux
+++ b/stdlib/universe/contains_test.flux
@@ -68,3 +68,33 @@ testcase invalid_mix_set_field_is_falsy {
 
     testing.diff(want: want, got: got) |> yield()
 }
+
+testcase invalid_mix_set_field_is_falsy2 {
+    want =
+        array.from(
+            rows: [
+                {
+                    _time: 2018-05-22T20:00:10Z,
+                    _value: 2,
+                    _measurement: "m0",
+                    _field: "f0",
+                    t0: "a",
+                },
+            ],
+        )
+            |> debug.opaque()
+    got =
+        want
+            |> debug.opaque()
+            |> filter(
+                fn: (r) =>
+                    contains(
+                        value: 2,
+                        // The ordering of items in `set` differs from that of the previous
+                        // test to make sure we hit each of the possible code paths.
+                        set: [r.unknown, r._value],
+                    ),
+            )
+
+    testing.diff(want: want, got: got) |> yield()
+}

--- a/stdlib/universe/contains_test.flux
+++ b/stdlib/universe/contains_test.flux
@@ -5,7 +5,7 @@ import "array"
 import "internal/debug"
 import "testing"
 
-testcase invalid_field_is_falsy {
+testcase invalid_value_field_is_falsy {
     want = array.from(rows: [{}]) |> filter(fn: (r) => false) |> debug.opaque()
     got =
         array.from(
@@ -21,6 +21,50 @@ testcase invalid_field_is_falsy {
         )
             |> debug.opaque()
             |> filter(fn: (r) => contains(value: r.unknown, set: [1, 2, 3]))
+
+    testing.diff(want: want, got: got) |> yield()
+}
+
+testcase invalid_only_set_field_is_falsy {
+    want = array.from(rows: [{}]) |> filter(fn: (r) => false) |> debug.opaque()
+    got =
+        array.from(
+            rows: [
+                {
+                    _time: 2018-05-22T20:00:10Z,
+                    _value: 0.336,
+                    _measurement: "m0",
+                    _field: "f0",
+                    t0: "a",
+                },
+            ],
+        )
+            |> debug.opaque()
+            |> filter(fn: (r) => contains(value: 1, set: [r.unknown]))
+
+    testing.diff(want: want, got: got) |> yield()
+}
+
+testcase invalid_mix_set_field_is_falsy {
+    // Ensure we return rows that match on the valid items even though set has an
+    // invalid item as well
+    want =
+        array.from(
+            rows: [
+                {
+                    _time: 2018-05-22T20:00:10Z,
+                    _value: 2,
+                    _measurement: "m0",
+                    _field: "f0",
+                    t0: "a",
+                },
+            ],
+        )
+            |> debug.opaque()
+    got =
+        want
+            |> debug.opaque()
+            |> filter(fn: (r) => contains(value: 2, set: [r._value, r.unknown]))
 
     testing.diff(want: want, got: got) |> yield()
 }


### PR DESCRIPTION
Flux treats the access of a missing field in the `value` parameter for `contains` as a hard error, whereas similar access in `filter` is treated as "falsy."

As noted in <https://github.com/influxdata/influxdb/issues/23025>, it's possible the error behavior was introduced as a breaking change accidentally in <https://github.com/influxdata/flux/pull/2696> since a user raised the issue as something that worked previously but  no longer does.

This patch checks to see if `value` is invalid and immediately returns `false` if it is, sidestepping the type check between the `value` and `set` parameters that produces the error.

Refs:
- <https://github.com/influxdata/flux/issues/4381>
- <https://github.com/influxdata/influxdb/issues/23025>
- <https://github.com/influxdata/flux/pull/2696>

### Done checklist
- [x] docs/SPEC.md updated **N/A**
- [x] Test cases written
