### PR TITLE
build: downgrade rust to v1.58

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,10 @@
 [toolchain]
-channel = "1.60"
-components = [ "rustfmt", "clippy" ]
+channel = "1.58"
+components = ["rustfmt", "clippy"]
 targets = [
-	"wasm32-unknown-unknown",
-	"x86_64-unknown-linux-musl",
-	"aarch64-unknown-linux-musl",
-	"x86_64-pc-windows-gnu",
-	"x86_64-apple-darwin",
+    "wasm32-unknown-unknown",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
 ]


### PR DESCRIPTION
Fixes an issue with the OSS build.

Nb. the `Dockerfile_build` rust version (which normally has to be in
lock-step with the `rust-toolchain.toml` _because of reasons_) was
already at 1.58. This is why the version isn't changing in this diff.

Separately, could the drift between these 2 have contributed to the
break in the OSS build?


### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
