### PR TITLE
fix(universe/join): remove `JoinOpSpec.TableNames` and favor `JoinOpSpec.params` to stay consistent inside `tableFind`

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -497,7 +497,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/join_mismatched_schema_test.flux":                                            "ec93ea26357783c15da7ac9be3b9b60d01122ad5fd482b802d5d9a6e7b3e5fb2",
 	"stdlib/universe/join_missing_on_col_test.flux":                                               "3d15e1bb1186ffbf39d68fb2698eca0812608a77be3592d5559fc2a3f5c0ae4a",
 	"stdlib/universe/join_panic_test.flux":                                                        "d974919167b6bf8c0ce323f23f09aebccdad7ba4fbe1fd3cc1cd90402d9af28f",
-	"stdlib/universe/join_test.flux":                                                              "7265656eb22c659f97e4ae15a4b6538f9081c2aef344a0131bcee09bdc6a61f8",
+	"stdlib/universe/join_test.flux":                                                              "6fc8c9432adfb31793b5dcf931fa0171a047cdd281d230b70cb76aa0cf1dcaa6",
 	"stdlib/universe/join_two_same_sources_test.flux":                                             "26e5aedfc27c8d97c9e4b85fd9734fe19b9031bc5386cd914d191e1e00c9b534",
 	"stdlib/universe/join_unsorted_columns_test.flux":                                             "1e67d4c1aef04040f9ce31cc6a7394ed84c066d286c9ba4d93f5e0db78308632",
 	"stdlib/universe/join_use_previous_test.flux":                                                 "2937ccc4ae970415ae8696a8cce91c4b52966b2597ac9447711b8391c25b4ef5",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -497,7 +497,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/join_mismatched_schema_test.flux":                                            "ec93ea26357783c15da7ac9be3b9b60d01122ad5fd482b802d5d9a6e7b3e5fb2",
 	"stdlib/universe/join_missing_on_col_test.flux":                                               "3d15e1bb1186ffbf39d68fb2698eca0812608a77be3592d5559fc2a3f5c0ae4a",
 	"stdlib/universe/join_panic_test.flux":                                                        "d974919167b6bf8c0ce323f23f09aebccdad7ba4fbe1fd3cc1cd90402d9af28f",
-	"stdlib/universe/join_test.flux":                                                              "531ad4a8d8a5d8a4b08eeaf1365206ed89d634dcaf7897cd517fccc9b132268f",
+	"stdlib/universe/join_test.flux":                                                              "d8f9b47355f89a8723c84fe383e4114496f644857a81f5b3709c0633286d7d0b",
 	"stdlib/universe/join_two_same_sources_test.flux":                                             "26e5aedfc27c8d97c9e4b85fd9734fe19b9031bc5386cd914d191e1e00c9b534",
 	"stdlib/universe/join_unsorted_columns_test.flux":                                             "1e67d4c1aef04040f9ce31cc6a7394ed84c066d286c9ba4d93f5e0db78308632",
 	"stdlib/universe/join_use_previous_test.flux":                                                 "2937ccc4ae970415ae8696a8cce91c4b52966b2597ac9447711b8391c25b4ef5",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -497,7 +497,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/join_mismatched_schema_test.flux":                                            "ec93ea26357783c15da7ac9be3b9b60d01122ad5fd482b802d5d9a6e7b3e5fb2",
 	"stdlib/universe/join_missing_on_col_test.flux":                                               "3d15e1bb1186ffbf39d68fb2698eca0812608a77be3592d5559fc2a3f5c0ae4a",
 	"stdlib/universe/join_panic_test.flux":                                                        "d974919167b6bf8c0ce323f23f09aebccdad7ba4fbe1fd3cc1cd90402d9af28f",
-	"stdlib/universe/join_test.flux":                                                              "6fc8c9432adfb31793b5dcf931fa0171a047cdd281d230b70cb76aa0cf1dcaa6",
+	"stdlib/universe/join_test.flux":                                                              "531ad4a8d8a5d8a4b08eeaf1365206ed89d634dcaf7897cd517fccc9b132268f",
 	"stdlib/universe/join_two_same_sources_test.flux":                                             "26e5aedfc27c8d97c9e4b85fd9734fe19b9031bc5386cd914d191e1e00c9b534",
 	"stdlib/universe/join_unsorted_columns_test.flux":                                             "1e67d4c1aef04040f9ce31cc6a7394ed84c066d286c9ba4d93f5e0db78308632",
 	"stdlib/universe/join_use_previous_test.flux":                                                 "2937ccc4ae970415ae8696a8cce91c4b52966b2597ac9447711b8391c25b4ef5",

