### PR TITLE
fix(stdlib): one of the updated map tests used range incorrectly

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -527,7 +527,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestAverage_test.flux":                                                     "3debee2f9c626a637b8842cf23d32f88ba1bf2bf98b53744e7c699a0c8f833cf",
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "f9575bdb7e2ee3a37153b296d9e59fa69334e675f2de4f4023c0e7aec541aba2",
 	"stdlib/universe/lowestMin_test.flux":                                                         "389fa9ceb38d066ad18a8b21220d4b554d8c31d83d80f1694bc703a14f86a0b2",
-	"stdlib/universe/map_test.flux":                                                               "a1f33feab70d350909576d0cbda55911d968ba2cc6e5a624d2708bfc3d9910dc",
+	"stdlib/universe/map_test.flux":                                                               "98e8c44787cd37a0f8c44519396fa6eba79724c8d36624411f560873ce253986",
 	"stdlib/universe/math_fn_constant_test.flux":                                                  "24091df7a982240ac5fdc4f6495d32a4a6078af1206d6d6cf51d2feb35abb7f7",
 	"stdlib/universe/math_m_max_test.flux":                                                        "9cc0aacc9a66209827b6ba83922fd6a291aa88205d86c5fa79fdce78be7599e0",
 	"stdlib/universe/max_test.flux":                                                               "3057f4d30f8c404af13b2f27ce13527c97ea77bf198c0f1a627f3b48673d4db8",

--- a/stdlib/universe/map_test.flux
+++ b/stdlib/universe/map_test.flux
@@ -30,8 +30,8 @@ testcase basic {
 
         got =
             csv.from(csv: inData)
-                |> range(start: 2018-05-22T19:53:26Z)
                 |> testing.load()
+                |> range(start: 2018-05-22T19:53:26Z)
                 |> map(fn: (r) => ({newValue: float(v: r._value)}))
         want = csv.from(csv: outData)
 
@@ -180,6 +180,7 @@ testcase shadow_var {
         myVal = "wrong"
         got =
             csv.from(csv: inData)
+                |> testing.load()
                 |> range(start: 2018-05-22T19:53:26Z)
                 |> map(
                     fn: (r) => {


### PR DESCRIPTION
One of the updated map tests put the range before `testing.load()` which
messed with the test. This swaps them so that range is after
`testing.load()` so the test works properly in influxdb.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written