### PR TITLE
feat(feature): allow feature flags to record metrics if configured

### DIFF
--- a/dependencies/feature/flagger.go
+++ b/dependencies/feature/flagger.go
@@ -33,3 +33,10 @@ func Flags() []Flag {
 func ByKey(k string) (Flag, bool) {
 	return feature.ByKey(k)
 }
+
+type Metrics = feature.Metrics
+
+// SetMetrics sets the metric store for feature flags.
+func SetMetrics(m Metrics) {
+	feature.SetMetrics(m)
+}

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -122,3 +122,10 @@ func ByKey(k string) (Flag, bool) {
 	v, found := byKey[k]
 	return v, found
 }
+
+type Metrics = feature.Metrics
+
+// SetMetrics sets the metric store for feature flags.
+func SetMetrics(m Metrics) {
+	feature.SetMetrics(m)
+}

--- a/internal/pkg/feature/cmd/feature/main.go
+++ b/internal/pkg/feature/cmd/feature/main.go
@@ -69,6 +69,13 @@ func ByKey(k string) (Flag, bool) {
 	v, found := byKey[k]
 	return v, found
 }
+
+type Metrics = feature.Metrics
+
+// SetMetrics sets the metric store for feature flags.
+func SetMetrics(m Metrics) {
+	feature.SetMetrics(m)
+}
 `
 
 type flagConfig struct {

--- a/internal/pkg/feature/flag.go
+++ b/internal/pkg/feature/flag.go
@@ -73,6 +73,10 @@ func (f Base) value(ctx context.Context) interface{} {
 	return flagger.FlagValue(ctx, f)
 }
 
+func (f Base) inc(v interface{}) {
+	metrics.Inc(f.key, v)
+}
+
 // StringFlag implements Flag for string values.
 type StringFlag struct {
 	Base
@@ -88,7 +92,8 @@ func MakeStringFlag(name, key, owner string, defaultValue string) StringFlag {
 }
 
 // String value of the flag on the request context.
-func (f StringFlag) String(ctx context.Context) string {
+func (f StringFlag) String(ctx context.Context) (v string) {
+	defer func() { f.inc(v) }()
 	s, ok := f.value(ctx).(string)
 	if !ok {
 		return f.defaultString
@@ -111,7 +116,8 @@ func MakeFloatFlag(name, key, owner string, defaultValue float64) FloatFlag {
 }
 
 // Float value of the flag on the request context.
-func (f FloatFlag) Float(ctx context.Context) float64 {
+func (f FloatFlag) Float(ctx context.Context) (v float64) {
+	defer func() { f.inc(v) }()
 	v, ok := f.value(ctx).(float64)
 	if !ok {
 		return f.defaultFloat
@@ -134,7 +140,8 @@ func MakeIntFlag(name, key, owner string, defaultValue int) IntFlag {
 }
 
 // Int value of the flag on the request context.
-func (f IntFlag) Int(ctx context.Context) int {
+func (f IntFlag) Int(ctx context.Context) (v int) {
+	defer func() { f.inc(v) }()
 	// Ints sometimes get returned as floats.
 	switch i := f.value(ctx).(type) {
 	case float64:
@@ -163,7 +170,8 @@ func MakeBoolFlag(name, key, owner string, defaultValue bool) BoolFlag {
 }
 
 // Enabled indicates whether flag is true or false on the request context.
-func (f BoolFlag) Enabled(ctx context.Context) bool {
+func (f BoolFlag) Enabled(ctx context.Context) (v bool) {
+	defer func() { f.inc(v) }()
 	i, ok := f.value(ctx).(bool)
 	if !ok {
 		return f.defaultBool

--- a/internal/pkg/feature/metrics.go
+++ b/internal/pkg/feature/metrics.go
@@ -1,0 +1,20 @@
+package feature
+
+type Metrics interface {
+	Inc(key string, value interface{})
+}
+
+type discardMetrics struct{}
+
+func (discardMetrics) Inc(key string, value interface{}) {}
+
+var metrics Metrics = discardMetrics{}
+
+// SetMetrics sets the metric store for feature flags.
+func SetMetrics(m Metrics) {
+	if m == nil {
+		metrics = discardMetrics{}
+	} else {
+		metrics = m
+	}
+}

--- a/internal/pkg/feature/metrics_test.go
+++ b/internal/pkg/feature/metrics_test.go
@@ -1,0 +1,90 @@
+package feature_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux/internal/pkg/feature"
+)
+
+type flagger map[string]interface{}
+
+func (f flagger) FlagValue(ctx context.Context, flag feature.Flag) interface{} {
+	v, ok := f[flag.Key()]
+	if !ok {
+		return flag.Default()
+	}
+	return v
+}
+
+type metrics map[string]interface{}
+
+func (m metrics) Inc(key string, value interface{}) {
+	m[key] = value
+}
+
+func TestMetrics(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		flagger flagger
+		flags   []feature.Flag
+		want    metrics
+	}{
+		{
+			name: "normal",
+			flagger: flagger{
+				"a": true,
+			},
+			flags: []feature.Flag{
+				feature.MakeBoolFlag("A", "a", "", false),
+				feature.MakeBoolFlag("B", "b", "", false),
+			},
+			want: metrics{
+				"a": true,
+				"b": false,
+			},
+		},
+		{
+			name: "mistyped",
+			flagger: flagger{
+				"a": "true",
+			},
+			flags: []feature.Flag{
+				feature.MakeBoolFlag("A", "a", "", false),
+			},
+			want: metrics{
+				"a": false,
+			},
+		},
+	} {
+		// Note: You cannot use t.Parallel() with this
+		// because it modifies global state.
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := feature.Inject(context.Background(), tt.flagger)
+
+			got := metrics{}
+			feature.SetMetrics(got)
+			defer feature.SetMetrics(nil)
+
+			for _, flag := range tt.flags {
+				switch f := flag.(type) {
+				case feature.BoolFlag:
+					_ = f.Enabled(ctx)
+				case feature.IntFlag:
+					_ = f.Int(ctx)
+				case feature.FloatFlag:
+					_ = f.Float(ctx)
+				case feature.StringFlag:
+					_ = f.String(ctx)
+				default:
+					panic("unreachable")
+				}
+			}
+
+			if !cmp.Equal(tt.want, got) {
+				t.Errorf("unexpected metrics -want/+got\n%s", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This allows feature flags to record that a metric has been accessed
through an interface that is set by the user. By default, this interface
discards the metric. This can be configured in order to allow an
application to gather things like prometheus metrics from accessing
feature flags.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written