### PR TITLE
test(experiemntal/http): add expected error message

### DIFF
--- a/stdlib/experimental/http/requests/requests_test.go
+++ b/stdlib/experimental/http/requests/requests_test.go
@@ -237,7 +237,7 @@ requests.do(method: "GET", url:"%s/path/a/b/c")
 	if err == nil {
 		t.Fatal("expected TLS failure")
 	}
-	if !strings.Contains(err.Error(), "unknown authority") {
+	if !strings.Contains(err.Error(), "unknown authority") && !strings.Contains(err.Error(), "certificate is not trusted") {
 		t.Errorf("unexpected cause of failure, got err: %v", err)
 	}
 }


### PR DESCRIPTION
On my Mac running Go 1.18.1 I see this test failing with an error
message that is different than expected. This adds to the
expected error messages so that the test passes.
