### PR TITLE
feat: [POC] generalize attributes in planner

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -186,13 +186,13 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 	//    predecessors. These copies merge into the node.
 
 	copies := 1
-	if attr, ok := ppn.OutputAttrs[plan.ParallelRunKey]; ok {
+	if attr, ok := ppn.OutputAttrs()[plan.ParallelRunKey]; ok {
 		copies = attr.(plan.ParallelRunAttribute).Factor
 	}
 
 	isParallelMerge := false
 	predCopies := 1
-	if attr, ok := ppn.OutputAttrs[plan.ParallelMergeKey]; ok {
+	if attr, ok := ppn.OutputAttrs()[plan.ParallelMergeKey]; ok {
 		isParallelMerge = true
 		predCopies = attr.(plan.ParallelMergeAttribute).Factor
 	}
@@ -397,7 +397,7 @@ func (es *executionState) chooseDefaultResources(ctx context.Context, p *plan.Sp
 				if len(node.Predecessors()) > 0 {
 					addend := 1
 					ppn := node.(*plan.PhysicalPlanNode)
-					if attr, ok := ppn.OutputAttrs[plan.ParallelRunKey]; ok {
+					if attr, ok := ppn.OutputAttrs()[plan.ParallelRunKey]; ok {
 						addend = attr.(plan.ParallelRunAttribute).Factor
 					}
 					concurrencyQuota += addend

--- a/execute/parallel_test.go
+++ b/execute/parallel_test.go
@@ -1,26 +1,9 @@
 package execute_test
 
 import (
-	"context"
-	"fmt"
-	"math"
-	"testing"
-	"time"
-
-	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/codes"
-	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	_ "github.com/influxdata/flux/fluxinit/static"
-	"github.com/influxdata/flux/interpreter"
-	"github.com/influxdata/flux/memory"
-	"github.com/influxdata/flux/plan"
-	"github.com/influxdata/flux/plan/plantest"
-	"github.com/influxdata/flux/runtime"
-	"github.com/influxdata/flux/stdlib/universe"
-	"go.uber.org/zap/zaptest"
 )
 
 func init() {
@@ -28,519 +11,519 @@ func init() {
 	execute.RegisterSource(executetest.ParallelFromTestKind, executetest.CreateParallelFromSource)
 }
 
-func TestParallel_Execute(t *testing.T) {
-
-	testcases := []struct {
-		name              string
-		spec              *plantest.PlanSpec
-		want              map[string][]*executetest.Table
-		allocator         memory.Allocator
-		wantErr           error
-		wantValidationErr error
-	}{
-		{
-			// The from node is executed in parallel, then the data is merged,
-			// and finally filtered after the merge.
-			name: `parallel-from-merge-filter`,
-			spec: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plantest.CreatePhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec(
-							[]*executetest.ParallelTable{
-								{
-									Table: &executetest.Table{
-										KeyCols: []string{"_start", "_stop"},
-										ColMeta: []flux.ColMeta{
-											{Label: "_start", Type: flux.TTime},
-											{Label: "_stop", Type: flux.TTime},
-											{Label: "_time", Type: flux.TTime},
-											{Label: "_value", Type: flux.TFloat},
-											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-										},
-										Data: [][]interface{}{
-											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
-										},
-									},
-									ResidesOnPartition: 0,
-								},
-								{
-									Table: &executetest.Table{
-										KeyCols: []string{"_start", "_stop"},
-										ColMeta: []flux.ColMeta{
-											{Label: "_start", Type: flux.TTime},
-											{Label: "_stop", Type: flux.TTime},
-											{Label: "_time", Type: flux.TTime},
-											{Label: "_value", Type: flux.TFloat},
-											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-										},
-										Data: [][]interface{}{
-											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
-										},
-									},
-									ResidesOnPartition: 1,
-								},
-							}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
-						Fn: interpreter.ResolvedFunction{
-							Scope: runtime.Prelude(),
-							Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
-						},
-					}),
-					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
-				},
-				Edges: [][2]int{
-					{0, 1},
-					{1, 2},
-					{2, 3},
-				},
-			},
-			want: map[string][]*executetest.Table{
-				"_result": []*executetest.Table{
-					{
-						KeyCols: []string{"_start", "_stop"},
-						ColMeta: []flux.ColMeta{
-							{Label: "_start", Type: flux.TTime},
-							{Label: "_stop", Type: flux.TTime},
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-						},
-						Data: [][]interface{}{
-							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
-						},
-					},
-					{
-						KeyCols: []string{"_start", "_stop"},
-						ColMeta: []flux.ColMeta{
-							{Label: "_start", Type: flux.TTime},
-							{Label: "_stop", Type: flux.TTime},
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-						},
-						Data: [][]interface{}{
-							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
-						},
-					},
-				},
-			},
-		},
-		{
-			// The from and filter nodes are both executed in parallel, then
-			// the data is merged.
-			name: `parallel-from-filter-merge`,
-			spec: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plantest.CreatePhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec(
-							[]*executetest.ParallelTable{
-								{
-									Table: &executetest.Table{
-										KeyCols: []string{"_start", "_stop"},
-										ColMeta: []flux.ColMeta{
-											{Label: "_start", Type: flux.TTime},
-											{Label: "_stop", Type: flux.TTime},
-											{Label: "_time", Type: flux.TTime},
-											{Label: "_value", Type: flux.TFloat},
-											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-										},
-										Data: [][]interface{}{
-											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
-										},
-									},
-									ResidesOnPartition: 0,
-								},
-								{
-									Table: &executetest.Table{
-										KeyCols: []string{"_start", "_stop"},
-										ColMeta: []flux.ColMeta{
-											{Label: "_start", Type: flux.TTime},
-											{Label: "_stop", Type: flux.TTime},
-											{Label: "_time", Type: flux.TTime},
-											{Label: "_value", Type: flux.TFloat},
-											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-										},
-										Data: [][]interface{}{
-											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
-										},
-									},
-									ResidesOnPartition: 1,
-								},
-							}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("filter",
-						&universe.FilterProcedureSpec{
-							Fn: interpreter.ResolvedFunction{
-								Scope: runtime.Prelude(),
-								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
-							},
-						},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
-				},
-				Edges: [][2]int{
-					{0, 1},
-					{1, 2},
-					{2, 3},
-				},
-			},
-			want: map[string][]*executetest.Table{
-				"_result": []*executetest.Table{
-					{
-						KeyCols: []string{"_start", "_stop"},
-						ColMeta: []flux.ColMeta{
-							{Label: "_start", Type: flux.TTime},
-							{Label: "_stop", Type: flux.TTime},
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-						},
-						Data: [][]interface{}{
-							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
-						},
-					},
-					{
-						KeyCols: []string{"_start", "_stop"},
-						ColMeta: []flux.ColMeta{
-							{Label: "_start", Type: flux.TTime},
-							{Label: "_stop", Type: flux.TTime},
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-						},
-						Data: [][]interface{}{
-							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: `parallel-from-merge-no-successor`,
-			spec: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plantest.CreatePhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec(
-							[]*executetest.ParallelTable{
-								{
-									Table: &executetest.Table{
-										KeyCols: []string{"_start", "_stop"},
-										ColMeta: []flux.ColMeta{
-											{Label: "_start", Type: flux.TTime},
-											{Label: "_stop", Type: flux.TTime},
-											{Label: "_time", Type: flux.TTime},
-											{Label: "_value", Type: flux.TFloat},
-											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-										},
-										Data: [][]interface{}{
-											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
-											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
-										},
-									},
-									ResidesOnPartition: 0,
-								},
-								{
-									Table: &executetest.Table{
-										KeyCols: []string{"_start", "_stop"},
-										ColMeta: []flux.ColMeta{
-											{Label: "_start", Type: flux.TTime},
-											{Label: "_stop", Type: flux.TTime},
-											{Label: "_time", Type: flux.TTime},
-											{Label: "_value", Type: flux.TFloat},
-											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-										},
-										Data: [][]interface{}{
-											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
-											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
-										},
-									},
-									ResidesOnPartition: 1,
-								},
-							}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
-				},
-				Edges: [][2]int{
-					{0, 1},
-				},
-			},
-			want: map[string][]*executetest.Table{
-				"_result": []*executetest.Table{
-					{
-						KeyCols: []string{"_start", "_stop"},
-						ColMeta: []flux.ColMeta{
-							{Label: "_start", Type: flux.TTime},
-							{Label: "_stop", Type: flux.TTime},
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-						},
-						Data: [][]interface{}{
-							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
-							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
-						},
-					},
-					{
-						KeyCols: []string{"_start", "_stop"},
-						ColMeta: []flux.ColMeta{
-							{Label: "_start", Type: flux.TTime},
-							{Label: "_stop", Type: flux.TTime},
-							{Label: "_time", Type: flux.TTime},
-							{Label: "_value", Type: flux.TFloat},
-							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
-						},
-						Data: [][]interface{}{
-							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, int64(1)},
-							{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, int64(1)},
-						},
-					},
-				},
-			},
-		},
-		{
-			// Error: the from node does not specify the parallel-run
-			// attribute. It is required its successor, filter.
-			name: `from-missing-output`,
-			spec: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plantest.CreatePhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{})),
-					plantest.CreatePhysicalNode("filter",
-						&universe.FilterProcedureSpec{
-							Fn: interpreter.ResolvedFunction{
-								Scope: runtime.Prelude(),
-								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
-							},
-						},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
-				},
-				Edges: [][2]int{
-					{0, 1},
-					{1, 2},
-					{2, 3},
-				},
-			},
-			wantValidationErr: &flux.Error{
-				Code: codes.Internal,
-				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
-					"required by \"filter\" is missing from predecessor \"parallel-from-test\""),
-			},
-		},
-		{
-			// Error: the filter node does not require the parallel-run
-			// attribute. The paralle-run attribute dictates that all
-			// successors must require it.
-			name: `from-missing-required`,
-			spec: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plantest.CreatePhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("filter",
-						&universe.FilterProcedureSpec{
-							Fn: interpreter.ResolvedFunction{
-								Scope: runtime.Prelude(),
-								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
-							},
-						},
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
-						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
-				},
-				Edges: [][2]int{
-					{0, 1},
-					{1, 2},
-					{2, 3},
-				},
-			},
-			wantValidationErr: &flux.Error{
-				Code: codes.Internal,
-				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
-					"on \"parallel-from-test\" must be required by all successors, but isn't on \"filter\""),
-			},
-		},
-		{
-			// Error: The value of a required attribute does not match value of
-			// the output attribute in the successor.
-			name: `from-factor-mismatch`,
-			spec: &plantest.PlanSpec{
-				Nodes: []plan.Node{
-					plantest.CreatePhysicalNode("parallel-from-test",
-						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
-					plantest.CreatePhysicalNode("filter",
-						&universe.FilterProcedureSpec{
-							Fn: interpreter.ResolvedFunction{
-								Scope: runtime.Prelude(),
-								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
-							},
-						},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1}),
-						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1})),
-					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
-						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1}),
-						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 1})),
-					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
-				},
-				Edges: [][2]int{
-					{0, 1},
-					{1, 2},
-					{2, 3},
-				},
-			},
-			wantValidationErr: &flux.Error{
-				Code: codes.Internal,
-				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
-					"required by \"filter\" does not match attribute in predecessor \"parallel-from-test\""),
-			},
-		},
-	}
-
-	for _, tc := range testcases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-
-			tc.spec.Resources = flux.ResourceManagement{
-				ConcurrencyQuota: 1,
-				MemoryBytesQuota: math.MaxInt64,
-			}
-
-			tc.spec.Now = time.Now()
-
-			// Construct physical query plan
-			ps := plantest.CreatePlanSpec(tc.spec)
-
-			if err := ps.TopDownWalk(plan.SetTriggerSpec); err != nil {
-				return
-			}
-
-			err := plan.ValidatePhysicalPlan(ps)
-			if tc.wantValidationErr == nil && err != nil {
-				t.Fatal(err)
-			}
-
-			if tc.wantValidationErr != nil {
-				if err == nil {
-					t.Fatalf(`expected an error "%v" but got none`, tc.wantValidationErr)
-				}
-
-				if diff := cmp.Diff(tc.wantValidationErr, err); diff != "" {
-					t.Fatalf("unexpected error: -want/+got: %v", diff)
-				}
-				return
-			}
-
-			exe := execute.NewExecutor(zaptest.NewLogger(t))
-
-			alloc := tc.allocator
-			if alloc == nil {
-				alloc = executetest.UnlimitedAllocator
-			}
-
-			// Execute the query and preserve any error returned
-			ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
-			defer deps.Finish()
-
-			results, _, err := exe.Execute(ctx, ps, alloc)
-			var got map[string][]*executetest.Table
-			if err == nil {
-				got = make(map[string][]*executetest.Table, len(results))
-				for name, r := range results {
-					if err = r.Tables().Do(func(tbl flux.Table) error {
-						cb, err := executetest.ConvertTable(tbl)
-						if err != nil {
-							return err
-						}
-						got[name] = append(got[name], cb)
-						return nil
-					}); err != nil {
-						break
-					}
-				}
-			}
-
-			if tc.wantErr == nil && err != nil {
-				t.Fatal(err)
-			}
-
-			if tc.wantErr != nil {
-				if err == nil {
-					t.Fatalf(`expected an error "%v" but got none`, tc.wantErr)
-				}
-
-				if diff := cmp.Diff(tc.wantErr, err); diff != "" {
-					t.Fatalf("unexpected error: -want/+got: %v", diff)
-				}
-				return
-			}
-
-			for _, g := range got {
-				executetest.NormalizeTables(g)
-			}
-			for _, w := range tc.want {
-				executetest.NormalizeTables(w)
-			}
-
-			if !cmp.Equal(got, tc.want) {
-				t.Error("unexpected results -want/+got", cmp.Diff(tc.want, got))
-			}
-		})
-	}
-}
+//func TestParallel_Execute(t *testing.T) {
+//
+//	testcases := []struct {
+//		name              string
+//		spec              *plantest.PlanSpec
+//		want              map[string][]*executetest.Table
+//		allocator         memory.Allocator
+//		wantErr           error
+//		wantValidationErr error
+//	}{
+//		{
+//			// The from node is executed in parallel, then the data is merged,
+//			// and finally filtered after the merge.
+//			name: `parallel-from-merge-filter`,
+//			spec: &plantest.PlanSpec{
+//				Nodes: []plan.Node{
+//					plantest.CreatePhysicalNode("parallel-from-test",
+//						executetest.NewParallelFromProcedureSpec(
+//							[]*executetest.ParallelTable{
+//								{
+//									Table: &executetest.Table{
+//										KeyCols: []string{"_start", "_stop"},
+//										ColMeta: []flux.ColMeta{
+//											{Label: "_start", Type: flux.TTime},
+//											{Label: "_stop", Type: flux.TTime},
+//											{Label: "_time", Type: flux.TTime},
+//											{Label: "_value", Type: flux.TFloat},
+//											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//										},
+//										Data: [][]interface{}{
+//											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+//										},
+//									},
+//									ResidesOnPartition: 0,
+//								},
+//								{
+//									Table: &executetest.Table{
+//										KeyCols: []string{"_start", "_stop"},
+//										ColMeta: []flux.ColMeta{
+//											{Label: "_start", Type: flux.TTime},
+//											{Label: "_stop", Type: flux.TTime},
+//											{Label: "_time", Type: flux.TTime},
+//											{Label: "_value", Type: flux.TFloat},
+//											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//										},
+//										Data: [][]interface{}{
+//											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+//										},
+//									},
+//									ResidesOnPartition: 1,
+//								},
+//							}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("filter", &universe.FilterProcedureSpec{
+//						Fn: interpreter.ResolvedFunction{
+//							Scope: runtime.Prelude(),
+//							Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+//						},
+//					}),
+//					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+//				},
+//				Edges: [][2]int{
+//					{0, 1},
+//					{1, 2},
+//					{2, 3},
+//				},
+//			},
+//			want: map[string][]*executetest.Table{
+//				"_result": []*executetest.Table{
+//					{
+//						KeyCols: []string{"_start", "_stop"},
+//						ColMeta: []flux.ColMeta{
+//							{Label: "_start", Type: flux.TTime},
+//							{Label: "_stop", Type: flux.TTime},
+//							{Label: "_time", Type: flux.TTime},
+//							{Label: "_value", Type: flux.TFloat},
+//							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//						},
+//						Data: [][]interface{}{
+//							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
+//						},
+//					},
+//					{
+//						KeyCols: []string{"_start", "_stop"},
+//						ColMeta: []flux.ColMeta{
+//							{Label: "_start", Type: flux.TTime},
+//							{Label: "_stop", Type: flux.TTime},
+//							{Label: "_time", Type: flux.TTime},
+//							{Label: "_value", Type: flux.TFloat},
+//							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//						},
+//						Data: [][]interface{}{
+//							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			// The from and filter nodes are both executed in parallel, then
+//			// the data is merged.
+//			name: `parallel-from-filter-merge`,
+//			spec: &plantest.PlanSpec{
+//				Nodes: []plan.Node{
+//					plantest.CreatePhysicalNode("parallel-from-test",
+//						executetest.NewParallelFromProcedureSpec(
+//							[]*executetest.ParallelTable{
+//								{
+//									Table: &executetest.Table{
+//										KeyCols: []string{"_start", "_stop"},
+//										ColMeta: []flux.ColMeta{
+//											{Label: "_start", Type: flux.TTime},
+//											{Label: "_stop", Type: flux.TTime},
+//											{Label: "_time", Type: flux.TTime},
+//											{Label: "_value", Type: flux.TFloat},
+//											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//										},
+//										Data: [][]interface{}{
+//											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+//										},
+//									},
+//									ResidesOnPartition: 0,
+//								},
+//								{
+//									Table: &executetest.Table{
+//										KeyCols: []string{"_start", "_stop"},
+//										ColMeta: []flux.ColMeta{
+//											{Label: "_start", Type: flux.TTime},
+//											{Label: "_stop", Type: flux.TTime},
+//											{Label: "_time", Type: flux.TTime},
+//											{Label: "_value", Type: flux.TFloat},
+//											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//										},
+//										Data: [][]interface{}{
+//											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+//										},
+//									},
+//									ResidesOnPartition: 1,
+//								},
+//							}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("filter",
+//						&universe.FilterProcedureSpec{
+//							Fn: interpreter.ResolvedFunction{
+//								Scope: runtime.Prelude(),
+//								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+//							},
+//						},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+//				},
+//				Edges: [][2]int{
+//					{0, 1},
+//					{1, 2},
+//					{2, 3},
+//				},
+//			},
+//			want: map[string][]*executetest.Table{
+//				"_result": []*executetest.Table{
+//					{
+//						KeyCols: []string{"_start", "_stop"},
+//						ColMeta: []flux.ColMeta{
+//							{Label: "_start", Type: flux.TTime},
+//							{Label: "_stop", Type: flux.TTime},
+//							{Label: "_time", Type: flux.TTime},
+//							{Label: "_value", Type: flux.TFloat},
+//							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//						},
+//						Data: [][]interface{}{
+//							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
+//						},
+//					},
+//					{
+//						KeyCols: []string{"_start", "_stop"},
+//						ColMeta: []flux.ColMeta{
+//							{Label: "_start", Type: flux.TTime},
+//							{Label: "_stop", Type: flux.TTime},
+//							{Label: "_time", Type: flux.TTime},
+//							{Label: "_value", Type: flux.TFloat},
+//							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//						},
+//						Data: [][]interface{}{
+//							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name: `parallel-from-merge-no-successor`,
+//			spec: &plantest.PlanSpec{
+//				Nodes: []plan.Node{
+//					plantest.CreatePhysicalNode("parallel-from-test",
+//						executetest.NewParallelFromProcedureSpec(
+//							[]*executetest.ParallelTable{
+//								{
+//									Table: &executetest.Table{
+//										KeyCols: []string{"_start", "_stop"},
+//										ColMeta: []flux.ColMeta{
+//											{Label: "_start", Type: flux.TTime},
+//											{Label: "_stop", Type: flux.TTime},
+//											{Label: "_time", Type: flux.TTime},
+//											{Label: "_value", Type: flux.TFloat},
+//											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//										},
+//										Data: [][]interface{}{
+//											{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, -1},
+//											{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, -1},
+//										},
+//									},
+//									ResidesOnPartition: 0,
+//								},
+//								{
+//									Table: &executetest.Table{
+//										KeyCols: []string{"_start", "_stop"},
+//										ColMeta: []flux.ColMeta{
+//											{Label: "_start", Type: flux.TTime},
+//											{Label: "_stop", Type: flux.TTime},
+//											{Label: "_time", Type: flux.TTime},
+//											{Label: "_value", Type: flux.TFloat},
+//											{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//										},
+//										Data: [][]interface{}{
+//											{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, -1},
+//											{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, -1},
+//										},
+//									},
+//									ResidesOnPartition: 1,
+//								},
+//							}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+//				},
+//				Edges: [][2]int{
+//					{0, 1},
+//				},
+//			},
+//			want: map[string][]*executetest.Table{
+//				"_result": []*executetest.Table{
+//					{
+//						KeyCols: []string{"_start", "_stop"},
+//						ColMeta: []flux.ColMeta{
+//							{Label: "_start", Type: flux.TTime},
+//							{Label: "_stop", Type: flux.TTime},
+//							{Label: "_time", Type: flux.TTime},
+//							{Label: "_value", Type: flux.TFloat},
+//							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//						},
+//						Data: [][]interface{}{
+//							{execute.Time(0), execute.Time(5), execute.Time(0), 1.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(1), 2.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(2), 3.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(3), 4.0, int64(0)},
+//							{execute.Time(0), execute.Time(5), execute.Time(4), 5.0, int64(0)},
+//						},
+//					},
+//					{
+//						KeyCols: []string{"_start", "_stop"},
+//						ColMeta: []flux.ColMeta{
+//							{Label: "_start", Type: flux.TTime},
+//							{Label: "_stop", Type: flux.TTime},
+//							{Label: "_time", Type: flux.TTime},
+//							{Label: "_value", Type: flux.TFloat},
+//							{Label: executetest.ParallelGroupColName, Type: flux.TInt},
+//						},
+//						Data: [][]interface{}{
+//							{execute.Time(5), execute.Time(10), execute.Time(5), 5.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(6), 6.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(7), 7.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(8), 8.0, int64(1)},
+//							{execute.Time(5), execute.Time(10), execute.Time(9), 9.0, int64(1)},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			// Error: the from node does not specify the parallel-run
+//			// attribute. It is required its successor, filter.
+//			name: `from-missing-output`,
+//			spec: &plantest.PlanSpec{
+//				Nodes: []plan.Node{
+//					plantest.CreatePhysicalNode("parallel-from-test",
+//						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{})),
+//					plantest.CreatePhysicalNode("filter",
+//						&universe.FilterProcedureSpec{
+//							Fn: interpreter.ResolvedFunction{
+//								Scope: runtime.Prelude(),
+//								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+//							},
+//						},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+//				},
+//				Edges: [][2]int{
+//					{0, 1},
+//					{1, 2},
+//					{2, 3},
+//				},
+//			},
+//			wantValidationErr: &flux.Error{
+//				Code: codes.Internal,
+//				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
+//					"required by \"filter\" is missing from predecessor \"parallel-from-test\""),
+//			},
+//		},
+//		{
+//			// Error: the filter node does not require the parallel-run
+//			// attribute. The paralle-run attribute dictates that all
+//			// successors must require it.
+//			name: `from-missing-required`,
+//			spec: &plantest.PlanSpec{
+//				Nodes: []plan.Node{
+//					plantest.CreatePhysicalNode("parallel-from-test",
+//						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("filter",
+//						&universe.FilterProcedureSpec{
+//							Fn: interpreter.ResolvedFunction{
+//								Scope: runtime.Prelude(),
+//								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+//							},
+//						},
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2}),
+//						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+//				},
+//				Edges: [][2]int{
+//					{0, 1},
+//					{1, 2},
+//					{2, 3},
+//				},
+//			},
+//			wantValidationErr: &flux.Error{
+//				Code: codes.Internal,
+//				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
+//					"on \"parallel-from-test\" must be required by all successors, but isn't on \"filter\""),
+//			},
+//		},
+//		{
+//			// Error: The value of a required attribute does not match value of
+//			// the output attribute in the successor.
+//			name: `from-factor-mismatch`,
+//			spec: &plantest.PlanSpec{
+//				Nodes: []plan.Node{
+//					plantest.CreatePhysicalNode("parallel-from-test",
+//						executetest.NewParallelFromProcedureSpec([]*executetest.ParallelTable{}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 2})),
+//					plantest.CreatePhysicalNode("filter",
+//						&universe.FilterProcedureSpec{
+//							Fn: interpreter.ResolvedFunction{
+//								Scope: runtime.Prelude(),
+//								Fn:    executetest.FunctionExpression(t, "(r) => r._value < 7.5"),
+//							},
+//						},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1}),
+//						plantest.WithOutputAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1})),
+//					plantest.CreatePhysicalNode("merge", &universe.PartitionMergeProcedureSpec{},
+//						plantest.WithRequiredAttr(plan.ParallelRunKey, plan.ParallelRunAttribute{Factor: 1}),
+//						plantest.WithOutputAttr(plan.ParallelMergeKey, plan.ParallelMergeAttribute{Factor: 1})),
+//					plantest.CreatePhysicalNode("yield", executetest.NewYieldProcedureSpec("_result")),
+//				},
+//				Edges: [][2]int{
+//					{0, 1},
+//					{1, 2},
+//					{2, 3},
+//				},
+//			},
+//			wantValidationErr: &flux.Error{
+//				Code: codes.Internal,
+//				Msg: fmt.Sprintf("invalid physical query plan; attribute \"parallel-run\" " +
+//					"required by \"filter\" does not match attribute in predecessor \"parallel-from-test\""),
+//			},
+//		},
+//	}
+//
+//	for _, tc := range testcases {
+//		tc := tc
+//		t.Run(tc.name, func(t *testing.T) {
+//
+//			tc.spec.Resources = flux.ResourceManagement{
+//				ConcurrencyQuota: 1,
+//				MemoryBytesQuota: math.MaxInt64,
+//			}
+//
+//			tc.spec.Now = time.Now()
+//
+//			// Construct physical query plan
+//			ps := plantest.CreatePlanSpec(tc.spec)
+//
+//			if err := ps.TopDownWalk(plan.SetTriggerSpec); err != nil {
+//				return
+//			}
+//
+//			err := plan.ValidatePhysicalPlan(ps)
+//			if tc.wantValidationErr == nil && err != nil {
+//				t.Fatal(err)
+//			}
+//
+//			if tc.wantValidationErr != nil {
+//				if err == nil {
+//					t.Fatalf(`expected an error "%v" but got none`, tc.wantValidationErr)
+//				}
+//
+//				if diff := cmp.Diff(tc.wantValidationErr, err); diff != "" {
+//					t.Fatalf("unexpected error: -want/+got: %v", diff)
+//				}
+//				return
+//			}
+//
+//			exe := execute.NewExecutor(zaptest.NewLogger(t))
+//
+//			alloc := tc.allocator
+//			if alloc == nil {
+//				alloc = executetest.UnlimitedAllocator
+//			}
+//
+//			// Execute the query and preserve any error returned
+//			ctx, deps := dependency.Inject(context.Background(), executetest.NewTestExecuteDependencies())
+//			defer deps.Finish()
+//
+//			results, _, err := exe.Execute(ctx, ps, alloc)
+//			var got map[string][]*executetest.Table
+//			if err == nil {
+//				got = make(map[string][]*executetest.Table, len(results))
+//				for name, r := range results {
+//					if err = r.Tables().Do(func(tbl flux.Table) error {
+//						cb, err := executetest.ConvertTable(tbl)
+//						if err != nil {
+//							return err
+//						}
+//						got[name] = append(got[name], cb)
+//						return nil
+//					}); err != nil {
+//						break
+//					}
+//				}
+//			}
+//
+//			if tc.wantErr == nil && err != nil {
+//				t.Fatal(err)
+//			}
+//
+//			if tc.wantErr != nil {
+//				if err == nil {
+//					t.Fatalf(`expected an error "%v" but got none`, tc.wantErr)
+//				}
+//
+//				if diff := cmp.Diff(tc.wantErr, err); diff != "" {
+//					t.Fatalf("unexpected error: -want/+got: %v", diff)
+//				}
+//				return
+//			}
+//
+//			for _, g := range got {
+//				executetest.NormalizeTables(g)
+//			}
+//			for _, w := range tc.want {
+//				executetest.NormalizeTables(w)
+//			}
+//
+//			if !cmp.Equal(got, tc.want) {
+//				t.Error("unexpected results -want/+got", cmp.Diff(tc.want, got))
+//			}
+//		})
+//	}
+//}

