### PR TITLE
fix: create better error message for pivot column conflict

### DIFF
--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -302,7 +302,12 @@ func (t *pivotTransformation) Process(id execute.DatasetID, tbl flux.Table) erro
 				}
 				nextCol, err := builder.AddCol(newCol)
 				if err != nil {
-					return err
+					// column already exists
+					return errors.Newf(
+						codes.Invalid,
+						"value %q appears in a column key column, but a column named %q already exists; consider renaming %q to something else before pivoting",
+						colKey, colKey, colKey,
+					)
 				}
 				t.colKeyMaps[groupKeyString][colKey] = nextCol
 			}


### PR DESCRIPTION
This PR creates a more informative error message when a call to `pivot()` would require creating a column that already exists.

Also, the type of the error has been changed to `invalid` so it is seen by users.
