### PR TITLE
chore: update dependencies

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.92.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a69d4142d51b208c9fc3cea68b1a7fcef30354e7aa6ccad07250fd8430fc76"
+checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
 dependencies = [
  "bitflags",
  "serde",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -797,14 +797,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -40,13 +40,13 @@ flatbuffers = "2.1.1"
 fnv = "1.0.7"
 libflate = "1.2.0"
 log = "0.4.16"
-lsp-types = { version = "0.92", optional = true }
+lsp-types = { version = "0.93", optional = true }
 maplit = "1.0.2"
 once_cell = { version = "1.10.0", optional = true }
 pad = { version = "0.1.6", optional = true }
 pulldown-cmark = { version = "0.9.0", default-features = false, optional = true }
 pretty = "0.11.2"
-rayon = { version = "1", optional = true }
+rayon = { version = "1.5.2", optional = true }
 regex = "1.5.5"
 serde = { version = "^1.0.136", features = ["derive", "rc"] }
 serde-aux = "3.0.1"

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,9 +12,9 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "e8ad826f7d95d0022586d2f07c8def0cad8b97c00cd6db5a0b7db9605695acd1",
+	"libflux/Cargo.lock":                                                                          "63bea6c11ae1b43a4ccfece4a45686a6e3d830cac57d671b2c43535e3b117f0e",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "60aa9723cf20ff627268e456962da005d7ebe3e40c89d9a9f7d5725f59b835d9",
+	"libflux/flux-core/Cargo.toml":                                                                "4a23fdfcf31b3f1f91208808e036bfdf66c2ac6b3724c61cdb3f17b05d2f9bb1",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "47e06631f249715a44c9c8fa897faf142ad0fa26f67f8cfd5cd201e82cb1afc8",
 	"libflux/flux-core/src/ast/mod.rs":                                                            "5e95066833895d8b3359a8f84f2cf025e1cf50483678e6f6c5dfc9101d1d5c3a",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "a49efe67d796351d29af7b4d1ad5b400b21dd0ddfff5f0d7af6d915294d3edcb",


### PR DESCRIPTION
This was mostly spurred by needing to update `lsp-types`, which is
preventing an update to `tower-lsp` in `flux-lsp`.