### PR TITLE
refactor: Add NewFluxAllocator as an injection point for the GcAllocator

### DIFF
--- a/array/array_test.go
+++ b/array/array_test.go
@@ -122,7 +122,7 @@ func TestString(t *testing.T) {
 }
 
 func TestNewStringFromBinaryArray(t *testing.T) {
-	alloc := fluxmemory.NewFluxAllocator(nil)
+	alloc := fluxmemory.NewResourceAllocator(nil)
 	// Need to use the Apache binary builder to be able to create an actual
 	// Arrow Binary array.
 	sb := apachearray.NewBinaryBuilder(alloc, array.StringType)
@@ -144,8 +144,6 @@ func TestNewStringFromBinaryArray(t *testing.T) {
 
 	a.Release()
 	s.Release()
-
-	alloc.GC()
 
 	if want, got := int64(0), alloc.Allocated(); want != got {
 		t.Errorf("epxected allocated to be %v, was %v", want, got)

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -122,7 +122,7 @@ func TestString(t *testing.T) {
 }
 
 func TestNewStringFromBinaryArray(t *testing.T) {
-	alloc := &fluxmemory.GcAllocator{ResourceAllocator: &fluxmemory.ResourceAllocator{}}
+	alloc := fluxmemory.NewFluxAllocator(nil)
 	// Need to use the Apache binary builder to be able to create an actual
 	// Arrow Binary array.
 	sb := apachearray.NewBinaryBuilder(alloc, array.StringType)

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -121,25 +121,6 @@ func TestString(t *testing.T) {
 	}
 }
 
-type A struct {
-}
-
-type B struct {
-	A
-}
-
-type C interface {
-	C() string
-}
-
-func (*A) C() string {
-	return "A"
-}
-
-func (*B) C() string {
-	return "B"
-}
-
 func TestNewStringFromBinaryArray(t *testing.T) {
 	alloc := &fluxmemory.GcAllocator{ResourceAllocator: &fluxmemory.ResourceAllocator{}}
 	// Need to use the Apache binary builder to be able to create an actual

--- a/compiler/vectorized_test.go
+++ b/compiler/vectorized_test.go
@@ -106,7 +106,7 @@ func TestVectorizedFns(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			checked := arrow.NewCheckedAllocator(memory.DefaultAllocator)
-			mem := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{Allocator: checked}}
+			mem := memory.NewFluxAllocator(checked)
 
 			pkg, err := runtime.AnalyzeSource(tc.fn)
 			if err != nil {
@@ -140,7 +140,7 @@ func TestVectorizedFns(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			want := vectorizedObjectFromMap(tc.want, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
+			want := vectorizedObjectFromMap(tc.want, memory.NewFluxAllocator(nil))
 			if !cmp.Equal(want, got, CmpOptions...) {
 				t.Errorf("unexpected value -want/+got\n%s", cmp.Diff(want, got, CmpOptions...))
 			}

--- a/compiler/vectorized_test.go
+++ b/compiler/vectorized_test.go
@@ -106,7 +106,7 @@ func TestVectorizedFns(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			checked := arrow.NewCheckedAllocator(memory.DefaultAllocator)
-			mem := memory.NewFluxAllocator(checked)
+			mem := memory.NewResourceAllocator(checked)
 
 			pkg, err := runtime.AnalyzeSource(tc.fn)
 			if err != nil {
@@ -140,7 +140,7 @@ func TestVectorizedFns(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err)
 			}
 
-			want := vectorizedObjectFromMap(tc.want, memory.NewFluxAllocator(nil))
+			want := vectorizedObjectFromMap(tc.want, memory.NewResourceAllocator(nil))
 			if !cmp.Equal(want, got, CmpOptions...) {
 				t.Errorf("unexpected value -want/+got\n%s", cmp.Diff(want, got, CmpOptions...))
 			}
@@ -148,7 +148,6 @@ func TestVectorizedFns(t *testing.T) {
 			got.Release()
 			input.Release()
 
-			mem.GC()
 			checked.AssertSize(t, 0)
 		})
 	}

--- a/execute/dataset_test.go
+++ b/execute/dataset_test.go
@@ -51,9 +51,7 @@ func TestTransportDataset_Process(t *testing.T) {
 	dataset.AddTransformation(transport)
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
-	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{
-		Allocator: mem,
-	}}
+	alloc := memory.NewFluxAllocator(mem)
 
 	defer func() {
 		alloc.GC()
@@ -101,9 +99,7 @@ func TestTransportDataset_AddTransformation(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{
-		Allocator: mem,
-	}}
+	alloc := memory.NewFluxAllocator(mem)
 
 	defer func() {
 		alloc.GC()
@@ -206,9 +202,7 @@ func TestTransportDataset_MultipleDownstream(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{
-		Allocator: mem,
-	}}
+	alloc := memory.NewFluxAllocator(mem)
 
 	defer func() {
 		alloc.GC()

--- a/execute/dataset_test.go
+++ b/execute/dataset_test.go
@@ -51,10 +51,9 @@ func TestTransportDataset_Process(t *testing.T) {
 	dataset.AddTransformation(transport)
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
-	alloc := memory.NewFluxAllocator(mem)
+	alloc := memory.NewResourceAllocator(mem)
 
 	defer func() {
-		alloc.GC()
 		mem.AssertSize(t, 0)
 	}()
 
@@ -99,10 +98,9 @@ func TestTransportDataset_AddTransformation(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := memory.NewFluxAllocator(mem)
+	alloc := memory.NewResourceAllocator(mem)
 
 	defer func() {
-		alloc.GC()
 		mem.AssertSize(t, 0)
 	}()
 
@@ -202,10 +200,9 @@ func TestTransportDataset_MultipleDownstream(t *testing.T) {
 
 	mem := arrowmem.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
-	alloc := memory.NewFluxAllocator(mem)
+	alloc := memory.NewResourceAllocator(mem)
 
 	defer func() {
-		alloc.GC()
 		mem.AssertSize(t, 0)
 	}()
 

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -666,7 +666,7 @@ func (tt TableTest) run(t *testing.T, name string, f func(tt *tableTest)) {
 			TableTest: tt,
 			t:         t,
 			logger:    zaptest.NewLogger(t),
-			alloc:     &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}},
+			alloc:     memory.NewFluxAllocator(nil),
 		})
 	})
 }
@@ -675,7 +675,7 @@ type tableTest struct {
 	TableTest
 	t      *testing.T
 	logger *zap.Logger
-	alloc  *memory.GcAllocator
+	alloc  memory.FluxAllocator
 }
 
 func (tt *tableTest) do(f func(tbl flux.Table) error) {

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -666,7 +666,7 @@ func (tt TableTest) run(t *testing.T, name string, f func(tt *tableTest)) {
 			TableTest: tt,
 			t:         t,
 			logger:    zaptest.NewLogger(t),
-			alloc:     memory.NewFluxAllocator(nil),
+			alloc:     memory.NewResourceAllocator(nil),
 		})
 	})
 }
@@ -675,7 +675,7 @@ type tableTest struct {
 	TableTest
 	t      *testing.T
 	logger *zap.Logger
-	alloc  memory.FluxAllocator
+	alloc  *memory.ResourceAllocator
 }
 
 func (tt *tableTest) do(f func(tbl flux.Table) error) {
@@ -709,8 +709,6 @@ func (tt *tableTest) finish(allocatorUsed bool) {
 			tt.t.Error("memory allocator was not used")
 		}
 	}
-
-	tt.alloc.GC()
 
 	// Verify that all memory is correctly released if we use the table properly.
 	if got := tt.alloc.Allocated(); got != 0 {

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -229,7 +229,7 @@ func TestColListTable(t *testing.T) {
 
 func TestColListTable_AppendNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
+	tb := execute.NewColListTableBuilder(key, memory.NewFluxAllocator(nil))
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -268,7 +268,7 @@ func TestColListTable_AppendNil(t *testing.T) {
 
 func TestColListTable_SetNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
+	tb := execute.NewColListTableBuilder(key, memory.NewFluxAllocator(nil))
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -307,7 +307,7 @@ func TestColListTable_SetNil(t *testing.T) {
 }
 
 func TestCopyTable(t *testing.T) {
-	alloc := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}}
+	alloc := memory.NewFluxAllocator(nil)
 
 	input, err := gen.Input(context.Background(), gen.Schema{
 		Tags: []gen.Tag{
@@ -450,7 +450,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 			name: "Strings",
 			typ:  flux.TString,
 			values: func() array.Array {
-				b := arrow.NewStringBuilder(&memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
+				b := arrow.NewStringBuilder(memory.NewFluxAllocator(nil))
 				b.Append("a")
 				b.Append("d")
 				b.AppendNull()
@@ -518,7 +518,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			key := execute.NewGroupKey(nil, nil)
-			b := execute.NewColListTableBuilder(key, &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}})
+			b := execute.NewColListTableBuilder(key, memory.NewFluxAllocator(nil))
 			if _, err := b.AddCol(flux.ColMeta{Label: "_value", Type: tt.typ}); err != nil {
 				t.Fatal(err)
 			}

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -229,7 +229,7 @@ func TestColListTable(t *testing.T) {
 
 func TestColListTable_AppendNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, memory.NewFluxAllocator(nil))
+	tb := execute.NewColListTableBuilder(key, memory.NewResourceAllocator(nil))
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -268,7 +268,7 @@ func TestColListTable_AppendNil(t *testing.T) {
 
 func TestColListTable_SetNil(t *testing.T) {
 	key := execute.NewGroupKey(nil, nil)
-	tb := execute.NewColListTableBuilder(key, memory.NewFluxAllocator(nil))
+	tb := execute.NewColListTableBuilder(key, memory.NewResourceAllocator(nil))
 
 	// Add a column for the value.
 	idx, _ := tb.AddCol(flux.ColMeta{
@@ -307,7 +307,7 @@ func TestColListTable_SetNil(t *testing.T) {
 }
 
 func TestCopyTable(t *testing.T) {
-	alloc := memory.NewFluxAllocator(nil)
+	alloc := memory.NewResourceAllocator(nil)
 
 	input, err := gen.Input(context.Background(), gen.Schema{
 		Tags: []gen.Tag{
@@ -363,7 +363,6 @@ func TestCopyTable(t *testing.T) {
 		buf.Done()
 	}
 
-	alloc.GC()
 	// Ensure there has been no memory leak.
 	if got, want := alloc.Allocated(), int64(0); got != want {
 		t.Errorf("memory leak -want/+got:\n\t- %d\n\t+ %d", want, got)
@@ -450,7 +449,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 			name: "Strings",
 			typ:  flux.TString,
 			values: func() array.Array {
-				b := arrow.NewStringBuilder(memory.NewFluxAllocator(nil))
+				b := arrow.NewStringBuilder(memory.NewResourceAllocator(nil))
 				b.Append("a")
 				b.Append("d")
 				b.AppendNull()
@@ -518,7 +517,7 @@ func TestColListTableBuilder_AppendValues(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			key := execute.NewGroupKey(nil, nil)
-			b := execute.NewColListTableBuilder(key, memory.NewFluxAllocator(nil))
+			b := execute.NewColListTableBuilder(key, memory.NewResourceAllocator(nil))
 			if _, err := b.AddCol(flux.ColMeta{Label: "_value", Type: tt.typ}); err != nil {
 				t.Fatal(err)
 			}

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -288,19 +288,20 @@ func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query
 		}
 	}
 
-	var statsAlloc memory.FluxAllocator
 	if feature.SetfinalizerMemoryTracking().Enabled(ctx) {
-		statsAlloc = &memory.GcAllocator{ResourceAllocator: resourceAlloc}
+		var x = memory.NewGcAllocator(resourceAlloc)
+		alloc = &x
 	} else {
-		statsAlloc = resourceAlloc
+		alloc = resourceAlloc
 	}
 
 	q := &query{
-		ctx:     cctx,
-		results: results,
-		alloc:   statsAlloc,
-		span:    s,
-		cancel:  cancel,
+		ctx:            cctx,
+		results:        results,
+		allocatorStats: resourceAlloc,
+		alloc:          alloc,
+		span:           s,
+		cancel:         cancel,
 		stats: flux.Statistics{
 			Metadata: make(metadata.Metadata),
 		},

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -288,7 +288,7 @@ func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query
 		}
 	}
 
-	var statsAlloc memory.StatsAllocator
+	var statsAlloc memory.FluxAllocator
 	if feature.SetfinalizerMemoryTracking().Enabled(ctx) {
 		statsAlloc = &memory.GcAllocator{ResourceAllocator: resourceAlloc}
 	} else {

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -289,8 +289,7 @@ func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query
 	}
 
 	if feature.SetfinalizerMemoryTracking().Enabled(ctx) {
-		var x = memory.NewGcAllocator(resourceAlloc)
-		alloc = &x
+		alloc = memory.NewGcAllocator(resourceAlloc)
 	} else {
 		alloc = resourceAlloc
 	}

--- a/lang/query.go
+++ b/lang/query.go
@@ -12,14 +12,15 @@ import (
 
 // query implements the flux.Query interface.
 type query struct {
-	ctx     context.Context
-	results chan flux.Result
-	stats   flux.Statistics
-	alloc   memory.FluxAllocator
-	span    opentracing.Span
-	cancel  func()
-	err     error
-	wg      sync.WaitGroup
+	ctx            context.Context
+	results        chan flux.Result
+	stats          flux.Statistics
+	allocatorStats *memory.ResourceAllocator
+	alloc          memory.Allocator
+	span           opentracing.Span
+	cancel         func()
+	err            error
+	wg             sync.WaitGroup
 }
 
 func (q *query) Results() <-chan flux.Result {
@@ -29,8 +30,8 @@ func (q *query) Results() <-chan flux.Result {
 func (q *query) Done() {
 	q.cancel()
 	q.wg.Wait()
-	q.stats.MaxAllocated = q.alloc.MaxAllocated()
-	q.stats.TotalAllocated = q.alloc.TotalAllocated()
+	q.stats.MaxAllocated = q.allocatorStats.MaxAllocated()
+	q.stats.TotalAllocated = q.allocatorStats.TotalAllocated()
 	if q.span != nil {
 		q.span.Finish()
 		q.span = nil

--- a/lang/query.go
+++ b/lang/query.go
@@ -15,7 +15,7 @@ type query struct {
 	ctx     context.Context
 	results chan flux.Result
 	stats   flux.Statistics
-	alloc   memory.StatsAllocator
+	alloc   memory.FluxAllocator
 	span    opentracing.Span
 	cancel  func()
 	err     error

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -66,14 +66,9 @@ type ResourceAllocator struct {
 }
 
 func NewResourceAllocator(allocator memory.Allocator) *ResourceAllocator {
-	// Avoid nesting multiple ResourceAllocator
-	resourceAlloc, ok := allocator.(*ResourceAllocator)
-	if !ok {
-		resourceAlloc = &ResourceAllocator{
-			Allocator: allocator,
-		}
+	return &ResourceAllocator{
+		Allocator: allocator,
 	}
-	return resourceAlloc
 }
 
 // Allocate will ensure that the requested memory is available and
@@ -255,8 +250,8 @@ type GcAllocator struct {
 	mem *ResourceAllocator
 }
 
-func NewGcAllocator(mem *ResourceAllocator) GcAllocator {
-	return GcAllocator{
+func NewGcAllocator(mem *ResourceAllocator) *GcAllocator {
+	return &GcAllocator{
 		mem: mem,
 	}
 }

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -247,10 +247,10 @@ func (a *ResourceAllocator) allocator() memory.Allocator {
 }
 
 type GcAllocator struct {
-	mem *ResourceAllocator
+	mem Allocator
 }
 
-func NewGcAllocator(mem *ResourceAllocator) *GcAllocator {
+func NewGcAllocator(mem Allocator) *GcAllocator {
 	return &GcAllocator{
 		mem: mem,
 	}
@@ -299,14 +299,6 @@ func (a *GcAllocator) Free(b []byte) {
 }
 
 func (a *GcAllocator) Account(size int) error { return a.mem.Account(size) }
-
-func (a *GcAllocator) Allocated() int64 {
-	return a.mem.Allocated()
-}
-
-func (a *GcAllocator) MaxAllocated() int64 {
-	return a.mem.MaxAllocated()
-}
 
 // Manager will manage the memory allowed for the Allocator.
 // The Allocator may use the Manager to request additional memory or to

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -15,7 +15,7 @@ func TestAllocator_Allocate(t *testing.T) {
 	mem := arrowmemory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{Allocator: mem}}
+	allocator := memory.NewFluxAllocator(mem)
 	b := allocator.Allocate(64)
 
 	assert.Equal(t, 64, mem.CurrentAlloc(), "unexpected memory allocation.")
@@ -42,7 +42,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 	mem := arrowmemory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
 
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{Allocator: mem}}
+	allocator := memory.NewFluxAllocator(mem)
 	b := allocator.Allocate(64)
 
 	assert.Equal(t, 64, mem.CurrentAlloc(), "unexpected memory allocation.")
@@ -76,7 +76,7 @@ func TestAllocator_Reallocate(t *testing.T) {
 }
 
 func TestAllocator_MaxAfterFree(t *testing.T) {
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{}}
+	allocator := memory.NewFluxAllocator(nil)
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -113,7 +113,7 @@ func TestAllocator_MaxAfterFree(t *testing.T) {
 
 func TestAllocator_Limit(t *testing.T) {
 	maxLimit := int64(64)
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{Limit: &maxLimit}}
+	allocator := memory.NewFluxAllocator(&memory.ResourceAllocator{Limit: &maxLimit})
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -186,7 +186,7 @@ func TestAllocator_Limit(t *testing.T) {
 }
 
 func TestAllocator_Free(t *testing.T) {
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{}}
+	allocator := memory.NewFluxAllocator(nil)
 	if err := allocator.Account(64); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -238,10 +238,10 @@ func TestAllocator_RequestMemory(t *testing.T) {
 
 	// Set the Limit to 64 and allocate 32 bytes of it.
 	// This should not request more memory from the manager.
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{
+	allocator := &memory.ResourceAllocator{
 		Limit:   func(v int64) *int64 { return &v }(64),
 		Manager: manager,
-	}}
+	}
 	if err := allocator.Account(32); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -313,10 +313,10 @@ func TestAllocator_RequestMemory_Concurrently(t *testing.T) {
 
 	// Set the Limit to 64 and allocate 32 bytes of it.
 	// This should not request more memory from the manager.
-	allocator := &memory.GcAllocator{&memory.ResourceAllocator{
+	allocator := &memory.ResourceAllocator{
 		Limit:   func(v int64) *int64 { return &v }(0),
 		Manager: manager,
-	}}
+	}
 	var wg sync.WaitGroup
 	for i := 0; i < 128; i++ {
 		wg.Add(1)

--- a/memory/allocator_test.go
+++ b/memory/allocator_test.go
@@ -43,7 +43,7 @@ func TestAllocator_GC_Allocate(t *testing.T) {
 
 	allocator.Free(b)
 
-	RunGC(&allocator)
+	RunGC(allocator)
 	mem.AssertSize(t, 0)
 	if want, got := int64(0), allocator.Allocated(); want != got {
 		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)
@@ -80,7 +80,7 @@ func TestAllocator_GC_Reallocate(t *testing.T) {
 
 	allocator.Free(b)
 
-	RunGC(&allocator)
+	RunGC(allocator)
 	mem.AssertSize(t, 0)
 	if want, got := int64(0), allocator.Allocated(); want != got {
 		t.Fatalf("unexpected allocated count -want/+got\n\t- %d\n\t+ %d", want, got)

--- a/values/vector_test.go
+++ b/values/vector_test.go
@@ -40,7 +40,7 @@ func TestVectorTypes(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mem := memory.NewFluxAllocator(nil)
+		mem := memory.NewResourceAllocator(nil)
 		got := NewVectorFromElements(mem, tc.input...)
 
 		if !got.ElementType().Equal(tc.wantType) {
@@ -48,8 +48,6 @@ func TestVectorTypes(t *testing.T) {
 		}
 
 		got.Release()
-
-		mem.GC()
 
 		if mem.Allocated() != 0 {
 			t.Errorf("expected bytes allocated to be 0, got %d", mem.Allocated())

--- a/values/vector_test.go
+++ b/values/vector_test.go
@@ -40,7 +40,7 @@ func TestVectorTypes(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		mem := &memory.GcAllocator{ResourceAllocator: &memory.ResourceAllocator{}}
+		mem := memory.NewFluxAllocator(nil)
 		got := NewVectorFromElements(mem, tc.input...)
 
 		if !got.ElementType().Equal(tc.wantType) {


### PR DESCRIPTION
This removes GcAllocator from all tests but still provides a way to inject it temporarily
for testing.

@jsternberg I think something like this is what you wanted?