### PR TITLE
feat(stdlib): deprecate experimental/http.get

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -183,7 +183,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/group_test.flux":                                                         "eabe72efa7bd5f2eb30a6e6afb19b65157d167b15740afa85d0f0849cd2fab94",
 	"stdlib/experimental/histogram_quantile_test.flux":                                            "b5968dbaf510bdc0c92033d300706c5dd2250c9788a0000fe39aca3189d45cca",
 	"stdlib/experimental/histogram_test.flux":                                                     "3d983cac860f92c05fd697ee447e34499e417653574fa1698a487f119dab7b50",
-	"stdlib/experimental/http/http.flux":                                                          "dda34b0579c8e5eefae9fac4b596dc2d40c432a257b69ce78715ad47e24e2ea4",
+	"stdlib/experimental/http/http.flux":                                                          "96268512928d041d17a9618d98987512589ac1d8e0d47beb87b064ba90caf42b",
 	"stdlib/experimental/http/requests/requests.flux":                                             "3ba3427669bbe11208afaef402da3f9fd74e6192c1aa071963060e611ce42c98",
 	"stdlib/experimental/influxdb/influxdb.flux":                                                  "2d37fe7bca8a7404f6e9589462fb4e8ac851052a8efa90cbac29f9adc890f9c9",
 	"stdlib/experimental/integral_test.flux":                                                      "4c9b6c866884839027946e93793689b8b3d328e2e777f8ee2f8973ffd72be036",

--- a/stdlib/experimental/http/http.flux
+++ b/stdlib/experimental/http/http.flux
@@ -1,7 +1,10 @@
 // Package http provides functions for transferring data using HTTP protocol.
 //
+// **Deprecated**: This package is deprecated in favor of [`requests`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/).
+//
 // ## Metadata
 // introduced: 0.39.0
+// deprecated: NEXT
 // tags: http
 //
 package http
@@ -9,6 +12,8 @@ package http
 
 // get submits an HTTP GET request to the specified URL and returns the HTTP
 // status code, response body, and response headers.
+//
+// **Deprecated**: `http.get()` is deprecated in favor of [`requests.get()`](https://docs.influxdata.com/flux/v0.x/stdlib/http/requests/get/).
 //
 // ## Response format
 // `http.get()` returns a record with the following properties:


### PR DESCRIPTION

Use `http/requests` instead of `experimental/http.get`.

Depends on https://github.com/influxdata/flux/pull/4921 merging first.

### Done checklist
- [ ] docs/SPEC.md updated
- [ ] Test cases written
