### PR TITLE
fix: reclasify csv decoding errors as user errors

### DIFF
--- a/csv/result.go
+++ b/csv/result.go
@@ -367,7 +367,8 @@ func readMetadata(r *bufferedCSVReader, c ResultDecoderConfig) (tableMetadata, e
 					}
 					switch {
 					case datatypes == nil:
-						return tableMetadata{}, fmt.Errorf("missing expected annotation datatype")
+						return tableMetadata{}, errors.New(codes.FailedPrecondition, "missing expected annotation datatype. "+
+							"Consider using the mode: \"raw\" for csv that is not expected to have annotations.")
 					case groups == nil:
 						return tableMetadata{}, fmt.Errorf("missing expected annotation group")
 					case defaults == nil:
@@ -407,7 +408,8 @@ func readMetadata(r *bufferedCSVReader, c ResultDecoderConfig) (tableMetadata, e
 				if !strings.HasPrefix(line[annotationIdx], commentPrefix) {
 					switch {
 					case datatypes == nil:
-						return tableMetadata{}, fmt.Errorf("missing expected annotation datatype")
+						return tableMetadata{}, errors.New(codes.FailedPrecondition, "missing expected annotation datatype. "+
+							"consider using the mode: \"raw\" for csv that is not expected to have annotations.")
 					case groups == nil:
 						return tableMetadata{}, fmt.Errorf("missing expected annotation group")
 					case defaults == nil:

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -1447,7 +1447,7 @@ data1,data2,data3
 			encoderConfig: csv.DefaultEncoderConfig(),
 			encoded:       toCRLF(`1,2`),
 			result: &executetest.Result{
-				Err: errors.New("failed to read metadata: missing expected annotation datatype"),
+				Err: errors.New("failed to read metadata: missing expected annotation datatype. consider using the mode: \"raw\" for csv that is not expected to have annotations."),
 			},
 		},
 


### PR DESCRIPTION
Added a note about using the `mode: "raw"` for csv that is not expected to have annotations.

Closes https://github.com/influxdata/idpe/issues/13332


