### PR TITLE
fix: ensure buffers are retained when copying an already buffered table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export PKG_CONFIG:=$(shell pwd)/pkg-config.sh
 
 export GOOS=$(shell go env GOOS)
 export GO_BUILD=env GO111MODULE=on go build $(GO_ARGS)
-export GO_TEST=env GO111MODULE=on go test $(GO_ARGS)
+export GO_TEST=env GO111MODULE=on go test $(GO_ARGS) -tags assert
 export GO_RUN=env GO111MODULE=on go run $(GO_ARGS)
 export GO_TEST_FLAGS=
 # Do not add GO111MODULE=on to the call to go generate so it doesn't pollute the environment.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export PKG_CONFIG:=$(shell pwd)/pkg-config.sh
 
 export GOOS=$(shell go env GOOS)
 export GO_BUILD=env GO111MODULE=on go build $(GO_ARGS)
-export GO_TEST=env GO111MODULE=on go test $(GO_ARGS) -tags assert
+export GO_TEST=env GO111MODULE=on go test $(GO_ARGS)
 export GO_RUN=env GO111MODULE=on go run $(GO_ARGS)
 export GO_TEST_FLAGS=
 # Do not add GO111MODULE=on to the call to go generate so it doesn't pollute the environment.

--- a/execute/executetest/selector.go
+++ b/execute/executetest/selector.go
@@ -33,7 +33,7 @@ func RowSelectorFuncTestHelper(t *testing.T, selector execute.RowSelector, data 
 //lint:ignore U1000 Not sure why we need this...someone write a better reason :) .
 var rows []execute.Row
 
-func RowSelectorFuncBenchmarkHelper(b *testing.B, selector execute.RowSelector, data flux.Table) {
+func RowSelectorFuncBenchmarkHelper(b *testing.B, selector execute.RowSelector, data flux.BufferedTable) {
 	b.Helper()
 
 	valueIdx := execute.ColIdx(execute.DefaultValueColLabel, data.Cols())
@@ -43,8 +43,9 @@ func RowSelectorFuncBenchmarkHelper(b *testing.B, selector execute.RowSelector, 
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		t := data.Copy()
 		s := selector.NewFloatSelector()
-		if err := data.Do(func(cr flux.ColReader) error {
+		if err := t.Do(func(cr flux.ColReader) error {
 			s.DoFloat(cr.Floats(valueIdx), cr)
 			return nil
 		}); err != nil {

--- a/execute/executetest/selector.go
+++ b/execute/executetest/selector.go
@@ -43,8 +43,9 @@ func RowSelectorFuncBenchmarkHelper(b *testing.B, selector execute.RowSelector, 
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		t := data.Copy()
 		s := selector.NewFloatSelector()
+
+		t := data.Copy()
 		if err := t.Do(func(cr flux.ColReader) error {
 			s.DoFloat(cr.Floats(valueIdx), cr)
 			return nil

--- a/execute/table/copy.go
+++ b/execute/table/copy.go
@@ -16,7 +16,7 @@ import "github.com/influxdata/flux"
 // this happens and prevent it.
 func Copy(t flux.Table) (flux.BufferedTable, error) {
 	if tbl, ok := t.(flux.BufferedTable); ok {
-		return tbl, nil
+		return tbl.Copy(), nil
 	}
 
 	tbl := tableBuffer{

--- a/execute/table/copy.go
+++ b/execute/table/copy.go
@@ -1,11 +1,11 @@
 package table
 
 import (
-	"log"
 	"sync/atomic"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/debug"
 	"github.com/influxdata/flux/internal/errors"
 )
 
@@ -103,12 +103,10 @@ func (tb *tableBuffer) BufferN() int {
 
 func (tb *tableBuffer) Copy() flux.BufferedTable {
 
-	// TODO: make this panic instead of just logging when running tests.
-	//  Arrow has a `debug.Assert` thing which will noop unless the assert build
-	//  tag is set. We could do something similar.
-	if atomic.LoadInt32(&tb.used) == 1 {
-		log.Println("tried to copy an already used tableBuffer")
-	}
+	debug.Assert(
+		atomic.LoadInt32(&tb.used) == 0,
+		"tried to copy an already used tableBuffer",
+	)
 
 	for i := 0; i < len(tb.buffers); i++ {
 		tb.buffers[i].Retain()

--- a/execute/table/copy.go
+++ b/execute/table/copy.go
@@ -1,6 +1,7 @@
 package table
 
 import (
+	"log"
 	"sync/atomic"
 
 	"github.com/influxdata/flux"
@@ -101,8 +102,12 @@ func (tb *tableBuffer) BufferN() int {
 }
 
 func (tb *tableBuffer) Copy() flux.BufferedTable {
+
+	// TODO: make this panic instead of just logging when running tests.
+	//  Arrow has a `debug.Assert` thing which will noop unless the assert build
+	//  tag is set. We could do something similar.
 	if atomic.LoadInt32(&tb.used) == 1 {
-		panic("tried to copy an already used tableBuffer")
+		log.Println("tried to copy an already used tableBuffer")
 	}
 
 	for i := 0; i < len(tb.buffers); i++ {

--- a/execute/table/copy.go
+++ b/execute/table/copy.go
@@ -101,7 +101,7 @@ func (tb *tableBuffer) BufferN() int {
 }
 
 func (tb *tableBuffer) Copy() flux.BufferedTable {
-	if tb.used == 1 {
+	if atomic.LoadInt32(&tb.used) == 1 {
 		panic("tried to copy an already used tableBuffer")
 	}
 

--- a/execute/table/copy.go
+++ b/execute/table/copy.go
@@ -1,6 +1,12 @@
 package table
 
-import "github.com/influxdata/flux"
+import (
+	"sync/atomic"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
 
 // Copy returns a buffered copy of the table and consumes the
 // input table. If the input table is already buffered, it "consumes"
@@ -15,10 +21,6 @@ import "github.com/influxdata/flux"
 // potentially cause a problem. The allocator is meant to catch when
 // this happens and prevent it.
 func Copy(t flux.Table) (flux.BufferedTable, error) {
-	if tbl, ok := t.(flux.BufferedTable); ok {
-		return tbl.Copy(), nil
-	}
-
 	tbl := tableBuffer{
 		key:     t.Key(),
 		colMeta: t.Cols(),
@@ -46,8 +48,8 @@ func Copy(t flux.Table) (flux.BufferedTable, error) {
 type tableBuffer struct {
 	key     flux.GroupKey
 	colMeta []flux.ColMeta
-	i       int
 	buffers []flux.ColReader
+	used    int32
 }
 
 func (tb *tableBuffer) Key() flux.GroupKey {
@@ -59,20 +61,30 @@ func (tb *tableBuffer) Cols() []flux.ColMeta {
 }
 
 func (tb *tableBuffer) Do(f func(flux.ColReader) error) error {
-	defer tb.Done()
-	for ; tb.i < len(tb.buffers); tb.i++ {
-		b := tb.buffers[tb.i]
+	if !atomic.CompareAndSwapInt32(&tb.used, 0, 1) {
+		return errors.New(codes.Internal, "table already read")
+	}
+	defer func() {
+		for i := 0; i < len(tb.buffers); i++ {
+			tb.buffers[i].Release()
+		}
+	}()
+
+	for i := 0; i < len(tb.buffers); i++ {
+		b := tb.buffers[i]
 		if err := f(b); err != nil {
 			return err
 		}
-		b.Release()
 	}
+
 	return nil
 }
 
 func (tb *tableBuffer) Done() {
-	for ; tb.i < len(tb.buffers); tb.i++ {
-		tb.buffers[tb.i].Release()
+	if atomic.CompareAndSwapInt32(&tb.used, 0, 1) {
+		for i := 0; i < len(tb.buffers); i++ {
+			tb.buffers[i].Release()
+		}
 	}
 }
 
@@ -89,13 +101,16 @@ func (tb *tableBuffer) BufferN() int {
 }
 
 func (tb *tableBuffer) Copy() flux.BufferedTable {
-	for i := tb.i; i < len(tb.buffers); i++ {
+	if tb.used == 1 {
+		panic("tried to copy an already used tableBuffer")
+	}
+
+	for i := 0; i < len(tb.buffers); i++ {
 		tb.buffers[i].Retain()
 	}
 	return &tableBuffer{
 		key:     tb.key,
 		colMeta: tb.colMeta,
-		i:       tb.i,
 		buffers: tb.buffers,
 	}
 }

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -369,7 +369,7 @@ func TestCopyTable(t *testing.T) {
 	}
 }
 
-func TestDoubleCopyTable(t *testing.T) {
+func TestCopyTable_DoubleCopy(t *testing.T) {
 	// This is a slight twist on the above `TestCopyTable`.
 	// In <https://github.com/influxdata/flux/issues/4780> we saw that when
 	// `yield` and `tableFind` are combined, we can end up calling `Copy`

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -372,10 +372,11 @@ func TestCopyTable(t *testing.T) {
 func TestDoubleCopyTable(t *testing.T) {
 	// This is a slight twist on the above `TestCopyTable`.
 	// In <https://github.com/influxdata/flux/issues/4780> we saw that when
-	// `yield` and `tableFind` are combined, we can end up calling `CopyTable`
+	// `yield` and `tableFind` are combined, we can end up calling `Copy`
 	// on and already copied table.
 	// This test checks that each copy can be consumed independently and that
-	// consuming one copy does not accidentally consume the other.
+	// consuming one copy does not accidentally consume the other, or even
+	// "double free" the underlying arrow arrays.
 
 	alloc := memory.NewResourceAllocator(nil)
 
@@ -396,18 +397,20 @@ func TestDoubleCopyTable(t *testing.T) {
 
 	var buffers []flux.BufferedTable
 	if err := input.Do(func(table flux.Table) error {
-		bt, err := execute.CopyTable(table)
+		src, err := execute.CopyTable(table)
 		if err != nil {
 			return err
 		}
-		buffers = append(buffers, bt)
 
-		// copy of a copy
-		bt2, err := execute.CopyTable(bt)
-		if err != nil {
-			return err
-		}
+		// two copies from the original src (buffered) table
+		bt := src.Copy()
+		bt2 := src.Copy()
+		// close out the src
+		src.Done()
+
+		buffers = append(buffers, bt)
 		buffers = append(buffers, bt2)
+		buffers = append(buffers, bt2.Copy()) // copy of a copy
 
 		return nil
 	}); err != nil {
@@ -415,14 +418,9 @@ func TestDoubleCopyTable(t *testing.T) {
 	}
 
 	for _, buf := range buffers {
-		// If a copy and _copy of a copy_ share underlying buffers without
-		// correctly managing the refcounts, calling `Do` on the original copy
-		// can accidentally mark second as `Done` early.
-		// This `did` value is used to ensure we actually trigger the callback
-		// for `Do` at least once for every single buffer.
-		did := 0
+		did := false
 		if err := buf.Do(func(cr flux.ColReader) error {
-			did += 1
+			did = true
 			if cr.Len() == 0 {
 				return nil
 			}
@@ -434,9 +432,67 @@ func TestDoubleCopyTable(t *testing.T) {
 		}); err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
-		if did == 0 {
+		if !did {
 			t.Errorf("expected Do() to run for buffer, but it didn't")
 		}
+	}
+
+	// Ensure there has been no memory leak.
+	if got, want := alloc.Allocated(), int64(0); got != want {
+		t.Errorf("memory leak -want/+got:\n\t- %d\n\t+ %d", want, got)
+	}
+}
+func TestTableDoneIdempotent(t *testing.T) {
+	alloc := memory.NewResourceAllocator(nil)
+
+	input, err := gen.Input(context.Background(), gen.Schema{
+		Tags: []gen.Tag{
+			{Name: "t0", Cardinality: 1},
+		},
+		NumPoints: 100,
+		Period:    time.Hour,
+		Types: map[flux.ColType]int{
+			flux.TFloat: 1,
+		},
+		Alloc: alloc,
+	})
+	if err != nil {
+		t.Fatalf("unable to generate tables: %s", err)
+	}
+
+	var buffers [][]flux.BufferedTable
+	if err := input.Do(func(table flux.Table) error {
+		bt, err := execute.CopyTable(table)
+		if err != nil {
+			return err
+		}
+		buffers = append(buffers, []flux.BufferedTable{bt.Copy(), bt})
+		return nil
+	}); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for _, pair := range buffers {
+		buf0 := pair[0]
+		buf1 := pair[1]
+
+		// Done before Do should produce an error
+		buf0.Done()
+		buf0.Done()
+		if err := buf0.Do(func(cr flux.ColReader) error {
+			return nil
+		}); err == nil {
+			t.Error("expected error, got nil")
+		}
+
+		// Do before Done should produce no error
+		if err := buf1.Do(func(cr flux.ColReader) error {
+			return nil
+		}); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+		buf1.Done()
+		buf1.Done()
 	}
 
 	// Ensure there has been no memory leak.

--- a/internal/debug/assert_off.go
+++ b/internal/debug/assert_off.go
@@ -1,0 +1,28 @@
+// The below was lifted entirely from
+// <https://github.com/apache/arrow/blob/e90472e35b40f58b17d408438bb8de1641bfe6ef/go/arrow/internal/debug/assert_off.go>
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !assert
+// +build !assert
+
+package debug
+
+// Assert will panic with msg if cond is false.
+//
+// msg must be a string, func() string or fmt.Stringer.
+func Assert(cond bool, msg interface{}) {}

--- a/internal/debug/assert_on.go
+++ b/internal/debug/assert_on.go
@@ -1,0 +1,32 @@
+// The below was lifted entirely from
+// <https://github.com/apache/arrow/blob/e90472e35b40f58b17d408438bb8de1641bfe6ef/go/arrow/internal/debug/assert_on.go>
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build assert
+// +build assert
+
+package debug
+
+// Assert will panic with msg if cond is false.
+//
+// msg must be a string, func() string or fmt.Stringer.
+func Assert(cond bool, msg interface{}) {
+	if !cond {
+		panic(getStringValue(msg))
+	}
+}

--- a/internal/debug/util.go
+++ b/internal/debug/util.go
@@ -1,0 +1,41 @@
+// The below was lifted entirely from
+// <https://github.com/apache/arrow/blob/e90472e35b40f58b17d408438bb8de1641bfe6ef/go/arrow/internal/debug/util.go>
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build debug || assert
+// +build debug assert
+
+package debug
+
+import "fmt"
+
+func getStringValue(v interface{}) string {
+	switch a := v.(type) {
+	case func() string:
+		return a()
+
+	case string:
+		return a
+
+	case fmt.Stringer:
+		return a.String()
+
+	default:
+		panic(fmt.Sprintf("unexpected type, %t", v))
+	}
+}


### PR DESCRIPTION
Refs #4780

When the tables sent into `tableFind` include a yield, the result generated by the yield can cause the tables to be released before `tableFind` can use them.

`tableFind` will make its own copy, but prior to this change the copy operation would hand back the input directly when it was already buffered. In effect, this means we produce references to the same underlying buffers without us incrementing the ref count.

~~With this diff, for the case where we try to copy an already buffered table, we call its own `Copy()` method which will `Retain()` each of the internal buffers.~~

After a few twists and turns, the fixes for this issue came from:

- making `tableBuffer`'s `Do` and `Done` idempotent such that calling `Done` after `Do` would not release the underlying arrow arrays repeatedly.
- ensuring `table.Copy()` always calls `Retain()` on the underlying arrow arrays (_previously this was not the case when the table is already buffered_).

A `tableBuffer` could be spent by calling either `Do()` or `Done()`, then later we might call `Do()` again. Prior to this patch, `Do()` would silently do nothing. Instead, it will now return an error "table already read." This is in line with other implementations of the Table APIs.

Similarly, `Copy()` will now panic if called on a table that is already "spent." Prior to the explicit panic, we'd see panics surfaced by invalid (`nil` pointer) access to underlying arrow arrays somewhere deeper into the execution of the program. _Seems as though this is a case where a `tableBuffer` lived too long via programmer error so a more immediate/explicit panic makes sense._

---

N.b this is not a total fix for #4780. We still have a separate problem related to how `tableFind` will use a random result from the input table stream when there is >1 result to be had. #4813 should address the remaining problems surfaced by the initial report.

### Done checklist
- [x] docs/SPEC.md updated **N/A**
- [x] Test cases written
