### PR TITLE
fix(dependencies): revert update to the dependencies package

### DIFF
--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -1,46 +1,69 @@
 package dependencies
 
 import (
+	"context"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/bigtable"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/influxdb"
 	"github.com/influxdata/flux/dependencies/mqtt"
-	"github.com/influxdata/flux/dependency"
 )
 
-func NewDefaultDependencies(defaultInfluxDBHost string) flux.Dependency {
+type Dependencies struct {
+	flux.Deps
+	influxdb influxdb.Dependency
+	bigtable bigtable.Dependency
+	mqtt     mqtt.Dependency
+}
+
+func (d Dependencies) Inject(ctx context.Context) context.Context {
+	ctx = d.Deps.Inject(ctx)
+	ctx = d.influxdb.Inject(ctx)
+	ctx = d.bigtable.Inject(ctx)
+	return d.mqtt.Inject(ctx)
+}
+
+func NewDefaultDependencies(defaultInfluxDBHost string) Dependencies {
 	deps := flux.NewDefaultDependencies()
 	deps.Deps.FilesystemService = filesystem.SystemFS
-	return dependency.List{
-		deps,
-		influxdb.Dependency{
+
+	return Dependencies{
+		Deps: deps,
+
+		influxdb: influxdb.Dependency{
 			Provider: &influxdb.HttpProvider{
 				DefaultConfig: influxdb.Config{
 					Host: defaultInfluxDBHost,
 				},
 			},
 		},
-		bigtable.Dependency{
+
+		bigtable: bigtable.Dependency{
 			Provider: bigtable.DefaultProvider{},
 		},
-		mqtt.Dependency{
+
+		mqtt: mqtt.Dependency{
 			Dialer: mqtt.DefaultDialer{},
 		},
 	}
 }
 
-func NewErrorDependencies() flux.Dependency {
+func NewErrorDependencies() Dependencies {
 	deps := flux.NewEmptyDependencies()
-	return dependency.List{
-		deps,
-		influxdb.Dependency{
+
+	return Dependencies{
+		Deps: deps,
+
+		influxdb: influxdb.Dependency{
 			Provider: &influxdb.ErrorProvider{},
 		},
-		bigtable.Dependency{
+
+		bigtable: bigtable.Dependency{
 			Provider: bigtable.ErrorProvider{},
 		},
-		mqtt.Dependency{
+
+		mqtt: mqtt.Dependency{
 			Dialer: mqtt.ErrorDialer{},
 		},
 	}


### PR DESCRIPTION
This reverts the change to the dependencies package. The change switched
the package to return a more generic interface rather than the struct
that held all of the dependencies, but there was existing code that used
this struct that was not easily refactorable.

The original version of the PR that introduced this change needed the
change to simplify a large change, but we ended up doing a different
change instead so this reverts the small section of the change back to
its original form just to simplify the area where this function was
consumed.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written