### PR TITLE
feat(mqtt): re-enable the dialer pool for everyone

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/testing"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/execute/table"
 	"github.com/influxdata/flux/fluxinit"
@@ -651,8 +652,11 @@ func (testExecutor) Run(pkg *ast.Package) error {
 	}
 	c := lang.ASTCompiler{AST: jsonAST}
 
-	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	ctx = testing.Inject(ctx)
+	ctx, span := dependency.Inject(context.Background(),
+		executetest.NewTestExecuteDependencies(),
+		testing.FrameworkConfig{},
+	)
+	defer span.Finish()
 	program, err := c.Compile(ctx, runtime.Default)
 	if err != nil {
 		return errors.Wrap(err, codes.Invalid, "failed to compile")

--- a/dependencies/dependenciestest/dependencies.go
+++ b/dependencies/dependenciestest/dependencies.go
@@ -47,7 +47,6 @@ type Deps struct {
 func (d Deps) Inject(ctx context.Context) context.Context {
 	ctx = d.Deps.Inject(ctx)
 	ctx = d.influxdb.Inject(ctx)
-	ctx, _ = dependency.Inject(ctx)
 	return d.mqtt.Inject(ctx)
 }
 
@@ -79,10 +78,8 @@ func ExecutionDefault() execute.ExecutionDependencies {
 }
 
 // Injects all default dependencies into the context
-func InjectAllDeps(ctx context.Context) context.Context {
+func InjectAllDeps(ctx context.Context) (context.Context, *dependency.Span) {
 	deps := Default()
 	execDeps := ExecutionDefault()
-
-	ctx = deps.Inject(ctx)
-	return execDeps.Inject(ctx)
+	return dependency.Inject(ctx, deps, execDeps)
 }

--- a/dependencies/influxdb/http_test.go
+++ b/dependencies/influxdb/http_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/dependencies/influxdb"
+	"github.com/influxdata/flux/dependency"
 	protocol "github.com/influxdata/line-protocol"
 )
 
@@ -143,7 +144,8 @@ disk,id=/dev/sdb usage_disk=45,log="disk message" 1510876800000000004
 			deps.Deps.Deps.HTTPClient = &http.Client{
 				Transport: roundTripper,
 			}
-			ctx := deps.Inject(context.Background())
+			ctx, span := dependency.Inject(context.Background(), deps)
+			defer span.Finish()
 			writer, err := h.WriterFor(ctx, influxdb.Config{
 				Org:    influxdb.NameOrID{Name: "myorg"},
 				Bucket: influxdb.NameOrID{Name: "mybucket"},
@@ -196,7 +198,8 @@ func TestHttpWriter_Write_Error(t *testing.T) {
 	deps.Deps.Deps.HTTPClient = &http.Client{
 		Transport: roundTripper,
 	}
-	ctx := deps.Inject(context.Background())
+	ctx, span := dependency.Inject(context.Background(), deps)
+	defer span.Finish()
 	writer, err := h.WriterFor(ctx, influxdb.Config{
 		Org:    influxdb.NameOrID{Name: "myorg"},
 		Bucket: influxdb.NameOrID{Name: "mybucket"},

--- a/dependencies/mqtt/mqtt.go
+++ b/dependencies/mqtt/mqtt.go
@@ -12,7 +12,6 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/errors"
-	"github.com/influxdata/flux/internal/feature"
 )
 
 const (
@@ -26,11 +25,9 @@ const clientKey key = iota
 
 // Inject will inject this Dialer into the dependency chain.
 func Inject(ctx context.Context, dialer Dialer) context.Context {
-	if feature.MqttPoolDialer().Enabled(ctx) {
-		pool := newPoolDialer(dialer)
-		dependency.OnFinish(ctx, pool)
-		dialer = pool
-	}
+	pool := newPoolDialer(dialer)
+	dependency.OnFinish(ctx, pool)
+	dialer = pool
 	return context.WithValue(ctx, clientKey, dialer)
 }
 

--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -38,6 +38,16 @@ func OnFinish(ctx context.Context, c io.Closer) {
 	span.onFinish(c)
 }
 
+type closeFunc func() error
+
+func (fn closeFunc) Close() error {
+	return fn()
+}
+
+func OnFinishFunc(ctx context.Context, fn func() error) {
+	OnFinish(ctx, closeFunc(fn))
+}
+
 type contextKey int
 
 const (

--- a/execute/aggregate_test.go
+++ b/execute/aggregate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/execute/table"
@@ -913,7 +914,9 @@ func TestSimpleAggregate_Process(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+			defer deps.Finish()
+
 			agg, d, err := execute.NewSimpleAggregateTransformation(ctx, executetest.RandomDatasetID(), tc.agg, tc.config, memory.DefaultAllocator)
 			if err != nil {
 				t.Fatal(err)
@@ -952,7 +955,9 @@ func TestSimpleAggregate_Process(t *testing.T) {
 func TestSimpleAggregate_Process_UnsupportedColumnType(t *testing.T) {
 	sumAgg := new(universe.SumAgg)
 
-	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+	defer deps.Finish()
+
 	agg, d, err := execute.NewSimpleAggregateTransformation(ctx, executetest.RandomDatasetID(), sumAgg, execute.DefaultSimpleAggregateConfig, memory.DefaultAllocator)
 	if err != nil {
 		t.Fatal(err)

--- a/execute/executor_test.go
+++ b/execute/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	_ "github.com/influxdata/flux/fluxinit/static"
@@ -752,7 +753,9 @@ func TestExecutor_Execute(t *testing.T) {
 			}
 
 			// Execute the query and preserve any error returned
-			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+			defer deps.Finish()
+
 			results, _, err := exe.Execute(ctx, plan, alloc)
 			var got map[string][]*executetest.Table
 			if err == nil {

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	_ "github.com/influxdata/flux/fluxinit/static"
@@ -494,7 +495,9 @@ func TestParallel_Execute(t *testing.T) {
 			}
 
 			// Execute the query and preserve any error returned
-			ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+			defer deps.Finish()
+
 			results, _, err := exe.Execute(ctx, ps, alloc)
 			var got map[string][]*executetest.Table
 			if err == nil {

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -65,18 +65,6 @@ func OptimizeUnionTransformation() BoolFlag {
 	return optimizeUnionTransformation
 }
 
-var mqttPoolDialer = feature.MakeBoolFlag(
-	"MQTT Pool Dialer",
-	"mqttPoolDialer",
-	"Jonathan Sternberg",
-	false,
-)
-
-// MqttPoolDialer - MQTT pool dialer
-func MqttPoolDialer() BoolFlag {
-	return mqttPoolDialer
-}
-
 var vectorizedMap = feature.MakeBoolFlag(
 	"Vectorized Map",
 	"vectorizedMap",
@@ -159,7 +147,6 @@ var all = []Flag{
 	groupTransformationGroup,
 	queryConcurrencyLimit,
 	optimizeUnionTransformation,
-	mqttPoolDialer,
 	vectorizedMap,
 	narrowTransformationDifference,
 	narrowTransformationFill,
@@ -173,7 +160,6 @@ var byKey = map[string]Flag{
 	"groupTransformationGroup":         groupTransformationGroup,
 	"queryConcurrencyLimit":            queryConcurrencyLimit,
 	"optimizeUnionTransformation":      optimizeUnionTransformation,
-	"mqttPoolDialer":                   mqttPoolDialer,
 	"vectorizedMap":                    vectorizedMap,
 	"narrowTransformationDifference":   narrowTransformationDifference,
 	"narrowTransformationFill":         narrowTransformationFill,

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -34,12 +34,6 @@
   default: false
   contact: Jonathan Sternberg
 
-- name: MQTT Pool Dialer
-  description: MQTT pool dialer
-  key: mqttPoolDialer
-  default: false
-  contact: Jonathan Sternberg
-
 - name: Vectorized Map
   description: Enables the version of map that supports vectorized functions
   key: vectorizedMap

--- a/internal/spec/build_test.go
+++ b/internal/spec/build_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/runtime"
@@ -33,7 +34,9 @@ check = from(bucket: "telegraf")
 check |> yield(name: "checkResult")
 check |> yield(name: "mean")
 `
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		if _, err := spec.FromScript(ctx, runtime.Default, time.Now(), query); err != nil {

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/repl"
@@ -438,7 +439,9 @@ func TestEval(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			src := prelude + tc.query
 
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+
 			sideEffects, _, err := runtime.Eval(ctx, src)
 			if err != nil {
 				if tc.wantErr == "" {
@@ -579,7 +582,9 @@ func TestEval_Operator_Precedence(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.src, func(t *testing.T) {
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+
 			sideEffects, _, err := runtime.Eval(ctx, tc.src)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
@@ -650,7 +655,9 @@ func TestInterpreter_MultiPhaseInterpretation(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+
 			r := repl.New(ctx)
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)
@@ -762,7 +769,9 @@ func TestInterpreter_MultipleEval(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+
 			r := repl.New(ctx)
 
 			if _, err := r.Eval(prelude); err != nil {
@@ -810,7 +819,9 @@ func TestResolver(t *testing.T) {
 			src := tc.env + "\n" + tc.fn
 
 			// Evaluate script with a function definition.
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+
 			_, scope, err := runtime.Eval(ctx, src)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
@@ -849,7 +860,9 @@ func getSideEffectsValues(ses []interpreter.SideEffect) []values.Value {
 
 func TestStack(t *testing.T) {
 	src := `from(bucket: "telegraf") |> range(start: -5m) |> aggregateWindow(every: 1m, fn: mean)`
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	sideEffects, _, err := runtime.Eval(ctx, src)
 	if err != nil {
 		t.Fatal(err)

--- a/interpreter/package_test.go
+++ b/interpreter/package_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/interpreter"
@@ -88,7 +89,8 @@ func TestAccessNestedImport(t *testing.T) {
 	}
 
 	expectedError := fmt.Errorf(`cannot access imported package "a" of imported package "b"`)
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
 	_, err := interpreter.NewInterpreter(interpreter.NewPackage(""), nil).Eval(ctx, node, values.NewScope(), &importer)
 
 	if err == nil {
@@ -366,7 +368,8 @@ func TestInterpreter_EvalPackage(t *testing.T) {
 
 func TestInterpreter_MutateOption(t *testing.T) {
 	pkg := interpreter.NewPackage("alert")
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
 	itrp := interpreter.NewInterpreter(pkg, nil)
 	script := `
 		package alert
@@ -392,7 +395,8 @@ func TestInterpreter_SetQualifiedOption(t *testing.T) {
 			"alert": externalPackage,
 		},
 	}
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
 	itrp := interpreter.NewInterpreter(interpreter.NewPackage(""), nil)
 	pkg := `
 		package foo

--- a/mock/dependency.go
+++ b/mock/dependency.go
@@ -1,0 +1,11 @@
+package mock
+
+import "context"
+
+type Dependency struct {
+	InjectFn func(ctx context.Context) context.Context
+}
+
+func (d Dependency) Inject(ctx context.Context) context.Context {
+	return d.InjectFn(ctx)
+}

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/spec"
@@ -24,7 +25,9 @@ import (
 )
 
 func compile(fluxText string, now time.Time) (*flux.Spec, error) {
-	return spec.FromScript(dependenciestest.Default().Inject(context.Background()), runtime.Default, now, fluxText)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	return spec.FromScript(ctx, runtime.Default, now, fluxText)
 }
 
 func TestPlan_LogicalPlanFromSpec(t *testing.T) {

--- a/querytest/compile.go
+++ b/querytest/compile.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic/semantictest"
@@ -40,7 +41,9 @@ func NewQueryTestHelper(t *testing.T, tc NewQueryTestCase) {
 	t.Helper()
 
 	now := time.Now().UTC()
-	got, err := spec.FromScript(dependenciestest.Default().Inject(context.Background()), runtime.Default, now, tc.Raw)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := spec.FromScript(ctx, runtime.Default, now, tc.Raw)
 	if (err != nil) != tc.WantErr {
 		t.Errorf("error compiling spec error = %v, wantErr %v", err, tc.WantErr)
 		return

--- a/querytest/execute.go
+++ b/querytest/execute.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/runtime"
@@ -17,9 +18,9 @@ func (q *Querier) Query(ctx context.Context, w io.Writer, c flux.Compiler, d flu
 	if err != nil {
 		return 0, err
 	}
-	ctx = executetest.NewTestExecuteDependencies().Inject(ctx)
-	alloc := &memory.ResourceAllocator{}
-	query, err := program.Start(ctx, alloc)
+	ctx, deps := dependency.Inject(ctx, executetest.NewTestExecuteDependencies())
+	defer deps.Finish()
+	query, err := program.Start(ctx, memory.DefaultAllocator)
 	if err != nil {
 		return 0, err
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/parser"
@@ -84,7 +85,9 @@ func Example_option() {
 	// The now option is a function value whose default behavior is to return
 	// the current system time when called. The function now() doesn't take
 	// any arguments so can be called with nil.
-	nowTime, _ := nowFunc.Function().Call(dependenciestest.Default().Inject(context.TODO()), nil)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	nowTime, _ := nowFunc.Function().Call(ctx, nil)
 	fmt.Fprintf(os.Stderr, "The current system time (UTC) is: %v\n", nowTime)
 	// Output:
 }
@@ -96,7 +99,9 @@ func Example_overrideDefaultOptionExternally() {
 		option now = () => 2018-07-13T00:00:00Z
 		what_time_is_it = now()`
 
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, scope, err := runtime.Eval(ctx, queryString)
 	if err != nil {
 		fmt.Println(err)

--- a/stdlib/contrib/bonitoo-io/alerta/alerta_test.go
+++ b/stdlib/contrib/bonitoo-io/alerta/alerta_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -22,7 +23,9 @@ import (
 )
 
 func TestAlerta(t *testing.T) {
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, _, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/bonitoo-io/alerta"

--- a/stdlib/contrib/bonitoo-io/servicenow/servicenow_test.go
+++ b/stdlib/contrib/bonitoo-io/servicenow/servicenow_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -22,7 +23,9 @@ import (
 )
 
 func TestServiceNow(t *testing.T) {
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, _, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/bonitoo-io/servicenow"

--- a/stdlib/contrib/bonitoo-io/victorops/victorops_test.go
+++ b/stdlib/contrib/bonitoo-io/victorops/victorops_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -21,7 +22,9 @@ import (
 )
 
 func TestVictorOps(t *testing.T) {
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, _, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/bonitoo-io/victorops"

--- a/stdlib/contrib/bonitoo-io/zenoss/zenoss_test.go
+++ b/stdlib/contrib/bonitoo-io/zenoss/zenoss_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -22,7 +23,9 @@ import (
 )
 
 func TestZenoss(t *testing.T) {
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, _, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/bonitoo-io/zenoss"

--- a/stdlib/contrib/chobbs/discord/discord_test.go
+++ b/stdlib/contrib/chobbs/discord/discord_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -18,7 +19,9 @@ import (
 )
 
 func TestDiscord(t *testing.T) {
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, scope, err := runtime.Eval(ctx, `
 import "contrib/chobbs/discord"
 send = discord.send(webhookToken:"ThisIsAFakeToken",webhookID:"123456789",username:"chobbs",content:"this is fake content!",avatar_url:"%s/somefakeurl.com/pic.png")

--- a/stdlib/contrib/rhajek/bigpanda/bigpanda_test.go
+++ b/stdlib/contrib/rhajek/bigpanda/bigpanda_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -22,7 +23,9 @@ import (
 func TestBigPanda(t *testing.T) {
 	s := NewServer(t)
 	defer s.Close()
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, scope, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/rhajek/bigpanda"

--- a/stdlib/contrib/sranka/sensu/sensu_test.go
+++ b/stdlib/contrib/sranka/sensu/sensu_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -24,7 +25,9 @@ import (
 func TestSensu(t *testing.T) {
 	s := NewServer(t)
 	defer s.Close()
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, _, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/sranka/sensu"

--- a/stdlib/contrib/sranka/teams/teams_test.go
+++ b/stdlib/contrib/sranka/teams/teams_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -22,7 +23,9 @@ import (
 func TestTeams(t *testing.T) {
 	s := NewServer(t)
 	defer s.Close()
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, scope, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/sranka/teams"

--- a/stdlib/contrib/sranka/telegram/telegram_test.go
+++ b/stdlib/contrib/sranka/telegram/telegram_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -23,7 +24,9 @@ import (
 func TestTelegram(t *testing.T) {
 	s := NewServer(t)
 	defer s.Close()
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, scope, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/sranka/telegram"

--- a/stdlib/contrib/sranka/webexteams/webexteams_test.go
+++ b/stdlib/contrib/sranka/webexteams/webexteams_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -23,7 +24,9 @@ import (
 func TestMessage(t *testing.T) {
 	s := NewServer(t)
 	defer s.Close()
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, _, err := runtime.Eval(ctx, `
 import "csv"
 import "contrib/sranka/webexteams"

--- a/stdlib/date/date_test.go
+++ b/stdlib/date/date_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/values"
 )
 
@@ -96,7 +97,9 @@ func TestTimeFns_Time(t *testing.T) {
 					"offset": values.NewDuration(values.Duration{}),
 				}),
 			})
-			got, err := fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -263,13 +266,17 @@ func TestTimeFns_Duration(t *testing.T) {
 				}),
 			})
 
-			//Setup deps with specific now time
-			deps := dependenciestest.Default()
+			// Setup deps with specific now time
 			execDeps := dependenciestest.ExecutionDefault()
 			nowVar := now.Time()
 			execDeps.Now = &nowVar
-			ctx := deps.Inject(context.Background())
-			ctx = execDeps.Inject(ctx)
+			ctx, deps := dependency.Inject(
+				context.Background(),
+				dependenciestest.Default(),
+				execDeps,
+			)
+			defer deps.Finish()
+
 			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
@@ -303,7 +310,9 @@ func TestNilErrors(t *testing.T) {
 			fluxFn := SpecialFns[tc]
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{"t": values.NewString("")})
 			fluxArg.Set("t", nil)
-			_, err := fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			_, err := fluxFn.Call(ctx, fluxArg)
 			if err == nil {
 				t.Errorf("%s did not error", tc)
 			}
@@ -360,7 +369,9 @@ func TestTruncate_Time(t *testing.T) {
 					"offset": values.NewDuration(values.Duration{}),
 				}),
 			})
-			got, err := fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -426,13 +437,16 @@ func TestTruncate_Duration(t *testing.T) {
 				}),
 			})
 
-			//Setup deps with specific now time
-			deps := dependenciestest.Default()
+			// Setup deps with specific now time
 			execDeps := dependenciestest.ExecutionDefault()
 			nowVar := now.Time()
 			execDeps.Now = &nowVar
-			ctx := deps.Inject(context.Background())
-			ctx = execDeps.Inject(ctx)
+			ctx, deps := dependency.Inject(
+				context.Background(),
+				dependenciestest.Default(),
+				execDeps,
+			)
+			defer deps.Finish()
 
 			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
@@ -474,7 +488,9 @@ func TestTruncateNilErrors(t *testing.T) {
 		}
 		fluxArg := values.NewObjectWithValues(map[string]values.Value{"t": values.NewTime(time), "unit": values.NewDuration(unit)})
 		fluxArg.Set("t", nil)
-		_, err = fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+		ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+		defer deps.Finish()
+		_, err = fluxFn.Call(ctx, fluxArg)
 		if err == nil {
 			t.Errorf("%s did not error", tc)
 		}
@@ -565,7 +581,9 @@ func TestTimeFnsWithLocationZone(t *testing.T) {
 					"offset": values.NewDuration(values.Duration{}),
 				}),
 			})
-			got, err := fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -653,7 +671,9 @@ func TestTimeFnsWithLocationOffset(t *testing.T) {
 					"offset": values.NewDuration(tc.offset),
 				}),
 			})
-			got, err := fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -755,7 +775,9 @@ func TestTimeFnsWithLocationZoneOffset(t *testing.T) {
 					"offset": values.NewDuration(tc.offset),
 				}),
 			})
-			got, err := fluxFn.Call(dependenciestest.InjectAllDeps(context.Background()), fluxArg)
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			got, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/stdlib/experimental/array/array_test.go
+++ b/stdlib/experimental/array/array_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/querytest"
 	"github.com/influxdata/flux/runtime"
@@ -117,7 +118,9 @@ func TestConcat_Process(t *testing.T) {
 				"v":   values.NewArrayWithBacking(semantic.NewArrayType(tc.typ), tovalarr(tc.typ, tc.v)),
 			})
 			want := values.NewArrayWithBacking(semantic.NewArrayType(tc.typ), tovalarr(tc.typ, tc.want))
-			result, err := concatFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			result, err := concatFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Error(err.Error())
 			}
