### PR TITLE
chore(fluxdoc): add support for deprecated: NEXT

### DIFF
--- a/docs/fluxdoc.md
+++ b/docs/fluxdoc.md
@@ -34,6 +34,8 @@ Package summary documentation consists of a **headline**, **description**,
   the package. _See [Package metadata](#package-metadata)_.
 
 #### Package metadata
+
+Identify the beginning of the metadata section with a `## Metadata` header.
 Package metadata are string key-value pairs separated by `:`.
 Each key-value pair must be on a single line.
 
@@ -43,7 +45,7 @@ Each key-value pair must be on a single line.
   and categorize packages. _See [Metadata tags](#metadata-tags)._
 - **contributors**: Contributor GitHub usernames or other contact information.
 
-When adding a new export to a Flux package the `introduced: NEXT` metadata can be added to the value's docs.
+When adding a new export to a Flux package the `introduced: NEXT` or `deprecated: NEXT` metadata can be added to the value's docs.
 The release process will automatically replace the `NEXT` with the version of the Flux release.
 
 ```js

--- a/etc/checkprepared.sh
+++ b/etc/checkprepared.sh
@@ -13,13 +13,13 @@ cd $DIR
 EXIT=0
 while read f
 do
-    # Check for any introduced: NEXT comments that still exist
-    grep "^//[[:space:]]*introduced:[[:space:]]\+NEXT[[:space:]]*$" $f > /dev/null
+    # Check for any 'introduced: NEXT' or 'deprecated: NEXT' comments that still exist
+    grep '^//[[:space:]]*\(introduced\|deprecated\):[[:space:]]\+NEXT[[:space:]]*$' $f > /dev/null
     ret=$?
     if [ $ret -eq 0 ]
     then
         EXIT=1
-        echo "$f contains 'introduced: NEXT'"
+        echo "$f contains 'introduced: NEXT' or 'deprecated: NEXT'"
     fi
 done < <(find ./stdlib -name '*.flux')
 

--- a/etc/fixup_docs_version.sh
+++ b/etc/fixup_docs_version.sh
@@ -9,6 +9,6 @@ version=${1//v/}
 
 while read f
 do
-    # Replace any introduced: NEXT comment with the actual version
-    sed -i "s/^\/\/[[:space:]]*introduced:[[:space:]]\+NEXT[[:space:]]*$/\/\/ introduced: $version/g" $f
+    # Replace any 'introduced: NEXT' or 'deprecated: NEXT' comment with the actual version
+    sed -i "s/^\/\/[[:space:]]*\(introduced\|deprecated\):[[:space:]]\+NEXT[[:space:]]*$/\/\/ \1: $version/g" $f
 done < <(find ./stdlib -name '*.flux')

--- a/libflux/flux-core/src/doc/mod.rs
+++ b/libflux/flux-core/src/doc/mod.rs
@@ -1795,6 +1795,40 @@ foo.a
         );
     }
     #[test]
+    fn test_metadata_no_desc_pkg() {
+        let src = "
+        // Package foo does a thing.
+        //
+        // ## Metadata
+        // key: valueA
+        // key: valueB
+        // key1: value with spaces
+        // key_with_underscores: value
+        package foo
+        ";
+        let loc = Locator::new(&src[..]);
+        assert_docs_full(
+            src,
+            PackageDoc {
+                path: "path".to_string(),
+                name: "foo".to_string(),
+                headline: "Package foo does a thing.".to_string(),
+                description: None,
+                members: BTreeMap::default(),
+                examples: Vec::new(),
+                metadata: Some(map![
+                    "key" => "valueB".to_string(),
+                    "key1" => "value with spaces".to_string(),
+                    "key_with_underscores" => "value".to_string(),
+                ]),
+            },
+            vec![Diagnostic {
+                msg: "found duplicate metadata key \"key\"".to_string(),
+                loc: loc.get(9, 9, 9, 20),
+            }],
+        );
+    }
+    #[test]
     fn test_function_doc() {
         let src = "
         // Package foo does a thing.

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -25,7 +25,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "bf275289e690236988049fc0a07cf832dbac25bb5739c02135b069dcdfab4d0f",
 	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "bad4b12bcf4a8bc1a94cb37cda004bf7fb593abf3f0c6c3a2af6fabc60337c5d",
 	"libflux/flux-core/src/doc/example.rs":                                                        "6414756b3c74df1b58fdb739592e74ded3f89d85d647809333f72a3f6aad146f",
-	"libflux/flux-core/src/doc/mod.rs":                                                            "282ea0baa20d1e43230d9c4914eebd19251b8397ffe4a4e3a3bc5be3178fb930",
+	"libflux/flux-core/src/doc/mod.rs":                                                            "3a42d710039b9fa7c51116291b58040ffa84969e3036ee538a2e5f55666dae5e",
 	"libflux/flux-core/src/errors.rs":                                                             "7eb977a67a5f26801ab4622f54722bac1e11945690891a7f98c11337e6b86fde",
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "981dbce1bc4c6ba8884a8244f0002b004a5e446df207f9dc70155f42b797d4e3",
 	"libflux/flux-core/src/lib.rs":                                                                "153f4b1d98494f5cab6e46cb2492c217e3dfec1e14368b251a8b48e9c2838fff",


### PR DESCRIPTION
Adds support for deprecated: NEXT the same as introduced: NEXT.

Additionally document that `## Metadata` is needed to delimit the
metadata section of docs.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
