### PR TITLE
fix: skip parallel merge nodes when selecting the result name

### DIFF
--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -308,7 +308,7 @@ func TestParallel_Execute(t *testing.T) {
 				},
 			},
 			want: map[string][]*executetest.Table{
-				"merge": []*executetest.Table{
+				"_result": []*executetest.Table{
 					{
 						KeyCols: []string{"_start", "_stop"},
 						ColMeta: []flux.ColMeta{


### PR DESCRIPTION
If a node is a parallel merge then it was added by the planner and might be a
successor of a node with side effects. In order to preserve behaviour, skip
these parallel merge nodes and check if the predecessor has side effects. If
so, use that node name instead.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