@@ -209,7 +212,8 @@ func TestMap_Process(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
 			_, scope, err := runtime.Eval(ctx, tc.fn)
 			if err != nil {
 				t.Error(err.Error())

--- a/stdlib/experimental/object_keys_test.go
+++ b/stdlib/experimental/object_keys_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/runtime"
 )
 
@@ -16,7 +17,8 @@ import "internal/testutil"
 o = {a: 1, b: 2, c: 3}
 experimental.objectKeys(o: o) == ["a", "b", "c"] or testutil.fail()
 `
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
 	if _, _, err := runtime.Eval(ctx, script); err != nil {
 		t.Fatal("evaluation of objectKeys failed: ", err)
 	}

--- a/stdlib/experimental/prometheus/prometheus_test.go
+++ b/stdlib/experimental/prometheus/prometheus_test.go
@@ -10,6 +10,7 @@ import (
 
 	flux "github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/mock"
@@ -229,7 +230,9 @@ func testSourceDecoder(p *PrometheusIterator, t *testing.T) *executetest.Result 
 	results := &executetest.Result{}
 	runOnce := true
 
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	err := p.Connect(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/stdlib/experimental/to_test.go
+++ b/stdlib/experimental/to_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/andreyvit/diff"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/execute/table/static"
@@ -114,7 +115,8 @@ func TestToTransformation(t *testing.T) {
 	d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
 	d.SetTriggerSpec(plan.DefaultTriggerSpec)
 
-	ctx := deps.Inject(context.Background())
+	ctx, span := dependency.Inject(context.Background(), deps)
+	defer span.Finish()
 	spec := &experimental.ToProcedureSpec{
 		Config: influxdb.Config{
 			Bucket: influxdb.NameOrID{Name: "mybucket"},
@@ -242,7 +244,8 @@ func TestToTransformation_Errors(t *testing.T) {
 			d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
 			d.SetTriggerSpec(plan.DefaultTriggerSpec)
 
-			ctx := deps.Inject(context.Background())
+			ctx, span := dependency.Inject(context.Background(), deps)
+			defer span.Finish()
 			spec := &experimental.ToProcedureSpec{
 				Config: influxdb.Config{
 					Bucket: influxdb.NameOrID{Name: "mybucket"},
@@ -290,8 +293,12 @@ func TestToTransformation_CloseOnError(t *testing.T) {
 	d := execute.NewDataset(executetest.RandomDatasetID(), execute.DiscardingMode, cache)
 	d.SetTriggerSpec(plan.DefaultTriggerSpec)
 
-	ctx := deps.Inject(context.Background())
-	ctx = provider.Inject(ctx)
+	ctx, span := dependency.Inject(
+		context.Background(),
+		deps,
+		provider,
+	)
+	defer span.Finish()
 	spec := &experimental.ToProcedureSpec{
 		Config: influxdb.Config{
 			Bucket: influxdb.NameOrID{Name: "mybucket"},

--- a/stdlib/flux_test.go
+++ b/stdlib/flux_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/lang"
@@ -129,9 +130,10 @@ func doTestRun(t testing.TB, c flux.Compiler) flux.Statistics {
 		t.Fatalf("unexpected error while compiling query: %v", err)
 	}
 
-	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	alloc := &memory.ResourceAllocator{}
-	r, err := program.Start(ctx, alloc)
+	ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+	defer deps.Finish()
+
+	r, err := program.Start(ctx, memory.DefaultAllocator)
 	if err != nil {
 		t.Fatalf("unexpected error while executing testing.run: %v", err)
 	}
@@ -158,9 +160,10 @@ func doTestInspect(t testing.TB, c flux.Compiler) flux.Statistics {
 	if err != nil {
 		t.Fatalf("unexpected error while compiling query: %v", err)
 	}
-	ctx := executetest.NewTestExecuteDependencies().Inject(context.Background())
-	alloc := &memory.ResourceAllocator{}
-	r, err := program.Start(ctx, alloc)
+	ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+	defer deps.Finish()
+
+	r, err := program.Start(ctx, memory.DefaultAllocator)
 	if err != nil {
 		t.Fatalf("unexpected error while executing testing.inspect: %v", err)
 	}

--- a/stdlib/influxdata/influxdb/secrets/get_test.go
+++ b/stdlib/influxdata/influxdb/secrets/get_test.go
@@ -6,17 +6,13 @@ import (
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/dependencies/secret"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/mock"
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb/secrets"
 	"github.com/influxdata/flux/values"
 )
 
 func TestGet(t *testing.T) {
-	deps := dependenciestest.Default()
-	deps.Deps.Deps.SecretService = &mock.SecretService{
-		"mykey": "myvalue",
-	}
-
 	for _, tt := range []struct {
 		name    string
 		secrets secret.Service
@@ -61,7 +57,8 @@ func TestGet(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			deps := dependenciestest.Default()
 			deps.Deps.Deps.SecretService = tt.secrets
-			ctx := deps.Inject(context.Background())
+			ctx, span := dependency.Inject(context.Background(), deps)
+			defer span.Finish()
 
 			args := values.NewObjectWithValues(tt.args)
 			got, err := secrets.Get(ctx, args)

--- a/stdlib/json/encode_test.go
+++ b/stdlib/json/encode_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/runtime"
 )
@@ -29,7 +30,8 @@ o = {
 }
 json.encode(v: o) == bytes(v:"{\"a\":1,\"b\":{\"x\":[1,2],\"y\":\"string\",\"z\":\"1m\"},\"c\":1.1,\"d\":false,\"e\":\".*\",\"f\":\"2019-08-14T10:03:12Z\",\"g\":{\"1\":\"hi\",\"2\":\"there\"}}") or testutil.fail()
 `
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
 	if _, _, err := runtime.Eval(ctx, script); err != nil {
 		t.Fatal("evaluation of json.encode failed: ", err)
 	}

--- a/stdlib/math/math_test.go
+++ b/stdlib/math/math_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/semantic"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
@@ -65,7 +66,9 @@ func TestMathFunctionsX(t *testing.T) {
 			got := tc.mathFn(x)
 
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
-			result, err := fluxFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			result, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -106,7 +109,9 @@ func TestMathFunctionsXY(t *testing.T) {
 			got := tc.mathFn(x, y)
 
 			fluxArg := values.NewObjectWithValues(map[string]values.Value{tc.xname: values.NewFloat(x), tc.yname: values.NewFloat(y)})
-			result, err := fluxFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			result, err := fluxFn.Call(ctx, fluxArg)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -222,7 +227,9 @@ func TestFloat64Bits(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	want := math.Float64bits(f)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +244,9 @@ func TestFloat64FromBits(t *testing.T) {
 	b := rand.Uint64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"b": values.NewUInt(b)})
 	want := math.Float64frombits(b)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +261,9 @@ func TestIlogb(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	want := math.Ilogb(x)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +278,9 @@ func TestFrexp(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	wantfrac, wantexp := math.Frexp(f)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +304,9 @@ func TestLGamma(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	wantLGamma, wantSign := math.Lgamma(x)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +330,9 @@ func TestModf(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	wantInt, wantFrac := math.Modf(f)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -339,7 +356,9 @@ func TestSinCos(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	wantSin, wantCos := math.Sincos(x)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,7 +383,9 @@ func TestIsInf(t *testing.T) {
 	sign := rand.Int()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f), "sign": values.NewInt(int64(sign))})
 	want := math.IsInf(f, sign)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -379,7 +400,9 @@ func TestIsNaN(t *testing.T) {
 	f := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"f": values.NewFloat(f)})
 	want := math.IsNaN(f)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +417,9 @@ func TestSignBit(t *testing.T) {
 	x := rand.Float64()
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x)})
 	want := math.Signbit(x)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +434,9 @@ func TestNaN(t *testing.T) {
 
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{})
 	want := math.NaN()
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +452,9 @@ func TestInf(t *testing.T) {
 	sign := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"sign": values.NewInt(int64(sign))})
 	want := math.Inf(sign)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +470,9 @@ func TestJn(t *testing.T) {
 	n := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x), "n": values.NewInt(int64(n))})
 	want := math.Jn(n, x)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,7 +488,9 @@ func TestYn(t *testing.T) {
 	n := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"x": values.NewFloat(x), "n": values.NewInt(int64(n))})
 	want := math.Yn(n, x)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +506,9 @@ func TestLdexp(t *testing.T) {
 	exp := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"frac": values.NewFloat(frac), "exp": values.NewInt(int64(exp))})
 	want := math.Ldexp(frac, exp)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +523,9 @@ func TestPow10(t *testing.T) {
 	n := rand.Intn(5000)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"n": values.NewInt(int64(n))})
 	want := math.Pow10(n)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stdlib/pagerduty/pagerduty_test.go