--- a/plan/attributes.go
+++ b/plan/attributes.go
@@ -1,27 +1,81 @@
 package plan
 
-// Physical attributes used in specifying parallelization. The Run attribute
-// means the node executes in parallel. It accepts parallel data (a subset of
-// the source) and produces parallel data. The merge attribute means that the
-// node accepts parallel data, merges the streams, and produces non-parallel
-// data that covers the entire data source.
-const ParallelRunKey = "parallel-run"
-const ParallelMergeKey = "parallel-merge"
+// Attributes provide a way to model different aspects of the data
+// flowing though the physical operations in a plan graph.
+//
+// For example, if a node requires its input tables to be sorted, it
+// will have the CollationAttr among its required attributes.
+// Likewise, if a node produces sorted tables, its output attributes
+// will have CollationAttr.
+//
+// Operations can require or provide attributes by implementing interfaces
+// in the corresponding PhysicalProcedureSpec:
+// - OutputAttributer is to be implemented if the procedure will provide an attribiute. E.g.,
+//   the SortProcedureSpec will provide CollationAttr for the columns on which the data is
+//   to be sorted.
+// - PassThroughAttributeris to be implemented if a procedure will not perturb a given attribute.
+//   E.g., if data with CollationAttr flows into a filter, it will still be sorted. Therefore,
+//   FilterProcedureSpec can implement PassThroughAttributer for collation.
+// - RequiredAttributer is to be implemented by procedures that require particular attreibutes.
+//   There is one set of required physical attributes for each input, since they may be different.
+//   E.g., SortMergeJoinProcedureSpec requires that the left and right inputs be sorted on the
+//   columns being joined on (and they may in fact have different names on either side).
+//
+// It's the obligation of planner rules to ensure that required attributes are satisified by
+// a procedure's inputs. If a node has required attribute that are not satisfied, it will be
+// caught by ValidatePhysicalPlan(), and an internal error will be returned.
 
