### PR TITLE
feat(mqtt): enable dialer pool for everyone

### DIFF
--- a/dependencies/mqtt/mqtt.go
+++ b/dependencies/mqtt/mqtt.go
@@ -12,7 +12,6 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/errors"
-	"github.com/influxdata/flux/internal/feature"
 )
 
 const (
@@ -26,11 +25,9 @@ const clientKey key = iota
 
 // Inject will inject this Dialer into the dependency chain.
 func Inject(ctx context.Context, dialer Dialer) context.Context {
-	if feature.MqttPoolDialer().Enabled(ctx) {
-		pool := newPoolDialer(dialer)
-		dependency.OnFinish(ctx, pool)
-		dialer = pool
-	}
+	pool := newPoolDialer(dialer)
+	dependency.OnFinish(ctx, pool)
+	dialer = pool
 	return context.WithValue(ctx, clientKey, dialer)
 }
 

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -65,18 +65,6 @@ func OptimizeUnionTransformation() BoolFlag {
 	return optimizeUnionTransformation
 }
 
-var mqttPoolDialer = feature.MakeBoolFlag(
-	"MQTT Pool Dialer",
-	"mqttPoolDialer",
-	"Jonathan Sternberg",
-	false,
-)
-
-// MqttPoolDialer - MQTT pool dialer
-func MqttPoolDialer() BoolFlag {
-	return mqttPoolDialer
-}
-
 var vectorizedMap = feature.MakeBoolFlag(
 	"Vectorized Map",
 	"vectorizedMap",
@@ -159,7 +147,6 @@ var all = []Flag{
 	groupTransformationGroup,
 	queryConcurrencyLimit,
 	optimizeUnionTransformation,
-	mqttPoolDialer,
 	vectorizedMap,
 	narrowTransformationDifference,
 	narrowTransformationFill,
@@ -173,7 +160,6 @@ var byKey = map[string]Flag{
 	"groupTransformationGroup":         groupTransformationGroup,
 	"queryConcurrencyLimit":            queryConcurrencyLimit,
 	"optimizeUnionTransformation":      optimizeUnionTransformation,
-	"mqttPoolDialer":                   mqttPoolDialer,
 	"vectorizedMap":                    vectorizedMap,
 	"narrowTransformationDifference":   narrowTransformationDifference,
 	"narrowTransformationFill":         narrowTransformationFill,

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -34,12 +34,6 @@
   default: false
   contact: Jonathan Sternberg
 
-- name: MQTT Pool Dialer
-  description: MQTT pool dialer
-  key: mqttPoolDialer
-  default: false
-  contact: Jonathan Sternberg
-
 - name: Vectorized Map
   description: Enables the version of map that supports vectorized functions
   key: vectorizedMap


### PR DESCRIPTION
Previously we had implemented a way to allow flux to reuse client
connections to mqtt across calls to `mqtt.publish`, but it was hidden
behind a feature flag pending verification of the new behavior.

After some manual testing, things appear to be in good shape. By
inspecting a mosquitto mqtt broker's server log, and toggling the flag
off/on, we could see that when the feature is enabled there's a single
client connection and serveral publishes (versus one connection per
publish when the flag is off).

This diff removes the feature flag, turning the new code path on for
everyone.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
