### PR TITLE
feat(execute): refactor the operator profile to be in the statistics

### DIFF
--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -164,6 +164,7 @@ func TestQuery_Stats(t *testing.T) {
 			t.Fatalf("unexpected error while iterating over tables: %s", err)
 		}
 	}
+	q.Done()
 
 	stats := q.Statistics()
 	if stats.TotalDuration <= 0 {
@@ -395,6 +396,10 @@ data
 			if q, close, err := runQuery(context.Background(), prelude+tc.script); err != nil {
 				t.Error(err)
 			} else {
+				// Mark the query as done as we won't read it.
+				q.Done()
+
+				// Access the statistics.
 				got := fmt.Sprintf("%v", q.Statistics().Metadata["flux/query-plan"])
 				if !cmp.Equal(tc.want, got) {
 					t.Errorf("unexpected value -want/+got\n%s", cmp.Diff(tc.want, got))

--- a/mock/executor.go
+++ b/mock/executor.go
@@ -6,34 +6,33 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
-	"github.com/influxdata/flux/metadata"
 	"github.com/influxdata/flux/plan"
 )
 
 var _ execute.Executor = (*Executor)(nil)
 
-var NoMetadata <-chan metadata.Metadata
+var EmptyStatistics <-chan flux.Statistics
 
 // Executor is a mock implementation of an execute.Executor.
 type Executor struct {
-	ExecuteFn func(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error)
+	ExecuteFn func(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan flux.Statistics, error)
 }
 
 // NewExecutor returns a mock Executor where its methods will return zero values.
 func NewExecutor() *Executor {
 	return &Executor{
-		ExecuteFn: func(context.Context, *plan.Spec, memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
-			return nil, NoMetadata, nil
+		ExecuteFn: func(context.Context, *plan.Spec, memory.Allocator) (map[string]flux.Result, <-chan flux.Statistics, error) {
+			return nil, EmptyStatistics, nil
 		},
 	}
 }
 
-func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan metadata.Metadata, error) {
+func (e *Executor) Execute(ctx context.Context, p *plan.Spec, a memory.Allocator) (map[string]flux.Result, <-chan flux.Statistics, error) {
 	return e.ExecuteFn(ctx, p, a)
 }
 
 func init() {
-	noMetaCh := make(chan metadata.Metadata)
-	close(noMetaCh)
-	NoMetadata = noMetaCh
+	emptyStatsCh := make(chan flux.Statistics)
+	close(emptyStatsCh)
+	EmptyStatistics = emptyStatsCh
 }


### PR DESCRIPTION
The operator profile is now always computed and it is part of the
`flux.Statistics` struct that is returned by the query. The operator
profile now uses that to return the profile instead of using Go channels
and the execution dependency injected into the context.

This allows the results of the operator profile to be present without it
being tied directly to the profiler return.

It has also been refactored to remove the use of channels for sending
span data and aggregating in a goroutine to instead just aggregate the
results as part of the source/transport code. This should simplify and
speed up those calculations as the overall time should be equivalent but
without the overhead of Go channels and only requiring a short-lived
lock for appending the source profiles in the executor.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written