### PR TITLE
fix(stdlib): fix a bug in how sort nodes created for new join

### DIFF
--- a/stdlib/join/sort_merge_join.go
+++ b/stdlib/join/sort_merge_join.go
@@ -72,7 +72,7 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 
 	successors := predecessors[0].Successors()
 
-	columns := make([]string, len(spec.On))
+	columns := make([]string, 0, len(spec.On))
 	for _, pair := range spec.On {
 		columns = append(columns, pair.Left)
 	}
@@ -80,7 +80,7 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 
 	successors = predecessors[1].Successors()
 
-	columns = make([]string, len(spec.On))
+	columns = make([]string, 0, len(spec.On))
 	for _, pair := range spec.On {
 		columns = append(columns, pair.Right)
 	}
@@ -88,7 +88,9 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 
 	// Replace the spec so we don't end up trying to apply this rewrite forever
 	x := SortMergeJoinProcedureSpec(*spec)
-	n.ReplaceSpec(&x)
+	if err := n.ReplaceSpec(&x); err != nil {
+		return n, false, err
+	}
 
 	return n, true, nil
 }


### PR DESCRIPTION
I found this issue while working on #4902. The list of columns to be sorted by in generated sort nodes included an initial set of empty strings. This would not have resulted in incorrect behavior I don't think, but it was confusing when I encountered it.
