### PR TITLE
fix: add the error to the span created for a transformation

### DIFF
--- a/execute/transport.go
+++ b/execute/transport.go
@@ -223,8 +223,9 @@ func (t *consecutiveTransport) contextWithSpan(ctx context.Context) context.Cont
 	return opentracing.ContextWithSpan(ctx, t.span)
 }
 
-func (t *consecutiveTransport) finishSpan() {
+func (t *consecutiveTransport) finishSpan(err error) {
 	t.span.LogFields(log.Int("messages_processed", int(atomic.LoadInt32(&t.totalMsgs))))
+	t.span.LogFields(log.Error(err))
 	t.span.Finish()
 }
 
@@ -251,7 +252,7 @@ PROCESS:
 				}
 				// We are finished
 				close(t.finished)
-				t.finishSpan()
+				t.finishSpan(err)
 				return
 			}
 		}


### PR DESCRIPTION
This PR amends https://github.com/influxdata/flux/pull/4616 to include any error in the tracing span generated for a transformation.