### PR TITLE
chore: Remove the experimental SetFinalizer allocator

### DIFF
--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -137,18 +137,6 @@ func OptimizeStateTracking() BoolFlag {
 	return optimizeStateTracking
 }
 
-var setFinalizerMemoryTracking = feature.MakeBoolFlag(
-	"SetFinalizer Memory Tracking",
-	"setFinalizerMemoryTracking",
-	"Markus Westerlind",
-	false,
-)
-
-// SetfinalizerMemoryTracking - Enable SetFinalizer based memory tracking (as opposed to explicit Retain/Release)
-func SetfinalizerMemoryTracking() BoolFlag {
-	return setFinalizerMemoryTracking
-}
-
 var vectorizeAddition = feature.MakeBoolFlag(
 	"Vectorize addition",
 	"vectorizeAddition",
@@ -237,7 +225,6 @@ var all = []Flag{
 	optimizeAggregateWindow,
 	narrowTransformationLimit,
 	optimizeStateTracking,
-	setFinalizerMemoryTracking,
 	vectorizeAddition,
 	vectorizeOperators,
 	labelPolymorphism,
@@ -257,7 +244,6 @@ var byKey = map[string]Flag{
 	"optimizeAggregateWindow":          optimizeAggregateWindow,
 	"narrowTransformationLimit":        narrowTransformationLimit,
 	"optimizeStateTracking":            optimizeStateTracking,
-	"setFinalizerMemoryTracking":       setFinalizerMemoryTracking,
 	"vectorizeAddition":                vectorizeAddition,
 	"vectorizeOperators":               vectorizeOperators,
 	"labelPolymorphism":                labelPolymorphism,

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -70,12 +70,6 @@
   default: false
   contact: Sean Brickley
 
-- name: SetFinalizer Memory Tracking
-  description: Enable SetFinalizer based memory tracking (as opposed to explicit Retain/Release)
-  key: setFinalizerMemoryTracking
-  default: false
-  contact: Markus Westerlind
-
 - name: Vectorize addition
   description: Vectorizes addition expressions inside map
   key: vectorizeAddition

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -289,21 +289,14 @@ func (p *Program) Start(ctx context.Context, alloc memory.Allocator) (flux.Query
 		}
 	}
 
-	if feature.SetfinalizerMemoryTracking().Enabled(ctx) {
-		alloc = memory.NewGcAllocator(resourceAlloc)
-	} else {
-		alloc = resourceAlloc
-	}
-
-	ctx = memory.WithAllocator(ctx, alloc)
+	ctx = memory.WithAllocator(ctx, resourceAlloc)
 
 	q := &query{
-		ctx:            ctx,
-		results:        results,
-		allocatorStats: resourceAlloc,
-		alloc:          alloc,
-		span:           s,
-		cancel:         cancel,
+		ctx:     ctx,
+		results: results,
+		alloc:   resourceAlloc,
+		span:    s,
+		cancel:  cancel,
 		stats: flux.Statistics{
 			Metadata: make(metadata.Metadata),
 		},

--- a/lang/query.go
+++ b/lang/query.go
@@ -12,15 +12,14 @@ import (
 
 // query implements the flux.Query interface.
 type query struct {
-	ctx            context.Context
-	results        chan flux.Result
-	stats          flux.Statistics
-	allocatorStats *memory.ResourceAllocator
-	alloc          memory.Allocator
-	span           opentracing.Span
-	cancel         func()
-	err            error
-	wg             sync.WaitGroup
+	ctx     context.Context
+	results chan flux.Result
+	stats   flux.Statistics
+	alloc   *memory.ResourceAllocator
+	span    opentracing.Span
+	cancel  func()
+	err     error
+	wg      sync.WaitGroup
 }
 
 func (q *query) Results() <-chan flux.Result {
@@ -30,8 +29,8 @@ func (q *query) Results() <-chan flux.Result {
 func (q *query) Done() {
 	q.cancel()
 	q.wg.Wait()
-	q.stats.MaxAllocated = q.allocatorStats.MaxAllocated()
-	q.stats.TotalAllocated = q.allocatorStats.TotalAllocated()
+	q.stats.MaxAllocated = q.alloc.MaxAllocated()
+	q.stats.TotalAllocated = q.alloc.TotalAllocated()
 	if q.span != nil {
 		q.span.Finish()
 		q.span = nil

--- a/memory/allocator.go
+++ b/memory/allocator.go
@@ -3,10 +3,8 @@ package memory
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"sync"
 	"sync/atomic"
-	"unsafe"
 
 	"github.com/apache/arrow/go/v7/arrow/memory"
 	"github.com/influxdata/flux/codes"
@@ -259,60 +257,6 @@ func (a *ResourceAllocator) allocator() memory.Allocator {
 	}
 	return a.Allocator
 }
-
-type GcAllocator struct {
-	mem Allocator
-}
-
-func NewGcAllocator(mem Allocator) *GcAllocator {
-	return &GcAllocator{
-		mem: mem,
-	}
-}
-
-func (a *GcAllocator) Allocate(size int) []byte {
-	bs := a.mem.Allocate(size)
-	if len(bs) > 0 {
-		l := len(bs)
-		runtime.SetFinalizer(&bs[0], func(b *byte) {
-			if l != 0 {
-				// Allows us to reconstruct the slice without creating a circular dependency between
-				// the finalizer and the slice
-				bs2 := unsafe.Slice(b, l)
-				a.mem.Free(bs2)
-				l = 0
-			}
-		})
-	}
-	return bs
-}
-
-func (a *GcAllocator) Reallocate(size int, b []byte) []byte {
-	bs := a.mem.Reallocate(size, b)
-
-	// If the reallocation extended `b` the previous finalizer are still attached
-	if len(bs) > 0 {
-		l := len(bs)
-		runtime.SetFinalizer(&b[0], nil)
-		runtime.SetFinalizer(&bs[0], func(b *byte) {
-			if l != 0 {
-				// Allows us to reconstruct the slice without creating a circular dependency between
-				// the finalizer and the slice
-				bs2 := unsafe.Slice(b, l)
-				a.mem.Free(bs2)
-				l = 0
-			}
-		})
-	}
-
-	return bs
-}
-
-func (a *GcAllocator) Free(b []byte) {
-
-}
-
-func (a *GcAllocator) Account(size int) error { return a.mem.Account(size) }
 
 // Manager will manage the memory allowed for the Allocator.
 // The Allocator may use the Manager to request additional memory or to


### PR DESCRIPTION
Every time we allocate an arrow array we check that we do not exceed the maximum memory limit.
Since this limit check is before the allocation step (and garbage collection) we inevitably
end up in a situation where the limit gets exceeded before the garbage collector has a chance
to run. Worse, go's garbage collector is highly incremental so even when it does run, we can
still end up allocating more than we collect, thereby exceeding the limit.

The only way I can see this allocator working is if the limit is so far above the amount of
memory actually being in use, which would let the garbage collector keep up. However in that case
the memory limit wouldn't really relate to how much memory were actually in use making it rather arbitrary.

Closes #4486