### PR TITLE
refactor: move implicit result generation to executor

### DIFF
--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -722,9 +722,6 @@ func TestExecutor_Execute(t *testing.T) {
 					{2, 3},
 				},
 			},
-			// XXX(onelson): unsure if the wrapped (inner) error is ever made
-			// visible to the user.
-			// Seems like in this case we'd want the user to get this feedback...
 			wantErr: errors.Wrap(
 				errors.New(codes.Invalid, "tried to produce more than one result with the name \"_result\""),
 				codes.Inherit,

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -239,11 +239,9 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &csv.FromCSVProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       parser.MustParseTime("2017-10-10T00:01:00Z").Value,
@@ -260,11 +258,9 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &csv.FromCSVProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       parser.MustParseTime("2018-10-10T00:00:00Z").Value,
@@ -294,11 +290,9 @@ csv.from(csv: "foo,bar") |> range(start: 2017-10-10T00:00:00Z)
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &csv.FromCSVProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       parser.MustParseTime("2018-10-10T00:00:00Z").Value,
@@ -511,11 +505,9 @@ func TestCompileOptions(t *testing.T) {
 		Nodes: []plan.Node{
 			&plan.PhysicalPlanNode{Spec: &csv.FromCSVProcedureSpec{}},
 			&plan.PhysicalPlanNode{Spec: &universe.RangeProcedureSpec{}},
-			&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 		},
 		Edges: [][2]int{
 			{0, 1},
-			{1, 2},
 		},
 		Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 		Now:       parser.MustParseTime("2018-10-10T00:00:00Z").Value,
@@ -559,11 +551,8 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
-				Edges: [][2]int{
-					{0, 1},
-				},
+				Edges:     [][2]int{},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
@@ -580,11 +569,9 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -604,12 +591,10 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
 					{1, 2},
-					{2, 3},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -629,12 +614,10 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
 					{1, 2},
-					{2, 3},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -652,11 +635,8 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
-				Edges: [][2]int{
-					{0, 1},
-				},
+				Edges:     [][2]int{},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
@@ -673,11 +653,8 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
-				Edges: [][2]int{
-					{0, 1},
-				},
+				Edges:     [][2]int{},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
@@ -739,11 +716,8 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 			want: plantest.CreatePlanSpec(&plantest.PlanSpec{
 				Nodes: []plan.Node{
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
-				Edges: [][2]int{
-					{0, 1},
-				},
+				Edges:     [][2]int{},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
 			}),
@@ -762,12 +736,10 @@ from(bucket: "bkt") |> range(start: 0) |> filter(fn: (r) => r._value > 0) |> cou
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
 					{1, 2},
-					{2, 3},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),
@@ -791,12 +763,10 @@ option planner.disableLogicalRules = ["removeCountRule"]`},
 					&plan.PhysicalPlanNode{Spec: &influxdb.FromRemoteProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.FilterProcedureSpec{}},
 					&plan.PhysicalPlanNode{Spec: &universe.CountProcedureSpec{}},
-					&plan.PhysicalPlanNode{Spec: &universe.YieldProcedureSpec{}},
 				},
 				Edges: [][2]int{
 					{0, 1},
 					{1, 2},
-					{2, 3},
 				},
 				Resources: flux.ResourceManagement{ConcurrencyQuota: 1, MemoryBytesQuota: math.MaxInt64},
 				Now:       nowFn(),

--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -328,22 +328,18 @@ experimental.chain(first: id, second: guild)
   range1
   filter2
   // r._field == "id"
-  generated_yield
 
   array.from0 -> range1
   range1 -> filter2
-  filter2 -> generated_yield
 }
  digraph {
   array.from3
   range4
   filter5
   // r._field == "guild"
-  generated_yield
 
   array.from3 -> range4
   range4 -> filter5
-  filter5 -> generated_yield
 }
 ]`,
 		},
@@ -369,23 +365,19 @@ data
   filter2
   // r._field == "id"
   sort3
-  generated_yield
 
   array.from0 -> range1
   range1 -> filter2
   filter2 -> sort3
-  sort3 -> generated_yield
 }
  digraph {
   array.from4
   range5
   filter6
   // r._field == "id"
-  generated_yield
 
   array.from4 -> range5
   range5 -> filter6
-  filter6 -> generated_yield
 }
 ]`,
 		},

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -255,23 +255,9 @@ func (v *fluxSpecVisitor) visitOperation(o *flux.Operation) error {
 
 	// no children => no successors => root node
 	if len(v.spec.Children(o.ID)) == 0 {
-		// Formerly we marked nodes as roots if:
-		// - are a yield
-		// - have side effects
-		//
-		// For all other cases inside this "zero children" block, we previously
-		// added a new yield to the end of the chain and marked *the new yield*
-		// as a root.
-		// To summarize: all terminal nodes would be marked as a root and
-		// produce a result by the time the executor is done.
-		//
-		// Now, instead of inserting a yields here we are adding a result
-		// directly in the executor for all terminal nodes. Look for usages of
-		// `generateResult()` in `executor.go` to find where this happens.
-		//
-		// N.b. the number of entries in the `Roots` map factor into the
-		// concurrency quota for the query and as such we must continue to mark
-		// these all as roots here.
+		// N.b. the number of entries in `Roots` is factored into the starting
+		// concurrency quota for the query. As such we must mark all terminal
+		// nodes as roots here.
 		v.plan.Roots[logicalNode] = struct{}{}
 	}
 

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -266,13 +266,20 @@ func (v *fluxSpecVisitor) visitOperation(o *flux.Operation) error {
 		// Formerly we marked nodes as roots if:
 		// - are a yield
 		// - have side effects
-		// For any other case inside this "zero children" block, we added a new
-		// yield to the end of the chain and marked *the new yield* as a root.
-		// Now, nstead of inserting a yield here we are adding a result directly
-		// in the executor for this case.
+		//
+		// For all other cases inside this "zero children" block, we previously
+		// added a new yield to the end of the chain and marked *the new yield*
+		// as a root.
+		// To summarize: all terminal nodes would be marked as a root and
+		// produce a result by the time the executor is done.
+		//
+		// Now, instead of inserting a yields here we are adding a result
+		// directly in the executor for all terminal nodes. Look for usages of
+		// `generateResult()` in `executor.go` to find where this happens.
 		//
 		// N.b. the number of entries in the `Roots` map factor into the
-		// concurrency quota for the query.
+		// concurrency quota for the query and as such we must continue to mark
+		// these all as roots here.
 		v.plan.Roots[logicalNode] = struct{}{}
 	}
 

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -263,18 +263,17 @@ func (v *fluxSpecVisitor) visitOperation(o *flux.Operation) error {
 
 	// no children => no successors => root node
 	if len(v.spec.Children(o.ID)) == 0 {
-		if isYield || HasSideEffect(procedureSpec) {
-			v.plan.Roots[logicalNode] = struct{}{}
-		} else {
-			// Generate a yield node
-			generateYieldNode := generateYieldNode(logicalNode)
-			err = v.addYieldName(generateYieldNode)
-			if err != nil {
-				return err
-			}
-			v.plan.Roots[generateYieldNode] = struct{}{}
-
-		}
+		// Formerly we marked nodes as roots if:
+		// - are a yield
+		// - have side effects
+		// For any other case inside this "zero children" block, we added a new
+		// yield to the end of the chain and marked *the new yield* as a root.
+		// Now, nstead of inserting a yield here we are adding a result directly
+		// in the executor for this case.
+		//
+		// N.b. the number of entries in the `Roots` map factor into the
+		// concurrency quota for the query.
+		v.plan.Roots[logicalNode] = struct{}{}
 	}
 
 	return nil

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -211,14 +211,6 @@ func (v *fluxSpecVisitor) addYieldName(pn Node) error {
 	return nil
 }
 
-func generateYieldNode(pred Node) Node {
-	yieldSpec := &GeneratedYieldProcedureSpec{Name: DefaultYieldName}
-	yieldNode := CreateLogicalNode(NodeID("generated_yield"), yieldSpec)
-	pred.AddSuccessors(yieldNode)
-	yieldNode.AddPredecessors(pred)
-	return yieldNode
-}
-
 // visitOperation takes a flux spec operation, converts it to its equivalent
 // logical procedure spec, and adds it to the current logical plan DAG.
 func (v *fluxSpecVisitor) visitOperation(o *flux.Operation) error {

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -273,14 +273,6 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 			},
 		},
 		{
-			// N.b. Formerly this test verified the behavior of yields that were
-			// injected for root nodes during planning, but we are no longer
-			// doing this!
-			// Instead terminal nodes have results produced without yields which
-			// don't show up in the plan.
-			// To force the error case we want to test, explicit yields without
-			// specifying names have been added. These should cause 2 yields
-			// using the default name of `_result` to get caught by the planner.
 			name: "multi unnamed yields",
 			query: `
 				from(bucket: "my-bucket") |> sum() |> yield()

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -31,9 +31,6 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 	standardYield := func(name string) *universe.YieldProcedureSpec {
 		return &universe.YieldProcedureSpec{Name: name}
 	}
