### PR TITLE
refactor: Rewrite the parser with lalrpop

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +72,21 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -295,6 +319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +403,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
@@ -440,6 +491,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
 name = "flatbuffers"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +546,8 @@ dependencies = [
  "expect-test",
  "flatbuffers",
  "fnv",
+ "lalrpop",
+ "lalrpop-util",
  "libflate",
  "log",
  "lsp-types",
@@ -556,6 +615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +656,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +696,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852b75a095da6b69da8c5557731c3afd06525d4f655a4fc1c799e2ec8bc4dce4"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d265705249fe209280676d8f68887859fa42e1d34f342fc05bd47726a5e188"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -644,6 +760,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
 dependencies = [
  "rle-decode-fast",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -694,6 +819,12 @@ checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "num-integer"
@@ -761,6 +892,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +966,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +1023,12 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty"
@@ -1052,6 +1239,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,10 +1354,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
+name = "siphasher"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "string_cache"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
+dependencies = [
+ "lazy_static",
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -1222,6 +1434,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1267,6 +1490,15 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/libflux/Cargo.toml
+++ b/libflux/Cargo.toml
@@ -5,3 +5,6 @@ members = ["flux-core", "flux"]
 [profile.release]
 lto = true
 opt-level = 'z'
+
+[profile.dev.build-override]
+opt-level = 2

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -49,6 +49,7 @@ maplit = "1.0.2"
 flatbuffers = "2.0.0"
 derivative = "2.1.1"
 walkdir = "2.2.9"
+lalrpop-util = "0.19"
 log = "0.4"
 lsp-types = { version = "0.91.1", optional = true }
 pulldown-cmark = { version = "0.8", default-features = false }
@@ -58,6 +59,9 @@ once_cell = "1"
 csv = "1.1"
 pad = "0.1.6"
 tempfile = "3"
+
+[build-dependencies]
+lalrpop = "0.19"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/libflux/flux-core/build.rs
+++ b/libflux/flux-core/build.rs
@@ -1,0 +1,10 @@
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+fn main() -> Result<()> {
+    const GRAMMAR: &str = "src/grammar.lalrpop";
+    lalrpop::Configuration::new()
+        .use_cargo_dir_conventions()
+        .process_file(GRAMMAR)?;
+
+    Ok(())
+}

--- a/libflux/flux-core/build.rs
+++ b/libflux/flux-core/build.rs
@@ -2,9 +2,12 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 fn main() -> Result<()> {
     const GRAMMAR: &str = "src/grammar.lalrpop";
+
     lalrpop::Configuration::new()
         .use_cargo_dir_conventions()
         .process_file(GRAMMAR)?;
+
+    println!("cargo:rerun-if-changed={}", GRAMMAR);
 
     Ok(())
 }

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -100,7 +100,11 @@ StringLit: StringLit = {
 }
 
 Atom: Expression = {
-    <Identifier> => Expression::Identifier(<>),
+    AtomIdent<"identifier">
+}
+
+AtomIdent<T>: Expression = {
+    <Identifier> if T == "identifier" => Expression::Identifier(<>),
 
     <t: "int literal"> =>? Ok(Expression::Integer(IntegerLit {
         base: Default::default(),
@@ -141,11 +145,18 @@ Atom: Expression = {
         }))
     },
 
-    <lparen: "("> <expression: Expression> <rparen: ")"> => Expression::Paren(Box::new(ParenExpr {
+    <lparen: Comments<"(">> <expression: Identifier> <tail: ParenTail> => Expression::Paren(Box::new(ParenExpr {
         base: Default::default(),
-        lparen: lparen.comments,
+        lparen,
         expression,
-        rparen: rparen.comments,
+        rparen,
+    })),
+
+    <lparen: Comments<"(">> <expression: ExpressionIdent<"">> <rparen: Comments<")">> => Expression::Paren(Box::new(ParenExpr {
+        base: Default::default(),
+        lparen,
+        expression,
+        rparen,
     })),
 
     <lbrack: "["> <elements: ArrayItems> <rbrack: "]"> => Expression::Array(Box::new(ArrayExpr {
@@ -162,11 +173,20 @@ Atom: Expression = {
         properties,
         rbrace,
     })),
+}
 
+ParenTail: () = {
+    <rparen: Comments<")">> => rparen,
+
+    <rparen: Comments<")">> "=>" => rparen,
 }
 
 Expression: Expression = {
-    Atom,
+    ExpressionIdent<"identifier">
+}
+
+ExpressionIdent<T>: Expression = {
+    AtomIdent<T>,
 
     <callee: Atom> <lparen: Comments<"(">> <arguments: CommaSep<Expression>> <rparen: Comments<")">> => {
         Expression::Call(Box::new(CallExpr {
@@ -177,6 +197,7 @@ Expression: Expression = {
             rparen,
         }))
     },
+
 
     <left: Atom> "/" <right: Expression> => {
         Expression::Binary(Box::new(BinaryExpr {

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -99,6 +99,11 @@ Statement: Statement = {
         id,
         init,
     })),
+
+    <expression: Expression> => Statement::Expr(Box::new(ExprStmt {
+        base: Default::default(),
+        expression,
+    })),
 }
 
 StringLit: StringLit = {
@@ -202,15 +207,15 @@ Expression: Expression = {
 ExpressionIdent<T>: Expression = {
     AtomIdent<T>,
 
-    <callee: Atom> <lparen: Comments<"(">> <arguments: CommaSep<Expression>> <rparen: Comments<")">> => {
-        Expression::Call(Box::new(CallExpr {
-            base: Default::default(),
-            callee,
-            lparen,
-            arguments,
-            rparen,
-        }))
-    },
+//    <callee: Atom> <lparen: Comments<"(">> <arguments: CommaSep<Expression>> <rparen: Comments<")">> => {
+//        Expression::Call(Box::new(CallExpr {
+//            base: Default::default(),
+//            callee,
+//            lparen,
+//            arguments,
+//            rparen,
+//        }))
+//    },
 
 
     <left: Atom> "+" <right: Expression> => {

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -20,6 +20,7 @@ extern {
         "then" => Token { tok: TokenType::Then, .. },
         "builtin" => Token { tok: TokenType::Builtin, .. },
         "package" => Token { tok: TokenType::Package, .. },
+        "import" => Token { tok: TokenType::Import, .. },
 
         ":" => Token { tok: TokenType::Colon, .. },
         "," => Token { tok: TokenType::Comma, .. },
@@ -78,6 +79,11 @@ Package: ast::PackageClause = {
 }
 
 Import: ast::ImportDeclaration = {
+    "import" <alias: Identifier?> <path: StringLit> => ast::ImportDeclaration {
+        base: Default::default(),
+        alias,
+        path,
+    }
 }
 
 Body: Vec<Statement> = {
@@ -145,14 +151,7 @@ AtomIdent<T>: Expression = {
         }))
     },
 
-    <lparen: Comments<"(">> <expression: Identifier> <tail: ParenTail> => Expression::Paren(Box::new(ParenExpr {
-        base: Default::default(),
-        lparen,
-        expression,
-        rparen,
-    })),
-
-    <lparen: Comments<"(">> <expression: ExpressionIdent<"">> <rparen: Comments<")">> => Expression::Paren(Box::new(ParenExpr {
+    <lparen: Comments<"(">> <expression: Expression> <rparen: Comments<")">> => Expression::Paren(Box::new(ParenExpr {
         base: Default::default(),
         lparen,
         expression,
@@ -175,11 +174,11 @@ AtomIdent<T>: Expression = {
     })),
 }
 
-ParenTail: () = {
-    <rparen: Comments<")">> => rparen,
-
-    <rparen: Comments<")">> "=>" => rparen,
-}
+// ParenTail: () = {
+//     <rparen: Comments<")">> => (),
+//
+//     <rparen: Comments<")">> "=>" => (),
+// }
 
 Expression: Expression = {
     ExpressionIdent<"identifier">

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -90,17 +90,33 @@ Import: ast::ImportDeclaration = {
 }
 
 Body: Vec<Statement> = {
-    <Statement*>
+    <mut body: Body_<"expr">> => { body.reverse(); body }
 }
 
-Statement: Statement = {
+Body_<EXPR>: Vec<Statement> = {
+    <s: Statement<"">> <b: Body_<"expr">> => {
+        b.push(s);
+        b
+    },
+
+    <s: ExprStatement> <mut b: Body_<"">> if EXPR == "expr" => {
+        b.push(s);
+        b
+    }
+}
+
+Statement<EXPR>: Statement = {
     <id: Identifier> "=" <init: Expression> => Statement::Variable(Box::new(VariableAssgn {
         base: Default::default(),
         id,
         init,
     })),
 
-    <expression: Expression> => Statement::Expr(Box::new(ExprStmt {
+    <ExprStatement> if EXPR == "expr" => <>
+}
+
+ExprStatement: Statement = {
+    <expression: ExpressionNoParen> => Statement::Expr(Box::new(ExprStmt {
         base: Default::default(),
         expression,
     })),
@@ -118,11 +134,11 @@ StringLit: StringLit = {
 }
 
 Atom: Expression = {
-    AtomIdent<"identifier">
+    AtomOpt<"identifier", "paren">
 }
 
-AtomIdent<T>: Expression = {
-    <Identifier> if T == "identifier" => Expression::Identifier(<>),
+AtomOpt<ID, PAREN>: Expression = {
+    <Identifier> if ID == "identifier" => Expression::Identifier(<>),
 
     <object: Atom> "." <property: Identifier> => Expression::Member(Box::new(MemberExpr {
         base: Default::default(),
@@ -171,7 +187,7 @@ AtomIdent<T>: Expression = {
         }))
     },
 
-    <lparen: Comments<"(">> <expression: Expression> <rparen: Comments<")">> => Expression::Paren(Box::new(ParenExpr {
+    <lparen: Comments<"(">> <expression: Expression> <rparen: Comments<")">> if PAREN == "paren" => Expression::Paren(Box::new(ParenExpr {
         base: Default::default(),
         lparen,
         expression,
@@ -201,24 +217,28 @@ AtomIdent<T>: Expression = {
 // }
 
 Expression: Expression = {
-    ExpressionIdent<"identifier">
+    ExpressionOpt<"identifier", "paren">
 }
 
-ExpressionIdent<T>: Expression = {
-    AtomIdent<T>,
+ExpressionNoParen: Expression = {
+    ExpressionOpt<"identifier", "">
+}
 
-//    <callee: Atom> <lparen: Comments<"(">> <arguments: CommaSep<Expression>> <rparen: Comments<")">> => {
-//        Expression::Call(Box::new(CallExpr {
-//            base: Default::default(),
-//            callee,
-//            lparen,
-//            arguments,
-//            rparen,
-//        }))
-//    },
+ExpressionOpt<ID, PAREN>: Expression = {
+    AtomOpt<ID, PAREN>,
+
+    <callee: AtomOpt<ID, PAREN>> <lparen: Comments<"(">>  <rparen: Comments<")">> if PAREN == "paren" => {
+        Expression::Call(Box::new(CallExpr {
+            base: Default::default(),
+            callee,
+            lparen,
+            arguments,
+            rparen,
+        }))
+    },
 
 
-    <left: Atom> "+" <right: Expression> => {
+    <left: AtomOpt<ID, PAREN>> "+" <right: Expression> => {
         Expression::Binary(Box::new(BinaryExpr {
             base: Default::default(),
             operator: Operator::AdditionOperator,
@@ -227,7 +247,7 @@ ExpressionIdent<T>: Expression = {
         }))
     },
 
-    <left: Atom> "/" <right: Expression> => {
+    <left: AtomOpt<ID, PAREN>> "/" <right: Expression> => {
         Expression::Binary(Box::new(BinaryExpr {
             base: Default::default(),
             operator: Operator::DivisionOperator,

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -1,0 +1,81 @@
+use crate::{ast, ast::*, scanner::*};
+
+grammar;
+
+extern {
+    type Location = u32;
+    type Error = String;
+
+    enum TokenType {
+        "identifier" => TokenType::Ident,
+        "string literal" => TokenType::String,
+        "int literal" => TokenType::Int,
+        "float literal" => TokenType::Float,
+
+        "if" => TokenType::If,
+        "else" => TokenType::Else,
+        "then" => TokenType::Then,
+        "builtin" => TokenType::Builtin,
+        "package" => TokenType::Package,
+
+        ":" => TokenType::Colon,
+        "," => TokenType::Comma,
+        "." => TokenType::Dot,
+        "=>" => TokenType::Arrow,
+
+        "=" => TokenType::Eq,
+
+        "==" => TokenType::Eq,
+        "!=" => TokenType::Neq,
+        "<=" => TokenType::Lte,
+        "<" => TokenType::Lt,
+        ">=" => TokenType::Gte,
+        ">" => TokenType::Gt,
+        "=~" => TokenType::RegexEq,
+        "!~" => TokenType::RegexNeq,
+
+        "{" => TokenType::LBrace,
+        "[" => TokenType::LBrack,
+        "(" => TokenType::LParen,
+
+        "}" => TokenType::RBrace,
+        "]" => TokenType::RBrack,
+        ")" => TokenType::RParen,
+
+        "EOF" => TokenType::Eof,
+    }
+}
+
+pub File: ast::File = {
+    <package: Package?> <imports: Import*> <body: Body> "EOF" => {
+        ast::File {
+            base: Default::default(),
+            name: "".into(),
+            package,
+            imports,
+            body,
+            metadata: String::from("parser-type=lalrpop"),
+            eof: Default::default(),
+        }
+    }
+}
+
+Package: ast::PackageClause = {
+    "package" <name: Identifier> => ast::PackageClause {
+        base: Default::default(),
+        name,
+    }
+}
+
+Import: ast::ImportDeclaration = {
+}
+
+Body: Vec<Statement> = {
+}
+
+Identifier: ast::Identifier = {
+    <name: "identifier"> => ast::Identifier {
+        base: Default::default(),
+        name,
+    },
+}

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -1,4 +1,4 @@
-use crate::{ast, ast::*, scanner::*};
+use crate::{ast, ast::*, scanner::*, parser::strconv};
 
 grammar;
 
@@ -6,48 +6,53 @@ extern {
     type Location = u32;
     type Error = String;
 
-    enum TokenType {
-        "identifier" => TokenType::Ident,
-        "string literal" => TokenType::String,
-        "int literal" => TokenType::Int,
-        "float literal" => TokenType::Float,
+    enum Token {
+        "identifier" => Token { tok: TokenType::Ident, .. },
+        "string literal" => Token { tok: TokenType::String, .. },
+        "int literal" => Token { tok: TokenType::Int, .. },
+        "float literal" => Token { tok: TokenType::Float, .. },
+        "duration literal" => Token { tok: TokenType::Duration, .. },
+        "time literal" => Token { tok: TokenType::Time, .. },
+        "regex literal" => Token { tok: TokenType::Regex, .. },
 
-        "if" => TokenType::If,
-        "else" => TokenType::Else,
-        "then" => TokenType::Then,
-        "builtin" => TokenType::Builtin,
-        "package" => TokenType::Package,
+        "if" => Token { tok: TokenType::If, .. },
+        "else" => Token { tok: TokenType::Else, .. },
+        "then" => Token { tok: TokenType::Then, .. },
+        "builtin" => Token { tok: TokenType::Builtin, .. },
+        "package" => Token { tok: TokenType::Package, .. },
 
-        ":" => TokenType::Colon,
-        "," => TokenType::Comma,
-        "." => TokenType::Dot,
-        "=>" => TokenType::Arrow,
+        ":" => Token { tok: TokenType::Colon, .. },
+        "," => Token { tok: TokenType::Comma, .. },
+        "." => Token { tok: TokenType::Dot, .. },
+        "=>" => Token { tok: TokenType::Arrow, .. },
 
-        "=" => TokenType::Eq,
+        "=" => Token { tok: TokenType::Assign, .. },
 
-        "==" => TokenType::Eq,
-        "!=" => TokenType::Neq,
-        "<=" => TokenType::Lte,
-        "<" => TokenType::Lt,
-        ">=" => TokenType::Gte,
-        ">" => TokenType::Gt,
-        "=~" => TokenType::RegexEq,
-        "!~" => TokenType::RegexNeq,
+        "/" => Token { tok: TokenType::Div, .. },
 
-        "{" => TokenType::LBrace,
-        "[" => TokenType::LBrack,
-        "(" => TokenType::LParen,
+        "==" => Token { tok: TokenType::Eq, .. },
+        "!=" => Token { tok: TokenType::Neq, .. },
+        "<=" => Token { tok: TokenType::Lte, .. },
+        "<" => Token { tok: TokenType::Lt, .. },
+        ">=" => Token { tok: TokenType::Gte, .. },
+        ">" => Token { tok: TokenType::Gt, .. },
+        "=~" => Token { tok: TokenType::RegexEq, .. },
+        "!~" => Token { tok: TokenType::RegexNeq, .. },
 
-        "}" => TokenType::RBrace,
-        "]" => TokenType::RBrack,
-        ")" => TokenType::RParen,
+        "{" => Token { tok: TokenType::LBrace, .. },
+        "[" => Token { tok: TokenType::LBrack, .. },
+        "(" => Token { tok: TokenType::LParen, .. },
 
-        "EOF" => TokenType::Eof,
+        "}" => Token { tok: TokenType::RBrace, .. },
+        "]" => Token { tok: TokenType::RBrack, .. },
+        ")" => Token { tok: TokenType::RParen, .. },
+
+        "EOF" => Token { tok: TokenType::Eof, .. },
     }
 }
 
 pub File: ast::File = {
-    <package: Package?> <imports: Import*> <body: Body> "EOF" => {
+    <package: Package?> <imports: Import*> <body: Body> <eof: Comments<"EOF">> => {
         ast::File {
             base: Default::default(),
             name: "".into(),
@@ -55,9 +60,14 @@ pub File: ast::File = {
             imports,
             body,
             metadata: String::from("parser-type=lalrpop"),
-            eof: Default::default(),
+            eof,
         }
     }
+}
+
+#[inline]
+Comments<T>: Vec<Comment> = {
+    T => <>.comments
 }
 
 Package: ast::PackageClause = {
@@ -71,11 +81,200 @@ Import: ast::ImportDeclaration = {
 }
 
 Body: Vec<Statement> = {
+    <Statement*>
+}
+
+Statement: Statement = {
+    <id: Identifier> "=" <init: Expression> => Statement::Variable(Box::new(VariableAssgn {
+        base: Default::default(),
+        id,
+        init,
+    })),
+}
+
+StringLit: StringLit = {
+    <t: "string literal"> => StringLit {
+        base: Default::default(),
+        value: t.lit,
+    }
+}
+
+Atom: Expression = {
+    <Identifier> => Expression::Identifier(<>),
+
+    <t: "int literal"> =>? Ok(Expression::Integer(IntegerLit {
+        base: Default::default(),
+        value: t.lit.parse::<i64>().map_err(|err| err.to_string())?,
+    })),
+
+    <t: "float literal"> =>? Ok(Expression::Float(FloatLit {
+        base: Default::default(),
+        value: t.lit.parse::<f64>().map_err(|err| err.to_string())?,
+    })),
+
+    <StringLit> => Expression::StringLit(<>),
+
+    <t: "time literal"> =>? {
+        let value = strconv::parse_time(t.lit.as_str())
+            .map_err(|err| err.to_string())?;
+        Ok(Expression::DateTime(DateTimeLit {
+            base: Default::default(),
+            value,
+        }))
+    },
+
+    <t: "regex literal"> =>? {
+        let value = strconv::parse_regex(t.lit.as_str())
+            .map_err(|err| err.to_string())?;
+        Ok(Expression::Regexp(RegexpLit {
+            base: Default::default(),
+            value,
+        }))
+    },
+
+    <t: "duration literal"> =>? {
+        let values = strconv::parse_duration(t.lit.as_str())
+            .map_err(|err| err.to_string())?;
+        Ok(Expression::Duration(DurationLit {
+            base: Default::default(),
+            values,
+        }))
+    },
+
+    <lparen: "("> <expression: Expression> <rparen: ")"> => Expression::Paren(Box::new(ParenExpr {
+        base: Default::default(),
+        lparen: lparen.comments,
+        expression,
+        rparen: rparen.comments,
+    })),
+
+    <lbrack: "["> <elements: ArrayItems> <rbrack: "]"> => Expression::Array(Box::new(ArrayExpr {
+        lbrack: lbrack.comments,
+        base: Default::default(),
+        elements,
+        rbrack: rbrack.comments,
+    })),
+
+    <lbrace: Comments<"{">> <properties: CommaSep<Property>> <rbrace: Comments<"}">> => Expression::Object(Box::new(ObjectExpr {
+        lbrace,
+        base: Default::default(),
+        with: None,
+        properties,
+        rbrace,
+    })),
+
+}
+
+Expression: Expression = {
+    Atom,
+
+    <callee: Atom> <lparen: Comments<"(">> <arguments: CommaSep<Expression>> <rparen: Comments<")">> => {
+        Expression::Call(Box::new(CallExpr {
+            base: Default::default(),
+            callee,
+            lparen,
+            arguments,
+            rparen,
+        }))
+    },
+
+    <left: Atom> "/" <right: Expression> => {
+        Expression::Binary(Box::new(BinaryExpr {
+            base: Default::default(),
+            operator: Operator::DivisionOperator,
+            left,
+            right,
+        }))
+    }
+}
+
+PropertyItems: Vec<Property> = {
+    => Vec::new(),
+
+    <prop: Property> => {
+        vec![prop]
+    },
+
+    <mut vec: PropertyItem+> <last: Property?> => {
+        vec.extend(last);
+        vec
+    },
+}
+
+PropertyItem: Property = {
+    <mut prop: Property> <comma: ","> => {
+        prop.comma = comma.comments;
+        prop
+    },
+}
+
+PropertyKey: PropertyKey = {
+    <Identifier> => PropertyKey::Identifier(<>),
+
+    <StringLit> => PropertyKey::StringLit(<>),
+}
+
+Property: Property = {
+    <key: PropertyKey> <prop: (Comments<":"> Expression)?> => {
+        let (separator, value) = match prop {
+            Some((s, v)) => (s, Some(v)),
+            None => (Vec::new(), None),
+        };
+        Property {
+            base: Default::default(),
+            key,
+            separator,
+            value,
+            comma: Vec::new(),
+        }
+    }
+}
+
+ArrayItems: Vec<ArrayItem> = {
+    => Vec::new(),
+
+    <expression: Expression> => {
+        vec![ArrayItem {
+            expression,
+            comma: Vec::new(),
+        }]
+    },
+
+    <mut vec: ArrayItem+> <last: Expression?> => {
+        vec.extend(last.map(|expression| ArrayItem {
+            expression,
+            comma: Vec::new(),
+        }));
+        vec
+    },
+}
+
+ArrayItem: ArrayItem = {
+    <expression: Expression> <comma: ","> => {
+        ArrayItem {
+            expression,
+            comma: comma.comments,
+        }
+    },
 }
 
 Identifier: ast::Identifier = {
     <name: "identifier"> => ast::Identifier {
         base: Default::default(),
-        name,
+        name: name.lit,
+    },
+}
+
+
+CommaSep<T>: Vec<T> = {
+    => Vec::new(),
+
+    <single: T> => {
+        vec![single]
+    },
+
+    <mut vec: (<T> ",")+> <last: T?> => {
+        vec.extend(last);
+        vec
     },
 }

--- a/libflux/flux-core/src/grammar.lalrpop
+++ b/libflux/flux-core/src/grammar.lalrpop
@@ -29,6 +29,9 @@ extern {
 
         "=" => Token { tok: TokenType::Assign, .. },
 
+        "+" => Token { tok: TokenType::Add, .. },
+        "-" => Token { tok: TokenType::Sub, .. },
+        "*" => Token { tok: TokenType::Mul, .. },
         "/" => Token { tok: TokenType::Div, .. },
 
         "==" => Token { tok: TokenType::Eq, .. },
@@ -99,9 +102,13 @@ Statement: Statement = {
 }
 
 StringLit: StringLit = {
-    <t: "string literal"> => StringLit {
-        base: Default::default(),
-        value: t.lit,
+    <t: "string literal"> =>? {
+        let value = strconv::parse_string(t.lit.as_str())
+            .map_err(|err| err.to_string())?;
+        Ok(StringLit {
+            base: Default::default(),
+            value,
+        })
     }
 }
 
@@ -111,6 +118,14 @@ Atom: Expression = {
 
 AtomIdent<T>: Expression = {
     <Identifier> if T == "identifier" => Expression::Identifier(<>),
+
+    <object: Atom> "." <property: Identifier> => Expression::Member(Box::new(MemberExpr {
+        base: Default::default(),
+        lbrack: Default::default(),
+        object,
+        property: PropertyKey::Identifier(property),
+        rbrack: Default::default(),
+    })),
 
     <t: "int literal"> =>? Ok(Expression::Integer(IntegerLit {
         base: Default::default(),
@@ -197,6 +212,15 @@ ExpressionIdent<T>: Expression = {
         }))
     },
 
+
+    <left: Atom> "+" <right: Expression> => {
+        Expression::Binary(Box::new(BinaryExpr {
+            base: Default::default(),
+            operator: Operator::AdditionOperator,
+            left,
+            right,
+        }))
+    },
 
     <left: Atom> "/" <right: Expression> => {
         Expression::Binary(Box::new(BinaryExpr {

--- a/libflux/flux-core/src/lib.rs
+++ b/libflux/flux-core/src/lib.rs
@@ -20,6 +20,8 @@ extern crate derive_more;
 extern crate fnv;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate lalrpop_util;
 extern crate serde_aux;
 #[macro_use]
 #[cfg(test)]
@@ -38,6 +40,12 @@ pub mod semantic;
 
 mod errors;
 mod map;
+
+lalrpop_mod!(
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[allow(unused_parens)]
+    grammar
+);
 
 use std::hash::BuildHasherDefault;
 

--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -33,7 +33,19 @@ pub(crate) fn parse_string_lalrpop(name: String, s: &str) -> File {
             eof |= token.tok == TokenType::Eof;
             Some((token.start_offset, token, end_offset))
         }))
-        .unwrap_or_else(|err| panic!("{}\n{:#?}", err, err));
+        .unwrap_or_else(|err| File {
+            base: BaseNode {
+                location: Default::default(),
+                comments: Default::default(),
+                errors: vec![err.to_string()],
+            },
+            name: Default::default(),
+            metadata: Default::default(),
+            package: Default::default(),
+            imports: Default::default(),
+            body: Default::default(),
+            eof: Default::default(),
+        });
 
     file.name = name;
 

--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -12,8 +12,26 @@ mod strconv;
 /// Returns a [`File`] with the value of the `name` parameter
 /// as the file name.
 pub fn parse_string(name: String, s: &str) -> File {
-    let mut p = Parser::new(s);
-    p.parse_file(name)
+    if true {
+        parse_string_lalrpop(name, s)
+    } else {
+        let mut p = Parser::new(s);
+        p.parse_file(name)
+    }
+}
+
+pub(crate) fn parse_string_lalrpop(name: String, s: &str) -> File {
+    let mut scanner = crate::scanner::Scanner::new(s);
+    let mut file = crate::grammar::FileParser::new()
+        .parse(std::iter::from_fn(|| {
+            let token = scanner.scan();
+            Some((token.start_offset, token.tok, token.end_offset))
+        }))
+        .unwrap();
+
+    file.name = name;
+
+    file
 }
 
 struct TokenError {

--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn parse_string_lalrpop(name: String, s: &str) -> File {
             if eof {
                 return None;
             }
-            let token = scanner.scan_with_regex();
+            let token = scanner.scan();
             let end_offset = token.end_offset;
             eof |= token.tok == TokenType::Eof;
             Some((token.start_offset, token, end_offset))

--- a/libflux/flux/build.rs
+++ b/libflux/flux/build.rs
@@ -49,13 +49,6 @@ fn canonicalize_all_files(root: &Path) -> Vec<String> {
 }
 
 fn main() -> Result<()> {
-    const GRAMMAR: &str = "src/parser/grammar.lalrpop";
-    lalrpop::Configuration::new()
-        .use_cargo_dir_conventions()
-        .process_file(GRAMMAR)?;
-
-    println!("cargo:rerun-if-changed={}", GRAMMAR);
-
     let dir = path::PathBuf::from(env::var("OUT_DIR")?);
 
     let stdlib_path = Path::new(stdlib_relative_path());

--- a/libflux/flux/build.rs
+++ b/libflux/flux/build.rs
@@ -49,6 +49,13 @@ fn canonicalize_all_files(root: &Path) -> Vec<String> {
 }
 
 fn main() -> Result<()> {
+    const GRAMMAR: &str = "src/parser/grammar.lalrpop";
+    lalrpop::Configuration::new()
+        .use_cargo_dir_conventions()
+        .process_file(GRAMMAR)?;
+
+    println!("cargo:rerun-if-changed={}", GRAMMAR);
+
     let dir = path::PathBuf::from(env::var("OUT_DIR")?);
 
     let stdlib_path = Path::new(stdlib_relative_path());


### PR DESCRIPTION
Took stab at investigating if we could rewrite the parser with https://github.com/lalrpop/lalrpop which could give us a more readable parser and allow for better recovery of syntax errors. Unfortunately statement lists seem too ambiguous for this to work (at least easily).

```
// is this a single `foo(x)` statement or two statements `foo` and `(x)` ?
foo
(x)
```