### PR TITLE
fix(universe): fix SortLimit for empty input group

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -569,7 +569,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/simple_max_test.flux":                                                        "1196fa76e5f603b53f3ab78980d8810ca94e690b5585fec7c0f5725d7b16518b",
 	"stdlib/universe/skew_test.flux":                                                              "7530c2fc2e84e508749e3a05f97eebf592e7070ae1290a0103cbd0da54271f07",
 	"stdlib/universe/sort2_test.flux":                                                             "3b31fa92a30fafb5ef80e1e24697aa7b62e9385a5174ec255c98cdd5eac3ee1c",
-	"stdlib/universe/sort_limit_test.flux":                                                        "b307b673ca5be930c6870ecbe592eb661e20cc57959761aaa79cd557512da023",
+	"stdlib/universe/sort_limit_test.flux":                                                        "fcf21958386f2913345532f863a15fb6a87aafdc61755d7d2c51d0d6adac200a",
 	"stdlib/universe/sort_test.flux":                                                              "d0481f200fdd35c4644c86a18215e5256825859a4900fc96bf7cf1a5bcdba846",
 	"stdlib/universe/spread_test.flux":                                                            "3e327ba0a1118f327964a581ac0c557b362d2a564ef1f1d14dbaa5640e085c04",
 	"stdlib/universe/state_count_test.flux":                                                       "b83e62d1e1cc16ce3b18b9c0a033f869912b41eaec381256e9abf1306671f561",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -569,7 +569,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/simple_max_test.flux":                                                        "1196fa76e5f603b53f3ab78980d8810ca94e690b5585fec7c0f5725d7b16518b",
 	"stdlib/universe/skew_test.flux":                                                              "7530c2fc2e84e508749e3a05f97eebf592e7070ae1290a0103cbd0da54271f07",
 	"stdlib/universe/sort2_test.flux":                                                             "3b31fa92a30fafb5ef80e1e24697aa7b62e9385a5174ec255c98cdd5eac3ee1c",
-	"stdlib/universe/sort_limit_test.flux":                                                        "dcce25b63df7f2a2ca40deda79e356b52aec4ecbbd9bc0d73238baa926aec60a",
+	"stdlib/universe/sort_limit_test.flux":                                                        "b307b673ca5be930c6870ecbe592eb661e20cc57959761aaa79cd557512da023",
 	"stdlib/universe/sort_test.flux":                                                              "d0481f200fdd35c4644c86a18215e5256825859a4900fc96bf7cf1a5bcdba846",
 	"stdlib/universe/spread_test.flux":                                                            "3e327ba0a1118f327964a581ac0c557b362d2a564ef1f1d14dbaa5640e085c04",
 	"stdlib/universe/state_count_test.flux":                                                       "b83e62d1e1cc16ce3b18b9c0a033f869912b41eaec381256e9abf1306671f561",

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -332,7 +332,7 @@ func (s *sortTableMergeHeap) ValueLen() int {
 
 func (s *sortTableMergeHeap) Table(limit int, mem memory.Allocator) (flux.Table, error) {
 	if s.ValueLen() == 0 {
-		// Degenerate case where ther are no rows to merge sort
+		// Degenerate case where there are no rows to merge sort
 		for len(s.items) > 0 {
 			s.Pop()
 		}

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -331,6 +331,14 @@ func (s *sortTableMergeHeap) ValueLen() int {
 }
 
 func (s *sortTableMergeHeap) Table(limit int, mem memory.Allocator) (flux.Table, error) {
+	if s.ValueLen() == 0 {
+		// Degenerate case where ther are no rows to merge sort
+		for len(s.items) > 0 {
+			s.Pop()
+		}
+		return execute.NewEmptyTable(s.key, s.cols), nil
+	}
+
 	// Construct the buffered builder that will contain the full table.
 	builder := table.NewBufferedBuilder(s.key, mem)
 

--- a/stdlib/universe/sort_limit_test.flux
+++ b/stdlib/universe/sort_limit_test.flux
@@ -3,6 +3,7 @@ package universe_test
 
 import "array"
 import "csv"
+import "internal/debug"
 import "testing"
 
 testcase sort_limit {
@@ -123,4 +124,14 @@ testcase sort_limit_unordered_columns {
             )
 
         testing.diff(got: got, want: want)
-    }
+}
+
+testcase sort_limit_zero_row_table {
+        input = array.from(rows: [{foo: "bar", _value: 10}])
+                |> filter(fn: (r) => r._value > 10, onEmpty: "keep")
+        want = input
+        // the call to pass() here is required due to
+        // https://github.com/influxdata/flux/issues/4699
+        got = input |> debug.pass() |> sort() |> limit(n: 5)
+        testing.diff(got, want)
+}

--- a/stdlib/universe/sort_limit_test.flux
+++ b/stdlib/universe/sort_limit_test.flux
@@ -124,14 +124,17 @@ testcase sort_limit_unordered_columns {
             )
 
         testing.diff(got: got, want: want)
-}
+    }
 
 testcase sort_limit_zero_row_table {
-        input = array.from(rows: [{foo: "bar", _value: 10}])
-                |> filter(fn: (r) => r._value > 10, onEmpty: "keep")
-        want = input
-        // the call to pass() here is required due to
-        // https://github.com/influxdata/flux/issues/4699
-        got = input |> debug.pass() |> sort() |> limit(n: 5)
-        testing.diff(got, want)
+    input =
+        array.from(rows: [{foo: "bar", _value: 10}])
+            |> filter(fn: (r) => r._value > 10, onEmpty: "keep")
+    want = input
+
+    // the call to pass() here is required due to
+    // https://github.com/influxdata/flux/issues/4699
+    got = input |> debug.pass() |> sort() |> limit(n: 5)
+
+    testing.diff(got, want)
 }


### PR DESCRIPTION
This PR adds a bit of logic to our handling of `sort |> limit` to catch the case where we have received an empty table. The code the does merging did not expect to have to deal with zero-row tables, and wound up in an infinite loop.

### Done checklist
- [ ] docs/SPEC.md updated (N/A)
- [x] Test cases written
