### PR TITLE
test(plan): make planner test helper validate by default

### DIFF
--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -157,13 +157,14 @@ func (sr *MultiRootRule) Name() string {
 
 // RuleTestCase allows for concise creation of test cases that exercise rules
 type RuleTestCase struct {
-	Name          string
-	Context       context.Context
-	Rules         []plan.Rule
-	Before        *PlanSpec
-	After         *PlanSpec
-	NoChange      bool
-	ValidateError error
+	Name           string
+	Context        context.Context
+	Rules          []plan.Rule
+	Before         *PlanSpec
+	After          *PlanSpec
+	NoChange       bool
+	SkipValidation bool
+	ValidateError  error
 }
 
 // PhysicalRuleTestHelper will run a rule test case.
@@ -181,7 +182,10 @@ func PhysicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Optio
 	opts := []plan.PhysicalOption{
 		plan.OnlyPhysicalRules(tc.Rules...),
 	}
-	if tc.ValidateError == nil {
+	if tc.ValidateError != nil && tc.SkipValidation {
+		panic("PhysicalRuleTestHelper requested to verify validation error and also skip validation")
+	}
+	if tc.SkipValidation {
 		// Disable validation so that we can avoid having to push a range into every from
 		opts = append(opts, plan.DisableValidation())
 	}

--- a/stdlib/influxdata/influxdb/rules_test.go
+++ b/stdlib/influxdata/influxdb/rules_test.go
@@ -85,6 +85,7 @@ func TestRuleCreatedNodeUniqueness(t *testing.T) {
 				},
 				Edges: joinEdges,
 			},
+			SkipValidation: true,
 		},
 	}
 
@@ -138,6 +139,7 @@ func TestFromRemoteRule_WithHost(t *testing.T) {
 			},
 			Edges: [][2]int{{0, 1}},
 		},
+		SkipValidation: true,
 	}
 	plantest.PhysicalRuleTestHelper(t, &tc)
 }
@@ -170,7 +172,8 @@ func TestFromRemoteRule_WithoutHost(t *testing.T) {
 			},
 			Edges: [][2]int{{0, 1}},
 		},
-		NoChange: true,
+		NoChange:       true,
+		SkipValidation: true,
 	}
 	plantest.PhysicalRuleTestHelper(t, &tc)
 }
@@ -433,6 +436,7 @@ func TestDefaultFromAttributes(t *testing.T) {
 					}),
 				},
 			},
+			SkipValidation: true,
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/stdlib/universe/filter_test.go
+++ b/stdlib/universe/filter_test.go
@@ -471,7 +471,8 @@ func TestMergeFilterAnyRule(t *testing.T) {
 				},
 				Edges: [][2]int{{0, 1}},
 			},
-			NoChange: true,
+			NoChange:       true,
+			SkipValidation: true,
 		},
 		{
 			Name: "filterFalse",
@@ -484,7 +485,8 @@ func TestMergeFilterAnyRule(t *testing.T) {
 				},
 				Edges: [][2]int{{0, 1}},
 			},
-			NoChange: true,
+			NoChange:       true,
+			SkipValidation: true,
 		},
 		{
 			Name: "filterTrue",
@@ -502,6 +504,7 @@ func TestMergeFilterAnyRule(t *testing.T) {
 					plan.CreatePhysicalNode("from", from),
 				},
 			},
+			SkipValidation: true,
 		},
 		{
 			Name: "count filterTrue",
@@ -539,6 +542,7 @@ func TestMergeFilterAnyRule(t *testing.T) {
 				},
 				Edges: [][2]int{{0, 1}},
 			},
+			SkipValidation: true,
 		},
 	}
 

--- a/stdlib/universe/sort_limit_test.go
+++ b/stdlib/universe/sort_limit_test.go
@@ -56,6 +56,7 @@ func TestSortLimitRule(t *testing.T) {
 					{0, 1},
 				},
 			},
+			SkipValidation: true,
 		},
 		{
 			Name:    "WithOffset",
@@ -74,7 +75,8 @@ func TestSortLimitRule(t *testing.T) {
 					{1, 2},
 				},
 			},
-			NoChange: true,
+			NoChange:       true,
+			SkipValidation: true,
 		},
 	}
 


### PR DESCRIPTION
Previously by default we would not perform validation steps
in physical planner tests since it presented a burden on the
test writer to make realistic plans and spend time on things
they are not actually testing.

This is an additive change that makes it so by default validation is
performed on the resulting plan, but it may be skipped if needed.
For tests that began failing due to validation failures, I have skipped
them.

Validation is a step performed after planning to make sure the plan
that is about to be executed is in fact sane. Validation will become more
important as we increase the use of physical attributes, as we will for #4678.
