### PR TITLE
refactor: Use TransformationSet's methods instead of iterating

### DIFF
--- a/execute/source_iterator.go
+++ b/execute/source_iterator.go
@@ -118,7 +118,5 @@ func (s *sourceIterator) Run(ctx context.Context) {
 	err := s.iterator.Do(ctx, func(tbl flux.Table) error {
 		return s.ts.Process(s.id, tbl)
 	})
-	for _, t := range s.ts {
-		t.Finish(s.id, err)
-	}
+	s.ts.Finish(s.id, err)
 }

--- a/stdlib/array/from.go
+++ b/stdlib/array/from.go
@@ -110,9 +110,7 @@ func (s *tableSource) Run(ctx context.Context) {
 		err = s.ts.Process(s.id, tbl)
 	}
 
-	for _, t := range s.ts {
-		t.Finish(s.id, err)
-	}
+	s.ts.Finish(s.id, err)
 }
 
 func buildTable(rows values.Array, mem *memory.Allocator) (flux.Table, error) {

--- a/stdlib/internal/gen/tables.go
+++ b/stdlib/internal/gen/tables.go
@@ -171,16 +171,12 @@ func (s *Source) Run(ctx context.Context) {
 
 	tables, err := gen.Input(ctx, schema)
 	if err != nil {
-		for _, t := range s.ts {
-			t.Finish(s.id, err)
-		}
+		s.ts.Finish(s.id, err)
 		return
 	}
 
 	err = tables.Do(func(table flux.Table) error {
 		return s.ts.Process(s.id, table)
 	})
-	for _, t := range s.ts {
-		t.Finish(s.id, err)
-	}
+	s.ts.Finish(s.id, err)
 }


### PR DESCRIPTION
`TransformationSet`'s implementation does the iteration automatically
