### PR TITLE
feat: Track freed memory with SetFinalizer

### DIFF
--- a/array/array_test.go
+++ b/array/array_test.go
@@ -144,6 +144,9 @@ func TestNewStringFromBinaryArray(t *testing.T) {
 
 	a.Release()
 	s.Release()
+
+	alloc.GC()
+
 	if want, got := int64(0), alloc.Allocated(); want != got {
 		t.Errorf("epxected allocated to be %v, was %v", want, got)
 	}

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -121,8 +121,27 @@ func TestString(t *testing.T) {
 	}
 }
 
+type A struct {
+}
+
+type B struct {
+	A
+}
+
+type C interface {
+	C() string
+}
+
+func (*A) C() string {
+	return "A"
+}
+
+func (*B) C() string {
+	return "B"
+}
+
 func TestNewStringFromBinaryArray(t *testing.T) {
-	alloc := &fluxmemory.ResourceAllocator{}
+	alloc := &fluxmemory.GcAllocator{ResourceAllocator: &fluxmemory.ResourceAllocator{}}
 	// Need to use the Apache binary builder to be able to create an actual
 	// Arrow Binary array.
 	sb := apachearray.NewBinaryBuilder(alloc, array.StringType)

--- a/compiler/vectorized_test.go
+++ b/compiler/vectorized_test.go
@@ -147,6 +147,8 @@ func TestVectorizedFns(t *testing.T) {
 
 			got.Release()
 			input.Release()
+
+			mem.GC()
 			checked.AssertSize(t, 0)
 		})
 	}

