### PR TITLE
test(doc): Improve doc tests

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "pretty",
  "pretty_assertions",
  "pulldown-cmark",
+ "rayon",
  "regex",
  "serde",
  "serde-aux",

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -23,7 +23,7 @@ bench = false
 default = ["strict"]
 strict = []
 lsp = ["lsp-types"]
-doc = []
+doc = ["rayon"]
 
 [dependencies]
 anyhow = "1"
@@ -37,6 +37,7 @@ derive_more = { version = "0.99.11", default-features = false, features = [
     "display"
 ] }
 pretty = "0.11.2"
+rayon = { version = "1", optional = true }
 serde = { version = "^1.0.59", features = ["rc"] }
 serde_derive = "^1.0.59"
 serde_json = "1.0"

--- a/libflux/flux-core/src/doc/example.rs
+++ b/libflux/flux-core/src/doc/example.rs
@@ -16,7 +16,7 @@ use crate::{
 /// Executes Flux code producing input and output tables.
 pub trait Executor {
     /// Execute the provided Flux code and return the CSV Flux results.
-    fn execute(&mut self, code: &str) -> Result<String>;
+    fn execute(&self, code: &str) -> Result<String>;
 }
 
 /// A list of test results
@@ -24,10 +24,7 @@ pub type TestResults = Vec<Result<String>>;
 
 /// Evaluates all examples in the documentation perfoming an inplace update of their inputs/outpts
 /// and content.
-pub fn evaluate_package_examples(
-    docs: &mut PackageDoc,
-    executor: &mut impl Executor,
-) -> TestResults {
+pub fn evaluate_package_examples(docs: &mut PackageDoc, executor: &impl Executor) -> TestResults {
     let path = &docs.path;
     let mut results = TestResults::new();
     for example in docs.examples.iter_mut() {
@@ -52,7 +49,7 @@ pub fn evaluate_package_examples(
     results
 }
 
-fn evaluate_doc_examples(doc: &mut Doc, executor: &mut impl Executor) -> TestResults {
+fn evaluate_doc_examples(doc: &mut Doc, executor: &impl Executor) -> TestResults {
     match doc {
         Doc::Package(pkg) => evaluate_package_examples(pkg, executor),
         Doc::Value(v) => v
@@ -72,7 +69,7 @@ fn evaluate_doc_examples(doc: &mut Doc, executor: &mut impl Executor) -> TestRes
     }
 }
 
-fn evaluate_example(example: &mut Example, executor: &mut impl Executor) -> Result<()> {
+fn evaluate_example(example: &mut Example, executor: &impl Executor) -> Result<()> {
     let blocks = preprocess_code_blocks(&example.content)?;
     if blocks.len() > 1 {
         bail!(
@@ -457,7 +454,7 @@ mod tests {
         results: &'a str,
     }
     impl<'a> Executor for MockExecutor<'a> {
-        fn execute(&mut self, code: &str) -> Result<String> {
+        fn execute(&self, code: &str) -> Result<String> {
             self.code.assert_eq(code);
             Ok(self.results.to_string())
         }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,9 +12,9 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "2887717e02e04fc1da40d04ae2654201713c2ed2852ef4387b132c36a4b50a0f",
+	"libflux/Cargo.lock":                                                                          "50f35947cccfbc74e9dc97deba12e7da0369abc634986e24c6b61daf2ec17497",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "590d5c9460527d2fa95d55c543ae528afce16dcb3fab1d02475f4e5b2be6b24c",
+	"libflux/flux-core/Cargo.toml":                                                                "ace9d1298e0251652b350f598453f14efa3fa3f5ac57efe150fdaca380a26e51",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "47e06631f249715a44c9c8fa897faf142ad0fa26f67f8cfd5cd201e82cb1afc8",
 	"libflux/flux-core/src/ast/flatbuffers/ast_generated.rs":                                      "895e09284030a8ea05883fbb71d67282a6b567678126f2e2aadfc5bca72ed47d",
 	"libflux/flux-core/src/ast/flatbuffers/mod.rs":                                                "4e2d11d442ba3985024d5102c22c007dd9686f54cf942e79e5911c367fac7586",
@@ -23,8 +23,8 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "82e5405ca63b3930c0383932b3768f90c5004e3b53d721559e2a7e5df871b4da",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "bf275289e690236988049fc0a07cf832dbac25bb5739c02135b069dcdfab4d0f",
-	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "4423115e5a101d780e6a7c5faf912ccc4f6af7777300efd2536f72647b7da930",
-	"libflux/flux-core/src/doc/example.rs":                                                        "8139a34993fd5b4db4fe37fe36340457d52cb6808fc9969ed020371904903156",
+	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "5d4b26472816433dc4708ac1249e34af5add684b92c6eebb623d29be499c98c6",
+	"libflux/flux-core/src/doc/example.rs":                                                        "6414756b3c74df1b58fdb739592e74ded3f89d85d647809333f72a3f6aad146f",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "282ea0baa20d1e43230d9c4914eebd19251b8397ffe4a4e3a3bc5be3178fb930",
 	"libflux/flux-core/src/errors.rs":                                                             "7eb977a67a5f26801ab4622f54722bac1e11945690891a7f98c11337e6b86fde",
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "ce5a9cc62729d03de253d97acf62b6ee385190a4acdcf14c75f4735e2c122ad1",


### PR DESCRIPTION
## test: Don't early exit on errors in flux doc tests

Gathers up the result of each individual test and prints them at the top level

## test: Run doc tests in parallel

Adds rayon as a dependency to run each tested package in parallel which cuts down the test time a bit. Adds some complexity to ensure that the test results are still printed in the same order.
