### PR TITLE
docs: separate build comment commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ To build Flux, first install the GNU `pkg-config` utility on your system, then e
 # First install GNU pkg-config.
 # On Debian/Ubuntu
 $ sudo apt-get install -y clang pkg-config
+
 # Or on Mac OS X with Homebrew
 $ brew install pkg-config
 
 # Next, install the pkg-config wrapper utility
 $ go get github.com/influxdata/pkg-config
+
 # Optionally, add the GOBIN directory to your PATH
 $ export PATH=${GOPATH}/bin:${PATH}
 ```


### PR DESCRIPTION
docs: separate build comment commands

I had failed installations as many people's brains see the start "#" and following lines of comments "#" as one. I missed a step and even raised an Issue (which I will close). Each new CLI command after a comment should have a new line and visual space.


### Done checklist (N/A) as README
- [ ] docs/SPEC.md updated
- [ ] Test cases written
