### PR TITLE
feat: Explain what [A], [A:B] etc means in errors

### DIFF
--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -693,7 +693,7 @@ option planner.disableLogicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `error @4:38-4:52: expected [string] but found string`,
+			wantErr: `error @4:38-4:52: expected [string] (array) but found string`,
 		},
 		{
 			name: "physical planner option must be an array",
@@ -704,7 +704,7 @@ option planner.disablePhysicalRules = "not an array"
 
 // remember to return streaming data
 from(bucket: "does_not_matter")`},
-			wantErr: `error @4:39-4:53: expected [string] but found string`,
+			wantErr: `error @4:39-4:53: expected [string] (array) but found string`,
 		},
 		{
 			name: "logical planner option must be an array of strings",

--- a/libflux/flux-core/src/semantic/tests.rs
+++ b/libflux/flux-core/src/semantic/tests.rs
@@ -298,7 +298,9 @@ macro_rules! test_infer_err {
 /// ```
 ///
 macro_rules! test_error_msg {
-    ( $(imp: $imp:expr,)? $(env: $env:expr,)? src: $src:expr $(,)?, expect: $expect:expr $(,)? ) => {{
+    ( $(test: $test: ident,)? $(imp: $imp:expr,)? $(env: $env:expr,)? src: $src:expr $(,)?, expect: $expect:expr $(,)? ) => {
+        $(#[test] fn $test() )? {
+
         #[allow(unused_mut, unused_assignments)]
         let mut imp = HashMap::default();
         $(
@@ -324,7 +326,9 @@ macro_rules! test_error_msg {
         }
     }};
 
-    ( $(imp: $imp:expr,)? $(env: $env:expr,)? src: $src:expr $(,)?, expect_short: $expect:expr $(,)? ) => {{
+    ( $(test: $test: ident,)? $(imp: $imp:expr,)? $(env: $env:expr,)? src: $src:expr $(,)?, expect_short: $expect:expr $(,)? ) => {
+        $(#[test] fn $test() )? {
+
         #[allow(unused_mut, unused_assignments)]
         let mut imp = HashMap::default();
         $(
@@ -350,7 +354,9 @@ macro_rules! test_error_msg {
         }
     }};
 
-    ( $(imp: $imp:expr,)? $(env: $env:expr,)? src: $src:expr $(,)?, err: $err:expr $(,)? ) => {{
+    ( $(test: $test: ident,)? $(imp: $imp:expr,)? $(env: $env:expr,)? src: $src:expr $(,)?, err: $err:expr $(,)? ) => {
+        $(#[test] fn $test() )? {
+
         #[allow(unused_mut, unused_assignments)]
         let mut imp = HashMap::default();
         $(
@@ -3548,122 +3554,136 @@ fn copy_bindings_from_other_env() {
     );
 }
 
-#[test]
-fn test_error_messages() {
-    test_error_msg! {
-        src: r#"
+test_error_msg! {
+    test: location_points_to_right_expression_error,
+    src: r#"
             1 + "1"
         "#,
-        // Location points to right expression expression
-        err: "error @2:17-2:20: expected int but found string",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to right expression expression
+    err: "error @2:17-2:20: expected int but found string",
+}
+
+test_error_msg! {
+    test: location_points_to_argument_of_unary_error,
+    src: r#"
             -"s"
         "#,
-        // Location points to argument of unary expression
-        err: "error @2:14-2:17: string is not Negatable",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to argument of unary expression
+    err: "error @2:14-2:17: string is not Negatable",
+}
+test_error_msg! {
+    test: location_points_to_entire_binary_error,
+    src: r#"
             1h + 2h
         "#,
-        // Location points to entire binary expression
-        err: "error @2:13-2:20: duration is not Addable",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to entire binary expression
+    err: "error @2:13-2:20: duration is not Addable",
+}
+test_error_msg! {
+    test: location_points_to_second_interpolated_error,
+    src: r#"
             bob = "Bob"
             joe = {a: 0, b: 0.1}
             "Hey ${bob} it's me ${joe}!"
         "#,
-        // Location points to second interpolated expression
-        err: "error @4:35-4:38: {b:float, a:int} is not Stringable",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to second interpolated expression
+    err: "error @4:35-4:38: {b:float, a:int} is not Stringable",
+}
+test_error_msg! {
+    test: location_points_to_if_error,
+    src: r#"
             if 0 then "a" else "b"
         "#,
-        // Location points to if expression
-        err: "error @2:16-2:17: expected bool but found int",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to if expression
+    err: "error @2:16-2:17: expected bool but found int",
+}
+test_error_msg! {
+    test: location_points_to_else_error,
+    src: r#"
             if exists 0 then 0 else "b"
         "#,
-        // Location points to else expression
-        err: "error @2:37-2:40: expected int but found string",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to else expression
+    err: "error @2:37-2:40: expected int but found string",
+}
+test_error_msg! {
+    test: location_points_to_second_element_error,
+    src: r#"
             [1, "2"]
         "#,
-        // Location points to second element of array
-        err: "error @2:17-2:20: expected int but found string",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to second element of array
+    err: "error @2:17-2:20: expected int but found string",
+}
+test_error_msg! {
+    test: location_points_to_index_error,
+    src: r#"
             a = [1, 2, 3]
             a[1.1]
         "#,
-        // Location points to expression representing the index
-        err: "error @3:15-3:18: expected int but found float",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to expression representing the index
+    err: "error @3:15-3:18: expected int but found float",
+}
+test_error_msg! {
+    test: location_points_to_right_error,
+    src: r#"
             a = [1, 2, 3]
             a[1] + 1.1
         "#,
-        // Location points to right expression
-        err: "error @3:20-3:23: expected int but found float",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to right expression
+    err: "error @3:20-3:23: expected int but found float",
+}
+test_error_msg! {
+    test: location_points_to_identifier_a_error,
+    src: r#"
             a = 1
             a[1]
         "#,
-        // Location points to the identifier a
-        err: "error @3:13-3:14: expected [A] but found int",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to the identifier a
+    err: "error @3:13-3:14: expected [A] but found int",
+}
+test_error_msg! {
+    test: location_points_to_identifier_a_error_2,
+    src: r#"
             a = [1, 2, 3]
             a.x
         "#,
-        // Location points to the identifier a
-        err: "error @3:13-3:14: expected {A with x:B} but found [int]",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to the identifier a
+    err: "error @3:13-3:14: expected {A with x:B} but found [int]",
+}
+test_error_msg! {
+    test: location_points_to_entire_call_error,
+    src: r#"
             f = (x, y) => x - y
             f(x: "x", y: "y")
         "#,
-        // Location points to entire call expression
-        err: "error @3:18-3:21: string is not Subtractable (argument x)",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to entire call expression
+    err: "error @3:18-3:21: string is not Subtractable (argument x)",
+}
+test_error_msg! {
+    test: location_points_to_entire_call_error_2,
+    src: r#"
             f = (r) => r.a
             f(r: {b: 1})
         "#,
-        // Location points to entire call expression
-        err: "error @3:18-3:24: record is missing label a (argument r)",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to entire call expression
+    err: "error @3:18-3:24: record is missing label a (argument r)",
+}
+test_error_msg! {
+    test: location_points_to_identifier_a_error_3,
+    src: r#"
             x = 1 + 1
             a
         "#,
-        // Location points to the identifier a
-        err: "error @3:13-3:14: undefined identifier a",
-    }
-    test_error_msg! {
-        src: r#"
+    // Location points to the identifier a
+    err: "error @3:13-3:14: undefined identifier a",
+}
+test_error_msg! {
+    test: location_points_to_call_error,
+    src: r#"
             match = (o) => o.name =~ /^a/
             fn = (r) => match(r)
         "#,
-        // Location points to call expression `match(r)`
-        expect: expect![[r#"
+    // Location points to call expression `match(r)`
+    expect: expect![[r#"
             error: found unexpected argument r
               ┌─ main:3:31
               │
@@ -3677,14 +3697,15 @@ fn test_error_messages() {
               │                         ^^^^^^^^
 
         "#]],
-    }
-    test_error_msg! {
-        src: r#"
+}
+test_error_msg! {
+    test: location_points_to_call_error_2,
+    src: r#"
             f = (a, b) => a + b
             f(a: 0, c: 1)
         "#,
-        // Location points to call expression `f(a: 0, c: 1)`
-        expect: expect![[r#"
+    // Location points to call expression `f(a: 0, c: 1)`
+    expect: expect![[r#"
             error: found unexpected argument c
               ┌─ main:3:24
               │
@@ -3698,15 +3719,15 @@ fn test_error_messages() {
               │             ^^^^^^^^^^^^^
 
         "#]],
-    }
-    test_error_msg! {
-        src: r#"
+}
+test_error_msg! {
+    test: location_points_to_call_error_3,
+    src: r#"
             f = (a, b) => a + b
             f(a: 0)
         "#,
-        // Location points to call expression `f(a: 0)`
-        err: "error @3:13-3:20: missing required argument b",
-    }
+    // Location points to call expression `f(a: 0)`
+    err: "error @3:13-3:20: missing required argument b",
 }
 
 #[test]

--- a/libflux/flux-core/src/semantic/tests.rs
+++ b/libflux/flux-core/src/semantic/tests.rs
@@ -3560,7 +3560,14 @@ test_error_msg! {
             1 + "1"
         "#,
     // Location points to right expression expression
-    err: "error @2:17-2:20: expected int but found string",
+    expect: expect![[r#"
+        error: expected int but found string
+          ┌─ main:2:17
+          │
+        2 │             1 + "1"
+          │                 ^^^
+
+    "#]],
 }
 
 test_error_msg! {
@@ -3569,7 +3576,14 @@ test_error_msg! {
             -"s"
         "#,
     // Location points to argument of unary expression
-    err: "error @2:14-2:17: string is not Negatable",
+    expect: expect![[r#"
+        error: string is not Negatable
+          ┌─ main:2:14
+          │
+        2 │             -"s"
+          │              ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_entire_binary_error,
@@ -3577,7 +3591,14 @@ test_error_msg! {
             1h + 2h
         "#,
     // Location points to entire binary expression
-    err: "error @2:13-2:20: duration is not Addable",
+    expect: expect![[r#"
+        error: duration is not Addable
+          ┌─ main:2:13
+          │
+        2 │             1h + 2h
+          │             ^^^^^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_second_interpolated_error,
@@ -3587,7 +3608,14 @@ test_error_msg! {
             "Hey ${bob} it's me ${joe}!"
         "#,
     // Location points to second interpolated expression
-    err: "error @4:35-4:38: {b:float, a:int} is not Stringable",
+    expect: expect![[r#"
+        error: {b:float, a:int} is not Stringable
+          ┌─ main:4:35
+          │
+        4 │             "Hey ${bob} it's me ${joe}!"
+          │                                   ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_if_error,
@@ -3595,7 +3623,14 @@ test_error_msg! {
             if 0 then "a" else "b"
         "#,
     // Location points to if expression
-    err: "error @2:16-2:17: expected bool but found int",
+    expect: expect![[r#"
+        error: expected bool but found int
+          ┌─ main:2:16
+          │
+        2 │             if 0 then "a" else "b"
+          │                ^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_else_error,
@@ -3603,7 +3638,14 @@ test_error_msg! {
             if exists 0 then 0 else "b"
         "#,
     // Location points to else expression
-    err: "error @2:37-2:40: expected int but found string",
+    expect: expect![[r#"
+        error: expected int but found string
+          ┌─ main:2:37
+          │
+        2 │             if exists 0 then 0 else "b"
+          │                                     ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_second_element_error,
@@ -3611,7 +3653,14 @@ test_error_msg! {
             [1, "2"]
         "#,
     // Location points to second element of array
-    err: "error @2:17-2:20: expected int but found string",
+    expect: expect![[r#"
+        error: expected int but found string
+          ┌─ main:2:17
+          │
+        2 │             [1, "2"]
+          │                 ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_index_error,
@@ -3620,7 +3669,14 @@ test_error_msg! {
             a[1.1]
         "#,
     // Location points to expression representing the index
-    err: "error @3:15-3:18: expected int but found float",
+    expect: expect![[r#"
+        error: expected int but found float
+          ┌─ main:3:15
+          │
+        3 │             a[1.1]
+          │               ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_right_error,
@@ -3629,7 +3685,14 @@ test_error_msg! {
             a[1] + 1.1
         "#,
     // Location points to right expression
-    err: "error @3:20-3:23: expected int but found float",
+    expect: expect![[r#"
+        error: expected int but found float
+          ┌─ main:3:20
+          │
+        3 │             a[1] + 1.1
+          │                    ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_identifier_a_error,
@@ -3638,7 +3701,14 @@ test_error_msg! {
             a[1]
         "#,
     // Location points to the identifier a
-    err: "error @3:13-3:14: expected [A] but found int",
+    expect: expect![[r#"
+        error: expected [A] but found int
+          ┌─ main:3:13
+          │
+        3 │             a[1]
+          │             ^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_identifier_a_error_2,
@@ -3647,7 +3717,14 @@ test_error_msg! {
             a.x
         "#,
     // Location points to the identifier a
-    err: "error @3:13-3:14: expected {A with x:B} but found [int]",
+    expect: expect![[r#"
+        error: expected {A with x:B} but found [int]
+          ┌─ main:3:13
+          │
+        3 │             a.x
+          │             ^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_entire_call_error,
@@ -3656,7 +3733,14 @@ test_error_msg! {
             f(x: "x", y: "y")
         "#,
     // Location points to entire call expression
-    err: "error @3:18-3:21: string is not Subtractable (argument x)",
+    expect: expect![[r#"
+        error: string is not Subtractable (argument x)
+          ┌─ main:3:18
+          │
+        3 │             f(x: "x", y: "y")
+          │                  ^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_entire_call_error_2,
@@ -3665,7 +3749,14 @@ test_error_msg! {
             f(r: {b: 1})
         "#,
     // Location points to entire call expression
-    err: "error @3:18-3:24: record is missing label a (argument r)",
+    expect: expect![[r#"
+        error: record is missing label a (argument r)
+          ┌─ main:3:18
+          │
+        3 │             f(r: {b: 1})
+          │                  ^^^^^^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_identifier_a_error_3,
@@ -3674,7 +3765,14 @@ test_error_msg! {
             a
         "#,
     // Location points to the identifier a
-    err: "error @3:13-3:14: undefined identifier a",
+    expect: expect![[r#"
+        error: undefined identifier a
+          ┌─ main:3:13
+          │
+        3 │             a
+          │             ^
+
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_call_error,
@@ -3720,6 +3818,7 @@ test_error_msg! {
 
         "#]],
 }
+
 test_error_msg! {
     test: location_points_to_call_error_3,
     src: r#"
@@ -3727,7 +3826,14 @@ test_error_msg! {
             f(a: 0)
         "#,
     // Location points to call expression `f(a: 0)`
-    err: "error @3:13-3:20: missing required argument b",
+    expect: expect![[r#"
+        error: missing required argument b
+          ┌─ main:3:13
+          │
+        3 │             f(a: 0)
+          │             ^^^^^^^
+
+    "#]],
 }
 
 #[test]

--- a/libflux/flux-core/src/semantic/tests.rs
+++ b/libflux/flux-core/src/semantic/tests.rs
@@ -3609,7 +3609,7 @@ test_error_msg! {
         "#,
     // Location points to second interpolated expression
     expect: expect![[r#"
-        error: {b:float, a:int} is not Stringable
+        error: {b:float, a:int} (record) is not Stringable
           ┌─ main:4:35
           │
         4 │             "Hey ${bob} it's me ${joe}!"
@@ -3702,7 +3702,7 @@ test_error_msg! {
         "#,
     // Location points to the identifier a
     expect: expect![[r#"
-        error: expected [A] but found int
+        error: expected [A] (array) but found int
           ┌─ main:3:13
           │
         3 │             a[1]
@@ -3718,7 +3718,7 @@ test_error_msg! {
         "#,
     // Location points to the identifier a
     expect: expect![[r#"
-        error: expected {A with x:B} but found [int]
+        error: expected {A with x:B} (record) but found [int] (array)
           ┌─ main:3:13
           │
         3 │             a.x
@@ -3909,13 +3909,13 @@ fn primitive_kind_errors() {
             isType(v: [], type: "array")
         "#,
         expect: expect_test::expect![[r#"
-            error: {} is not Basic (argument v)
+            error: {} (record) is not Basic (argument v)
               ┌─ main:2:23
               │
             2 │             isType(v: {}, type: "record")
               │                       ^^
 
-            error: [A] is not Basic (argument v)
+            error: [A] (array) is not Basic (argument v)
               ┌─ main:3:23
               │
             3 │             isType(v: [], type: "array")
@@ -3936,8 +3936,8 @@ fn primitive_kind_short_errors() {
             isType(v: [], type: "array")
         "#,
         expect_short: expect_test::expect![[r#"
-            main:2:23: error: {} is not Basic (argument v)
-            main:3:23: error: [A] is not Basic (argument v)
+            main:2:23: error: {} (record) is not Basic (argument v)
+            main:3:23: error: [A] (array) is not Basic (argument v)
         "#]]
     }
 }

--- a/libflux/flux-core/src/semantic/types.rs
+++ b/libflux/flux-core/src/semantic/types.rs
@@ -244,15 +244,18 @@ impl fmt::Display for Error {
         match self {
             Error::CannotUnify { exp, act } => write!(
                 f,
-                "expected {} but found {}",
-                exp.clone().fresh(&mut fresh, &mut TvarMap::new()),
-                act.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                "expected {exp}{exp_info} but found {act}{act_info}",
+                exp = exp.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                exp_info = exp.type_info(),
+                act = act.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                act_info = act.type_info(),
             ),
             Error::CannotConstrain { exp, act } => write!(
                 f,
-                "{} is not {}",
-                act.clone().fresh(&mut fresh, &mut TvarMap::new()),
-                exp,
+                "{act}{act_info} is not {exp}",
+                act = act.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                act_info = act.type_info(),
+                exp = exp,
             ),
             Error::OccursCheck(tv, ty) => {
                 write!(f, "recursive types not supported {} != {}", tv, ty)
@@ -266,21 +269,25 @@ impl fmt::Display for Error {
                 cause,
             } => write!(
                 f,
-                "expected {} but found {} for label {} caused by {}",
-                exp.clone().fresh(&mut fresh, &mut TvarMap::new()),
-                act.clone().fresh(&mut fresh, &mut TvarMap::new()),
-                lab,
-                cause,
+                "expected {exp}{exp_info} but found {act}{act_info} for label {lab} caused by {cause}",
+                exp = exp.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                exp_info = exp.type_info(),
+                act = act.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                act_info = act.type_info(),
+                lab = lab,
+                cause = cause
             ),
             Error::MissingArgument(x) => write!(f, "missing required argument {}", x),
             Error::ExtraArgument(x) => write!(f, "found unexpected argument {}", x),
             Error::CannotUnifyArgument(x, e) => write!(f, "{} (argument {})", e, x),
             Error::CannotUnifyReturn { exp, act, cause } => write!(
                 f,
-                "expected {} but found {} for return type caused by {}",
-                exp.clone().fresh(&mut fresh, &mut TvarMap::new()),
-                act.clone().fresh(&mut fresh, &mut TvarMap::new()),
-                cause
+                "expected {exp}{exp_info} but found {act}{act_info} for return type caused by {cause}",
+                exp = exp.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                exp_info = exp.type_info(),
+                act = act.clone().fresh(&mut fresh, &mut TvarMap::new()),
+                act_info = act.type_info(),
+                cause = cause
             ),
             Error::MissingPipeArgument => write!(f, "missing pipe argument"),
             Error::MultiplePipeArguments { exp, act } => {
@@ -920,6 +927,17 @@ impl MonoType {
         match self {
             MonoType::Record(r) => r.fields().find(|p| p.k == field),
             _ => None,
+        }
+    }
+
+    fn type_info(&self) -> &str {
+        match self {
+            MonoType::Arr(_) => " (array)",
+            MonoType::Fun(_) => " (function)",
+            MonoType::Dict(_) => " (dictionary)",
+            MonoType::Record(_) => " (record)",
+            MonoType::Vector(_) => " (vector)",
+            _ => "",
         }
     }
 }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -53,7 +53,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/mod.rs":                                                       "092f73c8c31064ab7b0221d61cdb04429e56436b7e3622b7642b89754f53f505",
 	"libflux/flux-core/src/semantic/nodes.rs":                                                     "18b45e6d6ba288dda9a6575b9b20ec679fbcd688e4c6a8ca1ad0c87fc7917148",
 	"libflux/flux-core/src/semantic/sub.rs":                                                       "05cf04fa0dd1bb04a85c249a5e65dcf5635fe3e49ef48e4620378a31d26d798f",
-	"libflux/flux-core/src/semantic/types.rs":                                                     "3ca8de5698306d133a53d6b6f8c16d4672a724a874d0d0a51a57215a9973b93d",
+	"libflux/flux-core/src/semantic/types.rs":                                                     "6055bd04eee221bd48547e20c1beff771d9a45b6ca26c3498bd593fce256e9c9",
 	"libflux/flux-core/src/semantic/walk/_walk.rs":                                                "03a862d35eac8b74cdc7fae0a91ae155859ac02e1b32aa5d503f523188fc5fde",
 	"libflux/flux-core/src/semantic/walk/mod.rs":                                                  "2d44af6df22c6b93f5155c15cffd28be940f45668883c9b2d4a1184a72a68c68",
 	"libflux/flux-core/src/semantic/walk/test_utils.rs":                                           "b980587707038c420d16b99f99587e69b71f02c32277db37c7e4a094d32f2b38",


### PR DESCRIPTION
This should address part of https://github.com/influxdata/flux/issues/4451, by adding a name for type instead of relying on the user knowing what the symbols mean (easier to google a name, if nothing else).

It is still a bit confusing that arrays and streams of tables are both "array", but that is a different change (https://github.com/influxdata/flux/issues/4275)

cc @rickspencer3 