### PR TITLE
test(plan): Use cmp.Options when comparing `ValidateError`

### DIFF
--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -190,7 +190,7 @@ func PhysicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Optio
 	pp, err := physicalPlanner.Plan(ctx, before)
 	if err != nil {
 		if tc.ValidateError != nil {
-			if got, want := err, tc.ValidateError; !cmp.Equal(want, got) {
+			if got, want := err, tc.ValidateError; !cmp.Equal(want, got, options...) {
 				t.Fatalf("unexpected planner error -want/+got:\n%s", cmp.Diff(want, got))
 			}
 			return


### PR DESCRIPTION
Normal go errors can't be compared unless you pass in an appropriate `cmp.Option`
which meant that `ValidateError` could only be used for errors created by the internal
flux error type. By adding in `cmp.Options` from the caller, we can allow other errors to be checked.