### PR TITLE
feat(repl): Suggestions now start off by default and added a new flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ $ which -a pkg-config
 /usr/bin/pkg-config
 ```
 
-To compile and use the REPL, use the following command:
+To compile and use the REPL, use the following command to run the repl with suggestions enabled:
 
 ```
 $ go build ./cmd/flux
-$ ./flux repl
+$ ./flux --enable-suggestions
 ```
 
 Alternatively, because the `pkg-config` wrapper may not work in all projects you may not want to add the wrapper `pkg-config` to your `PATH`. In this case you can set `PKG_CONFIG` and Go will use it. Eg, to build and install to ${GOPATH}/bin using `PKG_CONFIG`:

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -21,10 +21,11 @@ import (
 )
 
 var flags struct {
-	ExecScript bool
-	Trace      string
-	Format     string
-	Features   string
+	ExecScript        bool
+	Trace             string
+	Format            string
+	Features          string
+	EnableSuggestions bool
 }
 
 func runE(cmd *cobra.Command, args []string) error {
@@ -63,7 +64,7 @@ func runE(cmd *cobra.Command, args []string) error {
 	ctx = feature.Dependency{Flagger: flagger}.Inject(ctx)
 
 	if len(args) == 0 {
-		return replE(ctx)
+		return replE(ctx, flags.EnableSuggestions)
 	}
 	return executeE(ctx, script, flags.Format)
 }
@@ -115,6 +116,7 @@ func main() {
 		SilenceUsage: true,
 	}
 	fluxCmd.Flags().BoolVarP(&flags.ExecScript, "exec", "e", false, "Interpret file argument as a raw flux script")
+	fluxCmd.Flags().BoolVarP(&flags.EnableSuggestions, "enable-suggestions", "", false, "enable suggestions in the repl")
 	fluxCmd.Flags().StringVar(&flags.Trace, "trace", "", "Trace query execution")
 	fluxCmd.Flags().StringVarP(&flags.Format, "format", "", "cli", "Output format one of: cli,csv. Defaults to cli")
 	fluxCmd.Flag("trace").NoOptDefVal = "jaeger"

--- a/cmd/flux/repl.go
+++ b/cmd/flux/repl.go
@@ -6,8 +6,8 @@ import (
 	"github.com/influxdata/flux/repl"
 )
 
-func replE(ctx context.Context) error {
-	r := repl.New(ctx)
+func replE(ctx context.Context, enableSuggestions bool) error {
+	r := repl.New(ctx, enableSuggestions)
 	r.Run()
 	return nil
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -658,7 +658,7 @@ func TestInterpreter_MultiPhaseInterpretation(t *testing.T) {
 			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
 			defer deps.Finish()
 
-			r := repl.New(ctx)
+			r := repl.New(ctx, false)
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)
 			}
@@ -772,7 +772,7 @@ func TestInterpreter_MultipleEval(t *testing.T) {
 			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
 			defer deps.Finish()
 
-			r := repl.New(ctx)
+			r := repl.New(ctx, false)
 
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)


### PR DESCRIPTION
## Description

Added in a new flag to run the repl with suggestions and by default the real will start without suggestions. Addressed issue #4836. Updated docs to remove old argument in running the repl and showed how to run repl with the new flag.

## Usage
#### With suggestions:

``` ./repl --enable-suggestions ``` 

#### Without suggestions :

```./repl```


### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written
