### PR TITLE
feat(test/tags): adds tagging support to flux test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,13 +130,13 @@ INTEGRATION_READ_TESTS=integration_hdb_read_from_seed,integration_hdb_read_from_
 INTEGRATION_TESTS="$(INTEGRATION_INJECTION_TESTS),$(INTEGRATION_WRITE_TESTS),$(INTEGRATION_READ_TESTS)"
 
 test-flux:
-	$(GO_RUN) ./cmd/flux test -v --parallel 8 --skip $(INTEGRATION_TESTS)
+	$(GO_RUN) ./cmd/flux test -p stdlib -v --parallel 8 --skip $(INTEGRATION_TESTS)
 
 test-flux-integration:
 	./etc/spawn-containers.sh
-	$(GO_RUN) ./cmd/flux test -v --test $(INTEGRATION_INJECTION_TESTS)
-	$(GO_RUN) ./cmd/flux test -v --test $(INTEGRATION_WRITE_TESTS)
-	$(GO_RUN) ./cmd/flux test -v --test $(INTEGRATION_READ_TESTS)
+	$(GO_RUN) ./cmd/flux test -p stdlib -v --test $(INTEGRATION_INJECTION_TESTS)
+	$(GO_RUN) ./cmd/flux test -p stdlib -v --test $(INTEGRATION_WRITE_TESTS)
+	$(GO_RUN) ./cmd/flux test -p stdlib -v --test $(INTEGRATION_READ_TESTS)
 
 test-race: libflux-go
 	$(GO_TEST) -race -count=1 ./...

