### PR TITLE
fix(executor): do not assume ints are 64bits

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -366,7 +366,7 @@ func (es *executionState) validate() error {
 func getResourceLimits(ctx context.Context) (int64, int) {
 	// Initialize resources from the execution dependencies and/or properties of the plan.
 	if !HaveExecutionDependencies(ctx) {
-		return 0, math.MaxInt64
+		return 0, math.MaxInt
 	}
 
 	execOptions := GetExecutionDependencies(ctx).ExecutionOptions


### PR DESCRIPTION
`getResourceLimits(int64, int)` tries to `return 0, math.MaxInt64` which,
in 32-bit architectures causes an overflow.


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
