### PR TITLE
refactor(memory): convert the allocator into an interface

### DIFF
--- a/array/array.go
+++ b/array/array.go
@@ -21,9 +21,9 @@ var (
 	BooleanType = arrow.FixedWidthTypes.Boolean
 )
 
-// Interface represents an immutable sequence of values.
+// Array represents an immutable sequence of values.
 //
-// This type is derived from the arrow array.Array interface.
+// This type is derived from the arrow.Array interface.
 type Array interface {
 	// DataType returns the type metadata for this instance.
 	DataType() DataType

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -122,7 +122,7 @@ func TestString(t *testing.T) {
 }
 
 func TestNewStringFromBinaryArray(t *testing.T) {
-	alloc := &fluxmemory.Allocator{}
+	alloc := &fluxmemory.ResourceAllocator{}
 	// Need to use the Apache binary builder to be able to create an actual
 	// Arrow Binary array.
 	sb := apachearray.NewBinaryBuilder(alloc, array.StringType)

--- a/arrow/allocator.go
+++ b/arrow/allocator.go
@@ -5,6 +5,6 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-func NewAllocator(a *memory.Allocator) arrowmemory.Allocator {
+func NewAllocator(a memory.Allocator) arrowmemory.Allocator {
 	return a
 }

--- a/arrow/bool.go
+++ b/arrow/bool.go
@@ -5,7 +5,7 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-func NewBool(vs []bool, alloc *memory.Allocator) *array.Boolean {
+func NewBool(vs []bool, alloc memory.Allocator) *array.Boolean {
 	b := NewBoolBuilder(alloc)
 	b.Resize(len(vs))
 	for _, v := range vs {
@@ -20,6 +20,9 @@ func BoolSlice(arr *array.Boolean, i, j int) *array.Boolean {
 	return Slice(arr, int64(i), int64(j)).(*array.Boolean)
 }
 
-func NewBoolBuilder(a *memory.Allocator) *array.BooleanBuilder {
+func NewBoolBuilder(a memory.Allocator) *array.BooleanBuilder {
+	if a == nil {
+		a = memory.DefaultAllocator
+	}
 	return array.NewBooleanBuilder(a)
 }

--- a/arrow/float.go
+++ b/arrow/float.go
@@ -5,7 +5,7 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-func NewFloat(vs []float64, alloc *memory.Allocator) *array.Float {
+func NewFloat(vs []float64, alloc memory.Allocator) *array.Float {
 	b := NewFloatBuilder(alloc)
 	b.Resize(len(vs))
 	for _, v := range vs {
@@ -20,6 +20,9 @@ func FloatSlice(arr *array.Float, i, j int) *array.Float {
 	return Slice(arr, int64(i), int64(j)).(*array.Float)
 }
 
-func NewFloatBuilder(a *memory.Allocator) *array.FloatBuilder {
+func NewFloatBuilder(a memory.Allocator) *array.FloatBuilder {
+	if a == nil {
+		a = memory.DefaultAllocator
+	}
 	return array.NewFloatBuilder(a)
 }

--- a/arrow/int.go
+++ b/arrow/int.go
@@ -5,7 +5,7 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-func NewInt(vs []int64, alloc *memory.Allocator) *array.Int {
+func NewInt(vs []int64, alloc memory.Allocator) *array.Int {
 	b := NewIntBuilder(alloc)
 	b.Resize(len(vs))
 	for _, v := range vs {
@@ -20,6 +20,9 @@ func IntSlice(arr *array.Int, i, j int) *array.Int {
 	return Slice(arr, int64(i), int64(j)).(*array.Int)
 }
 
-func NewIntBuilder(a *memory.Allocator) *array.IntBuilder {
+func NewIntBuilder(a memory.Allocator) *array.IntBuilder {
+	if a == nil {
+		a = memory.DefaultAllocator
+	}
 	return array.NewIntBuilder(a)
 }

--- a/arrow/string.go
+++ b/arrow/string.go
@@ -5,7 +5,7 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-func NewString(vs []string, alloc *memory.Allocator) *array.String {
+func NewString(vs []string, alloc memory.Allocator) *array.String {
 	b := NewStringBuilder(alloc)
 	b.Resize(len(vs))
 	sz := 0
@@ -25,6 +25,9 @@ func StringSlice(arr *array.String, i, j int) *array.String {
 	return Slice(arr, int64(i), int64(j)).(*array.String)
 }
 
-func NewStringBuilder(a *memory.Allocator) *array.StringBuilder {
+func NewStringBuilder(a memory.Allocator) *array.StringBuilder {
+	if a == nil {
+		a = memory.DefaultAllocator
+	}
 	return array.NewStringBuilder(a)
 }

--- a/arrow/uint.go
+++ b/arrow/uint.go
@@ -5,7 +5,7 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-func NewUint(vs []uint64, alloc *memory.Allocator) *array.Uint {
+func NewUint(vs []uint64, alloc memory.Allocator) *array.Uint {
 	b := NewUintBuilder(alloc)
 	b.Resize(len(vs))
 	for _, v := range vs {
@@ -20,6 +20,9 @@ func UintSlice(arr *array.Uint, i, j int) *array.Uint {
 	return Slice(arr, int64(i), int64(j)).(*array.Uint)
 }
 
-func NewUintBuilder(a *memory.Allocator) *array.UintBuilder {
+func NewUintBuilder(a memory.Allocator) *array.UintBuilder {
+	if a == nil {
+		a = memory.DefaultAllocator
+	}
 	return array.NewUintBuilder(a)
 }

--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -658,7 +658,7 @@ func (testExecutor) Run(pkg *ast.Package) error {
 		return errors.Wrap(err, codes.Invalid, "failed to compile")
 	}
 
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	query, err := program.Start(ctx, alloc)
 	if err != nil {
 		return errors.Wrap(err, codes.Inherit, "error while executing program")

--- a/compiler.go
+++ b/compiler.go
@@ -33,5 +33,5 @@ type Program interface {
 	// Start begins execution of the program and returns immediately.
 	// As results are produced they arrive on the channel.
 	// The program is finished once the result channel is closed and all results have been consumed.
-	Start(context.Context, *memory.Allocator) (Query, error)
+	Start(context.Context, memory.Allocator) (Query, error)
 }

--- a/compiler/vectorized_test.go
+++ b/compiler/vectorized_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/flux/values"
 )
 
-func vectorizedObjectFromMap(mp map[string]interface{}, mem *memory.Allocator) values.Object {
+func vectorizedObjectFromMap(mp map[string]interface{}, mem memory.Allocator) values.Object {
 	obj := make(map[string]values.Value)
 	for k, v := range mp {
 		switch s := v.(type) {
@@ -106,7 +106,7 @@ func TestVectorizedFns(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			checked := arrow.NewCheckedAllocator(memory.DefaultAllocator)
-			mem := &memory.Allocator{Allocator: checked}
+			mem := &memory.ResourceAllocator{Allocator: checked}
 
 			pkg, err := runtime.AnalyzeSource(tc.fn)
 			if err != nil {
@@ -140,7 +140,7 @@ func TestVectorizedFns(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			want := vectorizedObjectFromMap(tc.want, &memory.Allocator{})
+			want := vectorizedObjectFromMap(tc.want, &memory.ResourceAllocator{})
 			if !cmp.Equal(want, got, CmpOptions...) {
 				t.Errorf("unexpected value -want/+got\n%s", cmp.Diff(want, got, CmpOptions...))
 			}

--- a/csv/result_test.go
+++ b/csv/result_test.go
@@ -2534,7 +2534,7 @@ func TestMultiResultDecoder(t *testing.T) {
 
 func TestTable(t *testing.T) {
 	executetest.RunTableTests(t, executetest.TableTest{
-		NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+		NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 			decoder := csv.NewResultDecoder(csv.ResultDecoderConfig{
 				// Set this to a low value so we can have a table with
 				// multiple buffers.

--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -168,9 +168,9 @@ func NewSimpleAggregateTransformation(ctx context.Context, id DatasetID, agg Sim
 		return NewAggregateTransformation(id, tr, mem)
 	}
 
-	alloc, ok := mem.(*fluxmemory.Allocator)
+	alloc, ok := mem.(*fluxmemory.ResourceAllocator)
 	if !ok {
-		alloc = &fluxmemory.Allocator{
+		alloc = &fluxmemory.ResourceAllocator{
 			Allocator: mem,
 		}
 	}

--- a/execute/allocator.go
+++ b/execute/allocator.go
@@ -13,11 +13,12 @@ const (
 	timeSize    = 8
 )
 
-// Allocator tracks the amount of memory being consumed by a query.
-// The allocator provides methods similar to make and append, to allocate large slices of data.
-// The allocator also provides a Free method to account for when memory will be freed.
+// Allocator is used to track memory allocations for directly allocated structs.
+// Normally, you should use arrow builders and the memory.Allocator by itself to
+// create arrays, but the Allocator is used by older builders that were pre-arrow
+// and directly allocated Go slices rather than relying on arrow's builders.
 type Allocator struct {
-	*memory.Allocator
+	memory.Allocator
 }
 
 // Free informs the allocator that memory has been freed.
@@ -165,7 +166,7 @@ func (a *Allocator) Strings(l, c int) []string {
 // AppendStrings appends strings to a slice.
 // Only the string headers are accounted for.
 func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
-	//TODO(nathanielc): Account for actual size of strings
+	// TODO(nathanielc): Account for actual size of strings
 	if cap(slice)-len(slice) >= len(vs) {
 		return append(slice, vs...)
 	}

--- a/execute/dataset_test.go
+++ b/execute/dataset_test.go
@@ -52,7 +52,7 @@ func TestTransportDataset_Process(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.Allocator{
+	alloc := &memory.ResourceAllocator{
 		Allocator: mem,
 	}
 	buffer := arrow.TableBuffer{
@@ -96,7 +96,7 @@ func TestTransportDataset_AddTransformation(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.Allocator{
+	alloc := &memory.ResourceAllocator{
 		Allocator: mem,
 	}
 	buffer := arrow.TableBuffer{
@@ -195,7 +195,7 @@ func TestTransportDataset_MultipleDownstream(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.Allocator{
+	alloc := &memory.ResourceAllocator{
 		Allocator: mem,
 	}
 	buffer := arrow.TableBuffer{

--- a/execute/dependencies.go
+++ b/execute/dependencies.go
@@ -30,7 +30,7 @@ type ExecutionOptions struct {
 // executed by the Interpreter needs in order to trigger the execution of a flux.Program
 type ExecutionDependencies struct {
 	// Must be set
-	Allocator *memory.Allocator
+	Allocator memory.Allocator
 	Now       *time.Time
 
 	// Allowed to be nil
@@ -76,9 +76,9 @@ func GetExecutionDependencies(ctx context.Context) ExecutionDependencies {
 
 // Create some execution dependencies. Any arg may be nil, this will choose
 // some suitable defaults.
-func NewExecutionDependencies(allocator *memory.Allocator, now *time.Time, logger *zap.Logger) ExecutionDependencies {
+func NewExecutionDependencies(allocator memory.Allocator, now *time.Time, logger *zap.Logger) ExecutionDependencies {
 	if allocator == nil {
-		allocator = new(memory.Allocator)
+		allocator = new(memory.ResourceAllocator)
 	}
 
 	if now == nil {

--- a/execute/executetest/allocator.go
+++ b/execute/executetest/allocator.go
@@ -4,4 +4,4 @@ import (
 	"github.com/influxdata/flux/memory"
 )
 
-var UnlimitedAllocator = &memory.Allocator{}
+var UnlimitedAllocator = &memory.ResourceAllocator{}

--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -118,7 +118,7 @@ type AllocatingFromProcedureSpec struct {
 	ByteCount int
 
 	id    execute.DatasetID
-	alloc *memory.Allocator
+	alloc memory.Allocator
 	ts    []execute.Transformation
 }
 

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -43,7 +43,7 @@ type Table struct {
 	Err error
 	// Alloc is the allocator used to create the column readers.
 	// Memory is not tracked unless this is set.
-	Alloc *memory.Allocator
+	Alloc memory.Allocator
 	// IsDone indicates if this table has been used.
 	IsDone bool
 }
@@ -647,7 +647,7 @@ type TableTest struct {
 	// tables of different shapes and sizes to get coverage of
 	// as much of the code as possible. The TableIterator will
 	// be created once for each subtest.
-	NewFn func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator
+	NewFn func(ctx context.Context, alloc memory.Allocator) flux.TableIterator
 
 	// IsDone will report if the table is considered done for reading.
 	// The call to Done should force this to be true, but it is possible
@@ -666,7 +666,7 @@ func (tt TableTest) run(t *testing.T, name string, f func(tt *tableTest)) {
 			TableTest: tt,
 			t:         t,
 			logger:    zaptest.NewLogger(t),
-			alloc:     &memory.Allocator{},
+			alloc:     &memory.ResourceAllocator{},
 		})
 	})
 }
@@ -675,7 +675,7 @@ type tableTest struct {
 	TableTest
 	t      *testing.T
 	logger *zap.Logger
-	alloc  *memory.Allocator
+	alloc  *memory.ResourceAllocator
 }
 
 func (tt *tableTest) do(f func(tbl flux.Table) error) {

--- a/execute/executetest/table_test.go
+++ b/execute/executetest/table_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestTable(t *testing.T) {
 	RunTableTests(t, TableTest{
-		NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+		NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 			return &TableIterator{
 				Tables: []*Table{
 					{

--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -119,7 +119,7 @@ func ProcessTestHelper2(
 	data []flux.Table,
 	want []*Table,
 	wantErr error,
-	create func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset),
+	create func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset),
 ) {
 	t.Helper()
 
@@ -130,7 +130,7 @@ func ProcessTestHelper2(
 		}
 	}()
 
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	store := NewDataStore()
 	tx, d := create(RandomDatasetID(), alloc)
 	d.SetTriggerSpec(plan.DefaultTriggerSpec)
@@ -256,12 +256,12 @@ func (d *DataStore) SetTriggerSpec(t plan.TriggerSpec) {
 
 func ProcessBenchmarkHelper(
 	b *testing.B,
-	genInput func(alloc *memory.Allocator) (flux.TableIterator, error),
-	create func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset),
+	genInput func(alloc memory.Allocator) (flux.TableIterator, error),
+	create func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset),
 ) {
 	b.Helper()
 
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	input, err := genInput(alloc)
 	if err != nil {
 		b.Fatalf("error generating input: %s", err)
@@ -289,8 +289,8 @@ func ProcessBenchmarkHelper(
 func RunBenchmark(
 	b *testing.B,
 	tables []flux.BufferedTable,
-	create func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset),
-	alloc *memory.Allocator,
+	create func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset),
+	alloc memory.Allocator,
 ) {
 	b.Helper()
 

--- a/execute/executor.go
+++ b/execute/executor.go
@@ -25,7 +25,7 @@ type Executor interface {
 	// may return zero or more values. The returned channel must not require itself to
 	// be read so the executor must allocate enough space in the channel so if the channel
 	// is unread that it will not block.
-	Execute(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error)
+	Execute(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error)
 }
 
 type executor struct {
@@ -55,7 +55,7 @@ type executionState struct {
 
 	ctx    context.Context
 	cancel func()
-	alloc  *memory.Allocator
+	alloc  memory.Allocator
 
 	resources flux.ResourceManagement
 
@@ -69,7 +69,7 @@ type executionState struct {
 	logger     *zap.Logger
 }
 
-func (e *executor) Execute(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
+func (e *executor) Execute(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
 	es, err := e.createExecutionState(ctx, p, a)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, codes.Inherit, "failed to initialize execute state")
@@ -78,7 +78,7 @@ func (e *executor) Execute(ctx context.Context, p *plan.Spec, a *memory.Allocato
 	return es.results, es.metaCh, nil
 }
 
-func (e *executor) createExecutionState(ctx context.Context, p *plan.Spec, a *memory.Allocator) (*executionState, error) {
+func (e *executor) createExecutionState(ctx context.Context, p *plan.Spec, a memory.Allocator) (*executionState, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	es := &executionState{
 		p:         p,
@@ -503,7 +503,7 @@ func (ec executionContext) StreamContext() StreamContext {
 	return ec.streamContext
 }
 
-func (ec executionContext) Allocator() *memory.Allocator {
+func (ec executionContext) Allocator() memory.Allocator {
 	return ec.es.alloc
 }
 

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -34,7 +34,7 @@ func TestExecutor_Execute(t *testing.T) {
 		name      string
 		spec      *plantest.PlanSpec
 		want      map[string][]*executetest.Table
-		allocator *memory.Allocator
+		allocator memory.Allocator
 		wantErr   error
 	}{
 		{
@@ -677,7 +677,7 @@ func TestExecutor_Execute(t *testing.T) {
 					{0, 1},
 				},
 			},
-			allocator: &memory.Allocator{
+			allocator: &memory.ResourceAllocator{
 				Limit: func(v int64) *int64 { return &v }(64),
 			},
 			wantErr: &flux.Error{

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -33,7 +33,7 @@ func TestParallel_Execute(t *testing.T) {
 		name              string
 		spec              *plantest.PlanSpec
 		want              map[string][]*executetest.Table
-		allocator         *memory.Allocator
+		allocator         memory.Allocator
 		wantErr           error
 		wantValidationErr error
 	}{

--- a/execute/profiler.go
+++ b/execute/profiler.go
@@ -14,8 +14,8 @@ import (
 
 type Profiler interface {
 	Name() string
-	GetResult(q flux.Query, alloc *memory.Allocator) (flux.Table, error)
-	GetSortedResult(q flux.Query, alloc *memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error)
+	GetResult(q flux.Query, alloc memory.Allocator) (flux.Table, error)
+	GetSortedResult(q flux.Query, alloc memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error)
 }
 
 type CreateProfilerFunc func() Profiler
@@ -155,7 +155,7 @@ func (o *OperatorProfiler) closeIncomingChannel() {
 	}
 }
 
-func (o *OperatorProfiler) GetResult(q flux.Query, alloc *memory.Allocator) (flux.Table, error) {
+func (o *OperatorProfiler) GetResult(q flux.Query, alloc memory.Allocator) (flux.Table, error) {
 	o.closeIncomingChannel()
 	b, err := o.getTableBuilder(alloc)
 	if err != nil {
@@ -171,7 +171,7 @@ func (o *OperatorProfiler) GetResult(q flux.Query, alloc *memory.Allocator) (flu
 // GetSortedResult is identical to GetResult, except it calls Sort()
 // on the ColListTableBuilder to make testing easier.
 // sortKeys and desc are passed directly into the Sort() call
-func (o *OperatorProfiler) GetSortedResult(q flux.Query, alloc *memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error) {
+func (o *OperatorProfiler) GetSortedResult(q flux.Query, alloc memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error) {
 	o.closeIncomingChannel()
 	b, err := o.getTableBuilder(alloc)
 	if err != nil {
@@ -185,7 +185,7 @@ func (o *OperatorProfiler) GetSortedResult(q flux.Query, alloc *memory.Allocator
 	return tbl, nil
 }
 
-func (o *OperatorProfiler) getTableBuilder(alloc *memory.Allocator) (*ColListTableBuilder, error) {
+func (o *OperatorProfiler) getTableBuilder(alloc memory.Allocator) (*ColListTableBuilder, error) {
 	groupKey := NewGroupKey(
 		[]flux.ColMeta{
 			{
@@ -297,7 +297,7 @@ func (s *QueryProfiler) Name() string {
 	return "query"
 }
 
-func (s *QueryProfiler) GetResult(q flux.Query, alloc *memory.Allocator) (flux.Table, error) {
+func (s *QueryProfiler) GetResult(q flux.Query, alloc memory.Allocator) (flux.Table, error) {
 	b, err := s.getTableBuilder(q, alloc)
 	if err != nil {
 		return nil, err
@@ -312,7 +312,7 @@ func (s *QueryProfiler) GetResult(q flux.Query, alloc *memory.Allocator) (flux.T
 // GetSortedResult is identical to GetResult, except it calls Sort()
 // on the ColListTableBuilder to make testing easier.
 // sortKeys and desc are passed directly into the Sort() call
-func (s *QueryProfiler) GetSortedResult(q flux.Query, alloc *memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error) {
+func (s *QueryProfiler) GetSortedResult(q flux.Query, alloc memory.Allocator, desc bool, sortKeys ...string) (flux.Table, error) {
 	b, err := s.getTableBuilder(q, alloc)
 	if err != nil {
 		return nil, err
@@ -325,7 +325,7 @@ func (s *QueryProfiler) GetSortedResult(q flux.Query, alloc *memory.Allocator, d
 	return tbl, nil
 }
 
-func (s *QueryProfiler) getTableBuilder(q flux.Query, alloc *memory.Allocator) (*ColListTableBuilder, error) {
+func (s *QueryProfiler) getTableBuilder(q flux.Query, alloc memory.Allocator) (*ColListTableBuilder, error) {
 	groupKey := NewGroupKey(
 		[]flux.ColMeta{
 			{

--- a/execute/profiler_test.go
+++ b/execute/profiler_test.go
@@ -81,7 +81,7 @@ func TestOperatorProfiler_GetResult(t *testing.T) {
 		go fn(typ, label, ctx, 100*i+i)
 	}
 	wg.Wait()
-	tbl, err := p.GetSortedResult(nil, &memory.Allocator{}, false, "MeanDuration")
+	tbl, err := p.GetSortedResult(nil, &memory.ResourceAllocator{}, false, "MeanDuration")
 	if err != nil {
 		t.Error(err)
 	}
@@ -127,7 +127,7 @@ func TestQueryProfiler_GetResult(t *testing.T) {
 ",10,11
 `
 	q.Done()
-	tbl, err := p.GetResult(q, &memory.Allocator{})
+	tbl, err := p.GetResult(q, &memory.ResourceAllocator{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -47,7 +47,7 @@ type indexSelectorTransformation struct {
 	selector IndexSelector
 }
 
-func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a *memory.Allocator) (*rowSelectorTransformation, Dataset) {
+func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a memory.Allocator) (*rowSelectorTransformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewRowSelectorTransformation(d, cache, selector, config), d
@@ -59,7 +59,7 @@ func NewRowSelectorTransformation(d Dataset, c TableBuilderCache, selector RowSe
 	}
 }
 
-func NewIndexSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector IndexSelector, config SelectorConfig, a *memory.Allocator) (*indexSelectorTransformation, Dataset) {
+func NewIndexSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector IndexSelector, config SelectorConfig, a memory.Allocator) (*indexSelectorTransformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)
 	return NewIndexSelectorTransformation(d, cache, selector, config), d

--- a/execute/table.go
+++ b/execute/table.go
@@ -255,7 +255,7 @@ func BuilderColsMatchReader(builder TableBuilder, cr flux.ColReader) bool {
 // columns, or if the data in any column does not match.  Returns true otherwise.  This function will consume the
 // ColumnReader so if you are calling this from the a Process method, you may need to copy the table if you need to
 // iterate over the data for other calculations.
-func TablesEqual(left, right flux.Table, alloc *memory.Allocator) (bool, error) {
+func TablesEqual(left, right flux.Table, alloc memory.Allocator) (bool, error) {
 	if colsMatch(left.Key().Cols(), right.Key().Cols()) && colsMatch(left.Cols(), right.Cols()) {
 		eq := true
 		// rbuffer will buffer out rows from the right table, always holding just enough to do a comparison with the left
@@ -521,7 +521,7 @@ type ColListTableBuilder struct {
 	alloc   *Allocator
 }
 
-func NewColListTableBuilder(key flux.GroupKey, a *memory.Allocator) *ColListTableBuilder {
+func NewColListTableBuilder(key flux.GroupKey, a memory.Allocator) *ColListTableBuilder {
 	return &ColListTableBuilder{
 		key:   key,
 		alloc: &Allocator{Allocator: a},
@@ -2016,12 +2016,12 @@ type TableBuilderCache interface {
 
 type tableBuilderCache struct {
 	tables *GroupLookup
-	alloc  *memory.Allocator
+	alloc  memory.Allocator
 
 	triggerSpec plan.TriggerSpec
 }
 
-func NewTableBuilderCache(a *memory.Allocator) *tableBuilderCache {
+func NewTableBuilderCache(a memory.Allocator) *tableBuilderCache {
 	return &tableBuilderCache{
 		tables: NewGroupLookup(),
 		alloc:  a,

--- a/execute/table/buffered_test.go
+++ b/execute/table/buffered_test.go
@@ -17,7 +17,7 @@ import (
 func TestBufferedTable(t *testing.T) {
 	executetest.RunTableTests(t,
 		executetest.TableTest{
-			NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+			NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 				// Only a single buffer.
 				tbl1 := table.FromBuffer(
 					func() flux.ColReader {

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -179,7 +179,7 @@ func TestTablesEqual(t *testing.T) {
 
 func TestColListTable(t *testing.T) {
 	executetest.RunTableTests(t, executetest.TableTest{
-		NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+		NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 			b1 := execute.NewColListTableBuilder(execute.NewGroupKey(
 				[]flux.ColMeta{
 					{Label: "host", Type: flux.TString},
@@ -229,7 +229,7 @@ func TestColListTable(t *testing.T) {
 
 func TestColListTable_AppendNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, &memory.Allocator{})
+	tb := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -268,7 +268,7 @@ func TestColListTable_AppendNil(t *testing.T) {
 
 func TestColListTable_SetNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, &memory.Allocator{})
+	tb := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -307,7 +307,7 @@ func TestColListTable_SetNil(t *testing.T) {
 }
 
 func TestCopyTable(t *testing.T) {
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 
 	input, err := gen.Input(context.Background(), gen.Schema{
 		Tags: []gen.Tag{
@@ -449,7 +449,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 			name: "Strings",
 			typ:  flux.TString,
 			values: func() array.Array {
-				b := arrow.NewStringBuilder(&memory.Allocator{})
+				b := arrow.NewStringBuilder(&memory.ResourceAllocator{})
 				b.Append("a")
 				b.Append("d")
 				b.AppendNull()
@@ -517,7 +517,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			key := execute.NewGroupKey(nil, nil)
-			b := execute.NewColListTableBuilder(key, &memory.Allocator{})
+			b := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
 			if _, err := b.AddCol(flux.ColMeta{Label: "_value", Type: tt.typ}); err != nil {
 				t.Fatal(err)
 			}
@@ -598,7 +598,7 @@ func TestCopyTable_Empty(t *testing.T) {
 
 func TestEmptyWindowTable(t *testing.T) {
 	executetest.RunTableTests(t, executetest.TableTest{
-		NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+		NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 			// Prime the allocator with an allocation to avoid
 			// an error happening for no allocations.
 			// No allocations is expected but the table tests check that

--- a/execute/transformation.go
+++ b/execute/transformation.go
@@ -93,7 +93,7 @@ type Administration interface {
 
 	ResolveTime(qt flux.Time) Time
 	StreamContext() StreamContext
-	Allocator() *memory.Allocator
+	Allocator() memory.Allocator
 	Parents() []DatasetID
 	ParallelOpts() ParallelOpts
 }

--- a/influxql/decoder.go
+++ b/influxql/decoder.go
@@ -15,12 +15,12 @@ import (
 )
 
 // NewResultDecoder will construct a new result decoder for an influxql response.
-func NewResultDecoder(a *memory.Allocator) flux.MultiResultDecoder {
+func NewResultDecoder(a memory.Allocator) flux.MultiResultDecoder {
 	return &resultDecoder{a: a}
 }
 
 type resultDecoder struct {
-	a *memory.Allocator
+	a memory.Allocator
 }
 
 func (dec *resultDecoder) Decode(r io.ReadCloser) (flux.ResultIterator, error) {
@@ -33,7 +33,7 @@ func (dec *resultDecoder) Decode(r io.ReadCloser) (flux.ResultIterator, error) {
 
 type resultIterator struct {
 	resp *Response
-	a    *memory.Allocator
+	a    memory.Allocator
 }
 
 func (ri *resultIterator) More() bool {
@@ -65,7 +65,7 @@ func (ri *resultIterator) Statistics() flux.Statistics {
 
 type result struct {
 	res *Result
-	a   *memory.Allocator
+	a   memory.Allocator
 }
 
 func (r *result) Name() string {

--- a/internal/cmd/flux/execute.go
+++ b/internal/cmd/flux/execute.go
@@ -22,7 +22,7 @@ func executeE(ctx context.Context, script, format string) error {
 		return err
 	}
 
-	mem := &memory.Allocator{}
+	mem := &memory.ResourceAllocator{}
 	q, err := prog.Start(ctx, mem)
 	if err != nil {
 		return err

--- a/internal/cmd/influxql-decode/v2.go
+++ b/internal/cmd/influxql-decode/v2.go
@@ -16,7 +16,7 @@ func v2(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		dec := influxql.NewResultDecoder(&memory.Allocator{})
+		dec := influxql.NewResultDecoder(&memory.ResourceAllocator{})
 		results, err := dec.Decode(f)
 		if err != nil {
 			return err

--- a/internal/execute/table/stream_test.go
+++ b/internal/execute/table/stream_test.go
@@ -17,7 +17,7 @@ import (
 func TestStream(t *testing.T) {
 	executetest.RunTableTests(t,
 		executetest.TableTest{
-			NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+			NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 				// Only a single buffer.
 				key1 := execute.NewGroupKey(
 					[]flux.ColMeta{

--- a/internal/gen/input.go
+++ b/internal/gen/input.go
@@ -77,7 +77,7 @@ type Schema struct {
 	// Alloc assigns an allocator to use when generating the
 	// tables. If this is not set, an unlimited allocator is
 	// used.
-	Alloc *memory.Allocator
+	Alloc memory.Allocator
 }
 
 // Input constructs a TableIterator with randomly generated
@@ -142,7 +142,7 @@ func Input(ctx context.Context, schema Schema) (flux.TableIterator, error) {
 
 	alloc := schema.Alloc
 	if alloc == nil {
-		alloc = &memory.Allocator{}
+		alloc = &memory.ResourceAllocator{}
 	}
 
 	g := &dataGenerator{
@@ -355,7 +355,7 @@ type dataGenerator struct {
 	Period    values.Duration
 	Nulls     float64
 	NumPoints int
-	Allocator *memory.Allocator
+	Allocator memory.Allocator
 
 	Rand     *rand.Rand
 	Groups   seriesGroups

--- a/internal/gen/input_test.go
+++ b/internal/gen/input_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestInput_TableTest(t *testing.T) {
 	executetest.RunTableTests(t, executetest.TableTest{
-		NewFn: func(ctx context.Context, alloc *memory.Allocator) flux.TableIterator {
+		NewFn: func(ctx context.Context, alloc memory.Allocator) flux.TableIterator {
 			schema := gen.Schema{
 				Tags: []gen.Tag{
 					{Name: "_measurement", Cardinality: 1},

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -274,7 +274,7 @@ func (p *Program) SetLogger(logger *zap.Logger) {
 	p.Logger = logger
 }
 
-func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Query, error) {
+func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query, error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	// This span gets closed by the query when it is done.
@@ -283,9 +283,11 @@ func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Quer
 	q := &query{
 		ctx:     cctx,
 		results: results,
-		alloc:   alloc,
-		span:    s,
-		cancel:  cancel,
+		alloc: &memory.ResourceAllocator{
+			Allocator: alloc,
+		},
+		span:   s,
+		cancel: cancel,
 		stats: flux.Statistics{
 			Metadata: make(metadata.Metadata),
 		},
@@ -427,7 +429,7 @@ func (eoc *ExecOptsConfig) ConfigureNow(ctx context.Context, now time.Time) {
 	*deps.Now = now
 }
 
-func (p *AstProgram) getSpec(ctx context.Context, alloc *memory.Allocator) (*flux.Spec, values.Scope, error) {
+func (p *AstProgram) getSpec(ctx context.Context, alloc memory.Allocator) (*flux.Spec, values.Scope, error) {
 	ast, astErr := p.GetAst()
 	if astErr != nil {
 		return nil, nil, astErr
@@ -472,7 +474,7 @@ func (p *AstProgram) getSpec(ctx context.Context, alloc *memory.Allocator) (*flu
 	return sp, scope, nil
 }
 
-func (p *AstProgram) Start(ctx context.Context, alloc *memory.Allocator) (flux.Query, error) {
+func (p *AstProgram) Start(ctx context.Context, alloc memory.Allocator) (flux.Query, error) {
 	// The program must inject execution dependencies to make it available to
 	// function calls during the evaluation phase (see `tableFind`).
 	deps := execute.NewExecutionDependencies(alloc, &p.Now, p.Logger)

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -191,7 +191,7 @@ func TestFluxCompiler(t *testing.T) {
 
 			// we need to start the program to get compile errors derived from AST evaluation
 			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-			if _, err = program.Start(ctx, &memory.Allocator{}); tc.startErr == "" && err != nil {
+			if _, err = program.Start(ctx, &memory.ResourceAllocator{}); tc.startErr == "" && err != nil {
 				t.Errorf("expected query %q to start successfully but got error %v", tc.q, err)
 			} else if tc.startErr != "" && err == nil {
 				t.Errorf("expected query %q to start with error but got no error", tc.q)
@@ -210,7 +210,7 @@ func TestCompilationError(t *testing.T) {
 	}
 
 	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	_, err = program.Start(ctx, &memory.Allocator{})
+	_, err = program.Start(ctx, &memory.ResourceAllocator{})
 	if err == nil {
 		t.Fatal("compilation error expected, got none")
 	}
@@ -401,7 +401,7 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 			}
 			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
 			// we need to start the program to get compile errors derived from AST evaluation
-			if _, err := program.Start(ctx, &memory.Allocator{}); err != nil {
+			if _, err := program.Start(ctx, &memory.ResourceAllocator{}); err != nil {
 				if tc.startErr == "" {
 					t.Fatalf("failed to start program: %v", err)
 				} else {
@@ -449,7 +449,7 @@ csv.from(csv: "
 		t.Fatalf("unexpected compile error: %s", err)
 	}
 
-	mem := &memory.Allocator{}
+	mem := &memory.ResourceAllocator{}
 	qry, err := program.Start(context.Background(), mem)
 	if err != nil {
 		t.Fatalf("unexpected program error: %s", err)
@@ -493,7 +493,7 @@ func TestCompileOptions(t *testing.T) {
 
 	// start program in order to evaluate planner options
 	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	if _, err := program.Start(ctx, &memory.Allocator{}); err != nil {
+	if _, err := program.Start(ctx, &memory.ResourceAllocator{}); err != nil {
 		t.Fatalf("failed to start program: %v", err)
 	}
 
@@ -788,7 +788,7 @@ option planner.disableLogicalRules = ["removeCountRule"]`},
 
 			program := lang.CompileAST(astPkg, runtime.Default, nowFn())
 			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-			if _, err := program.Start(ctx, &memory.Allocator{}); err != nil {
+			if _, err := program.Start(ctx, &memory.ResourceAllocator{}); err != nil {
 				if tc.wantErr == "" {
 					t.Fatalf("failed to start program: %v", err)
 				} else if got := getRootErr(err); tc.wantErr != got.Error() {
@@ -950,7 +950,7 @@ func getTableObjectTablesOrFail(t *testing.T, to *flux.TableObject) []*executete
 	}
 
 	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	q, err := program.Start(ctx, &memory.Allocator{})
+	q, err := program.Start(ctx, &memory.ResourceAllocator{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lang/query.go
+++ b/lang/query.go
@@ -15,7 +15,7 @@ type query struct {
 	ctx     context.Context
 	results chan flux.Result
 	stats   flux.Statistics
-	alloc   *memory.Allocator
+	alloc   *memory.ResourceAllocator
 	span    opentracing.Span
 	cancel  func()
 	err     error

--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -23,7 +23,7 @@ func runQuery(ctx context.Context, script string) (flux.Query, error) {
 		return nil, err
 	}
 	ctx = executetest.NewTestExecuteDependencies().Inject(ctx)
-	q, err := program.Start(ctx, &memory.Allocator{})
+	q, err := program.Start(ctx, &memory.ResourceAllocator{})
 	if err != nil {
 		return nil, err
 	}

--- a/line/result.go
+++ b/line/result.go
@@ -43,7 +43,7 @@ func (rd *ResultDecoder) Do(f func(flux.Table) error) error {
 	timeCol := flux.ColMeta{Label: "_time", Type: flux.TTime}
 	valueCol := flux.ColMeta{Label: "_value", Type: flux.TString}
 	key := execute.NewGroupKey(nil, nil)
-	builder := execute.NewColListTableBuilder(key, &memory.Allocator{})
+	builder := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
 	timeIdx, err := builder.AddCol(timeCol)
 	if err != nil {
 		return err

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -15,7 +15,7 @@ func TestAllocator_Allocate(t *testing.T) {
 	mem := arrowmemory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	allocator := &memory.Allocator{Allocator: mem}
+	allocator := &memory.ResourceAllocator{Allocator: mem}
 	b := allocator.Allocate(64)
 
 	assert.Equal(t, 64, mem.CurrentAlloc(), "unexpected memory allocation.")
@@ -41,7 +41,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 	mem := arrowmemory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	allocator := &memory.Allocator{Allocator: mem}
+	allocator := &memory.ResourceAllocator{Allocator: mem}
 	b := allocator.Allocate(64)
 
 	assert.Equal(t, 64, mem.CurrentAlloc(), "unexpected memory allocation.")
@@ -74,7 +74,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 }
 
 func TestAllocator_MaxAfterFree(t *testing.T) {
-	allocator := &memory.Allocator{}
+	allocator := &memory.ResourceAllocator{}
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -111,7 +111,7 @@ func TestAllocator_MaxAfterFree(t *testing.T) {
 
 func TestAllocator_Limit(t *testing.T) {
 	maxLimit := int64(64)
-	allocator := &memory.Allocator{Limit: &maxLimit}
+	allocator := &memory.ResourceAllocator{Limit: &maxLimit}
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -184,7 +184,7 @@ func TestAllocator_Limit(t *testing.T) {
 }
 
 func TestAllocator_Free(t *testing.T) {
-	allocator := &memory.Allocator{}
+	allocator := &memory.ResourceAllocator{}
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -236,7 +236,7 @@ func TestAllocator_RequestMemory(t *testing.T) {
 
 	// Set the Limit to 64 and allocate 32 bytes of it.
 	// This should not request more memory from the manager.
-	allocator := &memory.Allocator{
+	allocator := &memory.ResourceAllocator{
 		Limit:   func(v int64) *int64 { return &v }(64),
 		Manager: manager,
 	}
@@ -311,7 +311,7 @@ func TestAllocator_RequestMemory_Concurrently(t *testing.T) {
 
 	// Set the Limit to 64 and allocate 32 bytes of it.
 	// This should not request more memory from the manager.
-	allocator := &memory.Allocator{
+	allocator := &memory.ResourceAllocator{
 		Limit:   func(v int64) *int64 { return &v }(0),
 		Manager: manager,
 	}

--- a/mock/administration.go
+++ b/mock/administration.go
@@ -30,8 +30,8 @@ func (a *Administration) StreamContext() execute.StreamContext {
 	return nil
 }
 
-func (a *Administration) Allocator() *memory.Allocator {
-	return &memory.Allocator{}
+func (a *Administration) Allocator() memory.Allocator {
+	return &memory.ResourceAllocator{}
 }
 
 func (a *Administration) Parents() []execute.DatasetID {

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -16,19 +16,19 @@ var NoMetadata <-chan metadata.Metadata
 
 // Executor is a mock implementation of an execute.Executor.
 type Executor struct {
-	ExecuteFn func(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error)
+	ExecuteFn func(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error)
 }
 
 // NewExecutor returns a mock Executor where its methods will return zero values.
 func NewExecutor() *Executor {
 	return &Executor{
-		ExecuteFn: func(context.Context, *plan.Spec, *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
+		ExecuteFn: func(context.Context, *plan.Spec, memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
 			return nil, NoMetadata, nil
 		},
 	}
 }
 
-func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a *memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
+func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
 	return e.ExecuteFn(ctx, p, a)
 }
 

--- a/mock/program.go
+++ b/mock/program.go
@@ -10,16 +10,16 @@ import (
 // Program is a mock program that can be returned by the mock compiler.
 // It will construct a mock query that will then be passed to ExecuteFn.
 type Program struct {
-	StartFn   func(ctx context.Context, alloc *memory.Allocator) (*Query, error)
-	ExecuteFn func(ctx context.Context, q *Query, alloc *memory.Allocator)
+	StartFn   func(ctx context.Context, alloc memory.Allocator) (*Query, error)
+	ExecuteFn func(ctx context.Context, q *Query, alloc memory.Allocator)
 }
 
-func (p *Program) Start(ctx context.Context, alloc *memory.Allocator) (flux.Query, error) {
+func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query, error) {
 	startFn := p.StartFn
 	if startFn == nil {
 		var cancel func()
 		ctx, cancel = context.WithCancel(ctx)
-		startFn = func(ctx context.Context, alloc *memory.Allocator) (*Query, error) {
+		startFn = func(ctx context.Context, alloc memory.Allocator) (*Query, error) {
 			results := make(chan flux.Result)
 			q := &Query{
 				ResultsCh: results,

--- a/querytest/execute.go
+++ b/querytest/execute.go
@@ -18,7 +18,7 @@ func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flu
 		return 0, err
 	}
 	ctx = executetest.NewTestExecuteDependencies().Inject(ctx)
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	query, err := program.Start(ctx, alloc)
 	if err != nil {
 		return 0, err

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -234,7 +234,7 @@ func (r *REPL) doQuery(ctx context.Context, spec *flux.Spec) error {
 	if err != nil {
 		return err
 	}
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 
 	qry, err := program.Start(ctx, alloc)
 	if err != nil {

--- a/stdlib/array/from.go
+++ b/stdlib/array/from.go
@@ -91,7 +91,7 @@ func createFromSource(ps plan.ProcedureSpec, id execute.DatasetID, a execute.Adm
 type tableSource struct {
 	execute.ExecutionNode
 	id   execute.DatasetID
-	mem  *memory.Allocator
+	mem  memory.Allocator
 	rows values.Array
 	ts   execute.TransformationSet
 }
@@ -109,7 +109,7 @@ func (s *tableSource) Run(ctx context.Context) {
 	s.ts.Finish(s.id, err)
 }
 
-func buildTable(rows values.Array, mem *memory.Allocator) (flux.Table, error) {
+func buildTable(rows values.Array, mem memory.Allocator) (flux.Table, error) {
 	typ, err := rows.Type().ElemType()
 	if err != nil {
 		return nil, err

--- a/stdlib/contrib/bonitoo-io/alerta/alerta_test.go
+++ b/stdlib/contrib/bonitoo-io/alerta/alerta_test.go
@@ -162,7 +162,7 @@ csv.from(csv:data) |> endpoint()`
 			}
 
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/contrib/bonitoo-io/servicenow/servicenow_test.go
+++ b/stdlib/contrib/bonitoo-io/servicenow/servicenow_test.go
@@ -137,7 +137,7 @@ csv.from(csv:data) |> endpoint()`
 			}
 
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/contrib/bonitoo-io/victorops/victorops_test.go
+++ b/stdlib/contrib/bonitoo-io/victorops/victorops_test.go
@@ -126,7 +126,7 @@ csv.from(csv:data) |> endpoint()`
 			}
 
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/contrib/bonitoo-io/zenoss/zenoss_test.go
+++ b/stdlib/contrib/bonitoo-io/zenoss/zenoss_test.go
@@ -154,7 +154,7 @@ csv.from(csv:data) |> endpoint()`
 			}
 
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/contrib/chobbs/discord/discord_test.go
+++ b/stdlib/contrib/chobbs/discord/discord_test.go
@@ -145,7 +145,7 @@ data = "
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/contrib/rhajek/bigpanda/bigpanda_test.go
+++ b/stdlib/contrib/rhajek/bigpanda/bigpanda_test.go
@@ -156,7 +156,7 @@ data = "
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/contrib/sranka/opsgenie/opsgenie_test.go
+++ b/stdlib/contrib/sranka/opsgenie/opsgenie_test.go
@@ -213,7 +213,7 @@ data = "
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/contrib/sranka/sensu/sensu_test.go
+++ b/stdlib/contrib/sranka/sensu/sensu_test.go
@@ -132,7 +132,7 @@ csv.from(csv:data) |> endpoint()
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/contrib/sranka/teams/teams_test.go
+++ b/stdlib/contrib/sranka/teams/teams_test.go
@@ -178,7 +178,7 @@ data = "
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/contrib/sranka/telegram/telegram_test.go
+++ b/stdlib/contrib/sranka/telegram/telegram_test.go
@@ -176,7 +176,7 @@ data = "
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/contrib/sranka/webexteams/webexteams_test.go
+++ b/stdlib/contrib/sranka/webexteams/webexteams_test.go
@@ -94,7 +94,7 @@ csv.from(csv:data) |> endpoint()
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
 			fmt.Println("*** ", tc.name)
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/csv/from.go
+++ b/stdlib/csv/from.go
@@ -151,7 +151,7 @@ type CSVSource struct {
 	id            execute.DatasetID
 	getDataStream func() (io.ReadCloser, error)
 	ts            []execute.Transformation
-	alloc         *memory.Allocator
+	alloc         memory.Allocator
 	mode          string
 }
 

--- a/stdlib/experimental/join.go
+++ b/stdlib/experimental/join.go
@@ -199,7 +199,7 @@ func (t *mergeJoinTransformation) Finish(id execute.DatasetID, err error) {
 	t.done = true
 }
 
-func NewMergeJoinCache(ctx context.Context, alloc *memory.Allocator, fn interpreter.ResolvedFunction, left, right execute.DatasetID) *mergeJoinCache {
+func NewMergeJoinCache(ctx context.Context, alloc memory.Allocator, fn interpreter.ResolvedFunction, left, right execute.DatasetID) *mergeJoinCache {
 	return &mergeJoinCache{
 		left:  left,
 		right: right,
@@ -218,7 +218,7 @@ type mergeJoinCache struct {
 	spec plan.TriggerSpec
 
 	ctx   context.Context
-	alloc *memory.Allocator
+	alloc memory.Allocator
 }
 
 type cacheEntry struct {

--- a/stdlib/experimental/mqtt/to_test.go
+++ b/stdlib/experimental/mqtt/to_test.go
@@ -124,7 +124,7 @@ func runScriptWithPipeline(script string) error {
 		return err
 	}
 	ctx := flux.NewDefaultDependencies().Inject(context.Background())
-	query, err := prog.Start(ctx, &memory.Allocator{})
+	query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 	if err != nil {
 		return err
 	}

--- a/stdlib/experimental/to_test.go
+++ b/stdlib/experimental/to_test.go
@@ -110,7 +110,7 @@ func TestToTransformation(t *testing.T) {
 		}),
 	}
 
-	cache := execute.NewTableBuilderCache(&memory.Allocator{})
+	cache := execute.NewTableBuilderCache(&memory.ResourceAllocator{})
 	d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
 	d.SetTriggerSpec(plan.DefaultTriggerSpec)
 
@@ -238,7 +238,7 @@ func TestToTransformation_Errors(t *testing.T) {
 				}),
 			}
 
-			cache := execute.NewTableBuilderCache(&memory.Allocator{})
+			cache := execute.NewTableBuilderCache(&memory.ResourceAllocator{})
 			d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
 			d.SetTriggerSpec(plan.DefaultTriggerSpec)
 
@@ -286,7 +286,7 @@ func TestToTransformation_CloseOnError(t *testing.T) {
 		},
 	}
 
-	cache := execute.NewTableBuilderCache(&memory.Allocator{})
+	cache := execute.NewTableBuilderCache(&memory.ResourceAllocator{})
 	d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
 	d.SetTriggerSpec(plan.DefaultTriggerSpec)
 

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -130,7 +130,7 @@ func doTestRun(t testing.TB, c flux.Compiler) flux.Statistics {
 	}
 
 	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	r, err := program.Start(ctx, alloc)
 	if err != nil {
 		t.Fatalf("unexpected error while executing testing.run: %v", err)
@@ -159,7 +159,7 @@ func doTestInspect(t testing.TB, c flux.Compiler) flux.Statistics {
 		t.Fatalf("unexpected error while compiling query: %v", err)
 	}
 	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	r, err := program.Start(ctx, alloc)
 	if err != nil {
 		t.Fatalf("unexpected error while executing testing.inspect: %v", err)

--- a/stdlib/generate/from.go
+++ b/stdlib/generate/from.go
@@ -139,11 +139,11 @@ type GeneratorSource struct {
 	Start time.Time
 	Stop  time.Time
 	Count int64
-	alloc *memory.Allocator
+	alloc memory.Allocator
 	Fn    compiler.Func
 }
 
-func NewGeneratorSource(a *memory.Allocator) *GeneratorSource {
+func NewGeneratorSource(a memory.Allocator) *GeneratorSource {
 	return &GeneratorSource{alloc: a}
 }
 

--- a/stdlib/influxdata/influxdb/internal/testutil/testing.go
+++ b/stdlib/influxdata/influxdb/internal/testutil/testing.go
@@ -317,7 +317,7 @@ func ExecuteSourceTestHelper(t *testing.T, ctx context.Context, spec plan.Physic
 		},
 	})
 
-	mem := &memory.Allocator{}
+	mem := &memory.ResourceAllocator{}
 	executor := execute.NewExecutor(logger)
 	results, _, err := executor.Execute(ctx, ps, mem)
 	if err != nil {

--- a/stdlib/influxdata/influxdb/source.go
+++ b/stdlib/influxdata/influxdb/source.go
@@ -42,7 +42,7 @@ type source struct {
 	id   execute.DatasetID
 	spec RemoteProcedureSpec
 	deps flux.Dependencies
-	mem  *memory.Allocator
+	mem  memory.Allocator
 	ts   execute.TransformationSet
 }
 
@@ -207,7 +207,7 @@ func (s *source) parseError(p []byte) error {
 
 type sourceIterator struct {
 	reader influxdb.Reader
-	mem    *memory.Allocator
+	mem    memory.Allocator
 }
 
 func (s *sourceIterator) Do(ctx context.Context, f func(flux.Table) error) error {

--- a/stdlib/influxdata/influxdb/to_test.go
+++ b/stdlib/influxdata/influxdb/to_test.go
@@ -729,7 +729,7 @@ func TestTo_Process(t *testing.T) {
 				inTables,
 				wantTables,
 				tc.wantErr,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					tr, d, err := influxdb.NewToTransformation(context.TODO(), id, tc.spec, provider, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/internal/gen/tables.go
+++ b/stdlib/internal/gen/tables.go
@@ -158,7 +158,7 @@ type Source struct {
 	ts execute.TransformationSet
 
 	schema gen.Schema
-	alloc  *memory.Allocator
+	alloc  memory.Allocator
 }
 
 func (s *Source) AddTransformation(t execute.Transformation) {

--- a/stdlib/internal/promql/empty_table.go
+++ b/stdlib/internal/promql/empty_table.go
@@ -98,7 +98,7 @@ func (s *EmptyTableSource) Run(ctx context.Context) {
 		},
 	)
 
-	builder := execute.NewColListTableBuilder(key, &memory.Allocator{})
+	builder := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
 
 	for _, c := range []flux.ColMeta{startCol, stopCol, timeCol, valueCol} {
 		if _, err = builder.AddCol(c); err != nil {

--- a/stdlib/pagerduty/pagerduty_test.go
+++ b/stdlib/pagerduty/pagerduty_test.go
@@ -335,7 +335,7 @@ data = "
 				t.Error(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/slack/slack_test.go
+++ b/stdlib/slack/slack_test.go
@@ -189,7 +189,7 @@ data = "
 				t.Fatal(err)
 			}
 			ctx := flux.NewDefaultDependencies().Inject(context.Background())
-			query, err := prog.Start(ctx, &memory.Allocator{})
+			query, err := prog.Start(ctx, &memory.ResourceAllocator{})
 
 			if err != nil {
 				t.Fatal(err)

--- a/stdlib/sql/from.go
+++ b/stdlib/sql/from.go
@@ -190,7 +190,7 @@ func (c *sqlIterator) Do(ctx context.Context, f func(flux.Table) error) error {
 }
 
 // read will use the RowReader to construct a flux.Table.
-func read(ctx context.Context, reader execute.RowReader, alloc *memory.Allocator) (flux.Table, error) {
+func read(ctx context.Context, reader execute.RowReader, alloc memory.Allocator) (flux.Table, error) {
 	// Ensure that the reader is always freed so the underlying
 	// cursor can be returned.
 	defer func() { _ = reader.Close() }()

--- a/stdlib/sql/sql_test.go
+++ b/stdlib/sql/sql_test.go
@@ -75,7 +75,7 @@ func TestFromRowReader(t *testing.T) {
 
 		var rr execute.RowReader = &MockRowReader{row: 0}
 		rr.(*MockRowReader).InitColumnTypes(nil)
-		alloc := &memory.Allocator{}
+		alloc := &memory.ResourceAllocator{}
 		table, err := read(context.Background(), rr, alloc)
 		if err != nil {
 			t.Fatal(err)

--- a/stdlib/testing/assert_equals.go
+++ b/stdlib/testing/assert_equals.go
@@ -99,7 +99,7 @@ type AssertEqualsTransformation struct {
 
 	d     execute.Dataset
 	cache execute.TableBuilderCache
-	a     *memory.Allocator
+	a     memory.Allocator
 
 	name string
 }
@@ -141,7 +141,7 @@ func createAssertEqualsTransformation(id execute.DatasetID, mode execute.Accumul
 	return transform, dataset, nil
 }
 
-func NewAssertEqualsTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *AssertEqualsProcedureSpec, gotID, wantID execute.DatasetID, a *memory.Allocator) *AssertEqualsTransformation {
+func NewAssertEqualsTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *AssertEqualsProcedureSpec, gotID, wantID execute.DatasetID, a memory.Allocator) *AssertEqualsTransformation {
 	return &AssertEqualsTransformation{
 		gotParent:   &assertEqualsParentState{id: gotID},
 		wantParent:  &assertEqualsParentState{id: wantID},

--- a/stdlib/testing/diff.go
+++ b/stdlib/testing/diff.go
@@ -119,7 +119,7 @@ type DiffTransformation struct {
 
 	d     execute.Dataset
 	cache execute.TableBuilderCache
-	alloc *memory.Allocator
+	alloc memory.Allocator
 
 	inputCache *execute.RandomAccessGroupLookup
 
@@ -150,7 +150,7 @@ type tableColumn struct {
 	Values array.Array
 }
 
-func copyTable(id execute.DatasetID, tbl flux.Table, alloc *memory.Allocator) (*tableBuffer, error) {
+func copyTable(id execute.DatasetID, tbl flux.Table, alloc memory.Allocator) (*tableBuffer, error) {
 	// Find the value columns for the table and save them.
 	// We do not care about the group key.
 	type tableBuilderColumn struct {
@@ -306,7 +306,7 @@ func createDiffTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	return transform, dataset, nil
 }
 
-func NewDiffTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DiffProcedureSpec, wantID, gotID execute.DatasetID, a *memory.Allocator) *DiffTransformation {
+func NewDiffTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *DiffProcedureSpec, wantID, gotID execute.DatasetID, a memory.Allocator) *DiffTransformation {
 	parentState := make(map[execute.DatasetID]*diffParentState)
 	parentState[wantID] = new(diffParentState)
 	parentState[gotID] = new(diffParentState)

--- a/stdlib/universe/count_test.go
+++ b/stdlib/universe/count_test.go
@@ -146,7 +146,7 @@ func TestCount_Process(t *testing.T) {
 	}
 }
 func BenchmarkCount(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
 		new(universe.CountAgg),

--- a/stdlib/universe/derivative_test.go
+++ b/stdlib/universe/derivative_test.go
@@ -1009,7 +1009,7 @@ func TestDerivative_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				tc.wantErr,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					tr, d, err := universe.NewDerivativeTransformation(context.Background(), id, tc.spec, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/difference_test.go
+++ b/stdlib/universe/difference_test.go
@@ -1795,7 +1795,7 @@ func TestDifference_Process_Narrow(t *testing.T) {
 				tc.data,
 				tc.want,
 				tc.wantErr,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					tr, d, err := universe.NewNarrowDifferenceTransformation(tc.spec, id, alloc)
 					if err != nil {
 						t.Fatal(err)
@@ -2038,7 +2038,7 @@ func TestDifference_Process_Narrow_With_NonNegative_KeepFirst_InitialZero(t *tes
 				tc.data,
 				tc.want,
 				tc.wantErr,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					tr, d, err := universe.NewNarrowDifferenceTransformation(tc.spec, id, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/fill.go
+++ b/stdlib/universe/fill.go
@@ -191,10 +191,10 @@ type fillTransformation struct {
 	d     *execute.PassthroughDataset
 	ctx   context.Context
 	spec  *FillProcedureSpec
-	alloc *memory.Allocator
+	alloc memory.Allocator
 }
 
-func NewFillTransformation(ctx context.Context, spec *FillProcedureSpec, id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+func NewFillTransformation(ctx context.Context, spec *FillProcedureSpec, id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 	t := &fillTransformation{
 		d:     execute.NewPassthroughDataset(id),
 		ctx:   ctx,
@@ -277,7 +277,7 @@ type fillTransformationAdapter struct {
 	fillTransformation fillTransformation
 }
 
-func NewNarrowFillTransformation(ctx context.Context, spec *FillProcedureSpec, id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func NewNarrowFillTransformation(ctx context.Context, spec *FillProcedureSpec, id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	fillTransformation := fillTransformation{
 		ctx:  ctx,
 		spec: spec,

--- a/stdlib/universe/fill_test.go
+++ b/stdlib/universe/fill_test.go
@@ -807,7 +807,7 @@ func TestFill_Process(t *testing.T) {
 				tc.data(),
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					ctx := dependenciestest.Default().Inject(context.Background())
 					return universe.NewFillTransformation(ctx, tc.spec, id, alloc)
 				},
@@ -822,7 +822,7 @@ func TestFill_Process(t *testing.T) {
 				tc.data(),
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					ctx := dependenciestest.Default().Inject(context.Background())
 					tr, d, err := universe.NewNarrowFillTransformation(ctx, tc.spec, id, alloc)
 					if err != nil {
@@ -848,7 +848,7 @@ func benchmarkFill(b *testing.B, n int) {
 		Value:  values.NewFloat(0),
 	}
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: n,
 				Alloc:     alloc,
@@ -866,7 +866,7 @@ func benchmarkFill(b *testing.B, n int) {
 			}
 			return gen.Input(context.Background(), schema)
 		},
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			return universe.NewFillTransformation(context.Background(), spec, id, alloc)
 		},
 	)

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -139,7 +139,7 @@ func (s *FilterProcedureSpec) PlanDetails() string {
 	return "<non-Expression>"
 }
 
-func NewFilterTransformation(ctx context.Context, spec *FilterProcedureSpec, id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func NewFilterTransformation(ctx context.Context, spec *FilterProcedureSpec, id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	fn := execute.NewRowPredicateFn(spec.Fn.Fn, compiler.ToScope(spec.Fn.Scope))
 	t := &filterTransformation{
 		ctx:             ctx,

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -721,7 +721,7 @@ func TestFilter_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					ctx := dependenciestest.Default().Inject(context.Background())
 					tx, d, err := universe.NewFilterTransformation(ctx, tc.spec, id, alloc)
 					if err != nil {
@@ -761,7 +761,7 @@ gen.tables(n: 2048, tags: [{name: "a", cardinality: 10}])
 		t.Fatal(err)
 	}
 
-	alloc := &memory.Allocator{}
+	alloc := &memory.ResourceAllocator{}
 	q, err := program.Start(context.Background(), alloc)
 	if err != nil {
 		t.Fatal(err)
@@ -942,7 +942,7 @@ func benchmarkFilter(b *testing.B, n int, fn *semantic.FunctionExpression) {
 		},
 	}
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: n,
 				Alloc:     alloc,
@@ -955,7 +955,7 @@ func benchmarkFilter(b *testing.B, n int, fn *semantic.FunctionExpression) {
 			}
 			return gen.Input(context.Background(), schema)
 		},
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			t, d, err := universe.NewFilterTransformation(context.Background(), spec, id, alloc)
 			if err != nil {
 				b.Fatal(err)

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -181,13 +181,13 @@ type groupTransformation struct {
 	execute.ExecutionNode
 	d     execute.Dataset
 	cache table.BuilderCache
-	mem   *memory.Allocator
+	mem   memory.Allocator
 
 	mode flux.GroupMode
 	keys []string
 }
 
-func NewGroupTransformation(ctx context.Context, spec *GroupProcedureSpec, id execute.DatasetID, mem *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func NewGroupTransformation(ctx context.Context, spec *GroupProcedureSpec, id execute.DatasetID, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	t := &groupTransformation{
 		cache: table.BuilderCache{
 			New: func(key flux.GroupKey) table.Builder {

--- a/stdlib/universe/group_test.go
+++ b/stdlib/universe/group_test.go
@@ -773,7 +773,7 @@ func TestGroup_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				tc.wantErr,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					t, d, _ := universe.NewGroupTransformation(context.Background(), tc.spec, id, alloc)
 					return t, d
 				},
@@ -996,7 +996,7 @@ func benchmarkGroupByKey(b *testing.B, n int) {
 func benchmarkGroup(b *testing.B, n int, spec *universe.GroupProcedureSpec) {
 	b.ReportAllocs()
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: n,
 				Alloc:     alloc,
@@ -1009,7 +1009,7 @@ func benchmarkGroup(b *testing.B, n int, spec *universe.GroupProcedureSpec) {
 			}
 			return gen.Input(context.Background(), schema)
 		},
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			t, d, _ := universe.NewGroupTransformation(context.Background(), spec, id, alloc)
 			return t, d
 		},

--- a/stdlib/universe/holt_winters.go
+++ b/stdlib/universe/holt_winters.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
-	fluxmemory "github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/stdlib/universe/holt_winters"
@@ -141,7 +141,7 @@ type holtWintersTransformation struct {
 	execute.ExecutionNode
 	d     execute.Dataset
 	cache execute.TableBuilderCache
-	alloc *fluxmemory.Allocator
+	alloc memory.Allocator
 
 	withFit    bool
 	column     string
@@ -151,7 +151,7 @@ type holtWintersTransformation struct {
 	interval   values.Duration
 }
 
-func NewHoltWintersTransformation(d execute.Dataset, cache execute.TableBuilderCache, alloc *fluxmemory.Allocator, spec *HoltWintersProcedureSpec) *holtWintersTransformation {
+func NewHoltWintersTransformation(d execute.Dataset, cache execute.TableBuilderCache, alloc memory.Allocator, spec *HoltWintersProcedureSpec) *holtWintersTransformation {
 	return &holtWintersTransformation{
 		d:          d,
 		cache:      cache,

--- a/stdlib/universe/holt_winters_test.go
+++ b/stdlib/universe/holt_winters_test.go
@@ -137,7 +137,7 @@ func TestHoltWinters_PassThrough(t *testing.T) {
 		s := universe.NewHoltWintersTransformation(
 			d,
 			c,
-			&memory.Allocator{},
+			&memory.ResourceAllocator{},
 			&universe.HoltWintersProcedureSpec{},
 		)
 		return s
@@ -873,7 +873,7 @@ func TestHoltWinters_Process(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			alloc := &memory.Allocator{}
+			alloc := &memory.ResourceAllocator{}
 			executetest.ProcessTestHelper(
 				t,
 				tc.data,

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -392,7 +392,7 @@ type MergeJoinCache struct {
 	reverseLookup map[flux.GroupKey]preJoinGroupKeys
 
 	tables      map[flux.GroupKey]flux.Table
-	alloc       *memory.Allocator
+	alloc       memory.Allocator
 	triggerSpec plan.TriggerSpec
 }
 
@@ -402,10 +402,10 @@ type streamBuffer struct {
 	ready    map[values.Value]bool
 	stale    map[flux.GroupKey]bool
 	last     values.Value
-	alloc    *memory.Allocator
+	alloc    memory.Allocator
 }
 
-func newStreamBuffer(alloc *memory.Allocator) *streamBuffer {
+func newStreamBuffer(alloc memory.Allocator) *streamBuffer {
 	return &streamBuffer{
 		data:     make(map[flux.GroupKey]*execute.ColListTableBuilder),
 		consumed: make(map[values.Value]int),
@@ -511,7 +511,7 @@ func (s schema) Swap(i int, j int) {
 }
 
 // NewMergeJoinCache constructs a new instance of a MergeJoinCache
-func NewMergeJoinCache(alloc *memory.Allocator, datasetIDs []execute.DatasetID, tableNames map[execute.DatasetID]string, key []string) *MergeJoinCache {
+func NewMergeJoinCache(alloc memory.Allocator, datasetIDs []execute.DatasetID, tableNames map[execute.DatasetID]string, key []string) *MergeJoinCache {
 	// Join currently only accepts two data sources(streams) as input
 	if len(datasetIDs) != 2 {
 		panic("Join only accepts two data sources")

--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -351,7 +351,7 @@ func (t *limitTransformationAdapter) processChunk(
 func NewNarrowLimitTransformation(
 	spec *LimitProcedureSpec,
 	id execute.DatasetID,
-	mem *memory.Allocator,
+	mem memory.Allocator,
 ) (execute.Transformation, execute.Dataset, error) {
 	t := &limitTransformationAdapter{
 		limitTransformation: &limitTransformation{

--- a/stdlib/universe/limit_test.go
+++ b/stdlib/universe/limit_test.go
@@ -277,7 +277,7 @@ func TestLimit_Process(t *testing.T) {
 				tc.data(),
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					return universe.NewLimitTransformation(tc.spec, id)
 				},
 			)
@@ -294,7 +294,7 @@ func TestLimit_Process(t *testing.T) {
 					tc.data(),
 					tc.want,
 					nil,
-					func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+					func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 						tr, ds, err := universe.NewNarrowLimitTransformation(tc.spec, id, alloc)
 						if err != nil {
 							t.Fatal(err)
@@ -308,7 +308,7 @@ func TestLimit_Process(t *testing.T) {
 
 func TestProcess_Limit_MultiBuffer(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	mem := &memory.Allocator{}
+	mem := &memory.ResourceAllocator{}
 	b := table.NewBufferedBuilder(key, mem)
 	{
 		buf := arrow.TableBuffer{
@@ -412,7 +412,7 @@ func TestProcess_Limit_MultiBuffer(t *testing.T) {
 
 func TestProcess_NarrowLimit_MultiBuffer(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	mem := &memory.Allocator{}
+	mem := &memory.ResourceAllocator{}
 	b := table.NewBufferedBuilder(key, mem)
 	{
 		buf := arrow.TableBuffer{
@@ -538,7 +538,7 @@ func benchmarkLimit(b *testing.B, n, l int) {
 		N: int64(n),
 	}
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: l,
 				Alloc:     alloc,
@@ -551,7 +551,7 @@ func benchmarkLimit(b *testing.B, n, l int) {
 			}
 			return gen.Input(context.Background(), schema)
 		},
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			return universe.NewLimitTransformation(spec, id)
 		},
 	)
@@ -562,7 +562,7 @@ func benchmarkNarrowLimit(b *testing.B, n, l int) {
 		N: int64(n),
 	}
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: l,
 				Alloc:     alloc,
@@ -576,7 +576,7 @@ func benchmarkNarrowLimit(b *testing.B, n, l int) {
 			return gen.Input(context.Background(), schema)
 		},
 
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			tr, ds, err := universe.NewNarrowLimitTransformation(spec, id, alloc)
 			if err != nil {
 				b.Fatal(err)

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -1022,7 +1022,7 @@ f
 }
 
 func BenchmarkMap_Process(b *testing.B) {
-	genSource := func(alloc *memory.Allocator) (flux.TableIterator, error) {
+	genSource := func(alloc memory.Allocator) (flux.TableIterator, error) {
 		return gen.Input(context.Background(), gen.Schema{
 			Tags: []gen.Tag{
 				{Name: "t0", Cardinality: 1},
@@ -1033,8 +1033,8 @@ func BenchmarkMap_Process(b *testing.B) {
 		})
 	}
 
-	genTransformation := func(fn func(b *testing.B) *semantic.FunctionExpression) func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
-		return func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+	genTransformation := func(fn func(b *testing.B) *semantic.FunctionExpression) func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
+		return func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			spec := &universe.MapProcedureSpec{
 				Fn: interpreter.ResolvedFunction{
 					Fn:    fn(b),

--- a/stdlib/universe/mean_test.go
+++ b/stdlib/universe/mean_test.go
@@ -92,7 +92,7 @@ func TestMean_Process(t *testing.T) {
 }
 
 func BenchmarkMean(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
 		new(universe.MeanAgg),

--- a/stdlib/universe/parallel.go
+++ b/stdlib/universe/parallel.go
@@ -59,7 +59,7 @@ type PartitionMergeTransformation struct {
 	ctx     context.Context
 	dataset *execute.PassthroughDataset
 	span    opentracing.Span
-	alloc   *memory.Allocator
+	alloc   memory.Allocator
 
 	mu               sync.Mutex
 	predecessorState map[execute.DatasetID]*parallelPredecessorState
@@ -76,7 +76,7 @@ func (t *PartitionMergeTransformation) RetractTable(id execute.DatasetID, key fl
 	return t.dataset.RetractTable(key)
 }
 
-func NewPartitionMergeTransformation(ctx context.Context, dataset *execute.PassthroughDataset, alloc *memory.Allocator, spec *PartitionMergeProcedureSpec, predecessors []execute.DatasetID) (*PartitionMergeTransformation, error) {
+func NewPartitionMergeTransformation(ctx context.Context, dataset *execute.PassthroughDataset, alloc memory.Allocator, spec *PartitionMergeProcedureSpec, predecessors []execute.DatasetID) (*PartitionMergeTransformation, error) {
 	var span opentracing.Span
 	span, ctx = opentracing.StartSpanFromContext(ctx, "PartitionMergeTransformation.Process")
 

--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -451,7 +451,7 @@ type sortedPivotTransformation struct {
 	execute.ExecutionNode
 	d     *execute.PassthroughDataset
 	ctx   context.Context
-	alloc *memory.Allocator
+	alloc memory.Allocator
 	spec  SortedPivotProcedureSpec
 
 	watermark  execute.Time
@@ -461,7 +461,7 @@ type sortedPivotTransformation struct {
 	group         *pivotTableGroup
 }
 
-func newSortedPivotTransformation(ctx context.Context, spec SortedPivotProcedureSpec, id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func newSortedPivotTransformation(ctx context.Context, spec SortedPivotProcedureSpec, id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	t := &sortedPivotTransformation{
 		d:     execute.NewPassthroughDataset(id),
 		ctx:   ctx,

--- a/stdlib/universe/pivot_internal_test.go
+++ b/stdlib/universe/pivot_internal_test.go
@@ -11,6 +11,6 @@ import (
 // to the new transformation. This method should not be used
 // externally as the new pivot is not meant to be exposed publicly
 // at the moment and the name will probably change when it is exposed.
-func NewSortedPivotTransformation(ctx context.Context, spec SortedPivotProcedureSpec, id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func NewSortedPivotTransformation(ctx context.Context, spec SortedPivotProcedureSpec, id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	return newSortedPivotTransformation(ctx, spec, id, alloc)
 }

--- a/stdlib/universe/pivot_test.go
+++ b/stdlib/universe/pivot_test.go
@@ -920,7 +920,7 @@ func TestSortedPivot_ProcessWithTags(t *testing.T) {
 				tc.data,
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					spec := *tc.spec
 					tr, d, err := universe.NewSortedPivotTransformation(context.Background(), spec, id, alloc)
 					if err != nil {
@@ -1509,7 +1509,7 @@ func TestSortedPivot_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					spec := *tc.spec
 					tr, d, err := universe.NewSortedPivotTransformation(context.Background(), spec, id, alloc)
 					if err != nil {
@@ -1527,7 +1527,7 @@ func TestSortedPivot_Process_VariousSchemas(t *testing.T) {
 		ColumnKey:   []string{"_field"},
 		ValueColumn: "_value",
 	}
-	mem := &memory.Allocator{}
+	mem := &memory.ResourceAllocator{}
 	id := executetest.RandomDatasetID()
 	tr, d, err := universe.NewSortedPivotTransformation(context.Background(), spec, id, mem)
 	if err != nil {
@@ -1586,7 +1586,7 @@ func benchmarkPivot(b *testing.B, n int) {
 		ValueColumn: execute.DefaultValueColLabel,
 	}
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: n,
 				Alloc:     alloc,
@@ -1599,7 +1599,7 @@ func benchmarkPivot(b *testing.B, n int) {
 			}
 			return gen.Input(context.Background(), schema)
 		},
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			// cache := execute.NewTableBuilderCache(alloc)
 			// d := execute.NewDataset(id, execute.DiscardingMode, cache)
 			// t := NewPivotTransformation(d, cache, spec)

--- a/stdlib/universe/quantile.go
+++ b/stdlib/universe/quantile.go
@@ -200,10 +200,10 @@ type QuantileAgg struct {
 	Quantile,
 	Compression float64
 	freeDigests []*tdigest.TDigest
-	mem         *memory.Allocator
+	mem         memory.Allocator
 }
 
-func NewQuantileAgg(q, comp float64, mem *memory.Allocator, size int) *QuantileAgg {
+func NewQuantileAgg(q, comp float64, mem memory.Allocator, size int) *QuantileAgg {
 	digests := make([]*tdigest.TDigest, 0, size)
 	return &QuantileAgg{
 		Quantile:    q,
@@ -446,10 +446,10 @@ type ExactQuantileSelectorTransformation struct {
 	d     execute.Dataset
 	cache execute.TableBuilderCache
 	spec  ExactQuantileSelectProcedureSpec
-	a     *memory.Allocator
+	a     memory.Allocator
 }
 
-func NewExactQuantileSelectorTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *ExactQuantileSelectProcedureSpec, a *memory.Allocator) *ExactQuantileSelectorTransformation {
+func NewExactQuantileSelectorTransformation(d execute.Dataset, cache execute.TableBuilderCache, spec *ExactQuantileSelectProcedureSpec, a memory.Allocator) *ExactQuantileSelectorTransformation {
 	if spec.SelectorConfig.Column == "" {
 		spec.SelectorConfig.Column = execute.DefaultValueColLabel
 	}

--- a/stdlib/universe/quantile_test.go
+++ b/stdlib/universe/quantile_test.go
@@ -458,7 +458,7 @@ func TestQuantile_Process(t *testing.T) {
 			if tc.exact {
 				agg = &universe.ExactQuantileAgg{Quantile: tc.quantile}
 			} else {
-				agg = universe.NewQuantileAgg(tc.quantile, 1000.0, &memory.Allocator{}, 1)
+				agg = universe.NewQuantileAgg(tc.quantile, 1000.0, &memory.ResourceAllocator{}, 1)
 			}
 			executetest.AggFuncTestHelper(
 				t,
@@ -784,10 +784,10 @@ func TestQuantileSelector_Process(t *testing.T) {
 }
 
 func BenchmarkQuantile(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
-		universe.NewQuantileAgg(0.9, 1000.0, &memory.Allocator{}, 1),
+		universe.NewQuantileAgg(0.9, 1000.0, &memory.ResourceAllocator{}, 1),
 		data,
 		13.842132136909889,
 	)

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -434,7 +434,7 @@ func createSchemaMutationTransformation(id execute.DatasetID, mode execute.Accum
 	return NewSchemaMutationTransformation(a.Context(), s, id, a.Allocator())
 }
 
-func NewSchemaMutationTransformation(ctx context.Context, spec *SchemaMutationProcedureSpec, id execute.DatasetID, mem *memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func NewSchemaMutationTransformation(ctx context.Context, spec *SchemaMutationProcedureSpec, id execute.DatasetID, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	mutators := make([]SchemaMutator, len(spec.Mutations))
 	for i, mutation := range spec.Mutations {
 		m, err := mutation.Mutator()

--- a/stdlib/universe/schema_functions_test.go
+++ b/stdlib/universe/schema_functions_test.go
@@ -1504,7 +1504,7 @@ func TestDropRenameKeep_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				tc.wantErr,
-				func(id execute.DatasetID, mem *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, mem memory.Allocator) (execute.Transformation, execute.Dataset) {
 					spec := tc.spec.(*universe.SchemaMutationProcedureSpec)
 					tr, d, err := universe.NewSchemaMutationTransformation(context.Background(), spec, id, mem)
 					if err != nil {
@@ -1593,7 +1593,7 @@ func benchmarkSchemaMutator(b *testing.B, n int, m universe.SchemaMutation) {
 		Mutations: []universe.SchemaMutation{m},
 	}
 	executetest.ProcessBenchmarkHelper(b,
-		func(alloc *memory.Allocator) (flux.TableIterator, error) {
+		func(alloc memory.Allocator) (flux.TableIterator, error) {
 			schema := gen.Schema{
 				NumPoints: n,
 				Alloc:     alloc,
@@ -1607,7 +1607,7 @@ func benchmarkSchemaMutator(b *testing.B, n int, m universe.SchemaMutation) {
 			}
 			return gen.Input(context.Background(), schema)
 		},
-		func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+		func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 			t, d, err := universe.NewSchemaMutationTransformation(context.Background(), spec, id, alloc)
 			if err != nil {
 				b.Fatal(err)

--- a/stdlib/universe/shift_test.go
+++ b/stdlib/universe/shift_test.go
@@ -169,7 +169,7 @@ func TestShift_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					tr, d, err := universe.NewShiftTransformation(id, tc.spec, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/skew_test.go
+++ b/stdlib/universe/skew_test.go
@@ -111,7 +111,7 @@ func TestSkew_Process(t *testing.T) {
 }
 
 func BenchmarkSkew(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
 		new(universe.SkewAgg),

--- a/stdlib/universe/sort_test.go
+++ b/stdlib/universe/sort_test.go
@@ -386,7 +386,7 @@ func TestSort_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				nil,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					tr, d, err := universe.NewSortTransformation(id, tc.spec, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/spread_test.go
+++ b/stdlib/universe/spread_test.go
@@ -89,7 +89,7 @@ func TestSpread_Process(t *testing.T) {
 }
 
 func BenchmarkSpread(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
 		new(universe.SpreadAgg),

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -377,7 +377,7 @@ func TestStateTracking_Process(t *testing.T) {
 				tc.data,
 				tc.want,
 				tc.wantErr,
-				func(id execute.DatasetID, alloc *memory.Allocator) (execute.Transformation, execute.Dataset) {
+				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
 					ctx := dependenciestest.Default().Inject(context.Background())
 
 					ntx, nd, err := universe.NewNarrowStateTrackingTransformation(ctx, tc.spec, id, alloc)

--- a/stdlib/universe/stddev_test.go
+++ b/stdlib/universe/stddev_test.go
@@ -117,7 +117,7 @@ func TestStddev_Process(t *testing.T) {
 }
 
 func BenchmarkStddev(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
 		&universe.StddevAgg{Mode: "sample"},

--- a/stdlib/universe/sum_test.go
+++ b/stdlib/universe/sum_test.go
@@ -92,7 +92,7 @@ func TestSum_Process(t *testing.T) {
 }
 
 func BenchmarkSum(b *testing.B) {
-	data := arrow.NewFloat(NormalData, &memory.Allocator{})
+	data := arrow.NewFloat(NormalData, &memory.ResourceAllocator{})
 	executetest.AggFuncBenchmarkHelper(
 		b,
 		new(universe.SumAgg),

--- a/stdlib/universe/triple_exponential_derivative.go
+++ b/stdlib/universe/triple_exponential_derivative.go
@@ -105,7 +105,7 @@ type tripleExponentialDerivativeTransformation struct {
 	execute.ExecutionNode
 	d     execute.Dataset
 	cache execute.TableBuilderCache
-	alloc *memory.Allocator
+	alloc memory.Allocator
 
 	i                []int
 	lastVal          []interface{}
@@ -114,7 +114,7 @@ type tripleExponentialDerivativeTransformation struct {
 	n int64
 }
 
-func NewTripleExponentialDerivativeTransformation(d execute.Dataset, cache execute.TableBuilderCache, alloc *memory.Allocator, spec *TripleExponentialDerivativeProcedureSpec) *tripleExponentialDerivativeTransformation {
+func NewTripleExponentialDerivativeTransformation(d execute.Dataset, cache execute.TableBuilderCache, alloc memory.Allocator, spec *TripleExponentialDerivativeProcedureSpec) *tripleExponentialDerivativeTransformation {
 	return &tripleExponentialDerivativeTransformation{
 		d:     d,
 		cache: cache,
@@ -336,7 +336,7 @@ func (t *tripleExponentialDerivativeTransformation) Finish(id execute.DatasetID,
 	t.d.Finish(err)
 }
 
-func arrayToFloatArrow(a []interface{}, alloc *memory.Allocator) *array.Float {
+func arrayToFloatArrow(a []interface{}, alloc memory.Allocator) *array.Float {
 	bld := arrow.NewFloatBuilder(alloc)
 	defer bld.Release()
 

--- a/values/objects/table.go
+++ b/values/objects/table.go
@@ -160,7 +160,7 @@ func (t *Table) Equal(other values.Value) bool {
 	if !ok || !t.schema.Equal(ot.schema) {
 		return false
 	}
-	eq, err := execute.TablesEqual(t.BufferedTable, ot.BufferedTable, &memory.Allocator{})
+	eq, err := execute.TablesEqual(t.BufferedTable, ot.BufferedTable, &memory.ResourceAllocator{})
 	if err != nil || !eq {
 		return false
 	}

--- a/values/vector_test.go
+++ b/values/vector_test.go
@@ -40,7 +40,7 @@ func TestVectorTypes(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mem := &memory.Allocator{}
+		mem := &memory.ResourceAllocator{}
 		got := NewVectorFromElements(mem, tc.input...)
 
 		if !got.ElementType().Equal(tc.wantType) {

--- a/values/vector_values.gen.go
+++ b/values/vector_values.gen.go
@@ -42,7 +42,7 @@ func NewVectorValue(arr arrow.Array, typ semantic.MonoType) Vector {
 }
 
 // A convenience method for unit testing
-func NewVectorFromElements(mem *memory.Allocator, es ...interface{}) Vector {
+func NewVectorFromElements(mem memory.Allocator, es ...interface{}) Vector {
 	var typ semantic.MonoType
 	switch es[0].(type) {
 
@@ -75,7 +75,7 @@ func NewVectorFromElements(mem *memory.Allocator, es ...interface{}) Vector {
 	return newVectorFromSlice(vs, typ, mem)
 }
 
-func newVectorFromSlice(values []Value, typ semantic.MonoType, mem *memory.Allocator) Vector {
+func newVectorFromSlice(values []Value, typ semantic.MonoType, mem memory.Allocator) Vector {
 	switch typ {
 
 	case semantic.BasicInt:


### PR DESCRIPTION
This converts the allocator to an interface so we can wrap it in
different locations. It expands on the arrow allocator to add a direct
access to the account method of the underlying resource allocator.

The original plan was to separate these two so the allocator would not
have an `Account()` method. This proved to be too difficult as the
`Account()` method is used in some very deep places in the code and
changing all of those locations was just not practical.

Fixes #4472.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written