+++ b/stdlib/pagerduty/pagerduty_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -95,7 +96,8 @@ csv.from(csv:data) |> process()
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := dependenciestest.Default().Inject(context.Background())
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
 			_, _, err := runtime.Eval(ctx, tc.script)
 			if err != nil {
 				t.Error(err)

--- a/stdlib/regexp/regexp_test.go
+++ b/stdlib/regexp/regexp_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
@@ -19,7 +20,9 @@ func TestCompile(t *testing.T) {
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(v.Str())})
 	want, _ := regexp.Compile(v.Str())
 	realWant := values.NewRegexp(want)
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +36,9 @@ func TestQuoteMeta(t *testing.T) {
 	v := values.NewString("Escaping symbols like: .+*?()|[]{}^$")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"v": values.NewString(v.Str())})
 	want := regexp.QuoteMeta(v.Str())
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +54,9 @@ func TestFindString(t *testing.T) {
 	v := values.NewString("seafood fool")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str())})
 	want := r.Regexp().FindString(v.Str())
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +72,9 @@ func TestFindStringIndex(t *testing.T) {
 	v := values.NewString("tablett")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str())})
 	want := r.Regexp().FindStringIndex(v.Str())
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +90,9 @@ func TestMatchRegexpString(t *testing.T) {
 	v := values.NewString("gophergophergopher")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str())})
 	want := r.Regexp().MatchString(v.Str())
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +107,9 @@ func TestMatchRegexpStringNullV(t *testing.T) {
 	r := values.NewRegexp(re)
 	vStrNullV := values.NewNull(semantic.BasicString)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": vStrNullV})
-	_, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	_, err := fluxFunc.Call(ctx, fluxArg)
 	wantErr := errors.New(codes.Invalid, "cannot execute function containing argument r of type regexp value (gopher){2} and argument v of type string value <nil>")
 	if !cmp.Equal(wantErr, err) {
 		t.Errorf("input %s: expected %v, got %v", vStrNullV, wantErr, err)
@@ -111,7 +124,9 @@ func TestReplaceAllString(t *testing.T) {
 	tStr := values.NewString("T")
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str()), "t": values.NewString(tStr.Str())})
 	want := re.ReplaceAllString(v.Str(), tStr.Str())
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +142,9 @@ func TestReplaceAllStringNullT(t *testing.T) {
 	v := values.NewString("-ab-axxb-")
 	tStrNullV := values.NewNull(semantic.BasicString)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str()), "t": tStrNullV})