--- a/stdlib/universe/covariance_test.go
+++ b/stdlib/universe/covariance_test.go
@@ -88,11 +88,7 @@ func TestCovariance_NewQuery(t *testing.T) {
 					{
 						ID: "join2",
 						Spec: &universe.JoinOpSpec{
-							On: []string{"host"},
-							TableNames: map[flux.OperationID]string{
-								"from0": "x",
-								"from1": "y",
-							},
+							On:     []string{"host"},
 							Method: "inner",
 						},
 					},

--- a/stdlib/universe/join.go
+++ b/stdlib/universe/join.go
@@ -145,19 +145,18 @@ func createJoinOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operati
 }
 
 func (t *JoinOpSpec) IDer(ider flux.IDer) {
-	// When join is used inside a `tableFind`, the input tables are cloned
-	// granting them new ids.
-	// This can cause a panic to occur in `createMergeJoinTransformation` when
-	// trying to associate table names with their related datasets.
+	// When join is used inside a `tableFind`, the input table operations are
+	// "cloned" granting them new ids.
+	// This will cause a panic to occur in `createMergeJoinTransformation` when
+	// trying to associate table names with their related datasets if we don't
+	// first remove old entries from the map.
 	// Refs: <https://github.com/influxdata/flux/issues/4692>
-
-	// Treat `TableNames` as "immutable" - don't modify them after initialization.
-	// FIXME: find a "better fix" than only initializing this once.
-	if len(t.TableNames) == 0 {
-		for i, name := range t.params.names {
-			operation := t.params.operations[i]
-			t.TableNames[ider.ID(operation)] = name
-		}
+	for k := range t.TableNames {
+		delete(t.TableNames, k)
+	}
+	for i, name := range t.params.names {
+		operation := t.params.operations[i]
+		t.TableNames[ider.ID(operation)] = name
 	}
 }
 

--- a/stdlib/universe/join_test.flux
+++ b/stdlib/universe/join_test.flux
@@ -1,6 +1,7 @@
 package universe_test
 
 
+import "array"
 import "testing"
 
 option now = () => 2030-01-01T00:00:00Z
@@ -41,21 +42,59 @@ outData =
 ,,1,RAM,2018-05-22T19:53:46Z,3,4,user1,user2,b
 ,,1,RAM,2018-05-22T19:53:56Z,5,0,user1,user2,b
 "
-t_join = (table=<-) => {
+
+testcase join_base {
+    input = testing.loadStorage(csv: inData)
+    want = testing.loadMem(csv: outData)
     left =
-        table
+        input
             |> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
             |> drop(columns: ["_start", "_stop"])
             |> filter(fn: (r) => r.user == "user1")
             |> group(columns: ["user"])
     right =
-        table
+        input
             |> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
             |> drop(columns: ["_start", "_stop"])
             |> filter(fn: (r) => r.user == "user2")
             |> group(columns: ["_measurement", "_field"])
 
-    return join(tables: {left: left, right: right}, on: ["_time", "_measurement", "_field"])
+    got = join(tables: {left: left, right: right}, on: ["_time", "_measurement", "_field"])
+
+    testing.diff(want: want, got: got)
 }
 
-test _join = () => ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_join})
+testcase join_repro_4692 {
+    // Running `findRecord` repeatedly on the same stream can clone the
+    // inputs to a join, mutating the original spec each time to refer to more
+    // and more input streams each time. This leads to a panic.
+    //
+    // This tests verifies that repeated runs of `findRecord` on a `join` is
+    // "safe" to do in terms of "it no longer panics."
+    // Refs: <https://github.com/influxdata/flux/issues/4692>
+    xs = array.from(rows: [{id: 1, x: 1}, {id: 2, x: 2}, {id: 3, x: 3}])
+    ys = array.from(rows: [{id: 1, y: 1}, {id: 2, y: 2}, {id: 3, y: 3}])
+    zs = join(tables: {xs: xs, ys: ys}, on: ["id"])
+
+    getById = (id) => {
+        r = zs |> filter(fn: (r) => r.id == id) |> findRecord(fn: (key) => true, idx: 0)
+
+        return {x: r.x, y: r.y}
+    }
+
+    got =
+        array.from(
+            rows: [
+                {_value: 1},
+                {_value: 2},
+                // repeated lookups for id=2 should be okay...
+                {_value: 2},
+                {_value: 3},
+            ],
+        )
+            |> map(fn: (r) => getById(id: r._value))
+
+    want = array.from(rows: [{x: 1, y: 1}, {x: 2, y: 2}, {x: 2, y: 2}, {x: 3, y: 3}])
+
+    testing.diff(want: want, got: got)
+}

--- a/stdlib/universe/join_test.flux
+++ b/stdlib/universe/join_test.flux
@@ -98,3 +98,36 @@ testcase join_repro_4692 {
 
     testing.diff(want: want, got: got)
 }
