### PR TITLE
refactor: remove detailed query traces

### DIFF
--- a/execute/profiler.go
+++ b/execute/profiler.go
@@ -267,10 +267,6 @@ func StartSpanFromContext(ctx context.Context, operationName string, label strin
 	}
 	if start.IsZero() {
 		start = time.Now()
-		opts = append(opts, opentracing.StartTime(start))
-	}
-	if flux.IsQueryTracingEnabled(ctx) {
-		span, ctx = opentracing.StartSpanFromContext(ctx, operationName, opts...)
 	}
 
 	if HaveExecutionDependencies(ctx) {

--- a/internal/cmd/flux/main.go
+++ b/internal/cmd/flux/main.go
@@ -2,24 +2,17 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 
-	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies"
 	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/fluxinit"
-	"github.com/influxdata/flux/internal/errors"
-	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
-	jaegercfg "github.com/uber/jaeger-client-go/config"
 )
 
 var flags struct {
 	ExecScript bool
-	Trace      string
 	Format     string
 }
 
@@ -37,56 +30,17 @@ func runE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	ctx, close, err := configureTracing(context.Background())
-	if err != nil {
-		return err
-	}
-	defer close()
-
 	// Defer initialization until other common errors
 	// have already passed to avoid a long load time
 	// for a simple unrelated error.
 	fluxinit.FluxInit()
-	ctx, span := injectDependencies(ctx)
+	ctx, span := injectDependencies(context.Background())
 	defer span.Finish()
 
 	if len(args) == 0 {
 		return replE(ctx)
 	}
 	return executeE(ctx, script, flags.Format)
-}
-
-func configureTracing(ctx context.Context) (context.Context, func(), error) {
-	if flags.Trace == "" {
-		return ctx, func() {}, nil
-	} else if flags.Trace != "jaeger" {
-		return nil, nil, errors.Newf(codes.Invalid, "unknown tracer name: %s", flags.Trace)
-	}
-
-	cfg, err := jaegercfg.FromEnv()
-	if err != nil {
-		return nil, nil, err
-	}
-	if cfg.ServiceName == "" {
-		cfg.ServiceName = "flux"
-	}
-	if cfg.Sampler.Type == "" {
-		cfg.Sampler.Type = "const"
-		cfg.Sampler.Param = 1.0
-	}
-
-	tracer, closer, err := cfg.NewTracer()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	opentracing.SetGlobalTracer(tracer)
-	ctx = flux.WithQueryTracingEnabled(ctx)
-	return ctx, func() {
-		if err := closer.Close(); err != nil {
-			fmt.Printf("error closing tracer: %s.\n", err)
-		}
-	}, nil
 }
 
 const DefaultInfluxDBHost = "http://localhost:9999"
@@ -103,9 +57,7 @@ func main() {
 		RunE: runE,
 	}
 	cmd.Flags().BoolVarP(&flags.ExecScript, "exec", "e", false, "Interpret file argument as a raw flux script")
-	cmd.Flags().StringVar(&flags.Trace, "trace", "", "Trace query execution")
 	cmd.Flags().StringVarP(&flags.Format, "format", "", "cli", "Output format one of: cli,csv. Defaults to cli")
-	cmd.Flag("trace").NoOptDefVal = "jaeger"
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -29,8 +29,6 @@ import (
 	"github.com/influxdata/flux/stdlib/csv"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/mocktracer"
 )
 
 func init() {
@@ -847,81 +845,6 @@ option planner.disableLogicalRules = ["removeCountRule"]`},
 
 			if err := plantest.ComparePlansShallow(tc.want, program.PlanSpec); err != nil {
 				t.Errorf("unexpected plans: %v", err)
-			}
-		})
-	}
-}
-
-func TestQueryTracing(t *testing.T) {
-	// temporarily install a mock tracer to see which spans are created.
-	oldTracer := opentracing.GlobalTracer()
-	defer opentracing.SetGlobalTracer(oldTracer)
-	mockTracer := mocktracer.New()
-	opentracing.SetGlobalTracer(mockTracer)
-
-	plainCtx := context.Background()
-	for _, ctx := range []context.Context{flux.WithQueryTracingEnabled(plainCtx), plainCtx} {
-		// Clear spans from previous run
-		mockTracer.Reset()
-		var name string
-		if flux.IsQueryTracingEnabled(ctx) {
-			name = "tracing enabled"
-		} else {
-			name = "tracing disabled"
-		}
-		t.Run(name, func(t *testing.T) {
-			// Run a query
-			c := lang.FluxCompiler{
-				Query: `
-					import "array"
-					array.from(rows: [{key: 1, value: 2}, {key: 3, value: 4}])
-					  |> filter(fn: (r) => r.value == 2)
-					  |> map(fn: (r) => ({r with foo: "hi"}))`,
-			}
-
-			prog, err := c.Compile(ctx, runtime.Default)
-			if err != nil {
-				t.Fatal(err)
-			}
-			q, err := prog.Start(ctx, &memory.Allocator{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer q.Done()
-			for r := range q.Results() {
-				if err := r.Tables().Do(func(flux.Table) error {
-					return nil
-				}); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if err := q.Err(); err != nil {
-				t.Fatal(err)
-			}
-
-			// If tracing was enabled, then we should see spans for each
-			// source and transformation. If tracing is not enabled, we should
-			// not have those spans.
-			gotOps := make(map[string]struct{})
-			for _, span := range mockTracer.FinishedSpans() {
-				gotOps[span.OperationName] = struct{}{}
-			}
-			wantOps := []string{
-				"*array.tableSource",
-				"*universe.filterTransformation",
-				"*universe.mapTransformation",
-			}
-			for _, wantOp := range wantOps {
-				_, ok := gotOps[wantOp]
-				if flux.IsQueryTracingEnabled(ctx) {
-					if !ok {
-						t.Errorf("expected to find span %q but it wasn't there", wantOp)
-					}
-				} else {
-					if ok {
-						t.Errorf("did not expect to find span %q but it was found", wantOp)
-					}
-				}
 			}
 		})
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -4,26 +4,20 @@ import (
 	"context"
 )
 
-type contextKey string
-
-const queryTracingContextKey contextKey = "query-tracing-enabled"
-
 // WithQueryTracingEnabled will return a child context
 // that will turn on experimental query tracing.
+//
+// Deprecated: Query tracing has been removed because generated traces
+// would be too large and impractical. The query profiler is meant to be
+// used instead.
 func WithQueryTracingEnabled(parentCtx context.Context) context.Context {
-	return context.WithValue(parentCtx, queryTracingContextKey, true)
+	return parentCtx
 }
 
 // IsQueryTracingEnabled will return true if the context
 // contains a key indicating that experimental tracing is enabled.
+//
+// Deprecated: See note about in WithQueryTracingEnabled.
 func IsQueryTracingEnabled(ctx context.Context) bool {
-	v := ctx.Value(queryTracingContextKey)
-	if v == nil {
-		return false
-	}
-	b, ok := v.(bool)
-	if !ok {
-		return false
-	}
-	return b
+	return false
 }


### PR DESCRIPTION
The detailed query traces weren't really practical as they commonly
caused the tracing program, jaeger, to fall over with traces that were
too large.

This removes the code from the engine because we can't practically turn
it on.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written