### PR TITLE
feat(date): add builtin function time to the date package to convert any timeable into datetime (#4749)

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -102,7 +102,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/tomhollingworth/events/duration_with_stop_test.flux":                          "d776dcbc86133bc58cf7eeee79619d2b9797a280cbbeeebff28976a99cfa7acb",
 	"stdlib/csv/csv.flux":                                                                         "94a1d8dd59c0e092617e9c974bad4edaf1a2c6ebb20fd185524b58cb657329b0",
 	"stdlib/csv/csv_test.flux":                                                                    "8aaf56893a1aefb65883ba96ebdb0283670d76ec872bfedfe389d778bdc1bb8f",
-	"stdlib/date/date.flux":                                                                       "19f0b86a72d4c61ff2e16f0d5c4898c5da983efa175456583f39d2de5fc52cc0",
+	"stdlib/date/date.flux":                                                                       "352788909c9416f220ecb698a86ea48dea0f4682237bc92ba441c4ea213aae22",
 	"stdlib/date/date_test.flux":                                                                  "42ea61ee595ab6cfc5631505cf5a757f5a7fa24bd5cc43466099956552b071cf",
 	"stdlib/date/durations_test.flux":                                                             "610f791ede48d7dda9a1f6aaaa38fe7fe81a278339857716120ef56f946bfe33",
 	"stdlib/date/hour_duration_test.flux":                                                         "7da9263cddf0fa443e9dc55b176139d1dd67cb689c0be243d8b595799fc066f4",

--- a/stdlib/date/date.flux
+++ b/stdlib/date/date.flux
@@ -39,6 +39,44 @@ package date
 // ```
 builtin second : (t: T) => int where T: Timeable
 
+// time returns the time value of a specified relative duration or time.
+//
+// `date.time` assumes duration values are relative to `now()`.
+//
+// ## Parameters
+// - t: Duration or time value.
+//
+//   Use an absolute time or relative duration.
+//   Durations are relative to `now()`.
+//
+// ## Examples
+//
+// ### Return the time for a given time
+//
+// ```no_run
+// import "date"
+//
+// date.time(t: 2020-02-11T12:21:03.293534940Z)
+// // Returns 2020-02-11T12:21:03.293534940Z
+// ```
+//
+// ### Return the time for a given relative duration
+//
+// ```no_run
+// import "date"
+//
+// option now = () => 2022-01-01T00:00:00.000000000Z
+//
+// date.time(t: -1h)
+//
+// // Returns 2021-12-31T23:00:00.000000000Z
+// ```
+//
+// ## Metadata
+// introduced: NEXT
+//
+builtin time : (t: T) => time where T: Timeable
+
 // builtin _minute used by minute
 builtin _minute : (t: T, location: {zone: string, offset: duration}) => int where T: Timeable
 

--- a/stdlib/date/date_test.go
+++ b/stdlib/date/date_test.go
@@ -432,6 +432,138 @@ func TestTruncate_Time(t *testing.T) {
 		})
 	}
 }
+
+func TestTime_Time(t *testing.T) {
+	testCases := []struct {
+		name string
+		time string
+		want string
+	}{
+		{
+			name: "time",
+			time: "2019-06-03T13:59:01.000000000Z",
+			want: "2019-06-03T13:59:01.000000000Z",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fluxFn := SpecialFns[tc.name]
+			time, err := values.ParseTime(tc.time)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fluxArg := values.NewObjectWithValues(map[string]values.Value{
+				"t": values.NewTime(time),
+			})
+
+			ctx, deps := dependenciestest.InjectAllDeps(context.Background())
+			defer deps.Finish()
+			got, err := fluxFn.Call(ctx, fluxArg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wanted, err := values.ParseTime(tc.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if wanted != got.Time() {
+				t.Errorf("input %v: expected %v, got %v", time, wanted, got.Time())
+			}
+		})
+	}
+}
+
+func TestTime_Duration(t *testing.T) {
+	now, err := values.ParseTime("2022-01-01T00:00:00.000000000Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCases := []struct {
+		name string
+		time string
+		want string
+	}{
+		{
+			name: "time",
+			time: "-1h",
+			want: "2021-12-31T23:00:00.000000000Z",
+		},
+		{
+			name: "time",
+			time: "-1s",
+			want: "2021-12-31T23:59:59.000000000Z",
+		},
+		{
+			name: "time",
+			time: "-1y1mo1w",
+			want: "2020-11-24T00:00:00.000000000Z",
+		},
+		{
+			name: "time",
+			time: "-3d12h4m25s",
+			want: "2021-12-28T11:55:35.000000000Z",
+		},
+		{
+			name: "time",
+			time: "1h",
+			want: "2022-01-01T01:00:00.000000000Z",
+		},
+		{
+			name: "time",
+			time: "1y1mo1w",
+			want: "2023-02-08T00:00:00.000000000Z",
+		},
+		{
+			name: "time",
+			time: "1s",
+			want: "2022-01-01T00:00:01.000000000Z",
+		},
+		{
+			name: "time",
+			time: "3d12h4m25s",
+			want: "2022-01-04T12:04:25.000000000Z",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fluxFn := SpecialFns[tc.name]
+			time, err := values.ParseDuration(tc.time)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fluxArg := values.NewObjectWithValues(map[string]values.Value{
+				"t": values.NewDuration(time),
+			})
+
+			// Setup deps with specific now time
+			execDeps := dependenciestest.ExecutionDefault()
+			nowVar := now.Time()
+			execDeps.Now = &nowVar
+			ctx, deps := dependency.Inject(
+				context.Background(),
+				dependenciestest.Default(),
+				execDeps,
+			)
+			defer deps.Finish()
+
+			got, err := fluxFn.Call(ctx, fluxArg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wanted, err := values.ParseTime(tc.want)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if wanted != got.Time() {
+				t.Errorf("input %v: expected %v, got %f", time, tc.want, got)
+			}
+		})
+	}
+}
+
 func TestTruncate_Duration(t *testing.T) {
 	now, err := values.ParseTime("2019-06-03T13:59:01.000000000Z")
 	if err != nil {


### PR DESCRIPTION
This feature addition now addresses the need for a function as part of the date package to be able to convert any Timeable into a time.

fixes: https://github.com/influxdata/flux/issues/4749


### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
