### PR TITLE
test: need to copy physical attributes when we copy a plantest.PlanSpec

### DIFF
--- a/plan/plantest/plan.go
+++ b/plan/plantest/plan.go
@@ -49,7 +49,14 @@ func copyNode(n plan.Node) plan.Node {
 	case *plan.LogicalNode:
 		cn = plan.CreateLogicalNode(n.ID(), n.ProcedureSpec().Copy())
 	case *plan.PhysicalPlanNode:
-		cn = plan.CreatePhysicalNode(n.ID(), n.ProcedureSpec().Copy().(plan.PhysicalProcedureSpec))
+		pn := plan.CreatePhysicalNode(n.ID(), n.ProcedureSpec().Copy().(plan.PhysicalProcedureSpec))
+		for key, attr := range n.OutputAttrs {
+			pn.SetOutputAttr(key, attr)
+		}
+		for key, attr := range n.RequiredAttrs {
+			pn.SetRequiredAttr(key, attr)
+		}
+		cn = pn
 	}
 	return cn
 }


### PR DESCRIPTION
The physical attributes must be copied when copying a plantest.PlanSpec if we
want to be able to set NoChange to true in RuleTestCase


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
