### PR TITLE
feat: factor parallel execution into the concurrency quota calculation

### DIFF
--- a/plan/physical.go
+++ b/plan/physical.go
@@ -108,7 +108,12 @@ func (pp *physicalPlanner) Plan(ctx context.Context, spec *Spec) (*Spec, error) 
 				// Do not include source nodes in the node list as
 				// they do not use the dispatcher.
 				if len(node.Predecessors()) > 0 {
-					concurrencyQuota++
+					addend := 1
+					ppn := node.(*PhysicalPlanNode)
+					if attr, ok := ppn.OutputAttrs[ParallelRunKey]; ok {
+						addend = attr.(ParallelRunAttribute).Factor
+					}
+					concurrencyQuota += addend
 				}
 				return nil
 			})


### PR DESCRIPTION
If a plan node is to be executed in parallel, the node should contribute to the
concurrency quota by the same amount as the parallelization factor. The factor
specifies that the node will be instantiated factor times, and we want quota
for each instantiation.

### Background

In the first iteration of the parallelization work, the plan nodes were copied N times and the concurrency calculation was appropriate. Now the plan nodes are not copied, they just carry some attributes to indicate they will be instantiated multiple times when the execution graph is made, so we need to use the attribute as a factor when adding to the concurrency quota.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
