### PR TITLE
feat: add an attribute-based instantiation of parallel execution nodes

### DIFF
--- a/execute/dataset.go
+++ b/execute/dataset.go
@@ -72,7 +72,7 @@ func (id DatasetID) IsZero() bool {
 	return id == ZeroDatasetID
 }
 
-func DatasetIDFromNodeID(id plan.NodeID, instance int) DatasetID {
+func datasetIDFromNodeID(id plan.NodeID, instance int) DatasetID {
 	return DatasetID(uuid.NewV5(uuid.UUID{}, string(id)+"-"+strconv.Itoa(instance)))
 }
 

--- a/execute/dataset.go
+++ b/execute/dataset.go
@@ -2,6 +2,7 @@ package execute
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/apache/arrow/go/arrow/memory"
 	uuid "github.com/gofrs/uuid"
@@ -71,8 +72,8 @@ func (id DatasetID) IsZero() bool {
 	return id == ZeroDatasetID
 }
 
-func DatasetIDFromNodeID(id plan.NodeID) DatasetID {
-	return DatasetID(uuid.NewV5(uuid.UUID{}, string(id)))
+func DatasetIDFromNodeID(id plan.NodeID, instance int) DatasetID {
+	return DatasetID(uuid.NewV5(uuid.UUID{}, string(id)+"-"+strconv.Itoa(instance)))
 }
 
 type dataset struct {

--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	uuid "github.com/gofrs/uuid"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
@@ -25,8 +26,6 @@ type FromProcedureSpec struct {
 	execute.ExecutionNode
 	data []*Table
 	ts   []execute.Transformation
-	a    execute.Administration
-	id   execute.DatasetID
 }
 
 // NewFromProcedureSpec specifies a from-test procedure with source data
@@ -55,7 +54,9 @@ func (src *FromProcedureSpec) AddTransformation(t execute.Transformation) {
 }
 
 func (src *FromProcedureSpec) Run(ctx context.Context) {
-	popts := src.a.ParallelOpts()
+	// uuid.NewV4 can return an error because of enthropy. We will stick with the previous
+	// behavior of panicing on errors when creating new uuid's
+	id := execute.DatasetID(uuid.Must(uuid.NewV4()))
 
 	if len(src.ts) == 0 {
 		return
@@ -64,12 +65,7 @@ func (src *FromProcedureSpec) Run(ctx context.Context) {
 
 		var max execute.Time
 		for _, tbl := range src.data {
-			// If restricted to a parallel run group we may need to skip the table.
-			if popts.Factor > 1 && popts.Group != tbl.ResidesOnPartition {
-				continue
-			}
-			tbl.ParallelGroup = popts.Group
-			t.Process(src.id, tbl)
+			t.Process(id, tbl)
 			stopIdx := execute.ColIdx(execute.DefaultStopColLabel, tbl.Cols())
 			if stopIdx >= 0 {
 				if s := tbl.Key().ValueTime(stopIdx); s > max {
@@ -77,17 +73,15 @@ func (src *FromProcedureSpec) Run(ctx context.Context) {
 				}
 			}
 		}
-		t.UpdateWatermark(src.id, max)
-		t.Finish(src.id, nil)
+		t.UpdateWatermark(id, max)
+		t.Finish(id, nil)
 		return
 	}
 
 	buffers := make([]flux.BufferedTable, 0, len(src.data))
-	residesOnPartition := make([]int, 0, len(src.data))
 	for _, tbl := range src.data {
 		bufTable, _ := execute.CopyTable(tbl)
 		buffers = append(buffers, bufTable)
-		residesOnPartition = append(residesOnPartition, tbl.ResidesOnPartition)
 	}
 
 	// Ensure that the buffers are released after the source has finished.
@@ -99,11 +93,8 @@ func (src *FromProcedureSpec) Run(ctx context.Context) {
 
 	for _, t := range src.ts {
 		var max execute.Time
-		for i, tbl := range buffers {
-			if popts.Factor > 1 && popts.Group != residesOnPartition[i] {
-				continue
-			}
-			t.Process(src.id, tbl.Copy())
+		for _, tbl := range buffers {
+			t.Process(id, tbl.Copy())
 			stopIdx := execute.ColIdx(execute.DefaultStopColLabel, tbl.Cols())
 			if stopIdx >= 0 {
 				if s := tbl.Key().ValueTime(stopIdx); s > max {
@@ -111,16 +102,13 @@ func (src *FromProcedureSpec) Run(ctx context.Context) {
 				}
 			}
 		}
-		t.UpdateWatermark(src.id, max)
-		t.Finish(src.id, nil)
+		t.UpdateWatermark(id, max)
+		t.Finish(id, nil)
 	}
 }
 
 func CreateFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
-	fps := *spec.(*FromProcedureSpec)
-	fps.a = a
-	fps.id = id
-	return &fps, nil
+	return spec.(*FromProcedureSpec), nil
 }
 
 // AllocatingFromProcedureSpec is a procedure spec AND an execution node
@@ -210,6 +198,114 @@ func (testCases *SourceUrlValidationTestCases) Run(t *testing.T, fn execute.Crea
 		})
 	}
 }
+
+const ParallelFromTestKind = "parallel-from-test"
+
+// ParalFromProcedureSpec is a procedure spec AND an execution Node similar to
+// FromProcedureSpec. It differs in that it is aware of the possibility for
+// parallel execution.
+type ParallelFromProcedureSpec struct {
+	execute.ExecutionNode
+	data []*Table
+	ts   []execute.Transformation
+	a    execute.Administration
+	id   execute.DatasetID
+}
+
+// NewFromProcedureSpec specifies a from-test procedure with source data
+func NewParallelFromProcedureSpec(data []*Table) *ParallelFromProcedureSpec {
+	// Normalize data before anything can read it
+	for _, tbl := range data {
+		tbl.Normalize()
+	}
+	return &ParallelFromProcedureSpec{data: data}
+}
+
+func (src *ParallelFromProcedureSpec) Kind() plan.ProcedureKind {
+	return ParallelFromTestKind
+}
+
+func (src *ParallelFromProcedureSpec) Copy() plan.ProcedureSpec {
+	return src
+}
+
+func (src *ParallelFromProcedureSpec) Cost(inStats []plan.Statistics) (plan.Cost, plan.Statistics) {
+	return plan.Cost{}, plan.Statistics{}
+}
+
+func (src *ParallelFromProcedureSpec) AddTransformation(t execute.Transformation) {
+	src.ts = append(src.ts, t)
+}
+
+func (src *ParallelFromProcedureSpec) Run(ctx context.Context) {
+	popts := src.a.ParallelOpts()
+
+	if len(src.ts) == 0 {
+		return
+	} else if len(src.ts) == 1 {
+		t := src.ts[0]
+
+		var max execute.Time
+		for _, tbl := range src.data {
+			// If restricted to a parallel run group we may need to skip the table.
+			if popts.Factor > 1 && popts.Group != tbl.ResidesOnPartition {
+				continue
+			}
+			tbl.ParallelGroup = popts.Group
+			t.Process(src.id, tbl)
+			stopIdx := execute.ColIdx(execute.DefaultStopColLabel, tbl.Cols())
+			if stopIdx >= 0 {
+				if s := tbl.Key().ValueTime(stopIdx); s > max {
+					max = s
+				}
+			}
+		}
+		t.UpdateWatermark(src.id, max)
+		t.Finish(src.id, nil)
+		return
+	}
+
+	buffers := make([]flux.BufferedTable, 0, len(src.data))
+	residesOnPartition := make([]int, 0, len(src.data))
+	for _, tbl := range src.data {
+		bufTable, _ := execute.CopyTable(tbl)
+		buffers = append(buffers, bufTable)
+		residesOnPartition = append(residesOnPartition, tbl.ResidesOnPartition)
+	}
+
+	// Ensure that the buffers are released after the source has finished.
+	defer func() {
+		for _, tbl := range buffers {
+			tbl.Done()
+		}
+	}()
+
+	for _, t := range src.ts {
+		var max execute.Time
+		for i, tbl := range buffers {
+			if popts.Factor > 1 && popts.Group != residesOnPartition[i] {
+				continue
+			}
+			t.Process(src.id, tbl.Copy())
+			stopIdx := execute.ColIdx(execute.DefaultStopColLabel, tbl.Cols())
+			if stopIdx >= 0 {
+				if s := tbl.Key().ValueTime(stopIdx); s > max {
+					max = s
+				}
+			}
+		}
+		t.UpdateWatermark(src.id, max)
+		t.Finish(src.id, nil)
+	}
+}
+
+func CreateParallelFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a execute.Administration) (execute.Source, error) {
+	fps := *spec.(*ParallelFromProcedureSpec)
+	fps.a = a
+	fps.id = id
+	return &fps, nil
+}
+
 
 // RunSourceHelper is a helper for testing an execute.Source.
 // This can be called with a list of wanted tables from the source.

--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -206,14 +206,14 @@ const ParallelFromTestKind = "parallel-from-test"
 // parallel execution.
 type ParallelFromProcedureSpec struct {
 	execute.ExecutionNode
-	data []*Table
+	data []*ParallelTable
 	ts   []execute.Transformation
 	a    execute.Administration
 	id   execute.DatasetID
 }
 
 // NewFromProcedureSpec specifies a from-test procedure with source data
-func NewParallelFromProcedureSpec(data []*Table) *ParallelFromProcedureSpec {
+func NewParallelFromProcedureSpec(data []*ParallelTable) *ParallelFromProcedureSpec {
 	// Normalize data before anything can read it
 	for _, tbl := range data {
 		tbl.Normalize()

--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -306,7 +306,6 @@ func CreateParallelFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a e
 	return &fps, nil
 }
 
-
 // RunSourceHelper is a helper for testing an execute.Source.
 // This can be called with a list of wanted tables from the source.
 // The create function should create the source. If there is an error

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -46,6 +46,11 @@ type Table struct {
 	Alloc *memory.Allocator
 	// IsDone indicates if this table has been used.
 	IsDone bool
+	// PartitionSource indicates which partition the table is on.
+	ResidesOnPartition int
+	// ParallelGroup is assigned during execution so we can see in the
+	// execution output which group the data originated from.
+	ParallelGroup int
 }
 
 // Normalize ensures all fields of the table are set correctly.
@@ -130,7 +135,11 @@ func (t *Table) Do(f func(flux.ColReader) error) error {
 			b := arrow.NewIntBuilder(t.Alloc)
 			for i := range t.Data {
 				if v := t.Data[i][j]; v != nil {
-					b.Append(v.(int64))
+					if col.Label == "_parallel_group" {
+						b.Append(int64(t.ParallelGroup))
+					} else {
+						b.Append(v.(int64))
+					}
 				} else {
 					b.AppendNull()
 				}

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -46,11 +46,6 @@ type Table struct {
 	Alloc *memory.Allocator
 	// IsDone indicates if this table has been used.
 	IsDone bool
-	// PartitionSource indicates which partition the table is on.
-	ResidesOnPartition int
-	// ParallelGroup is assigned during execution so we can see in the
-	// execution output which group the data originated from.
-	ParallelGroup int
 }
 
 // Normalize ensures all fields of the table are set correctly.
@@ -135,11 +130,7 @@ func (t *Table) Do(f func(flux.ColReader) error) error {
 			b := arrow.NewIntBuilder(t.Alloc)
 			for i := range t.Data {
 				if v := t.Data[i][j]; v != nil {
-					if col.Label == "_parallel_group" {
-						b.Append(int64(t.ParallelGroup))
-					} else {
-						b.Append(v.(int64))
-					}
+					b.Append(v.(int64))
 				} else {
 					b.AppendNull()
 				}
@@ -368,6 +359,110 @@ func (t *RowWiseTable) Do(f func(flux.ColReader) error) error {
 		release(row)
 	}
 	return nil
+}
+
+const ParallelGroupColName = "_parallel_group"
+
+type ParallelTable struct {
+	*Table
+	// ResidesOnPartition indicates which partition the table is on.
+	ResidesOnPartition int
+	// ParallelGroup is assigned during execution so we can see in the
+	// execution output which group the data originated from.
+	ParallelGroup int
+}
+
+func (t *ParallelTable) Do(f func(flux.ColReader) error) error {
+	if t.Err != nil {
+		return t.Err
+	} else if t.IsDone {
+		return errors.New(codes.Internal, "table already read")
+	}
+	t.IsDone = true
+
+	cols := make([]array.Interface, len(t.ColMeta))
+	for j, col := range t.ColMeta {
+		switch col.Type {
+		case flux.TBool:
+			b := arrow.NewBoolBuilder(t.Alloc)
+			for i := range t.Data {
+				if v := t.Data[i][j]; v != nil {
+					b.Append(v.(bool))
+				} else {
+					b.AppendNull()
+				}
+			}
+			cols[j] = b.NewBooleanArray()
+			b.Release()
+		case flux.TFloat:
+			b := arrow.NewFloatBuilder(t.Alloc)
+			for i := range t.Data {
+				if v := t.Data[i][j]; v != nil {
+					b.Append(v.(float64))
+				} else {
+					b.AppendNull()
+				}
+			}
+			cols[j] = b.NewFloatArray()
+			b.Release()
+		case flux.TInt:
+			b := arrow.NewIntBuilder(t.Alloc)
+			for i := range t.Data {
+				if v := t.Data[i][j]; v != nil {
+					if col.Label == ParallelGroupColName {
+						b.Append(int64(t.ParallelGroup))
+					} else {
+						b.Append(v.(int64))
+					}
+				} else {
+					b.AppendNull()
+				}
+			}
+			cols[j] = b.NewIntArray()
+			b.Release()
+		case flux.TString:
+			b := arrow.NewStringBuilder(t.Alloc)
+			for i := range t.Data {
+				if v := t.Data[i][j]; v != nil {
+					b.Append(v.(string))
+				} else {
+					b.AppendNull()
+				}
+			}
+			cols[j] = b.NewStringArray()
+			b.Release()
+		case flux.TTime:
+			b := arrow.NewIntBuilder(t.Alloc)
+			for i := range t.Data {
+				if v := t.Data[i][j]; v != nil {
+					b.Append(int64(v.(values.Time)))
+				} else {
+					b.AppendNull()
+				}
+			}
+			cols[j] = b.NewIntArray()
+			b.Release()
+		case flux.TUInt:
+			b := arrow.NewUintBuilder(t.Alloc)
+			for i := range t.Data {
+				if v := t.Data[i][j]; v != nil {
+					b.Append(v.(uint64))
+				} else {
+					b.AppendNull()
+				}
+			}
+			cols[j] = b.NewUintArray()
+			b.Release()
+		}
+	}
+
+	cr := &ColReader{
+		key:  t.Key(),
+		meta: t.ColMeta,
+		cols: cols,
+	}
+	defer cr.Release()
+	return f(cr)
 }
 
 func TablesFromCache(c execute.DataCache) ([]*Table, error) {

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -172,7 +172,8 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 		}
 	}
 
-	// There are three types of instantiations we need to support here.
+	// There are three types of instantiations we need to support here, and for
+	// each one of these, there are source nodes and non-source nodes.
 	//
 	// 1. Standard instantiation. These are non-parallel, non-merge nodes.
 	//    There is a 1:1 relationship between planner node and execution graph

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -208,7 +208,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 
 		for pi, pred := range nonYieldPredecessors(node) {
 			for j := 0; j < predCopies; j++ {
-				ec[i].parents[pi*predCopies+j] = datasetIDFromNodeID(pred.ID(), j)
+				ec[i].parents[pi*predCopies+j] = datasetIDFromNodeID(pred.ID(), i+j)
 			}
 		}
 	}

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -208,7 +208,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 
 		for pi, pred := range nonYieldPredecessors(node) {
 			for j := 0; j < predCopies; j++ {
-				ec[i].parents[pi*predCopies+j] = DatasetIDFromNodeID(pred.ID(), j)
+				ec[i].parents[pi*predCopies+j] = datasetIDFromNodeID(pred.ID(), j)
 			}
 		}
 	}
@@ -223,7 +223,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 		}
 
 		for i := 0; i < copies; i++ {
-			id := DatasetIDFromNodeID(node.ID(), i)
+			id := datasetIDFromNodeID(node.ID(), i)
 
 			source, err := createSourceFn(spec, id, ec[i])
 
@@ -245,7 +245,7 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 		}
 
 		for i := 0; i < copies; i++ {
-			id := DatasetIDFromNodeID(node.ID(), i)
+			id := datasetIDFromNodeID(node.ID(), i)
 
 			tr, ds, err := createTransformationFn(id, DiscardingMode, spec, ec[i])
 

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -384,7 +384,11 @@ func TestParallel_Execute(t *testing.T) {
 			// Construct physical query plan
 			ps := plantest.CreatePlanSpec(tc.spec)
 
-			err := plan.ValidateAttributes(ps)
+			if err := ps.TopDownWalk(plan.SetTriggerSpec); err != nil {
+				return
+			}
+
+			err := plan.ValidatePhysicalPlan(ps)
 			if tc.wantValidationErr == nil && err != nil {
 				t.Fatal(err)
 			}

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -1,0 +1,436 @@
+package execute_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/executetest"
+	_ "github.com/influxdata/flux/fluxinit/static"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/stdlib/universe"
+	"go.uber.org/zap/zaptest"
+)
+
+func init() {
+	// We depend on the registrations that happen in executor_test.go
+}
+
+type physicalNodeOption func(*plan.PhysicalPlanNode)
+
+func withOutputAttr(name string, attr plan.PhysicalAttr) physicalNodeOption {
+	return func(node *plan.PhysicalPlanNode) {
+		node.SetOutputAttr(name, attr)
+	}
+}
+
+func withRequiredAttr(name string, attr plan.PhysicalAttr) physicalNodeOption {
+	return func(node *plan.PhysicalPlanNode) {
+		node.SetRequiredAttr(name, attr)
+	}
+}
+
+func createPhysicalNode(id plan.NodeID, spec plan.PhysicalProcedureSpec, opts ...physicalNodeOption) *plan.PhysicalPlanNode {
+	node := plan.CreatePhysicalNode(id, spec)
+	for _, opt := range opts {
+		opt(node)
+	}
+	return node
+}
+
+func TestParallel_Execute(t *testing.T) {
+
+	testcases := []struct {
+		name      string
+		spec      *plantest.PlanSpec
+		want      map[string][]*executetest.Table
+		allocator *memory.Allocator
+		wantErr   error
+		wantValidationErr   error
+	}{
+		{
+			name: `parallel-from`,
+			spec: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					createPhysicalNode("from-test",
+						executetest.NewFromProcedureSpec(
+							[]*executetest.Table{
+								{
+									KeyCols: []string{"_start", "_stop"},
+									ColMeta: []flux.ColMeta{
+										{Label: "_start", Type: flux.TTime},
+										{Label: "_stop", Type: flux.TTime},
+										{Label: "_time", Type: flux.TTime},
+										{Label: "_value", Type: flux.TFloat},
+										{Label: "_parallel_group", Type: flux.TInt},
+									},
+									Data: [][]interface{}{
+										{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+									},
+									ResidesOnPartition: 0,
+								},
+								{
+									KeyCols: []string{"_start", "_stop"},
+									ColMeta: []flux.ColMeta{
+										{Label: "_start", Type: flux.TTime},
+										{Label: "_stop", Type: flux.TTime},
+										{Label: "_time", Type: flux.TTime},
+										{Label: "_value", Type: flux.TFloat},
+										{Label: "_parallel_group", Type: flux.TInt},
+									},
+									Data: [][]interface{}{
+										{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+									},
+									ResidesOnPartition: 1,
+								},
+							}),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+						withOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+					createPhysicalNode("filter", &universe.FilterProcedureSpec{
+						Fn: interpreter.ResolvedFunction{
+							Scope: runtime.Prelude(),
+							Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+						},
+					}),
+					createPhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+				},
+			},
+			want: map[string][]*executetest.Table{
+				"_result": []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_value", Type: flux.TFloat},
+							{Label: "_parallel_group", Type: flux.TInt},
+						},
+						Data: [][]interface{}{
+							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_value", Type: flux.TFloat},
+							{Label: "_parallel_group", Type: flux.TInt},
+						},
+						Data: [][]interface{}{
+							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
+							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
+							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: `parallel-from-filter`,
+			spec: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					createPhysicalNode("from-test",
+						executetest.NewFromProcedureSpec(
+							[]*executetest.Table{
+								{
+									KeyCols: []string{"_start", "_stop"},
+									ColMeta: []flux.ColMeta{
+										{Label: "_start", Type: flux.TTime},
+										{Label: "_stop", Type: flux.TTime},
+										{Label: "_time", Type: flux.TTime},
+										{Label: "_value", Type: flux.TFloat},
+										{Label: "_parallel_group", Type: flux.TInt},
+									},
+									Data: [][]interface{}{
+										{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+										{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+									},
+									ResidesOnPartition: 0,
+								},
+								{
+									KeyCols: []string{"_start", "_stop"},
+									ColMeta: []flux.ColMeta{
+										{Label: "_start", Type: flux.TTime},
+										{Label: "_stop", Type: flux.TTime},
+										{Label: "_time", Type: flux.TTime},
+										{Label: "_value", Type: flux.TFloat},
+										{Label: "_parallel_group", Type: flux.TInt},
+									},
+									Data: [][]interface{}{
+										{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+										{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+									},
+									ResidesOnPartition: 1,
+								},
+							}),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("filter",
+						&universe.FilterProcedureSpec{
+							Fn: interpreter.ResolvedFunction{
+								Scope: runtime.Prelude(),
+								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+							},
+						},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+						withOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+					createPhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+				},
+			},
+			want: map[string][]*executetest.Table{
+				"_result": []*executetest.Table{
+					{
+						KeyCols: []string{"_start", "_stop"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_value", Type: flux.TFloat},
+							{Label: "_parallel_group", Type: flux.TInt},
+						},
+						Data: [][]interface{}{
+							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
+							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
+						},
+					},
+					{
+						KeyCols: []string{"_start", "_stop"},
+						ColMeta: []flux.ColMeta{
+							{Label: "_start", Type: flux.TTime},
+							{Label: "_stop", Type: flux.TTime},
+							{Label: "_time", Type: flux.TTime},
+							{Label: "_value", Type: flux.TFloat},
+							{Label: "_parallel_group", Type: flux.TInt},
+						},
+						Data: [][]interface{}{
+							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
+							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
+							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: `from-missing-output`,
+			spec: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					createPhysicalNode("from-test",
+						executetest.NewFromProcedureSpec( []*executetest.Table{ })),
+					createPhysicalNode("filter",
+						&universe.FilterProcedureSpec{
+							Fn: interpreter.ResolvedFunction{
+								Scope: runtime.Prelude(),
+								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+							},
+						},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+						withOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+					createPhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+				},
+			},
+			wantValidationErr: fmt.Errorf( "invalid physical query plan; attribute \"parallel-run\" " +
+				"required by \"filter\" is missing from predecessor \"from-test\""),
+		},
+		{
+			name: `from-missing-required`,
+			spec: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					createPhysicalNode("from-test",
+						executetest.NewFromProcedureSpec( []*executetest.Table{ }),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("filter",
+						&universe.FilterProcedureSpec{
+							Fn: interpreter.ResolvedFunction{
+								Scope: runtime.Prelude(),
+								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+							},
+						},
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+						withOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+					createPhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+				},
+			},
+			wantValidationErr: fmt.Errorf( "invalid physical query plan; attribute \"parallel-run\" " +
+				"on \"from-test\" must be required by all successors, but isn't on \"filter\""),
+		},
+		{
+			name: `from-factor-mismatch`,
+			spec: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					createPhysicalNode("from-test",
+						executetest.NewFromProcedureSpec( []*executetest.Table{ }),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+					createPhysicalNode("filter",
+						&universe.FilterProcedureSpec{
+							Fn: interpreter.ResolvedFunction{
+								Scope: runtime.Prelude(),
+								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+							},
+						},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1}),
+						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1})),
+					createPhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+						withRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1}),
+						withOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 1})),
+					createPhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{2, 3},
+				},
+			},
+			wantValidationErr: fmt.Errorf( "invalid physical query plan; attribute \"parallel-run\" " +
+				"required by \"filter\" does not match attribute in predecessor \"from-test\""),
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			tc.spec.Resources = flux.ResourceManagement{
+				ConcurrencyQuota: 1,
+				MemoryBytesQuota: math.MaxInt64,
+			}
+
+			tc.spec.Now = time.Now()
+
+			// Construct physical query plan
+			ps := plantest.CreatePlanSpec(tc.spec)
+
+			err := plan.ValidateAttributes(ps)
+			if tc.wantValidationErr == nil && err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.wantValidationErr != nil {
+				if err == nil {
+					t.Fatalf(`expected an error "%v" but got none`, tc.wantValidationErr)
+				}
+
+				if diff := cmp.Diff(tc.wantValidationErr.Error(), err.Error()); diff != "" {
+					t.Fatalf("unexpected error: -want/+got: %v", diff)
+				}
+				return
+			}
+
+
+			exe := execute.NewExecutor(zaptest.NewLogger(t))
+
+			alloc := tc.allocator
+			if alloc == nil {
+				alloc = executetest.UnlimitedAllocator
+			}
+
+			// Execute the query and preserve any error returned
+			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+			results, _, err := exe.Execute(ctx, ps, alloc)
+			var got map[string][]*executetest.Table
+			if err == nil {
+				got = make(map[string][]*executetest.Table, len(results))
+				for name, r := range results {
+					if err = r.Tables().Do(func(tbl flux.Table) error {
+						cb, err := executetest.ConvertTable(tbl)
+						if err != nil {
+							return err
+						}
+						got[name] = append(got[name], cb)
+						return nil
+					}); err != nil {
+						break
+					}
+				}
+			}
+
+			if tc.wantErr == nil && err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf(`expected an error "%v" but got none`, tc.wantErr)
+				}
+
+				if diff := cmp.Diff(tc.wantErr, err); diff != "" {
+					t.Fatalf("unexpected error: -want/+got: %v", diff)
+				}
+				return
+			}
+
+			for _, g := range got {
+				executetest.NormalizeTables(g)
+			}
+			for _, w := range tc.want {
+				executetest.NormalizeTables(w)
+			}
+
+			if !cmp.Equal(got, tc.want) {
+				t.Error("unexpected results -want/+got", cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -67,40 +67,44 @@ func TestParallel_Execute(t *testing.T) {
 				Nodes: []plan.Node{
 					createPhysicalNode("parallel-from-test",
 						executetest.NewParallelFromProcedureSpec(
-							[]*executetest.Table{
+							[]*executetest.ParallelTable{
 								{
-									KeyCols: []string{"_start", "_stop"},
-									ColMeta: []flux.ColMeta{
-										{Label: "_start", Type: flux.TTime},
-										{Label: "_stop", Type: flux.TTime},
-										{Label: "_time", Type: flux.TTime},
-										{Label: "_value", Type: flux.TFloat},
-										{Label: "_parallel_group", Type: flux.TInt},
-									},
-									Data: [][]interface{}{
-										{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+									Table: &executetest.Table{
+										KeyCols: []string{"_start", "_stop"},
+										ColMeta: []flux.ColMeta{
+											{Label: "_start", Type: flux.TTime},
+											{Label: "_stop", Type: flux.TTime},
+											{Label: "_time", Type: flux.TTime},
+											{Label: "_value", Type: flux.TFloat},
+											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+										},
+										Data: [][]interface{}{
+											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+										},
 									},
 									ResidesOnPartition: 0,
 								},
 								{
-									KeyCols: []string{"_start", "_stop"},
-									ColMeta: []flux.ColMeta{
-										{Label: "_start", Type: flux.TTime},
-										{Label: "_stop", Type: flux.TTime},
-										{Label: "_time", Type: flux.TTime},
-										{Label: "_value", Type: flux.TFloat},
-										{Label: "_parallel_group", Type: flux.TInt},
-									},
-									Data: [][]interface{}{
-										{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+									Table: &executetest.Table{
+										KeyCols: []string{"_start", "_stop"},
+										ColMeta: []flux.ColMeta{
+											{Label: "_start", Type: flux.TTime},
+											{Label: "_stop", Type: flux.TTime},
+											{Label: "_time", Type: flux.TTime},
+											{Label: "_value", Type: flux.TFloat},
+											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+										},
+										Data: [][]interface{}{
+											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+										},
 									},
 									ResidesOnPartition: 1,
 								},
@@ -132,7 +136,7 @@ func TestParallel_Execute(t *testing.T) {
 							{Label: "_stop", Type: flux.TTime},
 							{Label: "_time", Type: flux.TTime},
 							{Label: "_value", Type: flux.TFloat},
-							{Label: "_parallel_group", Type: flux.TInt},
+							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
 						},
 						Data: [][]interface{}{
 							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
@@ -149,7 +153,7 @@ func TestParallel_Execute(t *testing.T) {
 							{Label: "_stop", Type: flux.TTime},
 							{Label: "_time", Type: flux.TTime},
 							{Label: "_value", Type: flux.TFloat},
-							{Label: "_parallel_group", Type: flux.TInt},
+							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
 						},
 						Data: [][]interface{}{
 							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
@@ -168,40 +172,44 @@ func TestParallel_Execute(t *testing.T) {
 				Nodes: []plan.Node{
 					createPhysicalNode("parallel-from-test",
 						executetest.NewParallelFromProcedureSpec(
-							[]*executetest.Table{
+							[]*executetest.ParallelTable{
 								{
-									KeyCols: []string{"_start", "_stop"},
-									ColMeta: []flux.ColMeta{
-										{Label: "_start", Type: flux.TTime},
-										{Label: "_stop", Type: flux.TTime},
-										{Label: "_time", Type: flux.TTime},
-										{Label: "_value", Type: flux.TFloat},
-										{Label: "_parallel_group", Type: flux.TInt},
-									},
-									Data: [][]interface{}{
-										{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
-										{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+									Table: &executetest.Table{
+										KeyCols: []string{"_start", "_stop"},
+										ColMeta: []flux.ColMeta{
+											{Label: "_start", Type: flux.TTime},
+											{Label: "_stop", Type: flux.TTime},
+											{Label: "_time", Type: flux.TTime},
+											{Label: "_value", Type: flux.TFloat},
+											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+										},
+										Data: [][]interface{}{
+											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+										},
 									},
 									ResidesOnPartition: 0,
 								},
 								{
-									KeyCols: []string{"_start", "_stop"},
-									ColMeta: []flux.ColMeta{
-										{Label: "_start", Type: flux.TTime},
-										{Label: "_stop", Type: flux.TTime},
-										{Label: "_time", Type: flux.TTime},
-										{Label: "_value", Type: flux.TFloat},
-										{Label: "_parallel_group", Type: flux.TInt},
-									},
-									Data: [][]interface{}{
-										{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
-										{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+									Table: &executetest.Table{
+										KeyCols: []string{"_start", "_stop"},
+										ColMeta: []flux.ColMeta{
+											{Label: "_start", Type: flux.TTime},
+											{Label: "_stop", Type: flux.TTime},
+											{Label: "_time", Type: flux.TTime},
+											{Label: "_value", Type: flux.TFloat},
+											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+										},
+										Data: [][]interface{}{
+											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+										},
 									},
 									ResidesOnPartition: 1,
 								},
@@ -236,7 +244,7 @@ func TestParallel_Execute(t *testing.T) {
 							{Label: "_stop", Type: flux.TTime},
 							{Label: "_time", Type: flux.TTime},
 							{Label: "_value", Type: flux.TFloat},
-							{Label: "_parallel_group", Type: flux.TInt},
+							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
 						},
 						Data: [][]interface{}{
 							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
@@ -253,7 +261,7 @@ func TestParallel_Execute(t *testing.T) {
 							{Label: "_stop", Type: flux.TTime},
 							{Label: "_time", Type: flux.TTime},
 							{Label: "_value", Type: flux.TFloat},
-							{Label: "_parallel_group", Type: flux.TInt},
+							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
 						},
 						Data: [][]interface{}{
 							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
@@ -271,7 +279,7 @@ func TestParallel_Execute(t *testing.T) {
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec([]*executetest.Table{})),
+						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{})),
 					createPhysicalNode("filter",
 						&universe.FilterProcedureSpec{
 							Fn: interpreter.ResolvedFunction{
@@ -306,7 +314,7 @@ func TestParallel_Execute(t *testing.T) {
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec([]*executetest.Table{}),
+						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{}),
 						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
 					createPhysicalNode("filter",
 						&universe.FilterProcedureSpec{
@@ -340,7 +348,7 @@ func TestParallel_Execute(t *testing.T) {
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec([]*executetest.Table{}),
+						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{}),
 						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
 					createPhysicalNode("filter",
 						&universe.FilterProcedureSpec{

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	_ "github.com/influxdata/flux/fluxinit/static"
@@ -291,8 +292,11 @@ func TestParallel_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			wantValidationErr: fmt.Errorf("invalid physical query plan; attribute \"parallel-run\" " +
-				"required by \"filter\" is missing from predecessor \"parallel-from-test\""),
+			wantValidationErr: &flux.Error{
+				Code: codes.Internal,
+				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
+					"required by \"filter\" is missing from predecessor \"parallel-from-test\""),
+			},
 		},
 		{
 			// Error: the filter node does not require the parallel-run
@@ -323,8 +327,11 @@ func TestParallel_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			wantValidationErr: fmt.Errorf("invalid physical query plan; attribute \"parallel-run\" " +
-				"on \"parallel-from-test\" must be required by all successors, but isn't on \"filter\""),
+			wantValidationErr: &flux.Error{
+				Code: codes.Internal,
+				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
+					"on \"parallel-from-test\" must be required by all successors, but isn't on \"filter\""),
+			},
 		},
 		{
 			// Error: The value of a required attribute does not match value of
@@ -355,8 +362,11 @@ func TestParallel_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			wantValidationErr: fmt.Errorf("invalid physical query plan; attribute \"parallel-run\" " +
-				"required by \"filter\" does not match attribute in predecessor \"parallel-from-test\""),
+			wantValidationErr: &flux.Error{
+				Code: codes.Internal,
+				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
+					"required by \"filter\" does not match attribute in predecessor \"parallel-from-test\""),
+			},
 		},
 	}
 
@@ -384,7 +394,7 @@ func TestParallel_Execute(t *testing.T) {
 					t.Fatalf(`expected an error "%v" but got none`, tc.wantValidationErr)
 				}
 
-				if diff := cmp.Diff(tc.wantValidationErr.Error(), err.Error()); diff != "" {
+				if diff := cmp.Diff(tc.wantValidationErr, err); diff != "" {
 					t.Fatalf("unexpected error: -want/+got: %v", diff)
 				}
 				return

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -58,7 +58,9 @@ func TestParallel_Execute(t *testing.T) {
 		wantValidationErr error
 	}{
 		{
-			name: `parallel-from`,
+			// The from node is executed in parallel, then the data is merged,
+			// and finally filtered after the merge.
+			name: `parallel-from-merge-filter`,
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("from-test",
@@ -157,7 +159,9 @@ func TestParallel_Execute(t *testing.T) {
 			},
 		},
 		{
-			name: `parallel-from-filter`,
+			// The from and filter nodes are both executed in parallel, then
+			// the data is merged.
+			name: `parallel-from-filter-merge`,
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("from-test",

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -2,10 +2,10 @@ package execute_test
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
-	"fmt"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
@@ -50,12 +50,12 @@ func createPhysicalNode(id plan.NodeID, spec plan.PhysicalProcedureSpec, opts ..
 func TestParallel_Execute(t *testing.T) {
 
 	testcases := []struct {
-		name      string
-		spec      *plantest.PlanSpec
-		want      map[string][]*executetest.Table
-		allocator *memory.Allocator
-		wantErr   error
-		wantValidationErr   error
+		name              string
+		spec              *plantest.PlanSpec
+		want              map[string][]*executetest.Table
+		allocator         *memory.Allocator
+		wantErr           error
+		wantValidationErr error
 	}{
 		{
 			name: `parallel-from`,
@@ -263,7 +263,7 @@ func TestParallel_Execute(t *testing.T) {
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("from-test",
-						executetest.NewFromProcedureSpec( []*executetest.Table{ })),
+						executetest.NewFromProcedureSpec([]*executetest.Table{})),
 					createPhysicalNode("filter",
 						&universe.FilterProcedureSpec{
 							Fn: interpreter.ResolvedFunction{
@@ -284,7 +284,7 @@ func TestParallel_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			wantValidationErr: fmt.Errorf( "invalid physical query plan; attribute \"parallel-run\" " +
+			wantValidationErr: fmt.Errorf("invalid physical query plan; attribute \"parallel-run\" " +
 				"required by \"filter\" is missing from predecessor \"from-test\""),
 		},
 		{
@@ -292,7 +292,7 @@ func TestParallel_Execute(t *testing.T) {
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("from-test",
-						executetest.NewFromProcedureSpec( []*executetest.Table{ }),
+						executetest.NewFromProcedureSpec([]*executetest.Table{}),
 						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
 					createPhysicalNode("filter",
 						&universe.FilterProcedureSpec{
@@ -313,7 +313,7 @@ func TestParallel_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			wantValidationErr: fmt.Errorf( "invalid physical query plan; attribute \"parallel-run\" " +
+			wantValidationErr: fmt.Errorf("invalid physical query plan; attribute \"parallel-run\" " +
 				"on \"from-test\" must be required by all successors, but isn't on \"filter\""),
 		},
 		{
@@ -321,7 +321,7 @@ func TestParallel_Execute(t *testing.T) {
 			spec: &plantest.PlanSpec{
 				Nodes: []plan.Node{
 					createPhysicalNode("from-test",
-						executetest.NewFromProcedureSpec( []*executetest.Table{ }),
+						executetest.NewFromProcedureSpec([]*executetest.Table{}),
 						withOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
 					createPhysicalNode("filter",
 						&universe.FilterProcedureSpec{
@@ -343,7 +343,7 @@ func TestParallel_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			wantValidationErr: fmt.Errorf( "invalid physical query plan; attribute \"parallel-run\" " +
+			wantValidationErr: fmt.Errorf("invalid physical query plan; attribute \"parallel-run\" " +
 				"required by \"filter\" does not match attribute in predecessor \"from-test\""),
 		},
 	}
@@ -377,7 +377,6 @@ func TestParallel_Execute(t *testing.T) {
 				}
 				return
 			}
-
 
 			exe := execute.NewExecutor(zaptest.NewLogger(t))
 

--- a/execute/transformation.go
+++ b/execute/transformation.go
@@ -95,6 +95,7 @@ type Administration interface {
 	StreamContext() StreamContext
 	Allocator() *memory.Allocator
 	Parents() []DatasetID
+	ParallelOpts() ParallelOpts
 }
 
 type CreateTransformation func(id DatasetID, mode AccumulationMode, spec plan.ProcedureSpec, a Administration) (Transformation, Dataset, error)

--- a/mock/administration.go
+++ b/mock/administration.go
@@ -37,3 +37,7 @@ func (a *Administration) Allocator() *memory.Allocator {
 func (a *Administration) Parents() []execute.DatasetID {
 	return nil
 }
+
+func (a *Administration) ParallelOpts() execute.ParallelOpts {
+	return execute.ParallelOpts{Group: -1, Factor: 0}
+}

--- a/plan/attributes.go
+++ b/plan/attributes.go
@@ -1,0 +1,27 @@
+package plan
+
+// Physical attributes used in specifying parallelization. The Run attribute
+// means the node executes in parallel. It accepts parallel data (a subset of
+// the source) and produces parallel data. The merge attribute means that the
+// node accepts parallel data, merges the streams, and produces non-parallel
+// data that covers the entire data source.
+const ParallelRunKey = "parallel-run"
+const ParallelMergeKey = "parallel-merge"
+
+type ParallelRunAttribute struct {
+	Factor int
+}
+
+// If a node produces parallel data, then all successors must require parallel
+// data, otherwise there will be a plan error.
+func (ParallelRunAttribute) SuccessorsMustRequire() bool {
+	return true
+}
+
+type ParallelMergeAttribute struct {
+	Factor int
+}
+
+func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
+	return false
+}

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -364,7 +364,6 @@ type PhysicalAttr interface {
 	SuccessorsMustRequire() bool
 }
 
-
 // PhysicalAttributes encapsulates any physical attributes of the result produced
 // by a physical plan node, such as collation, etc.
 type PhysicalAttributes map[string]PhysicalAttr

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -182,20 +182,25 @@ func ValidateAttributes(plan *Spec) error {
 		return nil
 	})
 	return err
-
 }
 
-func validatePhysicalPlan(plan *Spec) error {
+func ValidatePhysicalPlan(plan *Spec) error {
 	err := plan.BottomUpWalk(func(pn Node) error {
 		if validator, ok := pn.ProcedureSpec().(PostPhysicalValidator); ok {
 			return validator.PostPhysicalValidate(pn.ID())
 		}
 		ppn, ok := pn.(*PhysicalPlanNode)
 		if !ok {
-			return fmt.Errorf("invalid physical query plan; found logical operation \"%v\"", pn.ID())
+			return &flux.Error{
+				Code: codes.Internal,
+				Msg:  fmt.Sprintf("invalid physical query plan; found logical operation \"%v\"", pn.ID()),
+			}
 		}
 		if ppn.TriggerSpec == nil {
-			return fmt.Errorf("invalid physical query plan; trigger spec not set on \"%v\"", ppn.id)
+			return &flux.Error{
+				Code: codes.Internal,
+				Msg:  fmt.Sprintf("invalid physical query plan; trigger spec not set on \"%v\"", ppn.id),
+			}
 		}
 
 		return nil
@@ -344,7 +349,10 @@ func (ppn *PhysicalPlanNode) ProcedureSpec() ProcedureSpec {
 func (ppn *PhysicalPlanNode) ReplaceSpec(newSpec ProcedureSpec) error {
 	physSpec, ok := newSpec.(PhysicalProcedureSpec)
 	if !ok {
-		return fmt.Errorf("couldn't replace ProcedureSpec for physical plan node \"%v\"", ppn.ID())
+		return &flux.Error{
+			Code: codes.Internal,
+			Msg:  fmt.Sprintf("couldn't replace ProcedureSpec for physical plan node \"%v\"", ppn.ID()),
+		}
 	}
 
 	ppn.Spec = physSpec

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -383,32 +383,6 @@ func (ppn *PhysicalPlanNode) SetRequiredAttr(name string, v PhysicalAttr) {
 	ppn.RequiredAttrs[name] = v
 }
 
-// Physical attributes used in specifying parallelization. The Run attribute
-// means the node executes in parallel. It accepts parallel data (a subset of
-// the source) and produces parallel data. The merge attribute means that the
-// node accepts parallel data, merges the streams, and produces non-parallel
-// data that covers the entire data source.
-const ParallelRunKey = "parallel-run"
-const ParallelMergeKey = "parallel-merge"
-
-type ParallelRunAttribute struct {
-	Factor int
-}
-
-// If a node produces parallel data, then all successors must require parallel
-// data, otherwise there will be a plan error.
-func (ParallelRunAttribute) SuccessorsMustRequire() bool {
-	return true
-}
-
-type ParallelMergeAttribute struct {
-	Factor int
-}
-
-func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
-	return false
-}
-
 // CreatePhysicalNode creates a single physical plan node from a procedure spec.
 // The newly created physical node has no incoming or outgoing edges.
 func CreatePhysicalNode(id NodeID, spec PhysicalProcedureSpec) *PhysicalPlanNode {

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -150,9 +150,10 @@ func ValidateAttributes(plan *Spec) error {
 				for _, succ := range ppn.Successors() {
 					has := false
 					psucc := succ.(*PhysicalPlanNode)
-					for skey, _ := range succ.(*PhysicalPlanNode).RequiredAttrs {
+					for skey := range succ.(*PhysicalPlanNode).RequiredAttrs {
 						if key == skey {
 							has = true
+							break
 						}
 					}
 					if !has {

--- a/stdlib/universe/parallel.go
+++ b/stdlib/universe/parallel.go
@@ -1,0 +1,168 @@
+package universe
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/execute/table"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/opentracing/opentracing-go"
+)
+
+const (
+	PartitionMergeKind = "influx2x/partitionMergeKind"
+)
+
+type PartitionMergeProcedureSpec struct {
+	plan.DefaultCost
+}
+
+func (o *PartitionMergeProcedureSpec) Kind() plan.ProcedureKind {
+	return PartitionMergeKind
+}
+
+func (o *PartitionMergeProcedureSpec) Copy() plan.ProcedureSpec {
+	return &PartitionMergeProcedureSpec{
+		DefaultCost: o.DefaultCost,
+	}
+}
+
+func init() {
+	execute.RegisterTransformation(PartitionMergeKind, createPartitionMergeTransformation)
+}
+
+func createPartitionMergeTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*PartitionMergeProcedureSpec)
+	if !ok {
+		return nil, nil, fmt.Errorf("invalid spec type %T", spec)
+	}
+
+	alloc := a.Allocator()
+
+	d := execute.NewPassthroughDataset(id)
+
+	t, err := NewPartitionMergeTransformation(a.Context(), d, alloc, s, a.Parents())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return t, d, nil
+}
+
+type PartitionMergeTransformation struct {
+	execute.ExecutionNode
+	ctx     context.Context
+	dataset *execute.PassthroughDataset
+	span    opentracing.Span
+	alloc   *memory.Allocator
+
+	mu          sync.Mutex
+	parentState map[execute.DatasetID]*parallelParentState
+}
+
+type parallelParentState struct {
+	mark       execute.Time
+	processing execute.Time
+	finished   bool
+}
+
+func (t *PartitionMergeTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	return t.dataset.RetractTable(key)
+}
+
+func NewPartitionMergeTransformation(ctx context.Context, dataset *execute.PassthroughDataset, alloc *memory.Allocator, spec *PartitionMergeProcedureSpec, parents []execute.DatasetID) (*PartitionMergeTransformation, error) {
+	var span opentracing.Span
+	span, ctx = opentracing.StartSpanFromContext(ctx, "PartitionMergeTransformation.Process")
+
+	parentState := make(map[execute.DatasetID]*parallelParentState, len(parents))
+	for _, id := range parents {
+		parentState[id] = new(parallelParentState)
+	}
+
+	return &PartitionMergeTransformation{
+		ctx:         ctx,
+		dataset:     dataset,
+		span:        span,
+		alloc:       alloc,
+		parentState: parentState,
+	}, nil
+}
+
+func (t *PartitionMergeTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	passthroughBuilder := table.NewBufferedBuilder(tbl.Key(), t.alloc)
+
+	err := tbl.Do(func(er flux.ColReader) error {
+		return passthroughBuilder.AppendBuffer(er)
+	})
+	if err != nil {
+		return err
+	}
+
+	out, err := passthroughBuilder.Table()
+	if err != nil {
+		return err
+	}
+
+	return t.dataset.Process(out)
+}
+
+func (t *PartitionMergeTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.parentState[id].mark = mark
+
+	min := execute.Time(math.MaxInt64)
+	for _, state := range t.parentState {
+		if state.mark < min {
+			min = state.mark
+		}
+	}
+
+	return t.dataset.UpdateWatermark(min)
+}
+
+func (t *PartitionMergeTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.parentState[id].processing = pt
+
+	min := execute.Time(math.MaxInt64)
+	for _, state := range t.parentState {
+		if state.processing < min {
+			min = state.processing
+		}
+	}
+
+	return t.dataset.UpdateProcessingTime(min)
+}
+
+func (t *PartitionMergeTransformation) Finish(id execute.DatasetID, err error) {
+	defer t.span.Finish()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.parentState[id].finished = true
+
+	if err != nil {
+		// FIXME: this doesn't seem right.
+		t.dataset.Finish(err)
+	}
+
+	finished := true
+	for _, state := range t.parentState {
+		finished = finished && state.finished
+	}
+
+	if finished {
+		t.dataset.Finish(nil)
+		//log.Printf("--------> %p passing finish on", t)
+	}
+}

--- a/stdlib/universe/parallel.go
+++ b/stdlib/universe/parallel.go
@@ -163,6 +163,5 @@ func (t *PartitionMergeTransformation) Finish(id execute.DatasetID, err error) {
 
 	if finished {
 		t.dataset.Finish(nil)
-		//log.Printf("--------> %p passing finish on", t)
 	}
 }

--- a/stdlib/universe/parallel.go
+++ b/stdlib/universe/parallel.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	PartitionMergeKind = "influx2x/partitionMergeKind"
+	ParallelMergeKind = "ParallelMergeKind"
 )
 
 type PartitionMergeProcedureSpec struct {
@@ -23,7 +23,7 @@ type PartitionMergeProcedureSpec struct {
 }
 
 func (o *PartitionMergeProcedureSpec) Kind() plan.ProcedureKind {
-	return PartitionMergeKind
+	return ParallelMergeKind
 }
 
 func (o *PartitionMergeProcedureSpec) Copy() plan.ProcedureSpec {
@@ -33,7 +33,7 @@ func (o *PartitionMergeProcedureSpec) Copy() plan.ProcedureSpec {
 }
 
 func init() {
-	execute.RegisterTransformation(PartitionMergeKind, createPartitionMergeTransformation)
+	execute.RegisterTransformation(ParallelMergeKind, createPartitionMergeTransformation)
 }
 
 func createPartitionMergeTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {


### PR DESCRIPTION
This PR expands the definition of an attribute on a physical plan node to a
collection of named simple interfaces:

```
    type PhysicalAttributes map[string]PhysicalAttr
```

The `PhysicalAttr` interface allows arbitrary data structures to be installed as
attribute values.

This PR then adds two attribute types:

 1. `ParallelRun` - indicates that a plan node should be instantiated multiple
    times when creating the execution graph. Each instantiation will handle
    some subset of the data. In the code we call this the parallel group. If
    the node is a source node, it should restrict source data to the specified
    group it has been assigned. If it is a non-source node, it should expect to
    receive parallel data (the group), and produce parallel data.

 2. `ParallelMerge` - indicates that plan node should merge the multiple
    instantiations of its predecessors. It receives parallel data and produces
    non-parallel data that can be sent to any existing transformation node.

For example, in the following graph, the `rwo` and `to` nodes will carry the
ParallelRun attribute and will be instantiated multiple times. The merge node
will carry the ParallelMerge attribute and will be responsible for unioning the
subsets.

```
    read-window-aggregate -> to -> merge
```

A node has output attributes and required attributes. There is a new validation
step after planning that ensures predecessors output the attributes that it
requires. It is also possible for an attribute to require that all successors
require it. Using these tools we can validate that we always have a sound
convergence from parallel data to non-parallel data after the planner rewrites
the graph to create parallel execution graphs.

During instantiation of the execution graph from the plan, there are three
types of instantiations we need to support, multiplied by the two existing
cases -- source and non-source.

 1. Standard instantiation. These are non-parallel, non-merge nodes.
    There is a 1:1 relationship between planner node and execution graph
    node. Only a single copy of the node is made and it references the
    single copy of the predecessor nodes.

 2. Parallel instantiation. There are multiple copies of the node and of
    all predecessors. This applies to both source and non-source nodes.

 3. Merge instantiation. There is a single copy of the node, but multiple
    copies of the predecessors. These copies merge into the node.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written