### PR TITLE
feat: Remove testing.loadStorage

### DIFF
--- a/docs/StandardLibrary.md
+++ b/docs/StandardLibrary.md
@@ -2,7 +2,7 @@
 
 The Flux standard library will define the set of functions, constants, and other
 values that are available out of the box with Flux, providing the functionality that is
-most frequently used. Everything in the Flux standard library is part of a package.  
+most frequently used. Everything in the Flux standard library is part of a package.
 The top-level package is called "universe."
 
 The Flux compiler provides the concept of a "prelude," which is the set of packages whose members
@@ -86,8 +86,6 @@ Other mathematical operations:
 
 ## Package `testing`
 - `assertEquals`
-- `loadStorage`
-- `loadMem`
 - `test`
 
 Others?

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -400,7 +400,7 @@ var sourceHashes = map[string]string{
 	"stdlib/testing/promql/resets_test.flux":                                                      "e01bb24f576f8a2cb69fa1f5d9061cc852431970792ae2c59c3753580058926d",
 	"stdlib/testing/promql/timestamp_test.flux":                                                   "350dc1161f222d2bfc327aee399ed9873e198c9858e845c2ca0b9ca0e2e38ef8",
 	"stdlib/testing/promql/year_test.flux":                                                        "1767fb414d4261075880b0b9e5f6084cc1d9124fcb3759d68d3bea8a7c42977d",
-	"stdlib/testing/testing.flux":                                                                 "e0b4cf8c03cdd4a8273db01be440cbf79b01d4261dc480fe870a769b19c4aff7",
+	"stdlib/testing/testing.flux":                                                                 "7017756cd255f45e19d7c485df52ea3ab9a178dcb1ca1fa23ff5cf36dff938a6",
 	"stdlib/testing/testing_test.flux":                                                            "8b3a959c5987f2217e520d5c42d45a66a7361d23946978a751ea75f337b8eee8",
 	"stdlib/testing/usage/api_test.flux":                                                          "2a39412eaf41ccb2436dbbdb250f9761544538252bbc6dd6d63b47d2d16e0136",
 	"stdlib/testing/usage/duration_test.flux":                                                     "f545e7e8f1820bdae0beb935d12f899f1065b7b7df1c05eed454ecfb48fa4225",

--- a/stdlib/testing/testing.flux
+++ b/stdlib/testing/testing.flux
@@ -140,54 +140,6 @@ builtin diff : (
         ?nansEqual: bool,
     ) => stream[{A with _diff: string}]
 
-// loadStorage loads annotated CSV test data as if queried from InfluxDB.
-// This function ensures tests behave correctly in both the Flux and InfluxDB test suites.
-//
-// ## Function Requirements
-// - Test data requires `_field`, `_measurement`, and `_time` columns.
-//
-// ## Parameters
-// - csv: Annotated CSV data to load.
-//
-// ## Examples
-//
-// ### Load annoated CSV as if queried from InfluxDB
-// ```
-// import "testing"
-//
-// csvData =
-//     "
-// #datatype,string,long,string,dateTime:RFC3339,string,double
-// #group,false,false,true,false,true,false
-// #default,_result,,,,,
-// ,result,table,_measurement,_time,_field,_value
-// ,,0,m,2021-01-01T00:00:00Z,t,1.2
-// ,,0,m,2021-01-02T00:00:00Z,t,1.4
-// ,,0,m,2021-01-03T00:00:00Z,t,2.2
-// "
-//
-// testing.loadStorage(csv: csvData)
-// ```
-//
-// ## Metadata
-// introduced: 0.20.0
-//
-option loadStorage = (csv) =>
-    c.from(csv: csv)
-        |> range(start: 1800-01-01T00:00:00Z, stop: 2200-12-31T11:59:59Z)
-        |> map(
-            fn: (r) =>
-                ({r with _field:
-                        if exists r._field then r._field else die(msg: "test input table does not have _field column"),
-                    _measurement:
-                        if exists r._measurement then
-                            r._measurement
-                        else
-                            die(msg: "test input table does not have _measurement column"),
-                    _time: if exists r._time then r._time else die(msg: "test input table does not have _time column"),
-                }),
-        )
-
 // load loads test data from a stream of tables.
 //
 // ## Parameters


### PR DESCRIPTION
This has been replaced by `csv.from() |> testing.load()`

BREAKING CHANGE:

Use `csv.from() |> testing.load()` instead

Part of https://github.com/influxdata/flux/issues/4768