### PR TITLE
test: add range to broken join test

### DIFF
--- a/stdlib/universe/join_test.flux
+++ b/stdlib/universe/join_test.flux
@@ -44,18 +44,17 @@ outData =
 "
 
 testcase join_base {
-    input = testing.loadStorage(csv: inData)
+    input =
+        testing.loadStorage(csv: inData)
+            |> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
+            |> drop(columns: ["_start", "_stop"])
     want = testing.loadMem(csv: outData)
     left =
         input
-            |> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
-            |> drop(columns: ["_start", "_stop"])
             |> filter(fn: (r) => r.user == "user1")
             |> group(columns: ["user"])
     right =
         input
-            |> range(start: 2018-05-22T19:53:00Z, stop: 2018-05-22T19:55:00Z)
-            |> drop(columns: ["_start", "_stop"])
             |> filter(fn: (r) => r.user == "user2")
             |> group(columns: ["_measurement", "_field"])
 


### PR DESCRIPTION
During a recent refactor of join, some tests were updated to run as
proper acceptance tests.

This apparently broke in our nightly job, I think thanks to pushdowns
not present in vanilla flux.

This diff aims to fix the nightly suite by adding a `range` to the
`testing.load` call.

Refs: https://github.com/influxdata/flux/pull/4698

### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [ ] Test cases written **N/A**