-	generatedYield := func(name string) *plan.GeneratedYieldProcedureSpec {
-		return &plan.GeneratedYieldProcedureSpec{Name: name}
-	}
 
 	now := time.Now().UTC()
 
@@ -140,11 +137,9 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 				Nodes: []plan.Node{
 					plan.CreateLogicalNode("from0", fromSpec),
 					plan.CreateLogicalNode("range1", rangeSpec),
-					plan.CreateLogicalNode("generated_yield", generatedYield("_result")),
 				},
 				Edges: [][2]int{
 					{0, 1},
-					{1, 2},
 				},
 				Now: now,
 			},
@@ -157,12 +152,10 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 					plan.CreateLogicalNode("from0", fromSpec),
 					plan.CreateLogicalNode("range1", rangeSpec),
 					plan.CreateLogicalNode("filter2", filterSpec),
-					plan.CreateLogicalNode("generated_yield", generatedYield("_result")),
 				},
 				Edges: [][2]int{
 					{0, 1},
 					{1, 2},
-					{2, 3},
 				},
 				Now: now,
 			},
@@ -212,7 +205,7 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 			},
 		},
 		{
-			name: `side effect and a generated yield`,
+			name: `side effect and NOT a generated yield`,
 			query: `
 				import "kafka"
 				from(bucket: "my-bucket") |> range(start:-1h) |> kafka.to(brokers: ["broker"], topic: "topic")
@@ -226,7 +219,6 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 					// Second plan
 					plan.CreateLogicalNode("from3", fromSpec),
 					plan.CreateLogicalNode("range4", rangeSpec),
-					plan.CreateLogicalNode("generated_yield", generatedYield("_result")),
 				},
 				Edges: [][2]int{
 					// First plan
@@ -234,7 +226,6 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 					{1, 2},
 					// Second plan
 					{3, 4},
-					{4, 5},
 				},
 				Now: now,
 			},

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -273,10 +273,18 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "multi-generated yields",
+			// N.b. Formerly this test verified the behavior of yields that were
+			// injected for root nodes during planning, but we are no longer
+			// doing this!
+			// Instead terminal nodes have results produced without yields which
+			// don't show up in the plan.
+			// To force the error case we want to test, explicit yields without
+			// specifying names have been added. These should cause 2 yields
+			// using the default name of `_result` to get caught by the planner.
+			name: "multi unnamed yields",
 			query: `
-				from(bucket: "my-bucket") |> sum()
-				from(bucket: "my-bucket") |> mean()`,
+				from(bucket: "my-bucket") |> sum() |> yield()
+				from(bucket: "my-bucket") |> mean() |> yield()`,
 			wantErr: true,
 		},
 	}

