### PR TITLE
build: downgrade Rust to 1.58 for Flux v0.166.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,10 +1,10 @@
 [toolchain]
-channel = "1.60"
-components = [ "rustfmt", "clippy" ]
+channel = "1.58"
+components = ["rustfmt", "clippy"]
 targets = [
-	"wasm32-unknown-unknown",
-	"x86_64-unknown-linux-musl",
-	"aarch64-unknown-linux-musl",
-	"x86_64-pc-windows-gnu",
-	"x86_64-apple-darwin",
+    "wasm32-unknown-unknown",
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl",
+    "x86_64-pc-windows-gnu",
+    "x86_64-apple-darwin",
 ]


### PR DESCRIPTION
39d14499 downgrades Rust to 1.58, but it exists after d2753ff4 (the tag & commit for `v0.166.0`). This cherry-picks 39d14499 and places the commit directly after d2753ff4 (`v0.166.0`). This is so the commits between d2753ff4 (`v0.166.0`) and 39d14499 are excluded. I intend to tag a `v0.166.1` release if possible.

Do not merge this! I just wanted a place to track the discussion. 