### PR TITLE
fix: don't set BaseLocation.file to Some("")

### DIFF
--- a/libflux/flux-core/src/ast/tests.rs
+++ b/libflux/flux-core/src/ast/tests.rs
@@ -2158,7 +2158,7 @@ impl<'a> Locator<'a> {
     /// column.
     pub fn get(&self, sl: u32, sc: u32, el: u32, ec: u32) -> SourceLocation {
         SourceLocation {
-            file: Some("".to_string()),
+            file: None,
             source: Some(self.get_src(sl, sc, el, ec).to_string()),
             start: Position {
                 line: sl,

--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -283,7 +283,11 @@ impl<'input> Parser<'input> {
         let e_off = self.s.offset(&scanner::Position::from(end)) as usize;
 
         SourceLocation {
-            file: Some(self.fname.clone()),
+            file: if self.fname.is_empty() {
+                None
+            } else {
+                Some(self.fname.clone())
+            },
             start: *start,
             end: *end,
             source: Some(self.source[s_off..e_off].to_string()),

--- a/libflux/flux-core/src/parser/tests.rs
+++ b/libflux/flux-core/src/parser/tests.rs
@@ -16,6 +16,20 @@ mod operator_precedence;
 mod strings;
 mod types;
 
+/// Parsed ast roundtrips across the serde boundary and generates the same ast.
+#[test]
+fn parse_ast_roundtrip() {
+    let mut p = Parser::new(
+        r#"from(bucket: "an-bucket") |> range(start: -15m) |> filter(fn: (r) => r.field == "value")"#,
+    );
+    let ast = p.parse_file("".to_string());
+
+    let serialized = serde_json::to_string(&ast).unwrap();
+    let new_ast = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(ast, new_ast);
+}
+
 #[test]
 fn parse_array_expr_no_rbrack() {
     let mut p = Parser::new(r#"group(columns: ["_time", "_field]", mode: "by")"#);

--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -453,9 +453,7 @@ fn missing_arrow_in_function_expression() {
         File {
             base: BaseNode {
                 location: SourceLocation {
-                    file: Some(
-                        "",
-                    ),
+                    file: None,
                     start: Position {
                         line: 1,
                         column: 1,
@@ -480,9 +478,7 @@ fn missing_arrow_in_function_expression() {
                     ExprStmt {
                         base: BaseNode {
                             location: SourceLocation {
-                                file: Some(
-                                    "",
-                                ),
+                                file: None,
                                 start: Position {
                                     line: 1,
                                     column: 1,
@@ -502,9 +498,7 @@ fn missing_arrow_in_function_expression() {
                             FunctionExpr {
                                 base: BaseNode {
                                     location: SourceLocation {
-                                        file: Some(
-                                            "",
-                                        ),
+                                        file: None,
                                         start: Position {
                                             line: 1,
                                             column: 1,
@@ -525,9 +519,7 @@ fn missing_arrow_in_function_expression() {
                                     Property {
                                         base: BaseNode {
                                             location: SourceLocation {
-                                                file: Some(
-                                                    "",
-                                                ),
+                                                file: None,
                                                 start: Position {
                                                     line: 1,
                                                     column: 2,
@@ -547,9 +539,7 @@ fn missing_arrow_in_function_expression() {
                                             Identifier {
                                                 base: BaseNode {
                                                     location: SourceLocation {
-                                                        file: Some(
-                                                            "",
-                                                        ),
+                                                        file: None,
                                                         start: Position {
                                                             line: 1,
                                                             column: 2,
@@ -575,9 +565,7 @@ fn missing_arrow_in_function_expression() {
                                     Property {
                                         base: BaseNode {
                                             location: SourceLocation {
-                                                file: Some(
-                                                    "",
-                                                ),
+                                                file: None,
                                                 start: Position {
                                                     line: 1,
                                                     column: 5,
@@ -597,9 +585,7 @@ fn missing_arrow_in_function_expression() {
                                             Identifier {
                                                 base: BaseNode {
                                                     location: SourceLocation {
-                                                        file: Some(
-                                                            "",
-                                                        ),
+                                                        file: None,
                                                         start: Position {
                                                             line: 1,
                                                             column: 5,
@@ -630,9 +616,7 @@ fn missing_arrow_in_function_expression() {
                                         BinaryExpr {
                                             base: BaseNode {
                                                 location: SourceLocation {
-                                                    file: Some(
-                                                        "",
-                                                    ),
+                                                    file: None,
                                                     start: Position {
                                                         line: 1,
                                                         column: 8,
@@ -653,9 +637,7 @@ fn missing_arrow_in_function_expression() {
                                                 Identifier {
                                                     base: BaseNode {
                                                         location: SourceLocation {
-                                                            file: Some(
-                                                                "",
-                                                            ),
+                                                            file: None,
                                                             start: Position {
                                                                 line: 1,
                                                                 column: 8,
@@ -680,9 +662,7 @@ fn missing_arrow_in_function_expression() {
                                                 Identifier {
                                                     base: BaseNode {
                                                         location: SourceLocation {
-                                                            file: Some(
-                                                                "",
-                                                            ),
+                                                            file: None,
                                                             start: Position {
                                                                 line: 1,
                                                                 column: 12,

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -27,7 +27,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "783339cfa1cca754a5469754fad4afebd74b8ebe3164e2ee76a0674e6fec569d",
 	"libflux/flux-core/src/lib.rs":                                                                "443aed16dd600eecc1ffbee2d2dead6788e796cd5a278eb5dafb123843b8959e",
 	"libflux/flux-core/src/map.rs":                                                                "342c1cc111d343f01b97f38be10a9f1097bdd57cdc56f55e92fd3ed5028e6973",
-	"libflux/flux-core/src/parser/mod.rs":                                                         "c364dc1bdef3bba57fb80e0791e301faa7c83c93240ad6ffd4e1394448bef7e3",
+	"libflux/flux-core/src/parser/mod.rs":                                                         "a2861ad9b5e5ed430c0927d7fd975e79f13b128a1e0863cb9d82059cdd38384a",
 	"libflux/flux-core/src/parser/strconv.rs":                                                     "84d24110f8af4a40ff7584cb0a41e8a1f8949d19c1ec329719057c5302f7615d",
 	"libflux/flux-core/src/scanner/mod.rs":                                                        "297809a7b5778363a490bc4e08add05005bdc50d7c8cd59f27390f6316aba69e",
 	"libflux/flux-core/src/scanner/scanner.rl":                                                    "e3755aed899244461e8b2a05a87ab41a89fe3d66d28f60c25ad9895f26675ba8",


### PR DESCRIPTION
A common pattern we have is this:

    parse_string("".to_string(), "from(...) |> range(...) |> filter(...)")

That first argument is supposed to serve as the filename and, in
general, we don't care about it. However, the `BaseLocation.file` has a
`#[serde(skip_serializing_if = "skip_string_option")]` on it, which
means that when we go over the serialization boundary,
`BaseLocation.file` is no longer `Some("")` but `None`. It's probably
not a huge deal, but when the result is inconsistent going over the
serialization boundary, that becomes an issue.

This patch fixes that by only assigning `BaseLocation.file` to a `Some`
value when the string is not empty. Otherwise, assign it as a `None`.