--- a/plan/rules_test.go
+++ b/plan/rules_test.go
@@ -53,7 +53,7 @@ func TestRuleRegistration(t *testing.T) {
 		t.Fatalf("could not do logical planning: %v", err)
 	}
 
-	wantSeenNodes := []plan.NodeID{"generated_yield", "range1", "from0"}
+	wantSeenNodes := []plan.NodeID{"range1", "from0"}
 	if !cmp.Equal(wantSeenNodes, simpleRule.SeenNodes) {
 		t.Errorf("did not find expected seen nodes, -want/+got:\n%v", cmp.Diff(wantSeenNodes, simpleRule.SeenNodes))
 	}


### PR DESCRIPTION
refs: #4465

Previously, terminal nodes (nodes without children) fell into 3
categories:

- those that _are literal yields_
- those that _have side-effects_
- everything else

In the planner, the first two cases are marked as "roots" which
contribute to the query's concurrecy quota.

The "everything else" case would add an implicit yield to the end of the
chain, which itself is marked as a "root." This essentially funnels the
"everything else" nodes into the "literal yields" category.

Later on in the executor, literal yields generate "results" and
separately, so are the nodes that _have side-effects_.

---

This diff aims to simplify the roles and responsibilities played by each
of the planner and executor.

At a high-level, the diff marks _all terminal nodes_ as "roots" in the
planner. In the executor, we handle the "everything else" nodes
similarly to how we handled the side-effecting nodes, by adding a
"result" for them to the execution state.

~~This seems to work fine for many simple cases but appears to break
things that depend on `TableObjectCompiler` which seems to no longer
produce results as expected. In tests, we'll see panics where we try to
consume the results from a "sub program" but get a `nil` back instead.~~

> Edit: it turned out this was an oversight on my part. The code for generating results we had in place in the executor previously ran only for nodes _that were not leaves_. With the full responsibility lying on the executor now, it needed to also produce results for leaves that are also roots. Details here: https://github.com/influxdata/flux/pull/4545#issuecomment-1064353746

Other tests will need to be adjusted to account for the shape of the
resultant plan having fewer yields in it, or the name of the results
being slightly different.


### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [x] Test cases written
