### PR TITLE
fix(join): return error if user modifies group key

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -271,7 +271,7 @@ var sourceHashes = map[string]string{
 	"stdlib/interpolate/interpolate.flux":                                                         "3d480c9058c584b65841db7889c459ad9bfed679f4ce24d17a84ec020cce768b",
 	"stdlib/interpolate/interpolate_test.flux":                                                    "f938f88db50a5ec8cddb765ac9e8836ef0aff2694c87778a2294810761cddef8",
 	"stdlib/join/join.flux":                                                                       "379330a0fa31a2a932ec94dbc84295b031832da08a416e6a57f2b581fc0d45d0",
-	"stdlib/join/join_test.flux":                                                                  "398e617db0b912ef7ad84a4688c14178660478a4dca57849bad464d82f1bff99",
+	"stdlib/join/join_test.flux":                                                                  "38d21350a89a9e561f52e3cf7efece4b071a3248a390e16ea940e1303652b580",
 	"stdlib/json/json.flux":                                                                       "180dec063b8042db9fafb7a9e633a00451f0343ccf565ed8bf9650bebcd12674",
 	"stdlib/kafka/kafka.flux":                                                                     "c93e5a56f16d56d69f905e8fd3b02156ccb41742bb513c9d6fd82b26187ab5e8",
 	"stdlib/math/math.flux":                                                                       "590b501bc712d134fae22c966dc8cec4722b2f5e05853474017ab4d0d93406be",

--- a/stdlib/join/join_fn.go
+++ b/stdlib/join/join_fn.go
@@ -131,7 +131,7 @@ func (f *JoinFn) crossProduct(ctx context.Context, p *joinProduct, mem memory.Al
 			}
 
 			if f.schema == nil {
-				cols, err := f.createSchema(joined)
+				cols, err := f.createSchema(joined, p.left[0].Key())
 				if err != nil {
 					return nil, err
 				}
@@ -147,7 +147,7 @@ func (f *JoinFn) crossProduct(ctx context.Context, p *joinProduct, mem memory.Al
 	return &c, nil
 }
 
-func (f *JoinFn) createSchema(record values.Object) ([]flux.ColMeta, error) {
+func (f *JoinFn) createSchema(record values.Object, groupkey flux.GroupKey) ([]flux.ColMeta, error) {
 	returnType := f.ReturnType()
 
 	numProps, err := returnType.NumProperties()
@@ -210,6 +210,22 @@ func (f *JoinFn) createSchema(record values.Object) ([]flux.ColMeta, error) {
 			Label: k,
 			Type:  ty,
 		})
+	}
+	for _, gcol := range groupkey.Cols() {
+		found := false
+		for _, col := range cols {
+			if gcol == col {
+				found = true
+			}
+		}
+		if !found {
+			return nil, errors.Newf(
+				codes.Invalid,
+				"join cannot modify group key: output record is missing column '%s:%s'",
+				gcol.Label,
+				gcol.Type,
+			)
+		}
 	}
 	return cols, nil
 }

--- a/stdlib/join/join_fn.go
+++ b/stdlib/join/join_fn.go
@@ -216,6 +216,7 @@ func (f *JoinFn) createSchema(record values.Object, groupkey flux.GroupKey) ([]f
 		for _, col := range cols {
 			if gcol == col {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/stdlib/join/join_test.flux
+++ b/stdlib/join/join_test.flux
@@ -178,9 +178,13 @@ testcase full_outer_join {
                 label = if exists l.label then l.label else r.id
                 time = if exists l._time then l._time else r._time
 
-                // Strange that this test passes when it's missing the `key` column
-                // Same issue with the other outer join test cases
-                return {label: label, intv: r._value, floatv: l._value, _time: time}
+                return {
+                    label: label,
+                    intv: r._value,
+                    floatv: l._value,
+                    _time: time,
+                    key: r.key,
+                }
             },
             method: "full",
         )
@@ -219,7 +223,14 @@ testcase left_outer_join {
             left: left,
             right: right,
             on: (l, r) => l.label == r.id and l._time == r._time,
-            as: (l, r) => ({label: l.label, intv: r._value, floatv: l._value, _time: l._time}),
+            as: (l, r) =>
+                ({
+                    label: l.label,
+                    intv: r._value,
+                    floatv: l._value,
+                    _time: l._time,
+                    key: r.key,
+                }),
             method: "left",
         )
 
@@ -258,7 +269,13 @@ testcase right_outer_join {
             right: right,
             on: (l, r) => l.label == r.id and l._time == r._time,
             as: (l, r) => {
-                return {label: r.id, intv: r._value, floatv: l._value, _time: r._time}
+                return {
+                    label: r.id,
+                    intv: r._value,
+                    floatv: l._value,
+                    _time: r._time,
+                    key: l.key,
+                }
             },
             method: "right",
         )


### PR DESCRIPTION
Return an error if a user defines an `as` function that returns a record that is missing a group key column.

Fixes #4909 