+testcase join_repro_4692_2 {
+    xs = array.from(rows: [{id: 1, x: 1, v: "hi"}, {id: 2, x: 2, v: "hi"}, {id: 3, x: 3, v: "hi"}])
+    ys = array.from(rows: [{id: 1, y: 1}, {id: 2, y: 2}, {id: 3, y: 3}])
+
+    getById = (id) => {
+        zs =
+            if id == 2 then
+                join(tables: {xs: xs |> map(fn: (r) => ({r with v: "hey"})), ys: ys}, on: ["id"])
+            else
+                join(tables: {xs: xs, ys: ys}, on: ["id"])
+
+        r = zs |> filter(fn: (r) => r.id == id) |> findRecord(fn: (key) => true, idx: 0)
+
+        return {x: r.x, y: r.y, v: r.v}
+    }
+
+    got =
+        array.from(
+            rows: [
+                {_value: 1},
+                {_value: 2},
+                // repeated lookups for id=2 should be okay...
+                {_value: 2},
+                {_value: 3},
+            ],
+        )
+            |> map(fn: (r) => getById(id: r._value))
+
+    want =
+        array.from(rows: [{x: 1, y: 1, v: "hi"}, {x: 2, y: 2, v: "hey"}, {x: 2, y: 2, v: "hey"}, {x: 3, y: 3, v: "hi"}])
+
+    testing.diff(want: want, got: got)
+}

--- a/stdlib/universe/join_test.go
+++ b/stdlib/universe/join_test.go
@@ -71,9 +71,8 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "join4",
 						Spec: &universe.JoinOpSpec{
-							On:         []string{"host"},
-							TableNames: map[flux.OperationID]string{"range1": "a", "range3": "b"},
-							Method:     "inner",
+							On:     []string{"host"},
+							Method: "inner",
 						},
 					},
 				},
@@ -139,9 +138,8 @@ func TestJoin_NewQuery(t *testing.T) {
 					{
 						ID: "join4",
 						Spec: &universe.JoinOpSpec{
-							On:         []string{"t1"},
-							TableNames: map[flux.OperationID]string{"range1": "a", "range3": "b"},
-							Method:     "inner",
+							On:     []string{"t1"},
+							Method: "inner",
 						},
 					},
 				},
@@ -193,8 +191,7 @@ func TestJoinOperation_Marshaling(t *testing.T) {
 	op := &flux.Operation{
 		ID: "join",
 		Spec: &universe.JoinOpSpec{
-			On:         []string{"t1", "t2"},
-			TableNames: map[flux.OperationID]string{"sum1": "a", "count3": "b"},
+			On: []string{"t1", "t2"},
 		},
 	}
 	querytest.OperationMarshalingTestHelper(t, data, op)


### PR DESCRIPTION
Fixes: #4692

When a `join` is used in conjunction with a `tableFind`, the input tables
are copied and given new operation IDs. This causes problems in
`createMergeJoinTransformation` where we rely on a mapping of
`TableNames` to associate the inputs to `join` with the corresponding
datasets.

The assumption violated in this situation is we expect the number of
"parents" to be the same as the number of tracked "table names." When
this does not hold true, we panic. Formerly the panic came from an out
of bounds index, but with this diff this is more explicit.

Ideally, I think it would be better to perform a deep copy on the join's
`JoinOpSpec` for the sub-program we build via `tableFind` such that the
"sub join" is entirely different and can hold references to the "sub
inputs."

In practice this appears out of reach based on the information I saw
available in the code paths that matter. We'd need to add "join aware"
blocks to `TableObject.Operation()`, which seems to be responsible for
the "cloning" of the Operation, or something else entirely.

~~The proposed fix here is to avoid altering the `TableNames` map for a
`JoinOpSpec` when this cloning happens. In effect, once a `JoinOpSpec`
is associated with a pair of input tables, this will be fixed. The
inputs may be cloned by `tableFind` but the cloned inputs  will no longer
be referred to as they are today.~~

## A change in tactics...

~~A previous attempt to fix a panic caused by the `TableNames` map
incorrectly growing when a `JoinOpSpec` is used repeatedly via
`tableFind` had "locked" the map after the initial entries had been
added.~~

~~e83ca5b switches to solve the same problem by instead removing old entries
before adding new ones. This in effect should mean `TableNames` and
`params` should agree with each other.~~

~~While the truth is, we should not be reusing and mutating the OpSpec at
least now the fields that are changing with repeated use will agree with
each other.~~

## Third attempt...

`JoinOpSpec.TableNames` mapped operationIDs to field names for the
`tables` argument to `join`.

Meanwhile `JoinOpSpec.params` held two separate fields:
- an array of strings (the field names of the object)
- an array of "operations" (the tables bound to those fields)

The `params` are in effect separate arrays of the keys/values seen in
the `TableNames` map, but holding references to the input table objects
rather than their operation IDs.

For the purposes of doing `join`'s work, the operation IDs are not
necessary, and in fact causes issues in situations like a when `join`
is used with `tableFind`.

Since the _extra information_ contained in the `TableNames` map is not
needed it's basically redundant.

f57d93bc removes the field in favor of just referring to `params`
directly.

### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [x] Test cases written
