### PR TITLE
fix: return a more helpful error message to the user when an http response exceeds maxResponseBody(100MB)

### DIFF
--- a/dependencies/http/http.go
+++ b/dependencies/http/http.go
@@ -53,6 +53,10 @@ func (l roundTripLimiter) RoundTrip(r *http.Request) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Check that the content length is not too large for us to handle.
+	if response.ContentLength > l.size {
+		return nil, errors.New(codes.FailedPrecondition, "http response body is too large, reduce the amount of data querying")
+	}
 	response.Body = limitReadCloser(response.Body, l.size)
 	return response, nil
 }

--- a/dependencies/http/http_test.go
+++ b/dependencies/http/http_test.go
@@ -8,11 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/foxcpp/go-mockdns"
-	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux/codes"
 	depsUrl "github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/internal/errors"
@@ -45,15 +45,14 @@ func TestLimitedDefaultClient(t *testing.T) {
 		}
 		resp, err := c.Do(req)
 		if err != nil {
-			t.Fatal(err)
+			matched, _ := regexp.MatchString("http response body is too large, reduce the amount of data querying", err.Error())
+			if !matched {
+				t.Fatalf("expected error:\n\t%s", err.Error())
+			}
+		} else {
+			t.Fatalf("got unexpected response body:\n\t%s", resp.Body)
 		}
-		bs, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := cmp.Diff(body[:size], string(bs)); diff != "" {
-			t.Fatalf("got unexpected response body:\n\t%s", diff)
-		}
+
 	})
 }
 


### PR DESCRIPTION
issue:
The flux HTTP client [limits response sizes](https://github.com/influxdata/flux/blob/master/dependencies/http/http.go#L18) to 100 MB. If a user runs a query that results in a large HTTP response, the resulting failure can manifest in a number of different error messages for the user, not all of which are helpful in effectively communicating the actual problem.
Another possible manifestation of this is truncated CSV, which produces a confusing error.

fixes: https://github.com/influxdata/flux/issues/4607


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
