### PR TITLE
fix: Make it an error to use a label variable without the Label constraint

### DIFF
--- a/libflux/flux-core/src/semantic/nodes.rs
+++ b/libflux/flux-core/src/semantic/nodes.rs
@@ -62,6 +62,8 @@ pub enum ErrorKind {
     InvalidReturn,
     #[display(fmt = "can't vectorize function: {}", _0)]
     UnableToVectorize(String),
+    #[display(fmt = "variable {} lacks the {} constraint", var, kind)]
+    MissingConstraint { var: Tvar, kind: Kind },
     #[display(fmt = "{}. This is a bug in type inference", _0)]
     Bug(String),
 }
@@ -81,6 +83,12 @@ impl Substitutable for ErrorKind {
     fn walk(&self, sub: &mut (impl ?Sized + Substituter)) -> Option<Self> {
         match self {
             Self::Inference(err) => err.visit(sub).map(Self::Inference),
+            Self::MissingConstraint { var, kind } => {
+                sub.try_apply_bound(*var).and_then(|typ| match typ {
+                    MonoType::Var(var) => Some(Self::MissingConstraint { var, kind: *kind }),
+                    _ => None,
+                })
+            }
             Self::UndefinedBuiltin(_)
             | Self::UndefinedIdentifier(_)
             | Self::InvalidBinOp(_)
@@ -594,11 +602,78 @@ pub struct BuiltinStmt {
 
 impl BuiltinStmt {
     fn infer(&mut self, infer: &mut InferState<'_, '_>) -> std::result::Result<(), Error> {
+        self.typ_expr.check_signture(&self.loc, infer);
         infer.env.add(self.id.name.clone(), self.typ_expr.clone());
         Ok(())
     }
     fn apply(self, _: &mut dyn Substituter) -> Self {
         self
+    }
+}
+
+impl PolyType {
+    fn check_signture(&self, loc: &ast::SourceLocation, infer: &mut InferState<'_, '_>) {
+        struct CheckSignature<'a, 'b, 'c> {
+            infer: &'a mut InferState<'b, 'c>,
+            loc: &'a ast::SourceLocation,
+            poly: &'a PolyType,
+        }
+
+        impl CheckSignature<'_, '_, '_> {
+            fn require_kind(&mut self, var: Tvar, required_kind: Kind) {
+                if self
+                    .poly
+                    .cons
+                    .get(&var)
+                    .into_iter()
+                    .flatten()
+                    .all(|kind| *kind != required_kind)
+                {
+                    self.infer.error(
+                        self.loc.clone(),
+                        ErrorKind::MissingConstraint {
+                            var,
+                            kind: required_kind,
+                        },
+                    );
+                }
+            }
+        }
+
+        impl Substituter for CheckSignature<'_, '_, '_> {
+            fn try_apply(&mut self, _: Tvar) -> Option<MonoType> {
+                None
+            }
+
+            fn visit_type(&mut self, typ: &MonoType) -> Option<MonoType> {
+                match typ {
+                    MonoType::Record(record) => {
+                        let mut fields = record.fields();
+
+                        for prop in &mut fields {
+                            if let RecordLabel::BoundVariable(var) = prop.k {
+                                self.require_kind(var, Kind::Label);
+                            }
+                            prop.v.visit(self);
+                        }
+
+                        if let Some(tail) = fields.tail() {
+                            tail.visit(self);
+                        }
+                    }
+                    _ => {
+                        typ.walk(self);
+                    }
+                }
+                None
+            }
+        }
+
+        self.expr.visit(&mut CheckSignature {
+            infer,
+            loc,
+            poly: self,
+        });
     }
 }
 

--- a/libflux/flux-core/src/semantic/tests/labels.rs
+++ b/libflux/flux-core/src/semantic/tests/labels.rs
@@ -329,3 +329,24 @@ fn constraints_propagate_fully() {
         ],
     }
 }
+
+#[test]
+fn variables_used_in_label_position_must_have_label_kind() {
+    test_error_msg! {
+        config: AnalyzerConfig{
+            features: vec![Feature::LabelPolymorphism],
+            ..AnalyzerConfig::default()
+        },
+        src: r#"
+            builtin abc: (record: { A with T: time }, ?timeColumn: T = "_time") => int
+        "#,
+        expect: expect![[r#"
+            error: variable B lacks the Label constraint
+              ┌─ main:2:13
+              │
+            2 │             builtin abc: (record: { A with T: time }, ?timeColumn: T = "_time") => int
+              │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+        "#]],
+    }
+}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -48,7 +48,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/import.rs":                                                    "184e955211db1ceb1be782b4daf75584b86907b1428e50015497909cfc2dd89a",
 	"libflux/flux-core/src/semantic/infer.rs":                                                     "9d4293f2471a90cc89c1e45cdc72082e0da1a484981b803aea05856e6b4d722f",
 	"libflux/flux-core/src/semantic/mod.rs":                                                       "3cec76c645e411592898a3e153d571787157bdfdf8552c21748c5e8c5e41d48d",
-	"libflux/flux-core/src/semantic/nodes.rs":                                                     "300de1a0f78f303b97736add050d9c8e5d90ad9554eaed6d24b79f9c39991f67",
+	"libflux/flux-core/src/semantic/nodes.rs":                                                     "d3514513174e98e015eab3adfdbd82475efe1bce5e069a7880e3dd3b37631126",
 	"libflux/flux-core/src/semantic/sub.rs":                                                       "a989e50c113ca899fe02f8d49a4744a420580a3f803f656db25beb2d0c2a247b",
 	"libflux/flux-core/src/semantic/types.rs":                                                     "ed414b695e925f18f74984ec88bba652ef8dd8c9e905cb9e8fa19b101a4601b4",
 	"libflux/flux-core/src/semantic/vectorize.rs":                                                 "6ce2dc4e6ff572abc0146a220291322ea88557ce674ae16220a2d67420e9fa0d",


### PR DESCRIPTION
Forgetting to add the `Label` constraint leads to confusing typechecking failures down the line as
it becomes possible to pass non-labels and string literals ends up treated as strings instead of labels.