### PR TITLE
fix(stdlib): vectorized map properly handles shadowed columns

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -516,7 +516,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestAverage_test.flux":                                                     "3debee2f9c626a637b8842cf23d32f88ba1bf2bf98b53744e7c699a0c8f833cf",
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "f9575bdb7e2ee3a37153b296d9e59fa69334e675f2de4f4023c0e7aec541aba2",
 	"stdlib/universe/lowestMin_test.flux":                                                         "389fa9ceb38d066ad18a8b21220d4b554d8c31d83d80f1694bc703a14f86a0b2",
-	"stdlib/universe/map_test.flux":                                                               "522e8caeb0a829481bf116c7c8c098866dc6bca571120e679ef89fce066557c2",
+	"stdlib/universe/map_test.flux":                                                               "4f1f8aad14a4e4d99422a816143e492c0616d237d8eee9cf01f8bfedd88c19ba",
 	"stdlib/universe/math_fn_constant_test.flux":                                                  "24091df7a982240ac5fdc4f6495d32a4a6078af1206d6d6cf51d2feb35abb7f7",
 	"stdlib/universe/math_m_max_test.flux":                                                        "9cc0aacc9a66209827b6ba83922fd6a291aa88205d86c5fa79fdce78be7599e0",
 	"stdlib/universe/max_test.flux":                                                               "3057f4d30f8c404af13b2f27ce13527c97ea77bf198c0f1a627f3b48673d4db8",

--- a/stdlib/universe/map_test.flux
+++ b/stdlib/universe/map_test.flux
@@ -519,3 +519,14 @@ testcase vectorize_or_operator {
 
     testing.diff(want: want, got: got) |> yield()
 }
+
+testcase vectorize_with_operator_overwrite_attribute {
+    got =
+        array.from(rows: [{x: 1, y: "a"}])
+            |> map(fn: (r) => ({r with x: r.x}))
+            |> drop(columns: ["y"])
+
+    want = array.from(rows: [{x: 1}])
+
+    testing.diff(got, want)
+}

--- a/values/object.go
+++ b/values/object.go
@@ -113,6 +113,10 @@ func BuildObjectWithSize(sz int, fn func(set ObjectSetter) error) (Object, error
 	if err := fn(func(k string, v Value) {
 		for i := 0; i < len(keys); i++ {
 			if keys[i] == k {
+				if values[i] != nil {
+					// Value overwritten. Usually due to a shadowed field.
+					values[i].Release()
+				}
 				values[i] = v
 				return
 			}


### PR DESCRIPTION
The vectorized version of map did not properly handle shadowed columns
the way the row based one worked. This copies over some of that code so
that it follows the correct logic. It also copies over the same logic
that is used to determine the column type when type inference does not
properly tell us the type.

This also fixes a bug in building objects that caused a bug in the
compiler. When a `with` is evaluated, the attributes from the original
record are copied over first and then overwritten values are assigned.
This overwriting did not properly release the values that were being
overwritten resulting in a memory leak.

Fixes #4812.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written