### PR TITLE
fix(repl): replace extra boolean parameter for suggestions with repl options

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/repl"
 	"github.com/opentracing/opentracing-go"
 	"github.com/spf13/cobra"
 	jaegercfg "github.com/uber/jaeger-client-go/config"
@@ -63,8 +64,13 @@ func runE(cmd *cobra.Command, args []string) error {
 	}
 	ctx = feature.Dependency{Flagger: flagger}.Inject(ctx)
 
+	var opts []repl.Option
+	if flags.EnableSuggestions {
+		opts = append(opts, repl.EnableSuggestions())
+	}
+
 	if len(args) == 0 {
-		return replE(ctx, flags.EnableSuggestions)
+		return replE(ctx, opts...)
 	}
 	return executeE(ctx, script, flags.Format)
 }

--- a/cmd/flux/repl.go
+++ b/cmd/flux/repl.go
@@ -6,8 +6,8 @@ import (
 	"github.com/influxdata/flux/repl"
 )
 
-func replE(ctx context.Context, enableSuggestions bool) error {
-	r := repl.New(ctx, enableSuggestions)
+func replE(ctx context.Context, opts ...repl.Option) error {
+	r := repl.New(ctx, opts...)
 	r.Run()
 	return nil
 }

--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -658,7 +658,7 @@ func TestInterpreter_MultiPhaseInterpretation(t *testing.T) {
 			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
 			defer deps.Finish()
 
-			r := repl.New(ctx, false)
+			r := repl.New(ctx)
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)
 			}
@@ -772,7 +772,7 @@ func TestInterpreter_MultipleEval(t *testing.T) {
 			ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
 			defer deps.Finish()
 
-			r := repl.New(ctx, false)
+			r := repl.New(ctx)
 
 			if _, err := r.Eval(prelude); err != nil {
 				t.Fatalf("unable to evaluate prelude: %s", err)


### PR DESCRIPTION
This uses the option pattern to configure the repl with enabling
suggestions as the currently available option. This option defaults to
false. The `repl.New()` function has also been changed back to accept
only a single argument, but to also allow an optional set of options to
configure the REPL.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written