--- a/compiler/vectorized_test.go
+++ b/compiler/vectorized_test.go
@@ -106,7 +106,7 @@ func TestVectorizedFns(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			checked := arrow.NewCheckedAllocator(memory.DefaultAllocator)
-			mem := &memory.ResourceAllocator{Allocator: checked}
+			mem := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{Allocator: checked}}
 
 			pkg, err := runtime.AnalyzeSource(tc.fn)
 			if err != nil {
@@ -140,7 +140,7 @@ func TestVectorizedFns(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			want := vectorizedObjectFromMap(tc.want, &memory.ResourceAllocator{})
+			want := vectorizedObjectFromMap(tc.want, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
 			if !cmp.Equal(want, got, CmpOptions...) {
 				t.Errorf("unexpected value -want/+got\n%s", cmp.Diff(want, got, CmpOptions...))
 			}

--- a/execute/dataset_test.go
+++ b/execute/dataset_test.go
@@ -51,10 +51,15 @@ func TestTransportDataset_Process(t *testing.T) {
 	dataset.AddTransformation(transport)
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
 	alloc := &memory.ResourceAllocator{
 		Allocator: mem,
 	}
+
+	defer func() {
+		alloc.GC()
+		mem.AssertSize(t, 0)
+	}()
+
 	buffer := arrow.TableBuffer{
 		GroupKey: execute.NewGroupKey(nil, nil),
 		Columns: []flux.ColMeta{
@@ -99,6 +104,12 @@ func TestTransportDataset_AddTransformation(t *testing.T) {
 	alloc := &memory.ResourceAllocator{
 		Allocator: mem,
 	}
+
+	defer func() {
+		alloc.GC()
+		mem.AssertSize(t, 0)
+	}()
+
 	buffer := arrow.TableBuffer{
 		GroupKey: execute.NewGroupKey(nil, nil),
 		Columns: []flux.ColMeta{
@@ -198,6 +209,12 @@ func TestTransportDataset_MultipleDownstream(t *testing.T) {
 	alloc := &memory.ResourceAllocator{
 		Allocator: mem,
 	}
+
+	defer func() {
+		alloc.GC()
+		mem.AssertSize(t, 0)
+	}()
+
 	buffer := arrow.TableBuffer{
 		GroupKey: execute.NewGroupKey(nil, nil),
 		Columns: []flux.ColMeta{

--- a/execute/dataset_test.go
+++ b/execute/dataset_test.go
@@ -51,9 +51,9 @@ func TestTransportDataset_Process(t *testing.T) {
 	dataset.AddTransformation(transport)
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
-	alloc := &memory.ResourceAllocator{
+	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{
 		Allocator: mem,
-	}
+	}}
 
 	defer func() {
 		alloc.GC()
@@ -101,9 +101,9 @@ func TestTransportDataset_AddTransformation(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.ResourceAllocator{
+	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{
 		Allocator: mem,
-	}
+	}}
 
 	defer func() {
 		alloc.GC()
@@ -206,9 +206,9 @@ func TestTransportDataset_MultipleDownstream(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.ResourceAllocator{
+	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{
 		Allocator: mem,
-	}
+	}}
 
 	defer func() {
 		alloc.GC()

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -666,7 +666,7 @@ func (tt TableTest) run(t *testing.T, name string, f func(tt *tableTest)) {
 			TableTest: tt,
 			t:         t,
 			logger:    zaptest.NewLogger(t),
-			alloc:     &memory.ResourceAllocator{},
+			alloc:     &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}},
 		})
 	})
 }
@@ -675,7 +675,7 @@ type tableTest struct {
 	TableTest
 	t      *testing.T
 	logger *zap.Logger
-	alloc  *memory.ResourceAllocator
+	alloc  *memory.GcAllocator
 }
 
 func (tt *tableTest) do(f func(tbl flux.Table) error) {

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -710,6 +710,8 @@ func (tt *tableTest) finish(allocatorUsed bool) {
 		}
 	}
 
+	tt.alloc.GC()
+
 	// Verify that all memory is correctly released if we use the table properly.
 	if got := tt.alloc.Allocated(); got != 0 {
 		tt.t.Errorf("caught memory leak: %d bytes were not released", got)

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -229,7 +229,7 @@ func TestColListTable(t *testing.T) {
 
 func TestColListTable_AppendNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
+	tb := execute.NewColListTableBuilder(key, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -268,7 +268,7 @@ func TestColListTable_AppendNil(t *testing.T) {
 
 func TestColListTable_SetNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
+	tb := execute.NewColListTableBuilder(key, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -307,7 +307,7 @@ func TestColListTable_SetNil(t *testing.T) {
 }
 
 func TestCopyTable(t *testing.T) {
-	alloc := &memory.ResourceAllocator{}
+	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}}
 
 	input, err := gen.Input(context.Background(), gen.Schema{
 		Tags: []gen.Tag{
@@ -450,7 +450,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 			name: "Strings",
 			typ:  flux.TString,
 			values: func() array.Array {
-				b := arrow.NewStringBuilder(&memory.ResourceAllocator{})
+				b := arrow.NewStringBuilder(&memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
 				b.Append("a")
 				b.Append("d")
 				b.AppendNull()
@@ -518,7 +518,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			key := execute.NewGroupKey(nil, nil)
-			b := execute.NewColListTableBuilder(key, &memory.ResourceAllocator{})
+			b := execute.NewColListTableBuilder(key, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
 			if _, err := b.AddCol(flux.ColMeta{Label: "_value", Type: tt.typ}); err != nil {
 				t.Fatal(err)
 			}

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -363,6 +363,7 @@ func TestCopyTable(t *testing.T) {
 		buf.Done()
 	}
 
+	alloc.GC()
 	// Ensure there has been no memory leak.
 	if got, want := alloc.Allocated(), int64(0); got != want {
 		t.Errorf("memory leak -want/+got:\n\t- %d\n\t+ %d", want, got)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/flux
 
-go 1.16
+go 1.17
 
 require (
 	cloud.google.com/go v0.82.0
@@ -58,4 +58,70 @@ require (
 	google.golang.org/api v0.47.0
 	google.golang.org/grpc v1.44.0
 	gopkg.in/yaml.v2 v2.3.0
+)
+
+require (
+	cloud.google.com/go/bigquery v1.8.0 // indirect
+	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
+	github.com/Azure/azure-storage-blob-go v0.14.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Masterminds/semver v1.4.2 // indirect
+	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
+	github.com/aws/aws-sdk-go v1.29.16 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.11.0 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.6.1 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.7.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.0 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.5.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.5.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.9.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.19.0 // indirect
+	github.com/aws/smithy-go v1.9.0 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deepmap/oapi-codegen v1.6.0 // indirect
+	github.com/dimchansky/utfbom v1.1.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
+	github.com/gabriel-vasile/mimetype v1.4.0 // indirect
+	github.com/goccy/go-json v0.7.10 // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-ieproxy v0.0.1 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/miekg/dns v1.1.22 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.11 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/uber-go/tally v3.3.15+incompatible // indirect
+	go.opencensus.io v0.23.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57 // indirect
+	golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210630183607-d20f26d13c79 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -149,6 +149,18 @@ func OptimizeStateTracking() BoolFlag {
 	return optimizeStateTracking
 }
 
+var setFinalizerMemoryTracking = feature.MakeBoolFlag(
+	"SetFinalizer Memory Tracking",
+	"setFinalizerMemoryTracking",
+	"Markus Westerlind",
+	false,
+)
+
+// SetfinalizerMemoryTracking - Enable SetFinalizer based memory tracking (as opposed to explicit Retain/Release)
+func SetfinalizerMemoryTracking() BoolFlag {
+	return setFinalizerMemoryTracking
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -166,6 +178,7 @@ var all = []Flag{
 	optimizeAggregateWindow,
 	narrowTransformationLimit,
 	optimizeStateTracking,
+	setFinalizerMemoryTracking,
 }
 
 var byKey = map[string]Flag{
@@ -180,6 +193,7 @@ var byKey = map[string]Flag{
 	"optimizeAggregateWindow":          optimizeAggregateWindow,
 	"narrowTransformationLimit":        narrowTransformationLimit,
 	"optimizeStateTracking":            optimizeStateTracking,
+	"setFinalizerMemoryTracking":       setFinalizerMemoryTracking,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -75,3 +75,9 @@
   key: optimizeStateTracking
   default: false
   contact: Sean Brickley
+
+- name: SetFinalizer Memory Tracking
+  description: Enable SetFinalizer based memory tracking (as opposed to explicit Retain/Release)
+  key: setFinalizerMemoryTracking
+  default: false
+  contact: Markus Westerlind

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -288,10 +288,17 @@ func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query
 		}
 	}
 
+	var statsAlloc memory.StatsAllocator
+	if feature.SetfinalizerMemoryTracking().Enabled(ctx) {
+		statsAlloc = &memory.GcAllocator{ResourceAllocator: resourceAlloc}
+	} else {
+		statsAlloc = resourceAlloc
+	}
+
 	q := &query{
 		ctx:     cctx,
 		results: results,
-		alloc:   resourceAlloc,
+		alloc:   statsAlloc,
 		span:    s,
 		cancel:  cancel,
 		stats: flux.Statistics{

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -280,14 +280,20 @@ func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query
 	// This span gets closed by the query when it is done.
 	s, cctx := opentracing.StartSpanFromContext(ctx, "execute")
 	results := make(chan flux.Result)
+
+	resourceAlloc, ok := alloc.(*memory.ResourceAllocator)
+	if !ok {
+		resourceAlloc = &memory.ResourceAllocator{
+			Allocator: alloc,
+		}
+	}
+
 	q := &query{
 		ctx:     cctx,
 		results: results,
-		alloc: &memory.ResourceAllocator{
-			Allocator: alloc,
-		},
-		span:   s,
-		cancel: cancel,
+		alloc:   resourceAlloc,
+		span:    s,
+		cancel:  cancel,
 		stats: flux.Statistics{
 			Metadata: make(metadata.Metadata),
 		},

--- a/lang/query.go
+++ b/lang/query.go
@@ -15,7 +15,7 @@ type query struct {
 	ctx     context.Context
 	results chan flux.Result
 	stats   flux.Statistics
-	alloc   *memory.ResourceAllocator
+	alloc   memory.StatsAllocator
 	span    opentracing.Span
 	cancel  func()
 	err     error

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -28,6 +28,7 @@ func TestAllocator_Allocate(t *testing.T) {
 
 	allocator.Free(b)
 
+	allocator.GC()
 	mem.AssertSize(t, 0)
 	if want, got := int64(0), allocator.Allocated(); want != got {
 		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
@@ -64,6 +65,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 
 	allocator.Free(b)
 
+	allocator.GC()
 	mem.AssertSize(t, 0)
 	if want, got := int64(0), allocator.Allocated(); want != got {
 		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -15,7 +15,7 @@ func TestAllocator_Allocate(t *testing.T) {
 	mem := arrowmemory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	allocator := &memory.ResourceAllocator{Allocator: mem}
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{Allocator: mem}}
 	b := allocator.Allocate(64)
 
 	assert.Equal(t, 64, mem.CurrentAlloc(), "unexpected memory allocation.")
@@ -42,7 +42,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 	mem := arrowmemory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	allocator := &memory.ResourceAllocator{Allocator: mem}
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{Allocator: mem}}
 	b := allocator.Allocate(64)
 
 	assert.Equal(t, 64, mem.CurrentAlloc(), "unexpected memory allocation.")
@@ -76,7 +76,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 }
 
 func TestAllocator_MaxAfterFree(t *testing.T) {
-	allocator := &memory.ResourceAllocator{}
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{}}
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -113,7 +113,7 @@ func TestAllocator_MaxAfterFree(t *testing.T) {
 
 func TestAllocator_Limit(t *testing.T) {
 	maxLimit := int64(64)
-	allocator := &memory.ResourceAllocator{Limit: &maxLimit}
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{Limit: &maxLimit}}
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -186,7 +186,7 @@ func TestAllocator_Limit(t *testing.T) {
 }
 
 func TestAllocator_Free(t *testing.T) {
-	allocator := &memory.ResourceAllocator{}
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{}}
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -238,10 +238,10 @@ func TestAllocator_RequestMemory(t *testing.T) {
 
 	// Set the Limit to 64 and allocate 32 bytes of it.
 	// This should not request more memory from the manager.
-	allocator := &memory.ResourceAllocator{
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{
 		Limit:   func(v int64) *int64 { return &v }(64),
 		Manager: manager,
-	}
+	}}
 	if err := allocator.Account(32); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -313,10 +313,10 @@ func TestAllocator_RequestMemory_Concurrently(t *testing.T) {
 
 	// Set the Limit to 64 and allocate 32 bytes of it.
 	// This should not request more memory from the manager.
-	allocator := &memory.ResourceAllocator{
+	allocator := &memory.GcAllocator{&memory.ResourceAllocator{
 		Limit:   func(v int64) *int64 { return &v }(0),
 		Manager: manager,
-	}
+	}}
 	var wg sync.WaitGroup
 	for i := 0; i < 128; i++ {
 		wg.Add(1)

--- a/stdlib/universe/holt_winters_test.go
+++ b/stdlib/universe/holt_winters_test.go
@@ -1,6 +1,7 @@
 package universe_test
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -883,6 +884,13 @@ func TestHoltWinters_Process(t *testing.T) {
 					return universe.NewHoltWintersTransformation(d, c, alloc, tc.spec)
 				},
 			)
+
+			for i := 0; i < 30; i++ {
+				runtime.GC()
+				if alloc.Allocated() <= 0 {
+					break
+				}
+			}
 
 			if m := alloc.Allocated(); m != 0 {
 				t.Errorf("HoltWinters is using memory after finishing: %d", m)

--- a/values/vector_test.go
+++ b/values/vector_test.go
@@ -48,6 +48,9 @@ func TestVectorTypes(t *testing.T) {
 		}
 
 		got.Release()
+
+		mem.GC()
+
 		if mem.Allocated() != 0 {
 			t.Errorf("expected bytes allocated to be 0, got %d", mem.Allocated())
 		}

--- a/values/vector_test.go
+++ b/values/vector_test.go
@@ -40,7 +40,7 @@ func TestVectorTypes(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mem := &memory.ResourceAllocator{}
+		mem := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}}
 		got := NewVectorFromElements(mem, tc.input...)
 
 		if !got.ElementType().Equal(tc.wantType) {


### PR DESCRIPTION
Instead of manual `Retain` and `Release` calls. I left those calls in right now, but since `Free` no longer actually frees the memory we can still see this works by observing the actual free being don in the finalizer.

As we can see from the repeated `GC` calls (and from being forced to manually GC in the first place), the maximum memory in use at any time will be larger and garbage collection may only clear up part of what is unreachable.

cc #4486