### PR TITLE
fix(stdlib): remove an extraneous go generate statement

### DIFF
--- a/stdlib/universe/map2.go
+++ b/stdlib/universe/map2.go
@@ -19,9 +19,6 @@ import (
 	"github.com/influxdata/flux/values"
 )
 
-//go:generate -command tmpl ../../gotool.sh github.com/benbjohnson/tmpl
-//go:generate tmpl -data=@../../array/types.tmpldata -o map2.gen.go map2.gen.go.tmpl
-
 type mapTransformation2 struct {
 	ctx context.Context
 	fn  mapFunc


### PR DESCRIPTION
This statement must have been used in development but the template file
was ultimately removed. This causes an error when you use go generate.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written