### PR TITLE
refactor: skip yields in input tables for cases like tableFind

### DIFF
--- a/internal/spec/build_test.go
+++ b/internal/spec/build_test.go
@@ -2,11 +2,14 @@ package spec_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/dependency"
+	"github.com/influxdata/flux/execute"
 	_ "github.com/influxdata/flux/fluxinit/static"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/runtime"
@@ -42,5 +45,370 @@ check |> yield(name: "mean")
 		if _, err := spec.FromScript(ctx, runtime.Default, time.Now(), query); err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestFromEvaluation(t *testing.T) {
+	ctx, deps := dependency.Inject(
+		context.Background(),
+		dependenciestest.Default(),
+		execute.DefaultExecutionDependencies(),
+	)
+	defer deps.Finish()
+	nowDefault := time.Unix(0, 0)
+
+	type args struct {
+		query      string
+		now        time.Time
+		skipYields bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *flux.Spec
+		wantErr bool
+	}{
+		{
+			name: "keep single trailing yield",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+				`,
+				now:        nowDefault,
+				skipYields: false,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "yield1"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "yield1"},
+				},
+			},
+		},
+		{
+			name: "skip single trailing yield",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+				},
+				// No edges since there's only a single node left
+			},
+		},
+		{
+			name: "keep multiple trailing yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> yield(name: "b")
+					|> yield(name: "c")
+				`,
+				now:        nowDefault,
+				skipYields: false,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "yield1"},
+					{ID: "yield2"},
+					{ID: "yield3"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "yield1"},
+					{Parent: "yield1", Child: "yield2"},
+					{Parent: "yield2", Child: "yield3"},
+				},
+			},
+		}, {
+			name: "skip multiple trailing yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> yield(name: "b")
+					|> yield(name: "c")
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+				},
+				// No edges since there's only a single node left
+			},
+		},
+		{
+			name: "keep interior yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> map(fn: (r) => r)
+				`,
+				now:        nowDefault,
+				skipYields: false,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "yield1"},
+					{ID: "map2"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "yield1"},
+					{Parent: "yield1", Child: "map2"},
+				},
+			},
+		},
+		{
+			name: "skip interior yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> map(fn: (r) => r)
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "map2"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "map2"},
+				},
+			},
+		},
+		{
+			name: "skip many interior yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> yield(name: "b")
+					|> yield(name: "c")
+					|> yield(name: "d")
+					|> yield(name: "e")
+					|> yield(name: "f")
+					|> map(fn: (r) => r)
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "map7"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "map7"},
+				},
+			},
+		},
+		{
+			name: "multiple ops keeping interior yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> yield(name: "b")
+					|> map(fn: (r) => r)
+					|> map(fn: (r) => r)
+					|> yield(name: "c")
+					|> map(fn: (r) => r)
+				`,
+				now:        nowDefault,
+				skipYields: false,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "yield1"},
+					{ID: "yield2"},
+					{ID: "map3"},
+					{ID: "map4"},
+					{ID: "yield5"},
+					{ID: "map6"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "yield1"},
+					{Parent: "yield1", Child: "yield2"},
+					{Parent: "yield2", Child: "map3"},
+					{Parent: "map3", Child: "map4"},
+					{Parent: "map4", Child: "yield5"},
+					{Parent: "yield5", Child: "map6"},
+				},
+			},
+		},
+		{
+			name: "multiple ops skipping interior yields",
+			args: args{
+				query: `
+				import "array"
+				array.from(rows:[{a: 1}])
+					|> yield(name: "a")
+					|> yield(name: "b")
+					|> map(fn: (r) => r)
+					|> map(fn: (r) => r)
+					|> yield(name: "c")
+					|> map(fn: (r) => r)
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "map3"},
+					{ID: "map4"},
+					{ID: "map6"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "map3"},
+					{Parent: "map3", Child: "map4"},
+					{Parent: "map4", Child: "map6"},
+				},
+			},
+		},
+		{
+			name: "multiple side effects when keeping yields",
+			args: args{
+				query: `
+				import "array"
+				import "sql"
+				array.from(rows:[{a: 1}])
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+				`,
+				now:        nowDefault,
+				skipYields: false,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "toSQL1"},
+					{ID: "toSQL2"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "toSQL1"},
+					{Parent: "toSQL1", Child: "toSQL2"},
+				},
+			},
+		},
+		{
+			name: "multiple side effects when skipping yields",
+			args: args{
+				query: `
+				import "array"
+				import "sql"
+				array.from(rows:[{a: 1}])
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple side effects with trailing yield when skipping yields",
+			args: args{
+				query: `
+				import "array"
+				import "sql"
+				array.from(rows:[{a: 1}])
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+					|> yield(name: "a")
+				`,
+				now:        nowDefault,
+				skipYields: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "multiple side effects with trailing yield when keeping yields",
+			args: args{
+				query: `
+				import "array"
+				import "sql"
+				array.from(rows:[{a: 1}])
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+					|> sql.to(driverName: "sqlite3", dataSourceName: ":memory:", table: "test")
+					|> yield(name: "a")
+				`,
+				now:        nowDefault,
+				skipYields: false,
+			},
+			want: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "array.from0"},
+					{ID: "toSQL1"},
+					{ID: "toSQL2"},
+					{ID: "yield3"},
+				},
+				Edges: []flux.Edge{
+					{Parent: "array.from0", Child: "toSQL1"},
+					{Parent: "toSQL1", Child: "toSQL2"},
+					{Parent: "toSQL2", Child: "yield3"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ses, _, err := runtime.Eval(ctx, tt.args.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := spec.FromEvaluation(ctx, ses, tt.args.now, tt.args.skipYields)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("FromEvaluation() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+
+			gotOpIDs := make([]flux.OperationID, len(got.Operations))
+			for _, o := range got.Operations {
+				gotOpIDs = append(gotOpIDs, o.ID)
+			}
+			wantOpIDs := make([]flux.OperationID, len(tt.want.Operations))
+			for _, o := range tt.want.Operations {
+				wantOpIDs = append(wantOpIDs, o.ID)
+			}
+
+			if !reflect.DeepEqual(gotOpIDs, wantOpIDs) {
+				t.Errorf("FromEvaluation() Operations \ngot:\n%v\nwant:\n%v", gotOpIDs, wantOpIDs)
+			}
+			if !reflect.DeepEqual(got.Edges, tt.want.Edges) {
+				t.Errorf("FromEvaluation() Edges \ngot:\n%v\nwant:\n%v", got.Edges, tt.want.Edges)
+			}
+		})
 	}
 }

--- a/lang/compiler.go
+++ b/lang/compiler.go
@@ -476,7 +476,7 @@ func (p *AstProgram) getSpec(ctx context.Context, alloc memory.Allocator) (*flux
 		return nil, nil, errors.Wrap(err, codes.Inherit, "error in evaluating AST while starting program")
 	}
 	p.Now = nowTime.Time().Time()
-	sp, err := spec.FromEvaluation(cctx, sideEffects, p.Now)
+	sp, err := spec.FromEvaluation(cctx, sideEffects, p.Now, false)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, codes.Inherit, "error in query specification while starting program")
 	}

