### PR TITLE
chore: disable MergeFiltersRule

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -15,7 +15,6 @@ func main() {
 		influxdb.DefaultFromAttributes{
 			Host: func(v string) *string { return &v }(cmd.DefaultInfluxDBHost),
 		},
-		universe.MergeFiltersRule{},
 		universe.OptimizeWindowRule{},
 	)
 	cmd.Execute()


### PR DESCRIPTION
The rule is _only enabled_ here in the CLI, making the behavior
inconsistent with other envs.

The rule is specifically problematic because it can cause some queries
to fail even when written explicitly to avoid type check failures.

The rule could be re-enabled at a later date if we can figure out a way
to get the type checking to be permissive enough in this case.

Refs: #4378
Fixes: #4436

To verify the patch, I didn't add any new tests since it felt wrong to base test cases on a behavior determined by which rules are registered or not. Instead I checked the work in the REPL.

```
> import "influxdata/influxdb/sample"
>
> // Looking at _value in the first filter breaks (as expected) 
> sample.data(set: "usgs") |> filter(fn: (r) => r._field == "mag" and r._measurement == "earthquake" and r._value > 0.0) |>  group() |> count()
Result: _result
Error: runtime error @1:29-1:119: filter: cannot compile @ 1:40-1:118: unsupported binary expression string > float
> 
> // Looking at _value in a 2nd filter (now) works since it's not merged
> sample.data(set: "usgs") |> filter(fn: (r) => r._field == "mag" and r._measurement == "earthquake") |> filter(fn: (r) => r._value > 0.0) |>  group() |> count()

Result: _result
Table: keys: []
                _value:int  
--------------------------  
                      1912  
>
```

### Done checklist
- [x] docs/SPEC.md updated **N/A**
- [ ] Test cases written
