### PR TITLE
chore(ci): upgrade go version to 1.18 in dockerfile and windows build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - run:
           name: Install system dependencies
           command: |
-            choco upgrade golang --version=1.17 --allow-downgrade
+            choco upgrade golang --version=1.18 --allow-downgrade
 
             choco install \
               grep \

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -6,7 +6,7 @@
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
 FROM rust:1.58 as RUSTBUILD
 
-FROM golang:1.17
+FROM golang:1.18
 
 # Install common packages
 RUN apt-get update && \


### PR DESCRIPTION
This only affects the builders. The version of go that we dictate ourselves to be compatible with is go 1.17. This is in preparation of switching to a minimum version of go 1.18.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written