### PR TITLE
fix(stdlib): hourSelection does not allow for selecting overnight time ranges

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -488,7 +488,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/histogram_test.flux":                                                         "a468e662ecf1adc1d9d035ff041a503cd08efe7354f096a88da12ff7edc347ef",
 	"stdlib/universe/holt_winters_panic_test.flux":                                                "c7681aadb9e4584b0002e47782af18c0c70734234c24adc0a631686cc3e32cb2",
 	"stdlib/universe/holt_winters_test.flux":                                                      "47a236ef553000fb36cdf2756d32a9a923a1b478a974c1369d08d8c6ba3535f9",
-	"stdlib/universe/hour_selection_test.flux":                                                    "a9215ceedd1c6fb297f7abadd45cfecdcfcd027ea393d1e05b996bd640c037a7",
+	"stdlib/universe/hour_selection_test.flux":                                                    "4713a9f12e529a237f9a61672577c0d09339c225658052cfc5d889a2c4bfefb3",
 	"stdlib/universe/increase_test.flux":                                                          "dc02027842468c99c3ff0dadadde6050a2e38c7ea4bd70c7cf0a7eb10e3f93d7",
 	"stdlib/universe/integral_columns_test.flux":                                                  "485b0319d5bbbd781cf6dbaa0cfcc56ae8d7b25ee9c02815d4b61fcfece993e9",
 	"stdlib/universe/integral_interpolate_test.flux":                                              "adebcba18f65e119dd3ccb0143b4de9593628765686d8932e679e85f007e786f",

--- a/stdlib/universe/hour_selection.go
+++ b/stdlib/universe/hour_selection.go
@@ -163,7 +163,7 @@ func (t *hourSelectionTransformation) Process(id execute.DatasetID, tbl flux.Tab
 				continue
 			}
 			curr := execute.Time(cr.Times(colIdx).Value(i)).Time().Hour()
-			if int64(curr) >= t.start && int64(curr) <= t.stop {
+			if (int64(curr) >= t.start && int64(curr) <= t.stop) || (t.start > t.stop && (int64(curr) >= t.start || int64(curr) <= t.stop)) {
 				for k := range cr.Cols() {
 					if err := builder.AppendValue(k, execute.ValueForRow(cr, i, k)); err != nil {
 						return err

--- a/stdlib/universe/hour_selection_test.flux
+++ b/stdlib/universe/hour_selection_test.flux
@@ -2,6 +2,7 @@ package universe_test
 
 
 import "testing"
+import "csv"
 
 option now = () => 2030-01-01T00:00:00Z
 
@@ -18,8 +19,17 @@ inData =
 ,,0,Sgf,DlXwgrw,2018-12-19T19:11:45Z,48
 ,,0,Sgf,DlXwgrw,2018-12-19T22:11:55Z,63
 "
-outData =
-    "
+
+testcase hour_selection {
+        got =
+            csv.from(csv: inData)
+                |> range(start: 2018-12-01T00:00:00Z)
+                |> hourSelection(start: 15, stop: 19, timeColumn: "_time")
+
+        want =
+            csv.from(
+                csv:
+                    "
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,dateTime:RFC3339,unsignedLong
 #group,false,false,true,true,true,true,false,false
 #default,_result,,,,,,,
@@ -28,11 +38,30 @@ outData =
 ,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-18T17:11:25Z,33
 ,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-19T18:11:35Z,63
 ,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-19T19:11:45Z,48
-"
-t_hourSelection = (table=<-) =>
-    table
-        |> range(start: 2018-12-01T00:00:00Z)
-        |> hourSelection(start: 15, stop: 19, timeColumn: "_time")
+",
+            )
 
-test _hourSelection = () =>
-    ({input: testing.loadStorage(csv: inData), want: testing.loadMem(csv: outData), fn: t_hourSelection})
+        testing.diff(got: got, want: want)
+    }
+
+testcase hour_selection_overnight_range {
+        got =
+            csv.from(csv: inData)
+                |> range(start: 2018-12-01T00:00:00Z)
+                |> hourSelection(start: 22, stop: 6, timeColumn: "_time")
+
+        want =
+            csv.from(
+                csv:
+                    "
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,dateTime:RFC3339,unsignedLong
+#group,false,false,true,true,true,true,false,false
+#default,_result,,,,,,,
+,result,table,_start,_stop,_measurement,_field,_time,_value
+,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-18T06:11:05Z,70
+,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-19T22:11:55Z,63
+",
+            )
+
+        testing.diff(got: got, want: want)
+    }

--- a/stdlib/universe/hour_selection_test.go
+++ b/stdlib/universe/hour_selection_test.go
@@ -154,6 +154,44 @@ func TestHourSelection_Process(t *testing.T) {
 			}},
 		},
 		{
+			name: "with group key - overnight range selection",
+			spec: &universe.HourSelectionProcedureSpec{Start: 10, Stop: 2, TimeColumn: execute.DefaultTimeColLabel},
+			data: []flux.Table{
+				&executetest.Table{
+					KeyCols: []string{"tag0"},
+					ColMeta: []flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "tag0", Type: flux.TString},
+						{Label: "tag1", Type: flux.TString},
+					},
+					Data: [][]interface{}{
+						{execute.Time(hour), 2.0, "a", "b"},
+						{execute.Time(hour * 2), 2.0, "a", "c"},
+						{execute.Time(hour * 4), 2.0, "a", "d"},
+						{execute.Time(hour * 6), 2.0, "a", "e"},
+						{execute.Time(hour * 10), 2.0, "a", "f"},
+						{execute.Time(hour * 11), 2.0, "a", "g"},
+					},
+				},
+			},
+			want: []*executetest.Table{{
+				KeyCols: []string{"tag0"},
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TFloat},
+					{Label: "tag0", Type: flux.TString},
+					{Label: "tag1", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(hour), 2.0, "a", "b"},
+					{execute.Time(hour * 2), 2.0, "a", "c"},
+					{execute.Time(hour * 10), 2.0, "a", "f"},
+					{execute.Time(hour * 11), 2.0, "a", "g"},
+				},
+			}},
+		},
+		{
 			name: "two tables",
 			spec: &universe.HourSelectionProcedureSpec{Start: 4, Stop: 23, TimeColumn: execute.DefaultTimeColLabel},
 			data: []flux.Table{


### PR DESCRIPTION
The fix is to provide [`hourSelection`](https://docs.influxdata.com/flux/v0.x/stdlib/universe/hourselection/) function to select data from a nighttime range, such as 10 pm to 6 am.

**Example query-** 
```
...
|> range(start: 2018-12-01T00:00:00Z)
|> hourSelection(start: 22, stop: 6, timeColumn: "_time")
```

**Input -** 
```
,result,table,_measurement,_field,_time,_value
,,0,Sgf,DlXwgrw,2018-12-18T06:11:05Z,70
,,0,Sgf,DlXwgrw,2018-12-18T16:11:15Z,48
,,0,Sgf,DlXwgrw,2018-12-18T17:11:25Z,33
,,0,Sgf,DlXwgrw,2018-12-19T18:11:35Z,63
,,0,Sgf,DlXwgrw,2018-12-19T19:11:45Z,48
,,0,Sgf,DlXwgrw,2018-12-19T22:11:55Z,63
```

**Output -**
```
,result,table,_start,_stop,_measurement,_field,_time,_value
,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-18T06:11:05Z,70
,,0,2018-12-01T00:00:00Z,2030-01-01T00:00:00Z,Sgf,DlXwgrw,2018-12-19T22:11:55Z,63
```

fixes: https://github.com/influxdata/flux/issues/3372


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
