### PR TITLE
fix: TagColumns in to() might get modified, copy them into the transformation

### DIFF
--- a/stdlib/influxdata/influxdb/to_test.go
+++ b/stdlib/influxdata/influxdb/to_test.go
@@ -741,9 +741,9 @@ func TestTo_Process(t *testing.T) {
 			// Check for modifications to the spec, but ignore the FieldFn.
 			// This is a deep structure with unexported types that are subject
 			// to change.
-			if ! cmp.Equal( tc.spec.Spec, specCopy.Spec,
-					cmpopts.IgnoreFields(influxdb.ToOpSpec{}, "FieldFn") ) {
-				t.Errorf("spec was modified during transformation %#v != %#v", tc.spec.Spec, specCopy.Spec )
+			if !cmp.Equal(tc.spec.Spec, specCopy.Spec,
+				cmpopts.IgnoreFields(influxdb.ToOpSpec{}, "FieldFn")) {
+				t.Errorf("spec was modified during transformation %#v != %#v", tc.spec.Spec, specCopy.Spec)
 			}
 
 			for _, m := range writer.writes {


### PR DESCRIPTION
The `to()` transformation may need to compute the `TagColumns`. Currently this is
written into the Spec object. In order to support parallel execution of to(),
where multiple execution nodes are derived from the same spec, copy the tag
columns into the transformation object and edit them there.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written