### PR TITLE
fix(execute): remove 64bit misalignment

### DIFF
--- a/internal/execute/groupkey/groupkey.go
+++ b/internal/execute/groupkey/groupkey.go
@@ -13,10 +13,10 @@ import (
 )
 
 type groupKey struct {
+	hash   uint64 // hash of the key for easy comparison
 	cols   []flux.ColMeta
 	values []values.Value
-	sorted []int  // maintains a list of the sorted indexes
-	hash   uint64 // hash of the key for easy comparison
+	sorted []int // maintains a list of the sorted indexes
 }
 
 func New(cols []flux.ColMeta, values []values.Value) flux.GroupKey {


### PR DESCRIPTION
Calling `atomic.LoadUint64(()` on `groupKey.hash` resulted in an alignment panic in armv7, due to it not being 64bit aligned.
    
Declaring it first in the struct solved it.
    
See https://pkg.go.dev/sync/atomic#pkg-note-BUG fore more details
    
For context: I already fixed a similar issue at https://github.com/influxdata/influxdb/pull/23260


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
