### PR TITLE
feat(execute): add method to parallelize aggregate transformations

### DIFF
--- a/mock/transformation.go
+++ b/mock/transformation.go
@@ -100,3 +100,29 @@ func (a *AggregateTransformation) Close() error {
 	}
 	return nil
 }
+
+type AggregateParallelTransformation struct {
+	AggregateFn func(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error)
+	MergeFn     func(into, from interface{}, mem memory.Allocator) (interface{}, error)
+	ComputeFn   func(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error
+	CloseFn     func() error
+}
+
+func (a *AggregateParallelTransformation) Aggregate(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error) {
+	return a.AggregateFn(chunk, state, mem)
+}
+
+func (a *AggregateParallelTransformation) Merge(into, from interface{}, mem memory.Allocator) (interface{}, error) {
+	return a.MergeFn(into, from, mem)
+}
+
+func (a *AggregateParallelTransformation) Compute(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error {
+	return a.ComputeFn(key, state, d, mem)
+}
+
+func (a *AggregateParallelTransformation) Close() error {
+	if a.CloseFn != nil {
+		return a.CloseFn()
+	}
+	return nil
+}

--- a/stdlib/universe/aggregate_window.gen.go.tmpl
+++ b/stdlib/universe/aggregate_window.gen.go.tmpl
@@ -26,6 +26,16 @@ func (a *aggregateWindowSum{{.Name}}) Aggregate(ts *array.Int, vs array.Array, s
 		b.Append(sum)
     })
 	result := b.New{{.Name}}Array()
+	a.merge(start, stop, result, mem)
+}
+
+func (a *aggregateWindowSum{{.Name}}) Merge(from aggregateWindow, mem memory.Allocator) {
+	other := from.(*aggregateWindowSum{{.Name}})
+	other.vs.Retain()
+	a.merge(other.ts, other.ts, other.vs, mem)
+}
+
+func (a *aggregateWindowSum{{.Name}}) merge(start, stop *array.Int, result *array.{{.Name}}, mem memory.Allocator) {
 	a.mergeWindows(start, stop, mem, func(ts, prev, next *array.Int) {
 		if a.vs == nil {
 			a.vs = result
@@ -68,7 +78,18 @@ func (a *aggregateWindowSum{{.Name}}) Compute(mem memory.Allocator) (*array.Int,
 		}
 		return append, done
 	})
+	a.ts.Retain()
+	a.vs.Retain()
 	return a.ts, {{.ColumnType}}, a.vs
+}
+
+func (a *aggregateWindowSum{{.Name}}) Close() error {
+	a.release()
+	if a.vs != nil {
+		a.vs.Release()
+		a.vs = nil
+	}
+	return nil
 }
 
 type aggregateWindowMean{{.Name}} struct {
@@ -95,6 +116,17 @@ func (a *aggregateWindowMean{{.Name}}) Aggregate(ts *array.Int, vs array.Array, 
 	})
 
 	counts, sums := countsB.NewIntArray(), sumsB.New{{.Name}}Array()
+	a.merge(start, stop, counts, sums, mem)
+}
+
+func (a *aggregateWindowMean{{.Name}}) Merge(from aggregateWindow, mem memory.Allocator) {
+	other := from.(*aggregateWindowMean{{.Name}})
+	other.counts.Retain()
+	other.sums.Retain()
+	a.merge(other.ts, other.ts, other.counts, other.sums, mem)
+}
+
+func (a *aggregateWindowMean{{.Name}}) merge(start, stop, counts *array.Int, sums *{{.ArrowType}}, mem memory.Allocator) {
 	a.mergeWindows(start, stop, mem, func(ts, prev, next *array.Int) {
 		if a.sums == nil {
 			a.counts, a.sums = counts, sums
@@ -126,9 +158,6 @@ func (a *aggregateWindowMean{{.Name}}) Aggregate(ts *array.Int, vs array.Array, 
 }
 
 func (a *aggregateWindowMean{{.Name}}) Compute(mem memory.Allocator) (*array.Int, flux.ColType, array.Array) {
-	defer a.counts.Release()
-	defer a.sums.Release()
-
 	b := array.NewFloatBuilder(mem)
 	b.Resize(a.ts.Len())
 	for i, n := 0, a.sums.Len(); i < n; i++ {
@@ -155,7 +184,21 @@ func (a *aggregateWindowMean{{.Name}}) Compute(mem memory.Allocator) (*array.Int
 		}
 		return append, done
 	})
+	a.ts.Retain()
 	return a.ts, flux.TFloat, vs
+}
+
+func (a *aggregateWindowMean{{.Name}}) Close() error {
+	a.release()
+	if a.counts != nil {
+		a.counts.Release()
+		a.counts = nil
+	}
+	if a.sums != nil {
+		a.sums.Release()
+		a.sums = nil
+	}
+	return nil
 }
 {{end}}
 {{end}}

--- a/stdlib/universe/aggregate_window.go
+++ b/stdlib/universe/aggregate_window.go
@@ -67,8 +67,15 @@ type aggregateWindow interface {
 	// are the buckets the values will be grouped into.
 	Aggregate(ts *array.Int, vs array.Array, start, stop *array.Int, mem memory.Allocator)
 
+	// Merge will take an aggregateWindow of the same type and merge the
+	// values from to the into state.
+	Merge(from aggregateWindow, mem memory.Allocator)
+
 	// Compute will compute the final values for the aggregated windows.
 	Compute(mem memory.Allocator) (*array.Int, flux.ColType, array.Array)
+
+	// Close will release resources associated with this aggregate window state.
+	Close() error
 }
 
 type aggregateWindowTransformation struct {
@@ -93,10 +100,10 @@ func createAggregateWindowTransformation(id execute.DatasetID, mode execute.Accu
 		return nil, nil, errors.New(codes.Invalid, "nil bounds passed to window; use range to set the window range").
 			WithDocURL(docURL)
 	}
-	return newAggregateWindowTransformation(id, s, bounds, a.Allocator())
+	return newAggregateWindowTransformation(id, a.Parents(), s, bounds, a.Allocator())
 }
 
-func newAggregateWindowTransformation(id execute.DatasetID, s *AggregateWindowProcedureSpec, bounds *execute.Bounds, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func newAggregateWindowTransformation(id execute.DatasetID, parents []execute.DatasetID, s *AggregateWindowProcedureSpec, bounds *execute.Bounds, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	loc, err := s.WindowSpec.Window.LoadLocation()
 	if err != nil {
 		return nil, nil, err
@@ -131,7 +138,7 @@ func newAggregateWindowTransformation(id execute.DatasetID, s *AggregateWindowPr
 	default:
 		return nil, nil, errors.Newf(codes.Internal, "cannot use %q for aggregate window", s.AggregateKind)
 	}
-	return execute.NewAggregateTransformation(id, tr, mem)
+	return execute.NewAggregateParallelTransformation(id, parents, tr, mem)
 }
 
 func (a *aggregateWindowTransformation) Aggregate(chunk table.Chunk, state interface{}, mem memory.Allocator) (interface{}, bool, error) {
@@ -141,6 +148,16 @@ func (a *aggregateWindowTransformation) Aggregate(chunk table.Chunk, state inter
 		return nil, false, err
 	}
 	return newState, true, nil
+}
+
+func (a *aggregateWindowTransformation) Merge(into, from interface{}, mem memory.Allocator) (interface{}, error) {
+	intoState := into.(*aggregateWindowState)
+	fromState := from.(*aggregateWindowState)
+	if intoState.inType != fromState.inType {
+		return nil, errors.Newf(codes.FailedPrecondition, "schema collision detected: column %q is both of type %s and %s", a.valueCol, intoState.inType, fromState.inType)
+	}
+	intoState.state.Merge(fromState.state, mem)
+	return into, nil
 }
 
 func (a *aggregateWindowTransformation) Compute(key flux.GroupKey, state interface{}, d *execute.TransportDataset, mem memory.Allocator) error {
@@ -652,6 +669,13 @@ func (a *aggregateWindowBase) createEmptyWindows(mem memory.Allocator, fn func(n
 	a.ts = ts
 }
 
+func (a *aggregateWindowBase) release() {
+	if a.ts != nil {
+		a.ts.Release()
+		a.ts = nil
+	}
+}
+
 type aggregateWindowCount struct {
 	aggregateWindowBase
 	vs *array.Int
@@ -671,6 +695,10 @@ func (a *aggregateWindowCount) Aggregate(ts *array.Int, vs array.Array, start, s
 	})
 
 	result := b.NewIntArray()
+	a.merge(start, stop, result, mem)
+}
+
+func (a *aggregateWindowCount) merge(start, stop, result *array.Int, mem memory.Allocator) {
 	a.mergeWindows(start, stop, mem, func(ts, prev, next *array.Int) {
 		if a.vs == nil {
 			a.vs = result
@@ -694,6 +722,12 @@ func (a *aggregateWindowCount) Aggregate(ts *array.Int, vs array.Array, start, s
 	})
 }
 
+func (a *aggregateWindowCount) Merge(from aggregateWindow, mem memory.Allocator) {
+	other := from.(*aggregateWindowCount)
+	other.vs.Retain()
+	a.merge(other.ts, other.ts, other.vs, mem)
+}
+
 func (a *aggregateWindowCount) Compute(mem memory.Allocator) (*array.Int, flux.ColType, array.Array) {
 	a.createEmptyWindows(mem, func(n int) (append func(i int), done func()) {
 		b := array.NewIntBuilder(mem)
@@ -713,7 +747,19 @@ func (a *aggregateWindowCount) Compute(mem memory.Allocator) (*array.Int, flux.C
 		}
 		return append, done
 	})
+
+	a.ts.Retain()
+	a.vs.Retain()
 	return a.ts, flux.TInt, a.vs
+}
+
+func (a *aggregateWindowCount) Close() error {
+	a.release()
+	if a.vs != nil {
+		a.vs.Release()
+		a.vs = nil
+	}
+	return nil
 }
 
 func newAggregateWindowSum(a *aggregateWindowTransformation, valueType flux.ColType) (aggregateWindow, error) {


### PR DESCRIPTION
Aggregate transformations can now be given multiple parents and will
work in parallel. To define an aggregate transformation as
parallelizable, a `Merge()` method must be implemented on the
transformation.

This can only happen if a planner rule modifies the plan so that a node
which normally has one parent will have multiple parents instead. This
allows aggregate transformations that implement this interface to act as
merge nodes.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written