--- a/spec_test.go
+++ b/spec_test.go
@@ -100,6 +100,17 @@ func TestSpec_Walk(t *testing.T) {
 			query: &flux.Spec{
 				Operations: []*flux.Operation{
 					{ID: "a"},
+				},
+				Edges: []flux.Edge{},
+			},
+			walkOrder: []flux.OperationID{
+				"a",
+			},
+		},
+		{
+			query: &flux.Spec{
+				Operations: []*flux.Operation{
+					{ID: "a"},
 					{ID: "b"},
 					{ID: "c"},
 					{ID: "d"},


### PR DESCRIPTION
Refs #4813 

Table functions (ie tableFind) don't have any way to prioritize the use
of one result or another when they consume tables as input. For tables
that produce more than 1 result, the receiver would essentially use only
the first found result, which is non-deterministic.

In many cases, this can lead to errors at runtime where the output from
the table function does not match the expected schema. Perhaps worse,
it's possible you'd just get an incorrect answer rather than an error.

This refactor adds a new `skipYields` parameter to `spec.FromEvaluation`
which will produce a simplified spec when `true` by omitting any yields
encountered while walking the input tables.
With yields taken out of the picture, the only results we should see would
come from whatever the terminal node is, as well as from "side effecting"
functions such as the various flavors of `to` (influxdb, sql, kafka, etc).

In cases where the result count is > 1 thanks to side effecting
operations, in spite of stripping out yields, an error is returned while
`skipYields` is true.

The previous behavior of leaving all the yields in place should be used
for code paths that don't have the "single result" requirement.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
