### PR TITLE
fix: require an earlier minimum lsp types

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.93.0"
+version = "0.92.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c74e2173b2b31f8655d33724b4b45ac13f439386f66290f539c22b144c2212"
+checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
 dependencies = [
  "bitflags",
  "serde",

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -41,7 +41,7 @@ flatbuffers = "2.1.1"
 fnv = "1.0.7"
 libflate = "1.2.0"
 log = "0.4.16"
-lsp-types = { version = "0.93", optional = true }
+lsp-types = { version = "0.92", optional = true }
 maplit = "1.0.2"
 once_cell = { version = "1.10.0", optional = true }
 pad = { version = "0.1.6", optional = true }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,9 +12,9 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "2864899703fe551dadb62bfe910efdd481baaca5a1b182c60834915145c25745",
+	"libflux/Cargo.lock":                                                                          "8825ad430df2d94d6ccd195a72d59bf38449096d05c227ec60a1828f91daa669",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "2290ce95d56e0f514b7c8285693a8011cddfc652bf2aad24edfeb43911f57ba9",
+	"libflux/flux-core/Cargo.toml":                                                                "594c5cc9a8ff9440418b49c37488112faa8e57b82df084b327b8252beded17b1",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "47e06631f249715a44c9c8fa897faf142ad0fa26f67f8cfd5cd201e82cb1afc8",
 	"libflux/flux-core/src/ast/mod.rs":                                                            "a410553122854cc383c75b06d553bc4b6a683e637962596ef946c52958b6a168",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "92dd40a0665f60ee1c1b0441580b3f2d3d57e75ea7f6d83fd5a73a759b10289d",


### PR DESCRIPTION
With the switch back down to `lspower` in `flux-lsp`, `flux` is now
requiring too new of a `lsp-types` for `flux-lsp` to use. `flux-lsp`
needs `lsp-types 0.92`, and flux is using `0.93`. This patch downgrades
this requirement.