### PR TITLE
fix(stdlib/strings): strings.joinStr panic when receives nil values

### DIFF
--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -451,10 +451,17 @@ func init() {
 					return nil, fmt.Errorf("missing argument %q", "arr")
 				}
 				arr := val.Array()
-				if arr.Len() >= 0 {
+				arrlen := arr.Len()
+				if arrlen >= 0 {
 					et, _ := arr.Type().ElemType()
 					if et.Nature() != semantic.String {
 						return nil, fmt.Errorf("expected elements of argument %q to be of type %v, got type %v", "arr", semantic.String, arr.Get(0).Type().Nature())
+					}
+					// check if any of the array elements from the input param's 'arr' is null
+					for i := 0; i < arrlen; i++ {
+						if arr.Get(i).IsNull() {
+							return nil, fmt.Errorf("expected elements of argument %q to be of type %v, got type string value <nil>", "arr", semantic.String)
+						}
 					}
 				}
 				argVals[0] = val

--- a/stdlib/strings/strings_test.go
+++ b/stdlib/strings/strings_test.go
@@ -8,9 +8,16 @@ package strings_test
 import (
 	"context"
 
+	"testing"
+
+	"github.com/influxdata/flux/dependency"
+	fluxstdlibstrings "github.com/influxdata/flux/stdlib/strings"
+
+	"github.com/influxdata/flux/dependencies/dependenciestest"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/runtime"
-	"testing"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
 )
 
 func TestJoinStr_ReceiveTableObjectIsError(t *testing.T) {
@@ -25,5 +32,25 @@ func TestJoinStr_ReceiveTableObjectIsError(t *testing.T) {
 
 	if want, got := "error @4:59-4:83: expected [string] (array) but found stream[string] (argument arr)", err.Error(); want != got {
 		t.Errorf("wanted error %q, got %q", want, got)
+	}
+}
+
+func TestJoinStr_NullInArrParam(t *testing.T) {
+	fluxFunc := fluxstdlibstrings.SpecialFns["joinStr"]
+	arr := values.NewArrayWithBacking(semantic.NewArrayType(semantic.BasicString), []values.Value{
+		values.NewString("a"), values.NewString("b"), values.NewNull(semantic.BasicString)})
+	fluxArg := values.NewObjectWithValues(map[string]values.Value{"arr": arr, "v": values.NewString(", ")})
+	wantErr := "expected elements of argument \"arr\" to be of type string, got type string value <nil>"
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	gotErr, err := fluxFunc.Call(ctx, fluxArg)
+	if err != nil {
+		if gotErr, wantErr := err.Error(), wantErr; gotErr != wantErr {
+			t.Errorf("unexpected error - wantErr: %s, gotErr: %s", wantErr, gotErr)
+		}
+		return
+	}
+	if wantErr != gotErr.Str() {
+		t.Errorf("input %f: expected %v, gotErr %f", arr, wantErr, gotErr)
 	}
 }


### PR DESCRIPTION
After the fix, the below query returns a type error rather than panicking.
```
import "strings"
import "array"
import "internal/debug"
arr = array.from(rows: [{x: 1}])
arr |> debug.opaque() |> map(fn: (r) => ({r with _field: strings.joinStr(arr: ["mean", r._field], v: "_")}))
```
```
Result: _result
Error: runtime error @5:26-5:109: map: failed to evaluate map function: expected elements of argument "arr" to be of type string, got type string value <nil>
```
fixes: https://github.com/influxdata/flux/issues/4554 https://github.com/influxdata/EAR/issues/3066



