### PR TITLE
feat(date): add builtin function time to the date package to convert any timeable into datetime (#4749)

### DIFF
--- a/stdlib/date/date.flux
+++ b/stdlib/date/date.flux
@@ -39,6 +39,8 @@ package date
 // ```
 builtin second : (t: T) => int where T: Timeable
 
+builtin time : (t: T) => time where T: Timeable
+
 // builtin _minute used by minute
 builtin _minute : (t: T, location: {zone: string, offset: duration}) => int where T: Timeable
 

--- a/stdlib/date/date.go
+++ b/stdlib/date/date.go
@@ -29,6 +29,17 @@ func init() {
 				return values.NewInt(int64(tm.Time().Second())), nil
 			}, false,
 		),
+		"time": values.NewFunction(
+			"time",
+			runtime.MustLookupBuiltinType("date", "time"),
+			func(ctx context.Context, args values.Object) (values.Value, error) {
+				tm, err := getTimeableTime(ctx, args)
+				if err != nil {
+					return nil, err
+				}
+				return values.NewTime(tm), nil
+			}, false,
+		),
 		"minute": values.NewFunction(
 			"minute",
 			runtime.MustLookupBuiltinType("date", "_minute"),
@@ -279,6 +290,7 @@ func init() {
 	}
 
 	runtime.RegisterPackageValue("date", "second", SpecialFns["second"])
+	runtime.RegisterPackageValue("date", "time", SpecialFns["time"])
 	runtime.RegisterPackageValue("date", "_minute", SpecialFns["minute"])
 	runtime.RegisterPackageValue("date", "_hour", SpecialFns["hour"])
 	runtime.RegisterPackageValue("date", "_weekDay", SpecialFns["weekDay"])


### PR DESCRIPTION
This feature addition now addresses the need for a function as part of the date package to be able to convert any Timeable into a datetime.

fixes: https://github.com/influxdata/flux/issues/4749

testing done:


import "date"

date.time(t: -1h)
2022-06-03T15:49:42.544101000Z
start = date.time(t: -1h)
start
2022-06-03T15:50:19.282299000Z
start = date.time(t: 2020-01-01)
start
2020-01-01T00:00:00.000000000Z
date.time(t: 2022-06-03T15:49:42.544101000Z)
2022-06-03T15:49:42.544101000Z
date.time(t: 2022-06-04T15:49:42Z)
2022-06-04T15:49:42.000000000Z
date.time(t: 2022-06-04T15:49:04.541Z)
2022-06-04T15:49:04.541000000Z
date.time(t: -3d12h4m25s1ms1us1ns)
2022-05-31T04:55:07.872817999Z
date.time(t: -1y1mo1w)
2021-04-26T17:00:24.855445000Z


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