-	_, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	_, err := fluxFunc.Call(ctx, fluxArg)
 	wantErr := errors.New(codes.Invalid, "cannot execute function containing argument r of type regexp value a(x*)b, argument v of type string value -ab-axxb-, and argument t of type string value <nil>")
 	if !cmp.Equal(wantErr, err) {
 		t.Errorf("input %s: expected %v, got %v", tStrNullV, wantErr, err)
@@ -142,7 +159,9 @@ func TestSplitRegexp(t *testing.T) {
 	i := values.NewInt(5)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp()), "v": values.NewString(v.Str()), "i": values.NewInt(i.Int())})
 	want := r.Regexp().Split(v.Str(), int(i.Int()))
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +180,9 @@ func TestGetString(t *testing.T) {
 	r := values.NewRegexp(re)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": values.NewRegexp(r.Regexp())})
 	want := re.String()
-	got, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	got, err := fluxFunc.Call(ctx, fluxArg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +196,9 @@ func TestGetStringNullR(t *testing.T) {
 	regexpNullV := values.NewNull(semantic.BasicRegexp)
 	fluxArg := values.NewObjectWithValues(map[string]values.Value{"r": regexpNullV})
 	wantErr := errors.New(codes.Invalid, "cannot execute function containing argument r of type regexp value <nil>")
-	_, err := fluxFunc.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	_, err := fluxFunc.Call(ctx, fluxArg)
 	if !cmp.Equal(wantErr, err) {
 		t.Errorf("input %s: expected %v, got %v", regexpNullV, wantErr, err)
 	}

--- a/stdlib/runtime/version_test.go
+++ b/stdlib/runtime/version_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/stdlib/runtime"
 	"github.com/influxdata/flux/values"
@@ -94,7 +95,9 @@ func TestVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			runtime.SetBuildInfo(tt.bi)
 
-			got, err := runtime.Version(dependenciestest.Default().Inject(context.Background()), nil)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := runtime.Version(ctx, nil)
 			if err != nil {
 				if tt.wantErr != nil {
 					if !cmp.Equal(tt.wantErr, err) {

--- a/stdlib/slack/slack_test.go
+++ b/stdlib/slack/slack_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/flux"
 	_ "github.com/influxdata/flux/csv"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/lang"
 	"github.com/influxdata/flux/memory"
@@ -21,7 +22,9 @@ import (
 )
 
 func TestSlack(t *testing.T) {
-	ctx := dependenciestest.Default().Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+
 	_, scope, err := runtime.Eval(ctx, `
 import "csv"
 import "slack"

--- a/stdlib/types/is_type_test.go
+++ b/stdlib/types/is_type_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/types"
 	"github.com/influxdata/flux/values"
@@ -60,8 +61,10 @@ func isTypeTestHelper(t *testing.T, tc isTypeCase) {
 			"type": values.NewString(tc.type_),
 		})
 
-		got, err := isTypeFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+		ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+		defer deps.Finish()
 
+		got, err := isTypeFn.Call(ctx, fluxArg)
 		if err != nil {
 			t.Error(err.Error())
 			return

--- a/stdlib/universe/contains_test.go
+++ b/stdlib/universe/contains_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -109,7 +110,9 @@ func TestContains_NewQuery(t *testing.T) {
 func containsTestHelper(t *testing.T, tc containsCase) {
 	t.Helper()
 	contains := universe.MakeContainsFunc()
-	result, err := contains.Call(dependenciestest.Default().Inject(context.Background()),
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	result, err := contains.Call(ctx,
 		values.NewObjectWithValues(map[string]values.Value{
 			"value": tc.value,
 			"set":   values.NewArrayWithBacking(semantic.NewArrayType(tc.value.Type()), tc.set),

--- a/stdlib/universe/die_test.go
+++ b/stdlib/universe/die_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/stdlib/universe"
 	"github.com/influxdata/flux/values"
 )
@@ -18,7 +19,9 @@ func TestDie(t *testing.T) {
 
 		fluxArg := values.NewObjectWithValues(map[string]values.Value{"msg": values.NewString("this is an error message")})
 
-		_, got := dieFn.Call(dependenciestest.Default().Inject(context.Background()), fluxArg)
+		ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+		defer deps.Finish()
+		_, got := dieFn.Call(ctx, fluxArg)
 
 		if got == nil {
 			t.Fatal("this function should produce an error")

--- a/stdlib/universe/fill_test.go
+++ b/stdlib/universe/fill_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/internal/gen"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
@@ -808,7 +809,8 @@ func TestFill_Process(t *testing.T) {
 				tc.want,
 				nil,
 				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
-					ctx := dependenciestest.Default().Inject(context.Background())
+					ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+					defer deps.Finish()
 					return universe.NewFillTransformation(ctx, tc.spec, id, alloc)
 				},
 			)
@@ -823,7 +825,8 @@ func TestFill_Process(t *testing.T) {
 				tc.want,
 				nil,
 				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
-					ctx := dependenciestest.Default().Inject(context.Background())
+					ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+					defer deps.Finish()
 					tr, d, err := universe.NewNarrowFillTransformation(ctx, tc.spec, id, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/gen"
@@ -722,7 +723,8 @@ func TestFilter_Process(t *testing.T) {
 				tc.want,
 				nil,
 				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
-					ctx := dependenciestest.Default().Inject(context.Background())
+					ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+					defer deps.Finish()
 					tx, d, err := universe.NewFilterTransformation(ctx, tc.spec, id, alloc)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/length_test.go
+++ b/stdlib/universe/length_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/universe"
@@ -68,8 +69,10 @@ func TestLength_NewQuery(t *testing.T) {
 func lengthTestHelper(t *testing.T, tc lengthCase) {
 	t.Helper()
 	length := universe.MakeLengthFunc()
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
 	result, err := length.Call(
-		dependenciestest.Default().Inject(context.Background()),
+		ctx,
 		values.NewObjectWithValues(map[string]values.Value{
 			"arr": values.NewArrayWithBacking(semantic.NewArrayType(tc.typ), tc.arr),
 		}),

--- a/stdlib/universe/map_test.go
+++ b/stdlib/universe/map_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/gen"
@@ -1009,7 +1010,8 @@ f
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					ctx := dependenciestest.Default().Inject(context.Background())
+					ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+					defer deps.Finish()
 					f, err := universe.NewMapTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/reduce_test.go
+++ b/stdlib/universe/reduce_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/internal/errors"
@@ -120,7 +121,8 @@ func TestReduce_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
-					ctx := dependenciestest.Default().Inject(context.Background())
+					ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+					defer deps.Finish()
 					f, err := universe.NewReduceTransformation(ctx, tc.spec, d, c)
 					if err != nil {
 						t.Fatal(err)

--- a/stdlib/universe/sort_limit_test.go
+++ b/stdlib/universe/sort_limit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/plan"
@@ -13,8 +14,8 @@ import (
 )
 
 func TestSortLimitRule(t *testing.T) {
-	deps := executetest.NewTestExecuteDependencies()
-	ctx := deps.Inject(context.Background())
+	ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+	defer deps.Finish()
 
 	from := &influxdb.FromProcedureSpec{
 		Bucket: influxdb.NameOrID{Name: "testbucket"},

--- a/stdlib/universe/state_tracking_test.go
+++ b/stdlib/universe/state_tracking_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/interpreter"
@@ -378,7 +379,8 @@ func TestStateTracking_Process(t *testing.T) {
 				tc.want,
 				tc.wantErr,
 				func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset) {
-					ctx := dependenciestest.Default().Inject(context.Background())
+					ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+					defer deps.Finish()
 
 					ntx, nd, err := universe.NewNarrowStateTrackingTransformation(ctx, tc.spec, id, alloc)
 					if err != nil {

--- a/stdlib/universe/typeconv_test.go
+++ b/stdlib/universe/typeconv_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/flux/dependencies/dependenciestest"
+	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/values"
 )
 
@@ -81,7 +82,9 @@ func TestTypeconv_String(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := stringConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -166,7 +169,9 @@ func TestTypeconv_Int(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := intConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -251,7 +256,9 @@ func TestTypeconv_UInt(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := uintConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -341,7 +348,9 @@ func TestTypeconv_Bool(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := boolConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -437,7 +446,9 @@ func TestTypeconv_Float(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := floatConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -511,7 +522,9 @@ func TestTypeconv_Time(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := timeConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -581,7 +594,9 @@ func TestTypeconv_Duration(t *testing.T) {
 			}
 			args := values.NewObjectWithValues(myMap)
 			c := durationConv
-			got, err := c.Call(dependenciestest.Default().Inject(context.Background()), args)
+			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+			defer deps.Finish()
+			got, err := c.Call(ctx, args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())


### PR DESCRIPTION
This re-enables the dialer pool and also updates the dependency injection to
fix how the test runner was injecting dependencies. It also adds some mock
structs for testing.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written