### PR TITLE
feat: Add conversion from flux.Bounds to plan/execute.Bounds

### DIFF
--- a/execute/bounds.go
+++ b/execute/bounds.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/values"
 )
 
@@ -85,4 +86,11 @@ func (b Bounds) Duration() Duration {
 
 func Now() Time {
 	return values.ConvertTime(time.Now())
+}
+
+func FromFluxBounds(bounds flux.Bounds) Bounds {
+	return Bounds{
+		Start: values.ConvertTime(bounds.Start.Time(bounds.Now)),
+		Stop:  values.ConvertTime(bounds.Stop.Time(bounds.Now)),
+	}
 }

--- a/plan/bounds.go
+++ b/plan/bounds.go
@@ -1,6 +1,9 @@
 package plan
 
-import "github.com/influxdata/flux/values"
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/values"
+)
 
 // EmptyBounds is a time range containing only a single point
 var EmptyBounds = &Bounds{
@@ -106,5 +109,12 @@ func (b *Bounds) Shift(d values.Duration) *Bounds {
 	return &Bounds{
 		Start: b.Start.Add(d),
 		Stop:  b.Stop.Add(d),
+	}
+}
+
+func FromFluxBounds(bounds flux.Bounds) Bounds {
+	return Bounds{
+		Start: values.ConvertTime(bounds.Start.Time(bounds.Now)),
+		Stop:  values.ConvertTime(bounds.Stop.Time(bounds.Now)),
 	}
 }

--- a/stdlib/influxdata/influxdb/cardinality.go
+++ b/stdlib/influxdata/influxdb/cardinality.go
@@ -9,7 +9,6 @@ import (
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
-	"github.com/influxdata/flux/values"
 )
 
 const (
@@ -134,10 +133,8 @@ func (s *CardinalityProcedureSpec) Copy() plan.ProcedureSpec {
 
 // TimeBounds implements plan.BoundsAwareProcedureSpec
 func (s *CardinalityProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bounds {
-	bounds := &plan.Bounds{
-		Start: values.ConvertTime(s.Bounds.Start.Time(s.Bounds.Now)),
-		Stop:  values.ConvertTime(s.Bounds.Stop.Time(s.Bounds.Now)),
-	}
+	b := plan.FromFluxBounds(s.Bounds)
+	bounds := &b
 	if predecessorBounds != nil {
 		bounds = bounds.Intersect(predecessorBounds)
 	}

--- a/stdlib/influxdata/influxdb/from.go
+++ b/stdlib/influxdata/influxdb/from.go
@@ -12,7 +12,6 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
-	"github.com/influxdata/flux/values"
 )
 
 const (
@@ -185,8 +184,7 @@ func (s *FromRemoteProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *pl
 
 	// set the bounds to the range specified in from call, if there is one
 	if !s.Bounds.IsEmpty() {
-		bounds.Start = values.ConvertTime(s.Bounds.Start.Time(s.Bounds.Now))
-		bounds.Stop = values.ConvertTime(s.Bounds.Stop.Time(s.Bounds.Now))
+		*bounds = plan.FromFluxBounds(s.Bounds)
 	}
 	if predecessorBounds != nil {
 		bounds = bounds.Intersect(predecessorBounds)

--- a/stdlib/universe/range.go
+++ b/stdlib/universe/range.go
@@ -76,10 +76,8 @@ type RangeProcedureSpec struct {
 
 // TimeBounds implements plan.BoundsAwareProcedureSpec
 func (s *RangeProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bounds {
-	bounds := &plan.Bounds{
-		Start: values.ConvertTime(s.Bounds.Start.Time(s.Bounds.Now)),
-		Stop:  values.ConvertTime(s.Bounds.Stop.Time(s.Bounds.Now)),
-	}
+	b := plan.FromFluxBounds(s.Bounds)
+	bounds := &b
 	if predecessorBounds != nil {
 		bounds = bounds.Intersect(predecessorBounds)
 	}


### PR DESCRIPTION
Not sure why there are multiple versions of `Bounds` but this removes some duplication which
will also be useful for `iox.from`