### PR TITLE
fix(plan): fix panic with half diamond logical plan

### DIFF
--- a/plan/heuristic_planner.go
+++ b/plan/heuristic_planner.go
@@ -126,7 +126,7 @@ func (p *heuristicPlanner) Plan(ctx context.Context, inputPlan *Spec) (*Spec, er
 					nodeStack = append(nodeStack, newNode.Predecessors()[i-1])
 				}
 
-				visited[newNode] = struct{}{}
+				visited[node] = struct{}{}
 			}
 		}
 	}

--- a/plan/heuristic_planner_test.go
+++ b/plan/heuristic_planner_test.go
@@ -118,6 +118,48 @@ func TestPlanTraversal(t *testing.T) {
 			},
 			nodeIDs: []plan.NodeID{"7", "6", "4", "1", "0", "3", "2", "5"},
 		},
+		{
+			name: "half diamond physical",
+			//            2
+			//           / \
+			//          |   1
+			//           \ /
+			//            0
+			plan: plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalMockNode("0"),
+					plantest.CreatePhysicalMockNode("1"),
+					plantest.CreatePhysicalMockNode("2"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{0, 2},
+				},
+			},
+			nodeIDs: []plan.NodeID{"2", "1", "0"},
+		},
+		{
+			name: "half diamond logical",
+			//            2
+			//           / \
+			//          |   1
+			//           \ /
+			//            0
+			plan: plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreateLogicalMockNode("0"),
+					plantest.CreateLogicalMockNode("1"),
+					plantest.CreateLogicalMockNode("2"),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+					{0, 2},
+				},
+			},
+			nodeIDs: []plan.NodeID{"2", "1", "0"},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
In the case of a half diamond of logical nodes in a plan the same
logical node could be added to the node stack during traversal, however
the visited map to avoid double traversing the same node only contained
physical nodes as such the second logical node would be visited twice.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
