### PR TITLE
feat(stdlib): deprecate experimental.csv 

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -154,7 +154,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/bitwise/bitwise.flux":                                                    "3e8d03804194a979fb6bbaa6b0a755bafa994698c48cd36e3db313f006abad95",
 	"stdlib/experimental/bitwise/bitwise_test.flux":                                               "2ca1f5aa9323b12d54deefe4778f1b89934474087d90fedcdcb2cd668ded3804",
 	"stdlib/experimental/count_test.flux":                                                         "120a145eb287266e35638cc5220f5cecf0eee5bf2eec1bb1e9852e7d382050c7",
-	"stdlib/experimental/csv/csv.flux":                                                            "94ae72b5fb50b8d65e9b384aebaa890f04bc914bb344ea751a64f729b5c849fe",
+	"stdlib/experimental/csv/csv.flux":                                                            "160e9c6e1a7e302fbbccd90871f235b1615c947422e57da1d18e4ac99afa61ad",
 	"stdlib/experimental/distinct_test.flux":                                                      "6d2891556d985d16ac9bd33176dd527bb34246afa1ac81dde65f1335885b6b02",
 	"stdlib/experimental/experimental.flux":                                                       "81a9cbdccc2cb9ad205e387afc453daebcb335f162a24d9e338b96ddca691a84",
 	"stdlib/experimental/experimental_test.flux":                                                  "0fb9e187e7c90ccf9dffa41587dd6cfe255990142d11e1772b0a219d6f8a75b1",

--- a/stdlib/experimental/csv/csv.flux
+++ b/stdlib/experimental/csv/csv.flux
@@ -2,6 +2,7 @@
 //
 // ## Metadata
 // introduced: 0.64.0
+// deprecated: NEXT
 // tags: csv
 //
 package csv
@@ -12,6 +13,8 @@ import "experimental/http"
 
 // from retrieves [annotated CSV](https://docs.influxdata.com/influxdb/latest/reference/syntax/annotated-csv/) **from a URL**.
 //
+// **Deprecated**: `csv.from()` is deprecated in favor of a combination of [`requests.get()`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/get/) and [`csv.from()`](https://docs.influxdata.com/flux/v0.x/stdlib/csv/from/).
+//
 // **Note:** Experimental `csv.from()` is an alternative to the standard
 // `csv.from()` function.
 //
@@ -19,6 +22,17 @@ import "experimental/http"
 // - url: URL to retrieve annotated CSV from.
 //
 // ## Examples
+//
+// ### Query annotated CSV data from a URL using the requests package
+//
+// ```no_run
+// import "csv"
+// import "http/requests"
+//
+// response = requests.get(url: "http://example.com/csv/example.csv")
+// csv.from(csv: string(v: response.body))
+// ```
+//
 // ### Query annotated CSV data from a URL
 // ```no_run
 // import "experimental/csv"


### PR DESCRIPTION
`experimental.csv` only provides a simple way to query a URL and parse
as CSV, now that `requests` package is complete its best to use and
compose this logic as needed. As it stands `experimental.csv` can't
check the HTTP status code and so its best this is left to the developer
writing the code.


Depends on https://github.com/influxdata/flux/pull/4921 merging first. 

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
