### PR TITLE
feat(date): add builtin function time to the date package to convert any timeable into datetime (#4749)

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -102,7 +102,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/tomhollingworth/events/duration_with_stop_test.flux":                          "ec06b590cf7010b89e57f1bb3aee7374fb46290dc8d3f441f5d12d94bce47925",
 	"stdlib/csv/csv.flux":                                                                         "94a1d8dd59c0e092617e9c974bad4edaf1a2c6ebb20fd185524b58cb657329b0",
 	"stdlib/csv/csv_test.flux":                                                                    "8aaf56893a1aefb65883ba96ebdb0283670d76ec872bfedfe389d778bdc1bb8f",
-	"stdlib/date/date.flux":                                                                       "19f0b86a72d4c61ff2e16f0d5c4898c5da983efa175456583f39d2de5fc52cc0",
+	"stdlib/date/date.flux":                                                                       "7fc8c47a0705afc7e6321437df6c538bb281ee18af59ea0695b463fc64cf24f2",
 	"stdlib/date/date_test.flux":                                                                  "42ea61ee595ab6cfc5631505cf5a757f5a7fa24bd5cc43466099956552b071cf",
 	"stdlib/date/durations_test.flux":                                                             "610f791ede48d7dda9a1f6aaaa38fe7fe81a278339857716120ef56f946bfe33",
 	"stdlib/date/hour_duration_test.flux":                                                         "7da9263cddf0fa443e9dc55b176139d1dd67cb689c0be243d8b595799fc066f4",

--- a/stdlib/date/date.flux
+++ b/stdlib/date/date.flux
@@ -39,6 +39,8 @@ package date
 // ```
 builtin second : (t: T) => int where T: Timeable
 
+builtin time : (t: T) => time where T: Timeable
+
 // builtin _minute used by minute
 builtin _minute : (t: T, location: {zone: string, offset: duration}) => int where T: Timeable
 

--- a/stdlib/date/date.go
+++ b/stdlib/date/date.go
@@ -29,6 +29,17 @@ func init() {
 				return values.NewInt(int64(tm.Time().Second())), nil
 			}, false,
 		),
+		"time": values.NewFunction(
+			"time",
+			runtime.MustLookupBuiltinType("date", "time"),
+			func(ctx context.Context, args values.Object) (values.Value, error) {
+				tm, err := getTimeableTime(ctx, args)
+				if err != nil {
+					return nil, err
+				}
+				return values.NewTime(tm), nil
+			}, false,
+		),
 		"minute": values.NewFunction(
 			"minute",
 			runtime.MustLookupBuiltinType("date", "_minute"),
@@ -279,6 +290,7 @@ func init() {
 	}
 
 	runtime.RegisterPackageValue("date", "second", SpecialFns["second"])
+	runtime.RegisterPackageValue("date", "time", SpecialFns["time"])
 	runtime.RegisterPackageValue("date", "_minute", SpecialFns["minute"])
 	runtime.RegisterPackageValue("date", "_hour", SpecialFns["hour"])
 	runtime.RegisterPackageValue("date", "_weekDay", SpecialFns["weekDay"])


### PR DESCRIPTION
This feature addition now addresses the need for a function as part of the date package to be able to convert any Timeable into a datetime.

fixes: https://github.com/influxdata/flux/issues/4749

testing done:

import "date"

date.time(t: -1h)
2022-06-03T15:49:42.544101000Z
start = date.time(t: -1h)
start
2022-06-03T15:50:19.282299000Z
start = date.time(t: 2020-01-01)
start
2020-01-01T00:00:00.000000000Z
date.time(t: 2022-06-03T15:49:42.544101000Z)
2022-06-03T15:49:42.544101000Z
date.time(t: 2022-06-04T15:49:42Z)
2022-06-04T15:49:42.000000000Z
date.time(t: 2022-06-04T15:49:04.541Z)
2022-06-04T15:49:04.541000000Z
date.time(t: -3d12h4m25s1ms1us1ns)
2022-05-31T04:55:07.872817999Z
date.time(t: -1y1mo1w)
2021-04-26T17:00:24.855445000Z

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
