### PR TITLE
Add opentracing spans for sources

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -428,9 +428,8 @@ func (es *executionState) do() {
 		wg.Add(1)
 		go func(src Source) {
 			ctx := es.ctx
-			if ctxWithSpan, span := StartSpanFromContext(ctx, reflect.TypeOf(src).String(), src.Label()); span != nil {
-				ctx = ctxWithSpan
-				defer span.Finish()
+			if opState := NewOperatorProfilingState(ctx, reflect.TypeOf(src).String(), src.Label()); opState != nil {
+				defer opState.Finish()
 			}
 			defer wg.Done()
 

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -218,8 +218,7 @@ func (t *consecutiveTransport) transition(new int32) {
 func (t *consecutiveTransport) contextWithSpan(ctx context.Context) context.Context {
 	didInit := false
 	t.initSpanOnce.Do(func() {
-		t.span, ctx = opentracing.StartSpanFromContext(ctx, t.op)
-		t.span.LogFields(log.String("label", t.label))
+		t.span, ctx = opentracing.StartSpanFromContext(ctx, t.op, opentracing.Tag{Key: "label", Value: t.label})
 		didInit = true
 	})
 	if didInit {

--- a/execute/transport.go
+++ b/execute/transport.go
@@ -284,8 +284,8 @@ PROCESS:
 // processMessage processes the message on t.
 // The return value is true if the message was a FinishMsg.
 func (t *consecutiveTransport) processMessage(ctx context.Context, m Message) (finished bool, err error) {
-	if _, span := StartSpanFromContext(ctx, t.op, t.label); span != nil {
-		defer span.Finish()
+	if opState := NewOperatorProfilingState(ctx, t.op, t.label); opState != nil {
+		defer opState.Finish()
 	}
 	if err := t.t.ProcessMessage(m); err != nil {
 		return false, err

--- a/lang/compiler_test.go
+++ b/lang/compiler_test.go
@@ -887,6 +887,7 @@ func TestQueryTracing(t *testing.T) {
 		{opName: "*universe.filterTransformation", msgCount: 2},
 		{opName: "*universe.groupTransformation", msgCount: 3},
 		{opName: "*universe.mapTransformation", msgCount: 3},
+		{opName: "*array.tableSource"},
 	}
 	for _, wantSpan := range wantSpans {
 		var gotSpan *mocktracer.MockSpan
@@ -916,11 +917,13 @@ func TestQueryTracing(t *testing.T) {
 				break
 			}
 		}
-		if msgCount == nil {
-			t.Fatalf("did not find %q log for operation %q", "messages_processed", wantSpan.opName)
-		}
-		if want, got := fmt.Sprintf("%d", wantSpan.msgCount), msgCount.ValueString; want != got {
-			t.Errorf("got unexpected message count for operation %q; -want/+got: %v/%v ", wantSpan.opName, want, got)
+		if wantSpan.msgCount != 0 {
+			if msgCount == nil {
+				t.Fatalf("did not find %q log for operation %q", "messages_processed", wantSpan.opName)
+			}
+			if want, got := fmt.Sprintf("%d", wantSpan.msgCount), msgCount.ValueString; want != got {
+				t.Errorf("got unexpected message count for operation %q; -want/+got: %v/%v ", wantSpan.opName, want, got)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR has two commits:

The first is a refactoring that decouples opentracing spans from operator profiling. At one time we used operator profiling to also generate opentracing spans, but this has been disabled for several months now. This mechanism generated too many spans (one per table) which would overwhelm the tracing infrastructure. It's also the case that we might want to look at a trace for a query that has not been profiled. Since tracing is an internal tool, and profiling is an external one, it makes sense to keep them separate.

The second commit adds an opentracing span for each source in a query, and makes a corresponding update to tests.