### PR TITLE
fix: create spans for transforms using context

### DIFF
--- a/execute/transport.go
+++ b/execute/transport.go
@@ -216,10 +216,16 @@ func (t *consecutiveTransport) transition(new int32) {
 }
 
 func (t *consecutiveTransport) contextWithSpan(ctx context.Context) context.Context {
+	didInit := false
 	t.initSpanOnce.Do(func() {
-		t.span = opentracing.StartSpan(t.op)
+		t.span, ctx = opentracing.StartSpanFromContext(ctx, t.op)
 		t.span.LogFields(log.String("label", t.label))
+		didInit = true
 	})
+	if didInit {
+		return ctx
+	}
+
 	return opentracing.ContextWithSpan(ctx, t.span)
 }
 


### PR DESCRIPTION
This PR builds on previous PRs (#4616, #4618) to fix the opentracing spans generated for transformations.

Previously, we would not create a transformation span using the existing span in the context as the parent. This lead to orphan spans, where the transformation spans were not connected to the rest of the query trace in the Jaeger UI.

This change set addresses this and also adds more testing to verify the behavior.