### PR TITLE
feat: add second pass to physical planner for parallelization rules

### DIFF
--- a/plan/physical_test.go
+++ b/plan/physical_test.go
@@ -2,6 +2,7 @@ package plan_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 
@@ -90,5 +91,107 @@ func TestPhysicalIntegrityCheckOption(t *testing.T) {
 	_, err = planner.Plan(context.Background(), inputPlan)
 	if err == nil {
 		t.Fatal("unexpected pass")
+	}
+}
+
+const MockParallelKind = "mock-parallel"
+
+// MockProcedureSpec provides a type that implements ProcedureSpec but does not require
+// importing packages which register rules and procedure kinds, which makes it useful for
+// unit testing.
+type MockParallelSpec struct {
+	plan.DefaultCost
+	physical bool
+	parallel bool
+}
+
+func (MockParallelSpec) Kind() plan.ProcedureKind {
+	return MockParallelKind
+}
+
+func (ps MockParallelSpec) Copy() plan.ProcedureSpec {
+	return MockParallelSpec{physical: ps.physical, parallel: ps.parallel}
+}
+
+// Ensure that all physical rules complete before parallel rules are executed.
+func TestPhysicalParallelSequence(t *testing.T) {
+	node0 := plan.CreatePhysicalNode(plan.NodeID("0"), MockParallelSpec{})
+	node1 := plan.CreatePhysicalNode(plan.NodeID("1"), MockParallelSpec{})
+	spec := &plantest.PlanSpec{
+		Nodes: []plan.Node{
+			node0,
+			node1,
+		},
+		Edges: [][2]int{
+			{0, 1},
+		},
+	}
+
+	inputPlan := plantest.CreatePlanSpec(spec)
+
+	// no integrity check enabled, everything should go smoothly
+	planner := plan.NewPhysicalPlanner(
+		plan.OnlyPhysicalRules(
+			&plantest.FunctionRule{
+				RewriteFn: func(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
+					ppn := node.(*plan.PhysicalPlanNode)
+					spec := ppn.Spec.(MockParallelSpec)
+
+					// Rewrite once only.
+					if spec.physical {
+						return node, false, nil
+					}
+
+					// Ensure the parallel rules have not executed.
+					if spec.parallel {
+						return nil, false, fmt.Errorf("parallel already executed")
+					}
+
+					ppn.Spec = MockParallelSpec{
+						physical: true,
+						parallel: spec.parallel,
+					}
+					return node, true, nil
+				},
+			},
+		),
+		plan.AddParallelRules(
+			&plantest.FunctionRule{
+				RewriteFn: func(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
+					ppn := node.(*plan.PhysicalPlanNode)
+					spec := ppn.Spec.(MockParallelSpec)
+
+					// Rewrite once only.
+					if spec.parallel {
+						return node, false, nil
+					}
+
+					// Ensure the physical rules have executed.
+					if !spec.physical {
+						return nil, false, fmt.Errorf("physical is not already executed")
+					}
+
+					ppn.Spec = MockParallelSpec{
+						physical: spec.physical,
+						parallel: true,
+					}
+					return node, true, nil
+				},
+			},
+		),
+	)
+
+	_, err := planner.Plan(context.Background(), inputPlan)
+	if err != nil {
+		t.Fatalf("unexpected fail: %v", err)
+	}
+
+	// Ensure all nodes were visited.
+	for _, node := range spec.Nodes {
+		ppn := node.(*plan.PhysicalPlanNode)
+		spec := ppn.Spec.(MockParallelSpec)
+		if !spec.parallel || !spec.physical {
+			t.Fatalf("all nodes must be visited by both physical and parallel passes")
+		}
 	}
 }

--- a/plan/registration.go
+++ b/plan/registration.go
@@ -72,6 +72,7 @@ func HasSideEffect(spec ProcedureSpec) bool {
 
 var ruleNameToLogicalRule = make(map[string]Rule)
 var ruleNameToPhysicalRule = make(map[string]Rule)
+var ruleNameToParallelizeRules = make(map[string]Rule)
 
 // RegisterLogicalRules registers the rule created by createFn with the logical plan.
 func RegisterLogicalRules(rules ...Rule) {
@@ -81,6 +82,11 @@ func RegisterLogicalRules(rules ...Rule) {
 // RegisterPhysicalRules registers the rule created by createFn with the physical plan.
 func RegisterPhysicalRules(rules ...Rule) {
 	registerRule(ruleNameToPhysicalRule, rules...)
+}
+
+// RegisterParallelizationRule registers the rule created by createFn with the physical plan.
+func RegisterParallelizeRules(rules ...Rule) {
+	registerRule(ruleNameToParallelizeRules, rules...)
 }
 
 func registerRule(ruleMap map[string]Rule, rules ...Rule) {
@@ -96,4 +102,5 @@ func registerRule(ruleMap map[string]Rule, rules ...Rule) {
 func ClearRegisteredRules() {
 	ruleNameToLogicalRule = make(map[string]Rule)
 	ruleNameToPhysicalRule = make(map[string]Rule)
+	ruleNameToParallelizeRules = make(map[string]Rule)
 }


### PR DESCRIPTION
This PR adds a second pass to the physical planner that is dedicated to
running parallelization rules.

Parallelization is something we want to embark on only after all pushdowns have
succeed. Adding a second pass ensures that we can never parallelize a node and
block a pushdown.

Suppose we include parallelization rules in the set of physical rules. Consider:

```    
    range -> filter -> agg
```

And the rules happen to parallelize the filter node first:

```
    parallel-range -> parallel-filter -> merge -> agg
```

However, if the rules fail to parallelize the aggregate as well, then we have
blocked the `range-filter-agg` pushdown. Using a second pass frees us
from the challenging task of ensuring we never block a pushdown.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
