### PR TITLE
fix(SPEC): use MultiplicativeOperator in MultiplicativeExpression

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1014,7 +1014,7 @@ The operator precedence is encoded directly into the grammar as the following.
                              | AdditiveExpression AdditiveOperator MultiplicativeExpression .
     AdditiveOperator         = "+" | "-" .
     MultiplicativeExpression = ExponentExpression
-                             | ExponentExpression ExponentOperator MultiplicativeExpression .
+                             | ExponentExpression MultiplicativeOperator MultiplicativeExpression .
     MultiplicativeOperator   = "*" | "/" | "%" .
     ExponentExpression       = PipeExpression
                              | ExponentExpression ExponentOperator PipeExpression .


### PR DESCRIPTION
While working on converting the EBNF for use with Grammar-Kit, I noticed
the `MultiplicativeOperator` was "unused." Seems like this is where it
should go.


### Done checklist
- [x] docs/SPEC.md updated
- [ ] Test cases written