--- a/ast/edit/task_editor.go
+++ b/ast/edit/task_editor.go
@@ -14,10 +14,17 @@ func GetOption(file *ast.File, name string) (ast.Expression, error) {
 	for _, st := range file.Body {
 		if val, ok := st.(*ast.OptionStatement); ok {
 			assign := val.Assignment
-			if va, ok := assign.(*ast.VariableAssignment); ok {
-				if va.ID.Name == name {
+			switch a := assign.(type) {
+			case *ast.VariableAssignment:
+				if a.ID.Name == name {
 					if ok {
-						return va.Init, nil
+						return a.Init, nil
+					}
+				}
+			case *ast.MemberAssignment:
+				if ident, ok := a.Member.Object.(*ast.Identifier); ok {
+					if ident.Name+"."+a.Member.Property.Key() == name {
+						return a.Init, nil
 					}
 				}
 			}

--- a/ast/testcase/testcase_test.go
+++ b/ast/testcase/testcase_test.go
@@ -115,7 +115,9 @@ testcase b extends "flux/a/a_test.a" {
 	pkg.Files[0].Name = "b/b_test.flux"
 
 	names, pkgs, err := testcase.Transform(ctx, pkg, testcase.TestModules{
-		"flux": fs,
+		"flux": testcase.TestModule{
+			Service: fs,
+		},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -7,17 +7,21 @@ import (
 	"compress/gzip"
 	"container/heap"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/ast/astutil"
+	"github.com/influxdata/flux/ast/edit"
 	"github.com/influxdata/flux/ast/testcase"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/filesystem"
@@ -68,52 +72,79 @@ var newSkips = []string{
 
 type TestFlags struct {
 	testNames     []string
+	testTags      []string
 	paths         []string
 	skipTestCases []string
+	skipUntagged  bool
 	parallel      bool
 	verbosity     int
+	noinit        bool
 }
+
+type failedTests struct{}
+
+func (e failedTests) Error() string {
+	return "tests failed"
+}
+func (e failedTests) Silent() {}
 
 func TestCommand(setup TestSetupFunc) *cobra.Command {
 	var flags TestFlags
 	testCommand := &cobra.Command{
 		Use:   "test",
 		Short: "Run flux tests",
-		Long:  "Run flux tests",
-		Run: func(cmd *cobra.Command, args []string) {
-			fluxinit.FluxInit()
-			if err := runFluxTests(setup, flags); err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+		Long: `Run flux tests
+
+An exit code of 0 means that no tests failed.
+Any other exit code means that either, there was an
+error running the tests or at least one test failed.
+`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !flags.noinit {
+				fluxinit.FluxInit()
 			}
+			if passed, err := runFluxTests(cmd.OutOrStdout(), setup, flags); err != nil {
+				return err
+			} else if !passed {
+				// Tests failed return a silent error since
+				// we have already reported about the failure according to
+				// the verbosity level.
+				return failedTests{}
+			}
+			return nil
 		},
 	}
 	testCommand.Flags().StringSliceVarP(&flags.paths, "path", "p", nil, "The root level directory for all packages.")
-	testCommand.Flags().StringSliceVar(&flags.testNames, "test", []string{}, "The name of a specific test to run.")
-	testCommand.Flags().StringSliceVar(&flags.skipTestCases, "skip", []string{}, "Comma-separated list of test cases to skip.")
+	testCommand.Flags().StringSliceVar(&flags.testNames, "test", []string{}, "List of test names to run. These tests will run regardless of tags or skips.")
+	testCommand.Flags().StringSliceVar(&flags.testTags, "tags", []string{}, "List of tags. Tests only run if all of their tags are provided.")
+	testCommand.Flags().StringSliceVar(&flags.skipTestCases, "skip", []string{}, "List of test names to skip.")
+	testCommand.Flags().BoolVar(&flags.skipUntagged, "skip-untagged", false, "Skip tests with an empty tag set.")
 	testCommand.Flags().BoolVarP(&flags.parallel, "parallel", "", false, "Enables parallel test execution.")
 	testCommand.Flags().CountVarP(&flags.verbosity, "verbose", "v", "verbose (-v, -vv, or -vvv)")
+	testCommand.Flags().BoolVarP(&flags.noinit, "noinit", "", false, "Disables Flux initialization, used for testing this command.")
 	return testCommand
 }
 
 // runFluxTests invokes the test runner.
-func runFluxTests(setup TestSetupFunc, flags TestFlags) error {
+// Returns true if no tests failed or an error if one was encountered.
+func runFluxTests(out io.Writer, setup TestSetupFunc, flags TestFlags) (bool, error) {
 	if len(flags.paths) == 0 {
 		flags.paths = []string{"."}
 	}
 
-	reporter := NewTestReporter(flags.verbosity)
+	reporter := NewTestReporter(out, flags.verbosity)
 	runner := NewTestRunner(reporter)
-	if err := runner.Gather(flags.paths, flags.testNames); err != nil {
-		return err
+	if err := runner.Gather(flags.paths); err != nil {
+		return false, err
 	}
 
-	executor, err := setup(context.Background())
-	if err != nil {
-		return err
+	if invalid := invalidTags(flags.testTags, runner.validTags); len(invalid) != 0 {
+		return false, errors.Newf(codes.Invalid, "provided tags are invalid: %v, valid tags are %v", invalid, runner.validTags)
 	}
-	defer func() { _ = executor.Close() }()
 
+	// Append hardcoded skips
 	for _, m := range skip {
 		for k := range m {
 			flags.skipTestCases = append(flags.skipTestCases, k)
@@ -121,12 +152,20 @@ func runFluxTests(setup TestSetupFunc, flags TestFlags) error {
 	}
 	flags.skipTestCases = append(flags.skipTestCases, newSkips...)
 
-	if flags.parallel {
-		runner.RunParallel(executor, flags.verbosity, flags.skipTestCases)
-	} else {
-		runner.Run(executor, flags.verbosity, flags.skipTestCases)
+	runner.MarkSkipped(flags.testNames, flags.skipTestCases, flags.testTags, flags.skipUntagged)
+
+	executor, err := setup(context.Background())
+	if err != nil {
+		return false, err
 	}
-	return runner.Finish()
+	defer func() { _ = executor.Close() }()
+
+	if flags.parallel {
+		runner.RunParallel(executor, flags.verbosity)
+	} else {
+		runner.Run(executor, flags.verbosity)
+	}
+	return runner.Finish(), nil
 }
 
 // Test wraps the functionality of a single testcase statement,
@@ -134,15 +173,19 @@ func runFluxTests(setup TestSetupFunc, flags TestFlags) error {
 type Test struct {
 	name string
 	ast  *ast.Package
-	err  error
+	// set of tags specified for the test case
+	tags []string
+	// indicates if the test should be skipped
 	skip bool
+	err  error
 }
 
 // NewTest creates a new Test instance from an ast.Package.
-func NewTest(name string, ast *ast.Package) Test {
+func NewTest(name string, ast *ast.Package, tags []string) Test {
 	return Test{
 		name: name,
 		ast:  ast,
+		tags: tags,
 	}
 }
 
@@ -231,8 +274,9 @@ func contains(names []string, name string) bool {
 
 // TestRunner gathers and runs all tests.
 type TestRunner struct {
-	tests    []*Test
-	reporter TestReporter
+	tests     []*Test
+	validTags []string
+	reporter  TestReporter
 }
 
 // NewTestRunner returns a new TestRunner.
@@ -243,11 +287,16 @@ func NewTestRunner(reporter TestReporter) TestRunner {
 	}
 }
 
-type gatherFunc func(filename string) ([]string, fs, testcase.TestModules, error)
+type testFile struct {
+	path   string
+	module string
+}
+
+type gatherFunc func(filename string) ([]testFile, fs, testcase.TestModules, error)
 
 // Gather gathers all tests from the filesystem and creates Test instances
 // from that info.
-func (t *TestRunner) Gather(roots []string, names []string) error {
+func (t *TestRunner) Gather(roots []string) error {
 	var modules testcase.TestModules
 	for _, root := range roots {
 		var gatherFrom gatherFunc
@@ -269,6 +318,11 @@ func (t *TestRunner) Gather(roots []string, names []string) error {
 		}
 		defer func() { _ = fs.Close() }()
 
+		// Gather valid tags from modules
+		for _, m := range mods {
+			t.validTags = union(t.validTags, m.Tags)
+		}
+
 		// Merge in any new modules.
 		if err := modules.Merge(mods); err != nil {
 			return err
@@ -276,30 +330,159 @@ func (t *TestRunner) Gather(roots []string, names []string) error {
 
 		ctx := filesystem.Inject(context.Background(), fs)
 		for _, file := range files {
-			q, err := filesystem.ReadFile(ctx, file)
+			q, err := filesystem.ReadFile(ctx, file.path)
 			if err != nil {
 				return errors.Wrapf(err, codes.Invalid, "could not find test file %q", file)
 			}
 			baseAST := parser.ParseSource(string(q))
 			if len(baseAST.Files) > 0 {
-				baseAST.Files[0].Name = file
+				baseAST.Files[0].Name = file.path
 			}
 			tcnames, asts, err := testcase.Transform(ctx, baseAST, modules)
 			if err != nil {
 				return err
 			}
 			for i, astf := range asts {
-				test := NewTest(tcnames[i], astf)
-				if len(names) == 0 || contains(names, test.Name()) {
-					t.tests = append(t.tests, &test)
+				tags, err := readTags(astf)
+				if err != nil {
+					return err
 				}
+				if invalid := invalidTags(tags, mods.Tags(file.module)); len(invalid) != 0 {
+					return errors.Newf(codes.Invalid, "testcase %q, contains invalid tags %v, valid tags are: %v", tcnames[i], invalid, mods.Tags(file.module))
+				}
+				test := NewTest(tcnames[i], astf, tags)
+				t.tests = append(t.tests, &test)
 			}
 		}
 	}
+	sort.Strings(t.validTags)
 	return nil
 }
 
-func gatherFromTarArchive(filename string) ([]string, fs, testcase.TestModules, error) {
+// invalidTags returns all tags that are not in the valid set.
+func invalidTags(tags, valid []string) []string {
+	var invalid []string
+	for _, t := range tags {
+		if !contains(valid, t) {
+			invalid = append(invalid, t)
+		}
+	}
+	return invalid
+}
+
+func union(a, b []string) []string {
+	for _, v := range b {
+		if !contains(a, v) {
+			a = append(a, v)
+		}
+	}
+	return a
+}
+
+// MarkSkipped checks the provided filters and marks each test case as skipped as needed.
+//
+// Skip rules:
+//  - When testNames is not empty any test in the list will be run, all others skipped.
+//  - When a test name is in skips, the test is skipped.
+//  - When a test contains any tags all tags must be specified for the test to run.
+//  - When skipUntagged is true, any test that does not have any tags is skipped.
+//
+// The list of tests takes precedence over all other parameters.
+func (t *TestRunner) MarkSkipped(testNames, skips, tags []string, skipUntagged bool) {
+	skipMap := make(map[string]bool)
+	for _, n := range skips {
+		skipMap[n] = true
+	}
+
+	for i := range t.tests {
+		// If testNames is not empty then check only that list
+		if len(testNames) > 0 {
+			t.tests[i].skip = !contains(testNames, t.tests[i].Name())
+			continue
+		}
+		// Now we assume the test is not skipped and check the rest of the rules
+		skip := false
+
+		if len(t.tests[i].tags) > 0 {
+			// Tags must be present for all test tags
+			isMatch := true
+			for _, tag := range t.tests[i].tags {
+				isMatch = isMatch && contains(tags, tag)
+			}
+			if !isMatch {
+				skip = true
+			}
+		}
+		t.tests[i].skip = skip || skipMap[t.tests[i].Name()] || (skipUntagged && len(t.tests[i].tags) == 0)
+	}
+}
+
+func readTags(pkg *ast.Package) ([]string, error) {
+	var tagOption *ast.ArrayExpression
+	var tags []string
+	for _, file := range pkg.Files {
+		option, err := edit.GetOption(file, "testing.tags")
+		if err != nil {
+			if err != edit.OptionNotFoundError {
+				return nil, err
+			}
+			continue
+		}
+		var ok bool
+		tagOption, ok = option.(*ast.ArrayExpression)
+		if !ok {
+			return nil, errors.New(codes.Invalid, "testing.tags option must be a list of strings")
+		}
+	}
+	if tagOption != nil {
+		tags = make([]string, 0, len(tagOption.Elements))
+		for _, tagExpr := range tagOption.Elements {
+			tag, ok := tagExpr.(*ast.StringLiteral)
+			if !ok {
+				return nil, errors.New(codes.Invalid, "testing.tags option list elements must be string literals")
+			}
+			tags = append(tags, ast.StringFromLiteral(tag))
+		}
+	}
+	return tags, nil
+
+}
+
+type rootCollector struct {
+	roots []root
+}
+type root struct {
+	path string
+	name string
+}
+
+func (r *rootCollector) Add(name, path string) {
+	r.roots = append(r.roots, root{
+		name: name,
+		path: path,
+	})
+}
+
+func (r *rootCollector) Assign(files []testFile) {
+	// Sort roots by longest path
+	sort.Slice(r.roots, func(i, j int) bool {
+		iL := len(strings.Split(r.roots[i].path, "/"))
+		jL := len(strings.Split(r.roots[j].path, "/"))
+		// Note we want longest first
+		return iL > jL
+	})
+	// Set module name for all test files
+	for i, f := range files {
+		for _, r := range r.roots {
+			if strings.HasPrefix(f.path, r.path) {
+				files[i].module = r.name
+				break
+			}
+		}
+	}
+}
+
+func gatherFromTarArchive(filename string) ([]testFile, fs, testcase.TestModules, error) {
 	var f io.ReadCloser
 	f, err := os.Open(filename)
 	if err != nil {
@@ -317,11 +500,12 @@ func gatherFromTarArchive(filename string) ([]string, fs, testcase.TestModules, 
 	}
 
 	var (
-		files []string
+		files []testFile
 		tfs   = &tarfs{
 			files: make(map[string]*tarfile),
 		}
 		modules testcase.TestModules
+		roots   rootCollector
 	)
 	archive := tar.NewReader(f)
 	for {
@@ -335,17 +519,20 @@ func gatherFromTarArchive(filename string) ([]string, fs, testcase.TestModules, 
 		info := hdr.FileInfo()
 		if !isTestFile(info, hdr.Name) {
 			if isTestRoot(hdr.Name) {
-				name, err := readTestRoot(archive, nil)
+				name, tags, err := readTestRoot(archive, nil)
 				if err != nil {
 					return nil, nil, nil, err
 				}
 
-				if err := modules.Add(name, prefixfs{
-					prefix: filepath.Dir(hdr.Name),
-					fs:     tfs,
-				}); err != nil {
+				if err := modules.Add(name, testcase.TestModule{
+					Tags: tags,
+					Service: prefixfs{
+						prefix: filepath.Dir(hdr.Name),
+						fs:     tfs,
+					}}); err != nil {
 					return nil, nil, nil, err
 				}
+				roots.Add(name, filepath.Dir(hdr.Name))
 			}
 			continue
 		}
@@ -358,8 +545,11 @@ func gatherFromTarArchive(filename string) ([]string, fs, testcase.TestModules, 
 			data: source,
 			info: info,
 		}
-		files = append(files, hdr.Name)
+		files = append(files, testFile{
+			path: hdr.Name,
+		})
 	}
+	roots.Assign(files)
 	return files, tfs, modules, nil
 }
 
@@ -400,7 +590,7 @@ func (t *tarfile) Stat() (os.FileInfo, error) {
 	return t.info, nil
 }
 
-func gatherFromZipArchive(filename string) ([]string, fs, testcase.TestModules, error) {
+func gatherFromZipArchive(filename string) ([]testFile, fs, testcase.TestModules, error) {
 	var modules testcase.TestModules
 
 	f, err := os.Open(filename)
@@ -423,28 +613,32 @@ func gatherFromZipArchive(filename string) ([]string, fs, testcase.TestModules, 
 		Closer: f,
 	}
 
-	var files []string
+	var roots rootCollector
+	var files []testFile
 	for _, file := range zipf.File {
 		info := file.FileInfo()
 		if !isTestFile(info, file.Name) {
 			if isTestRoot(file.Name) {
-				name, err := readTestRoot(file.Open())
+				name, tags, err := readTestRoot(file.Open())
 				if err != nil {
 					return nil, nil, nil, err
 				}
 
-				if err := modules.Add(name, prefixfs{
-					prefix: filepath.Dir(file.Name),
-					fs:     fs,
-				}); err != nil {
+				if err := modules.Add(name, testcase.TestModule{
+					Tags: tags,
+					Service: prefixfs{
+						prefix: filepath.Dir(file.Name),
+						fs:     fs,
+					}}); err != nil {
 					return nil, nil, nil, err
 				}
+				roots.Add(name, filepath.Dir(file.Name))
 			}
 			continue
 		}
-		files = append(files, file.Name)
-
+		files = append(files, testFile{path: file.Name})
 	}
+	roots.Assign(files)
 	return files, fs, modules, nil
 }
 
@@ -516,58 +710,66 @@ func (s prefixfs) Open(fpath string) (filesystem.File, error) {
 	return s.fs.Open(fpath)
 }
 
-func gatherFromDir(filename string) ([]string, fs, testcase.TestModules, error) {
+func gatherFromDir(filename string) ([]testFile, fs, testcase.TestModules, error) {
 	var (
-		files   []string
-		modules testcase.TestModules
+		files      []testFile
+		roots      rootCollector
+		modules    testcase.TestModules
+		parentRoot string
 	)
 
 	// Find a test root above the root if it exists.
-	if name, fs, ok, err := findParentTestRoot(filename); err != nil {
+	if name, tags, fs, ok, err := findParentTestRoot(filename); err != nil {
 		return nil, nil, nil, err
 	} else if ok {
-		if err := modules.Add(name, fs); err != nil {
+		if err := modules.Add(name, testcase.TestModule{Tags: tags, Service: fs}); err != nil {
 			return nil, nil, nil, err
 		}
+		parentRoot = name
 	}
 
 	if err := filepath.Walk(
 		filename,
 		func(path string, info os.FileInfo, err error) error {
 			if isTestFile(info, path) {
-				files = append(files, path)
+				files = append(files, testFile{path: path, module: parentRoot})
 			} else if isTestRoot(path) {
-				name, err := readTestRoot(os.Open(path))
+				name, tags, err := readTestRoot(os.Open(path))
 				if err != nil {
 					return err
 				}
 
-				if err := modules.Add(name, prefixfs{
-					prefix: filepath.Dir(path),
-					fs:     systemfs{},
-				}); err != nil {
+				if err := modules.Add(name, testcase.TestModule{
+					Tags: tags,
+					Service: prefixfs{
+						prefix: filepath.Dir(path),
+						fs:     systemfs{},
+					}}); err != nil {
 					return err
 				}
+				roots.Add(name, filepath.Dir(path))
 			}
 			return nil
 		}); err != nil {
 		return nil, nil, nil, err
 	}
+	roots.Assign(files)
 	return files, systemfs{}, modules, nil
 }
 
-func gatherFromFile(filename string) ([]string, fs, testcase.TestModules, error) {
+func gatherFromFile(filename string) ([]testFile, fs, testcase.TestModules, error) {
 	var modules testcase.TestModules
 
 	// Find a test root above the root if it exists.
-	if name, fs, ok, err := findParentTestRoot(filename); err != nil {
+	if name, tags, fs, ok, err := findParentTestRoot(filename); err != nil {
 		return nil, nil, nil, err
 	} else if ok {
-		if err := modules.Add(name, fs); err != nil {
+		if err := modules.Add(name, testcase.TestModule{Tags: tags, Service: fs}); err != nil {
 			return nil, nil, nil, err
 		}
+		return []testFile{{path: filename, module: name}}, systemfs{}, modules, nil
 	}
-	return []string{filename}, systemfs{}, modules, nil
+	return []testFile{{path: filename}}, systemfs{}, modules, nil
 }
 
 func isTestFile(fi os.FileInfo, filename string) bool {
@@ -580,33 +782,50 @@ func isTestRoot(filename string) bool {
 	return filepath.Base(filename) == testRootFilename
 }
 
-func readTestRoot(f io.Reader, err error) (string, error) {
+var rootPattern *regexp.Regexp
+
+func init() {
+	rootPattern = regexp.MustCompile("^[[:alpha:]]+$")
+}
+
+func readTestRoot(f io.Reader, err error) (string, []string, error) {
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	if rc, ok := f.(io.ReadCloser); ok {
 		defer func() { _ = rc.Close() }()
 	}
-	name, err := ioutil.ReadAll(f)
+	data, err := ioutil.ReadAll(f)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-
-	s := string(bytes.TrimSpace(name))
-	if len(s) == 0 {
-		return "", errors.New(codes.FailedPrecondition, "test module name must be non-empty")
+	info := struct {
+		Name string
+		Tags []string
+	}{}
+	trimmed := bytes.TrimSpace(data)
+	if rootPattern.Match(trimmed) {
+		info.Name = string(trimmed)
+	} else {
+		err = json.Unmarshal(data, &info)
+		if err != nil {
+			return "", nil, err
+		}
 	}
-	return s, nil
+	if len(info.Name) == 0 {
+		return "", nil, errors.New(codes.FailedPrecondition, "test module name must be non-empty")
+	}
+	return info.Name, info.Tags, nil
 }
 
 // findParentTestRoot searches the parents to find a test root.
 // This function only works for the system filesystem and isn't meant
 // to be used with archive filesystems.
-func findParentTestRoot(path string) (string, filesystem.Service, bool, error) {
+func findParentTestRoot(path string) (string, []string, filesystem.Service, bool, error) {
 	cur, err := filepath.Abs(path)
 	if err != nil {
-		return "", nil, false, err
+		return "", nil, nil, false, err
 	}
 	// Start with the parent directory of the path.
 	// A test root starting at the path will be found
@@ -616,18 +835,18 @@ func findParentTestRoot(path string) (string, filesystem.Service, bool, error) {
 	for cur != "/" {
 		fpath := filepath.Join(cur, testRootFilename)
 		if _, err := os.Stat(fpath); err == nil {
-			name, err := readTestRoot(os.Open(fpath))
+			name, tags, err := readTestRoot(os.Open(fpath))
 			if err != nil {
-				return "", nil, false, err
+				return "", nil, nil, false, err
 			}
-			return name, prefixfs{
+			return name, tags, prefixfs{
 				prefix: cur,
 				fs:     systemfs{},
 			}, true, nil
 		}
 		cur = filepath.Dir(cur)
 	}
-	return "", nil, false, nil
+	return "", nil, nil, false, nil
 }
 
 type IntHeap []int
@@ -651,20 +870,14 @@ func (h *IntHeap) Pop() interface{} {
 }
 
 // Run runs all tests, reporting their results.
-func (t *TestRunner) RunParallel(executor TestExecutor, verbosity int, skipTestCases []string) {
-	skipMap := make(map[string]struct{})
-	for _, n := range skipTestCases {
-		skipMap[n] = struct{}{}
-	}
+func (t *TestRunner) RunParallel(executor TestExecutor, verbosity int) {
 
 	results := make(chan int)
 
 	go func() {
 		wg := new(sync.WaitGroup)
 		for i, test := range t.tests {
-			if _, ok := skipMap[test.name]; ok {
-				test.skip = true
-
+			if test.skip {
 				// Send the index of this test to show that it is finished
 				results <- i
 			} else {
@@ -703,14 +916,9 @@ func (t *TestRunner) RunParallel(executor TestExecutor, verbosity int, skipTestC
 	}
 }
 
-func (t *TestRunner) Run(executor TestExecutor, verbosity int, skipTestCases []string) {
-	skipMap := make(map[string]struct{})
-	for _, n := range skipTestCases {
-		skipMap[n] = struct{}{}
-	}
+func (t *TestRunner) Run(executor TestExecutor, verbosity int) {
 	for _, test := range t.tests {
-		if _, ok := skipMap[test.name]; ok {
-			test.skip = true
+		if test.skip {
 		} else {
 			test.Run(executor)
 		}
@@ -720,24 +928,19 @@ func (t *TestRunner) Run(executor TestExecutor, verbosity int, skipTestCases []s
 
 // Finish summarizes the test run, and returns an
 // error in the event of a failure.
-func (t *TestRunner) Finish() error {
-	t.reporter.Summarize(t.tests)
-	for _, test := range t.tests {
-		if err := test.Error(); err != nil {
-			return err
-		}
-	}
-	return nil
+func (t *TestRunner) Finish() bool {
+	return t.reporter.Summarize(t.tests)
 }
 
 // TestReporter handles reporting of test results.
 type TestReporter struct {
+	out       io.Writer
 	verbosity int
 }
 
 // NewTestReporter creates a new TestReporter with a provided verbosity.
-func NewTestReporter(verbosity int) TestReporter {
-	return TestReporter{verbosity: verbosity}
+func NewTestReporter(out io.Writer, verbosity int) TestReporter {
+	return TestReporter{out: out, verbosity: verbosity}
 }
 
 // ReportTestRun reports the result a single test run, intended to be run as
@@ -745,39 +948,49 @@ func NewTestReporter(verbosity int) TestReporter {
 func (t *TestReporter) ReportTestRun(test *Test) {
 	if t.verbosity == 0 {
 		if test.skip {
-			fmt.Print("s")
+			fmt.Fprint(t.out, "s")
 		} else if test.Error() != nil {
-			fmt.Print("x")
+			fmt.Fprint(t.out, "x")
 		} else {
-			fmt.Print(".")
+			fmt.Fprint(t.out, ".")
 		}
 	} else if t.verbosity == 1 {
 		if test.skip {
-			fmt.Printf("%s...skip\n", test.FullName())
+			// Do not print skipped tests until the next verbosity level
 		} else if err := test.Error(); err != nil {
-			fmt.Printf("%s...fail: %s\n", test.FullName(), err)
+			fmt.Fprintf(t.out, "%s...fail: %s\n", test.FullName(), err)
 		} else {
-			fmt.Printf("%s...success\n", test.FullName())
+			fmt.Fprintf(t.out, "%s...success\n", test.FullName())
+		}
+	} else if t.verbosity == 2 {
+		if test.skip {
+			fmt.Fprintf(t.out, "%s...skip\n", test.FullName())
+		} else if err := test.Error(); err != nil {
+			fmt.Fprintf(t.out, "%s...fail: %s\n", test.FullName(), err)
+		} else {
+			fmt.Fprintf(t.out, "%s...success\n", test.FullName())
 		}
 	} else {
+		fmt.Fprintf(t.out, "Testcase: %s\n", test.FullName())
+		fmt.Fprintf(t.out, "Tags: %v\n", test.tags)
 		source, err := test.SourceCode()
 		if err != nil {
-			fmt.Printf("failed to get source for test %s: %s\n", test.FullName(), err)
+			fmt.Fprintln(t.out, "Source: FAILED")
 		} else {
-			fmt.Printf("Full source for test case %q\n%s", test.FullName(), source)
+			fmt.Fprintf(t.out, "Source: \n%s", source)
 		}
 		if test.skip {
-			fmt.Printf("%s...skip\n", test.FullName())
+			fmt.Fprintf(t.out, "Result: %s...skip\n", test.Name())
 		} else if err := test.Error(); err != nil {
-			fmt.Printf("%s...fail: %s\n", test.FullName(), err)
+			fmt.Fprintf(t.out, "Result: %s...fail: %s\n", test.Name(), err)
 		} else {
-			fmt.Printf("%s...success\n", test.FullName())
+			fmt.Fprintf(t.out, "Result: %s...success\n", test.Name())
 		}
 	}
 }
 
 // Summarize summarizes the test run.
-func (t *TestReporter) Summarize(tests []*Test) {
+func (t *TestReporter) Summarize(tests []*Test) bool {
 	failures := 0
 	skips := 0
 	for _, test := range tests {
@@ -788,16 +1001,17 @@ func (t *TestReporter) Summarize(tests []*Test) {
 		}
 	}
 	if failures > 0 {
-		fmt.Printf("\nfailures:\n\n")
+		fmt.Fprintf(t.out, "\nfailures:\n\n")
 		for _, test := range tests {
 			if err := test.Error(); err != nil {
-				fmt.Printf("\t%s...fail: %s\n", test.FullName(), err)
+				fmt.Fprintf(t.out, "\t%s...fail: %s\n", test.FullName(), err)
 			}
 		}
 	}
 
 	passed := len(tests) - skips - failures
-	fmt.Printf("\n---\nFound %d tests: passed %d, failed %d, skipped %d\n", len(tests), passed, failures, skips)
+	fmt.Fprintf(t.out, "\n---\nFound %d tests: passed %d, failed %d, skipped %d\n", len(tests), passed, failures, skips)
+	return failures == 0
 }
 
 type (

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -116,10 +116,11 @@ func injectDependencies(ctx context.Context) (context.Context, *dependency.Span)
 
 func main() {
 	fluxCmd := &cobra.Command{
-		Use:          "flux",
-		Args:         cobra.MaximumNArgs(1),
-		RunE:         runE,
-		SilenceUsage: true,
+		Use:           "flux",
+		Args:          cobra.MaximumNArgs(1),
+		RunE:          runE,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 	fluxCmd.Flags().BoolVarP(&flags.ExecScript, "exec", "e", false, "Interpret file argument as a raw flux script")
 	fluxCmd.Flags().BoolVarP(&flags.EnableSuggestions, "enable-suggestions", "", false, "enable suggestions in the repl")
@@ -129,13 +130,11 @@ func main() {
 	fluxCmd.Flags().StringVar(&flags.Features, "feature", "", "JSON object specifying the features to execute with. See internal/feature/flags.yml for a list of the current features")
 
 	fmtCmd := &cobra.Command{
-		Use:           "fmt",
-		Short:         "Format a Flux script",
-		Long:          "Format a Flux script (flux fmt [-w] <directory | file>)",
-		Args:          cobra.MinimumNArgs(1),
-		RunE:          formatFile,
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Use:   "fmt",
+		Short: "Format a Flux script",
+		Long:  "Format a Flux script (flux fmt [-w] <directory | file>)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  formatFile,
 	}
 	fmtCmd.Flags().BoolVarP(&fmtFlags.WriteResultToSource, "write-result-to-source", "w", false, "write result to (source) file instead of stdout")
 	fmtCmd.Flags().BoolVarP(&fmtFlags.AnalyzeCurrentDirectory, "analyze-current-directory", "c", false, "analyze the current <directory | file> and report if file(s) are not formatted")
@@ -145,6 +144,14 @@ func main() {
 	fluxCmd.AddCommand(testCmd)
 
 	if err := fluxCmd.Execute(); err != nil {
+		if _, ok := err.(silentError); !ok {
+			fmt.Fprintln(fluxCmd.OutOrStderr(), err)
+		}
 		os.Exit(1)
 	}
+}
+
+// silentError indicates the error should not be printed to stderr.
+type silentError interface {
+	Silent()
 }

--- a/cmd/flux/test_test.go
+++ b/cmd/flux/test_test.go
@@ -1,0 +1,364 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/influxdata/flux/cmd/flux/cmd"
+	"github.com/influxdata/flux/fluxinit"
+)
+
+type Summary struct {
+	Found   int64
+	Passed  int64
+	Failed  int64
+	Skipped int64
+}
+
+var (
+	summaryPattern *regexp.Regexp
+	zipPath        string
+	tarPath        string
+)
+
+func TestMain(m *testing.M) {
+	summaryPattern = regexp.MustCompile("^Found ([0-9]+) tests: passed ([0-9]+), failed ([0-9]+), skipped ([0-9]+)$")
+	fluxinit.FluxInit()
+
+	// Create temp zip file
+	zf, err := createZip()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		os.Remove(zf.Name())
+	}()
+
+	// Create temp tar file
+	tf, err := createTar()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		os.Remove(tf.Name())
+	}()
+
+	zipPath = zf.Name()
+	tarPath = tf.Name()
+
+	// Do the tests
+	m.Run()
+}
+
+func createTar() (*os.File, error) {
+	f, err := os.CreateTemp("", "testdata.*.tar")
+	if err != nil {
+		return nil, err
+	}
+
+	w := tar.NewWriter(f)
+	err = filepath.WalkDir("testdata", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr := &tar.Header{
+			Name: path,
+			Mode: 0400,
+			Size: info.Size(),
+		}
+		if err := w.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if _, err := io.Copy(w, src); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func createZip() (*os.File, error) {
+	f, err := os.CreateTemp("", "testdata.*.zip")
+	if err != nil {
+		return nil, err
+	}
+
+	w := zip.NewWriter(f)
+	err = filepath.WalkDir("testdata", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		dst, err := w.Create(path)
+		if err != nil {
+			return err
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(dst, src); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// Runs the test command against the testdata dir, zip archive and tar archive
+func runAll(t *testing.T, wantErr error, args ...string) map[string]Summary {
+	// Run against the directory
+	summaries := make(map[string]Summary)
+	summaries["dir"] = runForPath(t, "./testdata", wantErr, args...)
+
+	// Run against the zip file
+	summaries["zip"] = runForPath(t, zipPath, wantErr, args...)
+
+	// Run against the tar archive
+	summaries["tar"] = runForPath(t, tarPath, wantErr, args...)
+	return summaries
+}
+
+func runForPath(t *testing.T, path string, wantErr error, args ...string) Summary {
+	t.Helper()
+	tcmd := cmd.TestCommand(NewTestExecutor)
+	b := bytes.NewBuffer(nil)
+	tcmd.SetOutput(b)
+	tcmd.SetArgs(append([]string{"--noinit", "-p", path}, args...))
+	if err := tcmd.Execute(); err != nil {
+		if wantErr != nil {
+			if wantErr.Error() != err.Error() {
+				t.Fatalf("unexpected error, got %q want %q", err, wantErr)
+			}
+		} else if wantErr == nil {
+			t.Fatal(err)
+		}
+	}
+	scanner := bufio.NewScanner(b)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if summaryPattern.MatchString(line) {
+			matches := summaryPattern.FindStringSubmatch(line)
+			found, err := strconv.ParseInt(matches[1], 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			passed, err := strconv.ParseInt(matches[2], 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			failed, err := strconv.ParseInt(matches[3], 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			skipped, err := strconv.ParseInt(matches[4], 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return Summary{
+				Found:   found,
+				Passed:  passed,
+				Failed:  failed,
+				Skipped: skipped,
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if wantErr == nil {
+		t.Fatal("did not find summary output")
+	}
+	return Summary{}
+}
+
+func Test_TestCmd(t *testing.T) {
+	want := Summary{
+		Found:   6,
+		Passed:  1,
+		Failed:  0,
+		Skipped: 5,
+	}
+	got := runAll(t, nil)
+	for name, got := range got {
+		if want != got {
+			t.Errorf("%s: unexpected summary got %+v want %+v", name, got, want)
+		}
+	}
+}
+
+func Test_TestCmd_TestName(t *testing.T) {
+	want := Summary{
+		Found:   6,
+		Passed:  1,
+		Failed:  0,
+		Skipped: 5,
+	}
+	got := runAll(t, nil, "--test", "a")
+	for name, got := range got {
+		if want != got {
+			t.Errorf("%s: unexpected summary got %+v want %+v", name, got, want)
+		}
+	}
+}
+func Test_TestCmd_Fails(t *testing.T) {
+	want := Summary{
+		Found:   6,
+		Passed:  1,
+		Failed:  1,
+		Skipped: 4,
+	}
+	got := runAll(t, errors.New("tests failed"), "--tags", "fail")
+	for name, got := range got {
+		if want != got {
+			t.Errorf("%s: unexpected summary got %+v want %+v", name, got, want)
+		}
+	}
+}
+
+func Test_TestCmd_InvalidTags(t *testing.T) {
+	runAll(t, errors.New("provided tags are invalid: [invalid], valid tags are [a b c fail foo]"), "--tags", "invalid")
+}
+
+func Test_TestCmd_Tags(t *testing.T) {
+	testCases := []struct {
+		tags []string
+		want Summary
+	}{
+		{
+			tags: []string{"a"},
+			want: Summary{
+				Found:   6,
+				Passed:  2,
+				Skipped: 4,
+			},
+		},
+		{
+			tags: []string{"a", "b"},
+			want: Summary{
+				Found:   6,
+				Passed:  3,
+				Skipped: 3,
+			},
+		},
+		{
+			tags: []string{"a", "b", "c"},
+			want: Summary{
+				Found:   6,
+				Passed:  4,
+				Skipped: 2,
+			},
+		},
+		{
+			tags: []string{"b", "c"},
+			want: Summary{
+				Found:   6,
+				Passed:  1,
+				Skipped: 5,
+			},
+		},
+		{
+			tags: []string{"c"},
+			want: Summary{
+				Found:   6,
+				Passed:  1,
+				Skipped: 5,
+			},
+		},
+		{
+			tags: []string{"b"},
+			want: Summary{
+				Found:   6,
+				Passed:  1,
+				Skipped: 5,
+			},
+		},
+		{
+			tags: []string{"foo"},
+			want: Summary{
+				Found:   6,
+				Passed:  2,
+				Skipped: 4,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		tags := strings.Join(tc.tags, ",")
+		t.Run(tags, func(t *testing.T) {
+			got := runAll(t, nil, "--tags", tags)
+			for name, got := range got {
+				if tc.want != got {
+					t.Errorf("%s: unexpected summary got %+v want %+v", name, got, tc.want)
+				}
+			}
+		})
+	}
+}
+func Test_TestCmd_Skip(t *testing.T) {
+	want := Summary{
+		Found:   6,
+		Passed:  0,
+		Skipped: 6,
+	}
+	got := runAll(t, nil, "--skip", "untagged")
+	for name, got := range got {
+		if want != got {
+			t.Errorf("%s: unexpected summary got %+v want %+v", name, got, want)
+		}
+	}
+}
+
+func Test_TestCmd_SkipUntagged(t *testing.T) {
+	want := Summary{
+		Found:   6,
+		Passed:  0,
+		Skipped: 6,
+	}
+	got := runAll(t, nil, "--skip-untagged")
+	for name, got := range got {
+		if want != got {
+			t.Errorf("%s: unexpected summary got %+v want %+v", name, got, want)
+		}
+	}
+}

--- a/cmd/flux/testdata/fluxtest.root
+++ b/cmd/flux/testdata/fluxtest.root
@@ -1,0 +1,9 @@
+{
+    "name": "testdata",
+    "tags": [
+        "a",
+        "b",
+        "c",
+        "fail"
+    ]
+}

--- a/cmd/flux/testdata/pkga/fluxtest.root
+++ b/cmd/flux/testdata/pkga/fluxtest.root
@@ -1,0 +1,6 @@
+{
+    "name": "pkga",
+    "tags": [
+        "foo"
+    ]
+}

--- a/cmd/flux/testdata/pkga/pkga_test.flux
+++ b/cmd/flux/testdata/pkga/pkga_test.flux
@@ -1,0 +1,11 @@
+package pkga_test
+
+
+import "testing"
+import "array"
+
+option testing.tags = ["foo"]
+
+testcase bar {
+    array.from(rows: [{}])
+}

--- a/cmd/flux/testdata/test_test.flux
+++ b/cmd/flux/testdata/test_test.flux
@@ -1,0 +1,33 @@
+package test_test
+
+
+import "array"
+import "testing"
+
+testcase a {
+    option testing.tags = ["a"]
+
+    array.from(rows: [{}])
+}
+testcase ab {
+    option testing.tags = ["a", "b"]
+
+    array.from(rows: [{}])
+}
+testcase abc {
+    option testing.tags = ["a", "b", "c"]
+
+    array.from(rows: [{}])
+}
+
+testcase fails {
+    option testing.tags = ["fail"]
+
+    want = array.from(rows: [{_value: 1}])
+    got = array.from(rows: [{_value: 0}])
+
+    testing.diff(want, got)
+}
+testcase untagged {
+    array.from(rows: [{}])
+}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -406,7 +406,7 @@ var sourceHashes = map[string]string{
 	"stdlib/testing/promql/resets_test.flux":                                                      "e01bb24f576f8a2cb69fa1f5d9061cc852431970792ae2c59c3753580058926d",
 	"stdlib/testing/promql/timestamp_test.flux":                                                   "350dc1161f222d2bfc327aee399ed9873e198c9858e845c2ca0b9ca0e2e38ef8",
 	"stdlib/testing/promql/year_test.flux":                                                        "1767fb414d4261075880b0b9e5f6084cc1d9124fcb3759d68d3bea8a7c42977d",
-	"stdlib/testing/testing.flux":                                                                 "80ae93c701c5c7f37078616fb8c5f807629dad9f53a712ff8a1f6a1a2d448ff4",
+	"stdlib/testing/testing.flux":                                                                 "3a946f63d55a621067917f03e190c42e463ede0c8fc6b15a999f0bfff9a9239a",
 	"stdlib/testing/testing_test.flux":                                                            "33c69744df7f9c6959a3ba05a273fe67260fca3d34f903210ca2ba7eb74f3a25",
 	"stdlib/testing/usage/api_test.flux":                                                          "2a39412eaf41ccb2436dbbdb250f9761544538252bbc6dd6d63b47d2d16e0136",
 	"stdlib/testing/usage/duration_test.flux":                                                     "f545e7e8f1820bdae0beb935d12f899f1065b7b7df1c05eed454ecfb48fa4225",

--- a/stdlib/testing/testing.flux
+++ b/stdlib/testing/testing.flux
@@ -9,6 +9,14 @@ package testing
 import "array"
 import c "csv"
 
+//  tags is a list of tags that will be applied to a test case.
+//
+//  The test harness allows filtering based on included tags.
+//
+//  Tags are expected to be overridden per test file and test case
+//  using normal option semantics.
+option tags = []
+
 // assertEquals tests whether two streams of tables are identical.
 //
 // If equal, the function outputs the tested data stream unchanged.


### PR DESCRIPTION
Now you can add tags to test cases and pass tags to the `flux test`
command to only run specific tests.

Additionally unit tests have been added for the `flux test` command.

Fixes #4577
Fixes #4574 
Fixes #4575 

Not tags are added or changed with this PR, that will come as a follow on PR.

### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
