### PR TITLE
fix(schema): update tests to use explicit yield

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -245,7 +245,7 @@ var sourceHashes = map[string]string{
 	"stdlib/influxdata/influxdb/schema/influxFieldsAsCols_test.flux":                              "6d97a41cba0c9d1f850f7d96d2992dc4f9b1857b6902b62eec3ea8858c6584e9",
 	"stdlib/influxdata/influxdb/schema/influxRawQuery_test.flux":                                  "18bb812c67cf6a6f7fa57e5f3f185eca74400af4eba5490b36f8c00bd289d31b",
 	"stdlib/influxdata/influxdb/schema/schema.flux":                                               "f867154633c2448ffebde0ba4febc53fe0bea9be8f44432d0c961d56c4da9042",
-	"stdlib/influxdata/influxdb/schema/schema_test.flux":                                          "5d4f55abf11a08a539675c70075420597fc6ff00dbe9106972c8213cda077aa6",
+	"stdlib/influxdata/influxdb/schema/schema_test.flux":                                          "b1e66a39f1544c155f34c073357a1270f9bf8aa52225b144afaa079515cbe2b1",
 	"stdlib/influxdata/influxdb/secrets/secrets.flux":                                             "bb18f4f710630536b7b0d86bff0d51b5b146f896dc8a45f0421d943bf13eab54",
 	"stdlib/influxdata/influxdb/secrets/secrets_test.flux":                                        "32de87692a7ab5ddeb211bdc4e548a710e373ab9cefeb5f99301808d8f77dc5d",
 	"stdlib/influxdata/influxdb/tasks/last_success_duration_no_option_test.flux":                  "e6cbb655dff0ecf1f9790446a18088a3a757eef49da7cfedf1ed5bd018735e0c",

--- a/stdlib/influxdata/influxdb/schema/schema_test.flux
+++ b/stdlib/influxdata/influxdb/schema/schema_test.flux
@@ -497,7 +497,7 @@ testcase tagValues {
         schema.tagValues(bucket: "bucket", tag: "host", start: start, stop: stop)
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase tagValues_with_predicate {
     want = array.from(rows: [{_value: "cpu0"}, {_value: "cpu1"}])
@@ -512,7 +512,7 @@ testcase tagValues_with_predicate {
         )
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase tagValues_empty {
     want =
@@ -532,7 +532,7 @@ testcase tagValues_empty {
         )
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase measurementTagValues {
     want = array.from(rows: [{_value: "cpu0"}, {_value: "cpu1"}])
@@ -547,7 +547,7 @@ testcase measurementTagValues {
         )
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase tagKeys {
     want =
@@ -566,7 +566,7 @@ testcase tagKeys {
             |> filter(fn: (r) => r._value != "_start" and r._value != "_stop")
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase tagKeys_with_predicate {
     want = array.from(rows: [{_value: "_field"}, {_value: "_measurement"}, {_value: "cpu"}, {_value: "host"}])
@@ -576,7 +576,7 @@ testcase tagKeys_with_predicate {
             |> filter(fn: (r) => r._value != "_start" and r._value != "_stop")
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase measurementTagKeys {
     want = array.from(rows: [{_value: "_field"}, {_value: "_measurement"}, {_value: "cpu"}, {_value: "host"}])
@@ -586,7 +586,7 @@ testcase measurementTagKeys {
             |> filter(fn: (r) => r._value != "_start" and r._value != "_stop")
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase fieldKeys {
     want = array.from(rows: [{_value: "usage_idle"}, {_value: "usage_user"}, {_value: "used_percent"}])
@@ -595,7 +595,7 @@ testcase fieldKeys {
         schema.fieldKeys(bucket: "bucket", start: start, stop: stop)
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 
 testcase fieldKeys_with_predicate {
@@ -610,7 +610,7 @@ testcase fieldKeys_with_predicate {
         )
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase measurementFieldKeys {
     want = array.from(rows: [{_value: "usage_idle"}, {_value: "usage_user"}])
@@ -619,7 +619,7 @@ testcase measurementFieldKeys {
         schema.measurementFieldKeys(bucket: "bucket", measurement: "cpu", start: start, stop: stop)
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }
 testcase measurements {
     want = array.from(rows: [{_value: "cpu"}, {_value: "swap"}])
@@ -628,5 +628,5 @@ testcase measurements {
         schema.measurements(bucket: "bucket", start: start, stop: stop)
             |> sort()
 
-    testing.diff(want: want, got: got)
+    testing.diff(want: want, got: got) |> yield()
 }


### PR DESCRIPTION
Test that are extended need to use an explicit yield, these tests are
extended in order to validate their planner rules.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