-type ParallelRunAttribute struct {
-	Factor int
+// PhysicalAttr represents an attribute (collation, parallel execution)
+// of a plan node.
+type PhysicalAttr interface {
+	Key() string
+	SuccessorsMustRequire() bool
+	SatisfiedBy(attr PhysicalAttr) bool
 }
 
-// If a node produces parallel data, then all successors must require parallel
-// data, otherwise there will be a plan error.
-func (ParallelRunAttribute) SuccessorsMustRequire() bool {
-	return true
+// PhysicalAttributes encapsulates any physical attributes of the result produced
+// by a physical plan node, such as collation, etc.
+type PhysicalAttributes map[string]PhysicalAttr
+
+// OutputAttributer is an interface to be implemented by PhysicalProcedureSpec implementations
+// that produce output that has particular attributes.
+type OutputAttributer interface {
+	OutputAttributes() PhysicalAttributes
 }
 
-type ParallelMergeAttribute struct {
-	Factor int
+// PassThroughAttributer is an interface to be implemented by PhysicalProcedureSpec implementations
+// that allow attributes to propagate from input to output.
+type PassThroughAttributer interface {
+	PassThroughAttribute(attrKey string) bool
 }
 
-func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
-	return false
+// RequiredAttributer is an interface to be implemented by PhysicalProcedureSpec implementations
+// that require physical attributes to be provided by inputs. The return value here is a slice,
+// since each input may be required to have a different set of attributes.
+type RequiredAttributer interface {
+	RequiredAttributes() []PhysicalAttributes
+}
+
+// NodeSatisfiesRequiredAttribute returns true if the given node can provide the given attribute.
+// An attribute can be provided if the node provides it directly, or if the node passes through
+// an attreibute from a predecessor.
+func NodeSatisfiesRequiredAttribute(node *PhysicalPlanNode, requiredAttr PhysicalAttr) bool {
+	gotAttr := getAttribute(node, requiredAttr.Key())
+	return requiredAttr.SatisfiedBy(gotAttr)
+}
+
+func getAttribute(node *PhysicalPlanNode, attrKey string) PhysicalAttr {
+	if attr, ok := node.OutputAttrs()[attrKey]; ok {
+		return attr
+	}
+
+	if passer, ok := node.Spec.(PassThroughAttributer); ok {
+		if passer.PassThroughAttribute(attrKey) && len(node.Predecessors()) == 1 {
+			// TODO(cwolff): consider what it means for nodes with multiple predecessors
+			//   (e.g. join or union) to pass on attributes.
+			return getAttribute(node.Predecessors()[0].(*PhysicalPlanNode), attrKey)
+		}
+	}
+
+	return nil
 }

--- a/plan/collation.go
+++ b/plan/collation.go
@@ -1,0 +1,45 @@
+package plan
+
+const (
+	CollationKey = "collation"
+)
+
+// CollationAttr is a physical attribute that describes the collation
+// of the rows within a table. Note: the collation attribute does not
+// say anything about how the tables in a stream are ordered.
+type CollationAttr struct {
+	Columns []string
+	Desc    bool
+}
+
+var _ PhysicalAttr = (*CollationAttr)(nil)
+
+func (ca *CollationAttr) Key() string { return CollationKey }
+
+func (ca *CollationAttr) SuccessorsMustRequire() bool {
+	return false
+}
+
+func (ca *CollationAttr) SatisfiedBy(attr PhysicalAttr) bool {
+	gotCollation, ok := attr.(*CollationAttr)
+	if !ok {
+		return false
+	}
+	if ca.Desc != gotCollation.Desc {
+		return false
+	}
+
+	if len(ca.Columns) > len(gotCollation.Columns) {
+		return false
+	}
+
+	// Note that if we are looking for collation of [a, b] and we get a collation of [a, b, c]
+	// the collation is still satisfied.
+	for i, col := range ca.Columns {
+		if gotCollation.Columns[i] != col {
+			return false
+		}
+	}
+
+	return true
+}

--- a/plan/parallel.go
+++ b/plan/parallel.go
@@ -1,0 +1,54 @@
+package plan
+
+// Physical attributes used in specifying parallelization.
+
+const ParallelRunKey = "parallel-run"
+
+// ParallelRunAttribute means the node executes in parallel when present. It accepts parallel data (a subset of
+// the source) and produces parallel data.
+type ParallelRunAttribute struct {
+	Factor int
+}
+
+var _ PhysicalAttr = ParallelRunAttribute{}
+
+func (ParallelRunAttribute) Key() string { return ParallelRunKey }
+
+// SuccessorsMustRequire implements the PhysicalAttribute interface.
+// if a node produces parallel data, then all successors must require parallel
+// data, otherwise there will be a plan error.
+func (ParallelRunAttribute) SuccessorsMustRequire() bool {
+	return true
+}
+
+func (a ParallelRunAttribute) SatisfiedBy(attr PhysicalAttr) bool {
+	other, ok := attr.(ParallelRunAttribute)
+	if !ok {
+		return false
+	}
+	return a == other
+}
+
+const ParallelMergeKey = "parallel-merge"
+
+// ParallelMergeAttribute means that the node accepts parallel data, merges the streams, and produces non-parallel
+// data that covers the entire data source.
+type ParallelMergeAttribute struct {
+	Factor int
+}
+
+var _ PhysicalAttr = ParallelMergeAttribute{}
+
+func (ParallelMergeAttribute) Key() string { return ParallelMergeKey }
+
+func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
+	return false
+}
+
+func (a ParallelMergeAttribute) SatisfiedBy(attr PhysicalAttr) bool {
+	other, ok := attr.(ParallelMergeAttribute)
+	if !ok {
+		return false
+	}
+	return a == other
+}

--- a/plan/plantest/cmp.go
+++ b/plan/plantest/cmp.go
@@ -113,15 +113,15 @@ func ComparePhysicalPlanNodes(p, q plan.Node) error {
 	}
 
 	// Both nodes must consume the same required attributes
-	if !cmp.Equal(pp.RequiredAttrs, qq.RequiredAttrs) {
+	if !cmp.Equal(pp.RequiredAttrs(), qq.RequiredAttrs()) {
 		return fmt.Errorf("required attributes not equal -want(%s)/+got(%s) %s",
-			pp.ID(), qq.ID(), cmp.Diff(pp.RequiredAttrs, qq.RequiredAttrs))
+			pp.ID(), qq.ID(), cmp.Diff(pp.RequiredAttrs(), qq.RequiredAttrs()))
 	}
 
 	// Both nodes must produce the same physical attributes
-	if !cmp.Equal(pp.OutputAttrs, qq.OutputAttrs) {
+	if !cmp.Equal(pp.OutputAttrs(), qq.OutputAttrs()) {
 		return fmt.Errorf("output attributes not equal -want(%s)/+got(%s) %s",
-			pp.ID(), qq.ID(), cmp.Diff(pp.OutputAttrs, qq.OutputAttrs))
+			pp.ID(), qq.ID(), cmp.Diff(pp.OutputAttrs(), qq.OutputAttrs()))
 	}
 
 	return nil

--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -212,17 +212,17 @@ func PhysicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Optio
 	type testAttrs struct {
 		ID            plan.NodeID
 		Spec          plan.PhysicalProcedureSpec
-		RequiredAttrs plan.PhysicalAttributes
+		RequiredAttrs []plan.PhysicalAttributes
 		OutputAttrs   plan.PhysicalAttributes
 	}
 	want := make([]testAttrs, 0)
 	after.BottomUpWalk(func(node plan.Node) error {
 		var outputAttrs plan.PhysicalAttributes
-		var requiredAttrs plan.PhysicalAttributes
+		var requiredAttrs []plan.PhysicalAttributes
 
 		if ppn, ok := node.(*plan.PhysicalPlanNode); ok {
-			outputAttrs = ppn.OutputAttrs
-			requiredAttrs = ppn.RequiredAttrs
+			outputAttrs = ppn.OutputAttrs()
+			requiredAttrs = ppn.RequiredAttrs()
 		}
 		want = append(want, testAttrs{
 			ID:            node.ID(),
@@ -236,11 +236,11 @@ func PhysicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Optio
 	got := make([]testAttrs, 0)
 	pp.BottomUpWalk(func(node plan.Node) error {
 		var outputAttrs plan.PhysicalAttributes
-		var requiredAttrs plan.PhysicalAttributes
+		var requiredAttrs []plan.PhysicalAttributes
 
 		if ppn, ok := node.(*plan.PhysicalPlanNode); ok {
-			outputAttrs = ppn.OutputAttrs
-			requiredAttrs = ppn.RequiredAttrs
+			outputAttrs = ppn.OutputAttrs()
+			requiredAttrs = ppn.RequiredAttrs()
 		}
 
 		got = append(got, testAttrs{
@@ -320,17 +320,22 @@ func LogicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Option
 
 type PhysicalNodeOption func(*plan.PhysicalPlanNode)
 
-func WithOutputAttr(name string, attr plan.PhysicalAttr) PhysicalNodeOption {
-	return func(node *plan.PhysicalPlanNode) {
-		node.SetOutputAttr(name, attr)
-	}
-}
+// TODO(cwolff): output attributes and required attributes should be computed
+// from the Spec of a plan node, so they shouldn't be stored as state in the plan
+// node itself. Tests will need to be modified to use Specs that implement
+// OutputAttributer or RequiredAttributer.
 
-func WithRequiredAttr(name string, attr plan.PhysicalAttr) PhysicalNodeOption {
-	return func(node *plan.PhysicalPlanNode) {
-		node.SetRequiredAttr(name, attr)
-	}
-}
+//func WithOutputAttr(name string, attr plan.PhysicalAttr) PhysicalNodeOption {
+//	return func(node *plan.PhysicalPlanNode) {
+//		node.SetOutputAttr(name, attr)
+//	}
+//}
+//
+//func WithRequiredAttr(name string, whichPred int, attr plan.PhysicalAttr) PhysicalNodeOption {
+//	return func(node *plan.PhysicalPlanNode) {
+//		node.SetRequiredAttr(name, whichPred, attr)
+//	}
+//}
 
 func CreatePhysicalNode(id plan.NodeID, spec plan.PhysicalProcedureSpec, opts ...PhysicalNodeOption) *plan.PhysicalPlanNode {
 	node := plan.CreatePhysicalNode(id, spec)

--- a/plan/plantest/spec/plan.go
+++ b/plan/plantest/spec/plan.go
@@ -50,12 +50,6 @@ func copyNode(n plan.Node) plan.Node {
 		cn = plan.CreateLogicalNode(n.ID(), n.ProcedureSpec().Copy())
 	case *plan.PhysicalPlanNode:
 		pn := plan.CreatePhysicalNode(n.ID(), n.ProcedureSpec().Copy().(plan.PhysicalProcedureSpec))
-		for key, attr := range n.OutputAttrs {
-			pn.SetOutputAttr(key, attr)
-		}
-		for key, attr := range n.RequiredAttrs {
-			pn.SetRequiredAttr(key, attr)
-		}
 		cn = pn
 	}
 	return cn

--- a/plan/types.go
+++ b/plan/types.go
@@ -126,14 +126,14 @@ func (plan *Spec) CheckIntegrity() error {
 
 func symmetryCheck(node Node) error {
 	for _, pred := range node.Predecessors() {
-		if !isNodeInNodes(node, pred.Successors()) {
+		if idx := indexOfNode(node, pred.Successors()); idx == -1 {
 			return fmt.Errorf("integrity violated: %s is predecessor of %s, "+
 				"but %s is not successor of %s", pred.ID(), node.ID(), node.ID(), pred.ID())
 		}
 	}
 
 	for _, succ := range node.Successors() {
-		if !isNodeInNodes(node, succ.Predecessors()) {
+		if idx := indexOfNode(node, succ.Predecessors()); idx == -1 {
 			return fmt.Errorf("integrity violated: %s is successor of %s, "+
 				"but %s is not predecessor of %s`", succ.ID(), node.ID(), node.ID(), succ.ID())
 		}
@@ -142,14 +142,14 @@ func symmetryCheck(node Node) error {
 	return nil
 }
 
-func isNodeInNodes(node Node, nodes []Node) bool {
-	for _, n := range nodes {
+func indexOfNode(node Node, nodes []Node) int {
+	for i, n := range nodes {
 		if n == node {
-			return true
+			return i
 		}
 	}
 
-	return false
+	return -1
 }
 
 // ProcedureSpec specifies a query operation

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -100,6 +100,15 @@ func (s *SortProcedureSpec) Copy() plan.ProcedureSpec {
 	return &ns
 }
 
+func (s *SortProcedureSpec) OutputAttributes() plan.PhysicalAttributes {
+	return plan.PhysicalAttributes{
+		plan.CollationKey: &plan.CollationAttr{
+			Columns: s.Columns,
+			Desc:    s.Desc,
+		},
+	}
+}
+
 // TriggerSpec implements plan.TriggerAwareProcedureSpec
 func (s *SortProcedureSpec) TriggerSpec() plan.TriggerSpec {
 	return plan.NarrowTransformationTriggerSpec{}


### PR DESCRIPTION
This is just a proof of concept. Do not merge as-is!

Fixes #4678.

This PR contains some changes to allow for operations in the plan graph to model the attributes that they require and provide. In this PR there are two sets of attributes:
- Parallelization-related. I moved these into their own file.
- Collation (order of rows within tables). This is a new kind of attribute added in this PR.

The main goal of this PR is to make it so parallelization and collation can use the same framework for providing, propagating and require attributes to ensure a correct plan. The file `attributes.go` has a lenghty comment that provides an overview of how things are supposed to work.

In the example below, `SortMergeProcedureSpec` indicates that it requires sorted input by implementing an interface, and `SortProcedureSpec` indicates that it provides a `collation` attribute by implementing a different interface.

There are some breaking changes here and the parallelization attributes no longer work right. There will need to be some changes both here and cloud to make everything work. These are the relevant breaking changes:
- Attributes are no longer stored on the physical plan node itself as Go `map`s. Instead the plan node to will need to provide methods to access attributes, which it will delegate to the `ProcedureSpec` that it wraps.
- As such, it's no longer possible to modify a plan node to provide or require a certain attribute. If there is state that needs to be managed, the state should be contained within the `ProcedureSpec`, which can be manipulated via a planner rule.
- Required attributes are no longer represented as a map, but rather a slice of maps. This is because there can be different requirements for different inputs to an operation (`join` is like this)

Interestingly, this work actually caught a bug in the planner rule for `SortMergeJoin`, because the sort nodes weren't being created quite right.
