### PR TITLE
fix(feature): int feature flags work properly when returned as floats

### DIFF
--- a/internal/pkg/feature/feature_test.go
+++ b/internal/pkg/feature/feature_test.go
@@ -26,9 +26,9 @@ func Test_feature(t *testing.T) {
 			name: "int happy path",
 			flag: newFlag("test", 0),
 			values: map[string]interface{}{
-				"test": int32(42),
+				"test": 42,
 			},
-			expected: int32(42),
+			expected: 42,
 		},
 		{
 			name: "float happy path",
@@ -59,7 +59,7 @@ func Test_feature(t *testing.T) {
 		{
 			name:     "int missing use default",
 			flag:     newFlag("test", 65),
-			expected: int32(65),
+			expected: 65,
 		},
 		{
 			name:     "float missing use default",
@@ -84,9 +84,9 @@ func Test_feature(t *testing.T) {
 			name: "int invalid use default",
 			flag: newFlag("test", 42),
 			values: map[string]interface{}{
-				"test": 99.99,
+				"test": "notanint",
 			},
-			expected: int32(42),
+			expected: 42,
 		},
 		{
 			name: "float invalid use default",
@@ -103,6 +103,14 @@ func Test_feature(t *testing.T) {
 				"test": true,
 			},
 			expected: "restaurantattheendoftheuniverse",
+		},
+		{
+			name: "int as float",
+			flag: newFlag("test", 42),
+			values: map[string]interface{}{
+				"test": 99.99,
+			},
+			expected: 99,
 		},
 	}
 

--- a/internal/pkg/feature/flag.go
+++ b/internal/pkg/feature/flag.go
@@ -24,9 +24,9 @@ func MakeFlag(name, key, owner string, defaultValue interface{}) Flag {
 	case float64:
 		return FloatFlag{b, v}
 	case int32:
-		return IntFlag{b, v}
+		return IntFlag{b, int(v)}
 	case int:
-		return IntFlag{b, int32(v)}
+		return IntFlag{b, v}
 	case string:
 		return StringFlag{b, v}
 	default:
@@ -122,24 +122,30 @@ func (f FloatFlag) Float(ctx context.Context) float64 {
 // IntFlag implements Flag for integer values.
 type IntFlag struct {
 	Base
-	defaultInt int32
+	defaultInt int
 }
 
 var _ Flag = IntFlag{}
 
 // MakeIntFlag returns a string flag with the given Base and default.
-func MakeIntFlag(name, key, owner string, defaultValue int32) IntFlag {
+func MakeIntFlag(name, key, owner string, defaultValue int) IntFlag {
 	b := MakeBase(name, key, owner, defaultValue)
 	return IntFlag{b, defaultValue}
 }
 
 // Int value of the flag on the request context.
-func (f IntFlag) Int(ctx context.Context) int32 {
-	i, ok := f.value(ctx).(int32)
-	if !ok {
+func (f IntFlag) Int(ctx context.Context) int {
+	// Ints sometimes get returned as floats.
+	switch i := f.value(ctx).(type) {
+	case float64:
+		return int(i)
+	case int32:
+		return int(i)
+	case int:
+		return i
+	default:
 		return f.defaultInt
 	}
-	return i
 }
 
 // BoolFlag implements Flag for boolean values.


### PR DESCRIPTION
The int type for feature flags has been switched from int32 to int since
it is more consistent. Additionally, if a float value is returned and is
meant to be interpreted as an int, the conversion now happens. This can
sometimes happen because feature flag libraries may transfer the data as
JSON and JSON doesn't have an integer type instead treating them as
floats.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written