### PR TITLE
chore: Add a tool to analyze the impact of changes to the typesystem

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +418,7 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "criterion",
+ "crossbeam-channel",
  "csv",
  "derivative",
  "derive_more",
@@ -415,6 +439,7 @@ dependencies = [
  "pulldown-cmark",
  "rayon",
  "regex",
+ "rusqlite",
  "serde",
  "serde-aux",
  "serde_derive",
@@ -465,6 +490,18 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"
@@ -583,6 +620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cafc7c74096c336d9d27145f7ebd4f4b6f95ba16aa5a282387267e6925cb58"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "log"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +742,12 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
@@ -871,6 +924,21 @@ name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "rusqlite"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba4d3462c8b2e4d7f4fcfcf2b296dc6b65404fbbc7b63daa37fd485c149daf7"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1165,6 +1233,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -9,6 +9,12 @@ name = "fluxcore"
 crate-type = ["rlib"]
 
 [[bin]]
+name = "analyze_query_log"
+test = false
+bench = false
+required-features = ["crossbeam-channel", "csv", "rayon", "rusqlite", "pretty_assertions"]
+
+[[bin]]
 name = "fluxdoc"
 test = false
 bench = false
@@ -29,6 +35,7 @@ doc = ["csv", "once_cell", "pad", "pulldown-cmark", "rayon", "tempfile"]
 anyhow = "1.0.56"
 chrono = { version = "0.4", features = ["serde"] }
 codespan-reporting = "0.11"
+crossbeam-channel = { version = "0.5", optional = true }
 csv = { version = "1.1", optional = true }
 derivative = "2.1.1"
 derive_more = { version = "0.99.17", default-features = false, features = [
@@ -58,6 +65,9 @@ structopt = "0.3.26"
 thiserror = "1"
 tempfile = { version = "3.3.0", optional = true }
 walkdir = "2.2.9"
+
+rusqlite = { version = "0.26", optional = true }
+pretty_assertions = { version = "1", optional = true }
 
 [dev-dependencies]
 colored = "2.0"

--- a/libflux/flux-core/src/bin/analyze_query_log.rs
+++ b/libflux/flux-core/src/bin/analyze_query_log.rs
@@ -1,0 +1,276 @@
+use std::{io, path::PathBuf};
+
+use anyhow::{anyhow, Context as _, Error, Result};
+use rayon::prelude::*;
+use serde::Deserialize;
+use structopt::StructOpt;
+
+use fluxcore::semantic::{self, Analyzer};
+
+#[derive(Debug, StructOpt)]
+#[structopt(about = "analyze a query log database")]
+struct AnalyzeQueryLog {
+    #[structopt(long, help = "How many sources to skip")]
+    skip: Option<usize>,
+    #[structopt(
+        long,
+        min_values = 1,
+        use_delimiter = true,
+        help = "Which new features to compare against"
+    )]
+    new_features: Vec<semantic::Feature>,
+    #[structopt(
+        long,
+        help = "Report differences when the script fails to compile under both sets of features"
+    )]
+    report_already_failing_scripts: bool,
+    database: PathBuf,
+}
+
+trait Source {
+    fn read(&mut self) -> Result<Box<dyn Iterator<Item = Result<String>> + '_>>;
+}
+
+impl Source for rusqlite::Statement<'_> {
+    fn read(&mut self) -> Result<Box<dyn Iterator<Item = Result<String>> + '_>> {
+        Ok(Box::new(
+            self.query_map([], |row| row.get(0))?
+                .map(|e| e.map_err(Error::from)),
+        ))
+    }
+}
+
+impl<R> Source for csv::Reader<R>
+where
+    R: io::Read + Send,
+{
+    fn read(&mut self) -> Result<Box<dyn Iterator<Item = Result<String>> + '_>> {
+        let headers = self.headers()?;
+        let i = headers
+            .iter()
+            .position(|field| field == "_value")
+            .ok_or_else(|| anyhow!("Missing _value field"))?;
+
+        #[derive(Deserialize, Debug)]
+        struct QueryLogValue {
+            request: QueryLogRequest,
+        }
+        #[derive(Deserialize, Debug)]
+        struct QueryLogRequest {
+            compiler: QueryLogCompiler,
+        }
+        #[derive(Deserialize, Debug)]
+        struct QueryLogCompiler {
+            query: String,
+        }
+
+        Ok(Box::new(self.records().map(move |record| {
+            let record = record?;
+            let s = record.get(i).unwrap();
+            let value = serde_json::from_str::<QueryLogValue>(s)?;
+            Ok::<_, Error>(value.request.compiler.query)
+        })))
+    }
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let app = AnalyzeQueryLog::from_args();
+
+    let new_config = semantic::AnalyzerConfig {
+        features: app.new_features,
+    };
+
+    let stdlib_path = PathBuf::from("../stdlib");
+
+    let (prelude, imports, _sem_pkgs) =
+        semantic::bootstrap::infer_stdlib_dir(&stdlib_path, semantic::AnalyzerConfig::default())?;
+
+    let analyzer = || {
+        Analyzer::new(
+            (&prelude).into(),
+            &imports,
+            semantic::AnalyzerConfig::default(),
+        )
+    };
+
+    let (prelude, imports, _sem_pkgs) =
+        semantic::bootstrap::infer_stdlib_dir(&stdlib_path, new_config.clone())?;
+
+    let new_analyzer = || Analyzer::new((&prelude).into(), &imports, new_config.clone());
+
+    let mut connection;
+
+    let sources: Box<dyn FnOnce() -> Box<dyn Source> + Send> =
+        match app.database.extension().and_then(|e| e.to_str()) {
+            Some("flux") => {
+                let source = std::fs::read_to_string(&app.database)?;
+                new_analyzer()
+                    .analyze_source("".into(), "".into(), &source)
+                    .map_err(|err| err.error.pretty_error())?;
+                return Ok(());
+            }
+            Some("csv") => {
+                let input = std::fs::read_to_string(&app.database)
+                    .with_context(|| format!("`{}` could not be read", app.database.display()))?;
+
+                // The flux csv format has extra headers which we remove before parsing the csv
+                let mut first = true;
+                let input = input
+                    .lines()
+                    .filter(|line| {
+                        if line.starts_with(",result") {
+                            if first {
+                                first = false;
+                                true
+                            } else {
+                                false
+                            }
+                        } else {
+                            true
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\r\n");
+
+                let reader = csv::ReaderBuilder::new()
+                    .comment(Some(b'#'))
+                    .flexible(true)
+                    .from_reader(std::io::Cursor::new(input.into_bytes()));
+
+                Box::new(move || Box::new(reader))
+            }
+            _ => {
+                connection = rusqlite::Connection::open(&app.database)?;
+                let connection = &mut connection;
+                Box::new(move || {
+                    Box::new(
+                        connection
+                            .prepare("SELECT source FROM query limit 100000")
+                            .unwrap(),
+                    )
+                })
+            }
+        };
+
+    let (tx, rx) = crossbeam_channel::bounded(128);
+
+    let (final_tx, final_rx) = crossbeam_channel::bounded(128);
+
+    let mut count = 0;
+
+    let (r, r2, ()) = join3(
+        move || {
+            for (i, result) in sources().read()?.enumerate() {
+                if let Some(skip) = app.skip {
+                    if i < skip {
+                        continue;
+                    }
+                }
+
+                let source: String = result?;
+                tx.send((i, source))?;
+            }
+
+            Ok::<_, Error>(())
+        },
+        move || {
+            rx.into_iter()
+                .par_bridge()
+                .try_for_each(|(i, source): (usize, String)| {
+                    // eprintln!("{}", source);
+
+                    let current_result = match std::panic::catch_unwind(|| {
+                        analyzer().analyze_source("".into(), "".into(), &source)
+                    }) {
+                        Ok(x) => x,
+                        Err(_) => panic!("Panic at source {}: {}", i, source),
+                    };
+
+                    let new_result = match std::panic::catch_unwind(|| {
+                        new_analyzer().analyze_source("".into(), "".into(), &source)
+                    }) {
+                        Ok(x) => x,
+                        Err(_) => panic!("Panic at source {}: {}", i, source),
+                    };
+
+                    match (current_result, new_result) {
+                        (Ok(_), Ok(_)) => (),
+                        (Err(err), Ok(_)) => {
+                            eprintln!("### {}", i);
+                            eprintln!("{}", source);
+
+                            eprintln!(
+                                "Missing errors when the features are enabled: {}",
+                                err.error.pretty(&source)
+                            );
+                            eprintln!("-------------------------------");
+                        }
+                        (Ok(_), Err(err)) => {
+                            eprintln!("### {}", i);
+                            eprintln!("{}", source);
+
+                            eprintln!(
+                                "New errors when the features are enabled: {}",
+                                err.error.pretty(&source)
+                            );
+                            eprintln!("-------------------------------");
+                        }
+                        (Err(current_err), Err(new_err)) => {
+                            if app.report_already_failing_scripts {
+                                let current_err = current_err.error.pretty(&source);
+                                let new_err = new_err.error.pretty(&source);
+                                if current_err != new_err {
+                                    eprintln!("{}", source);
+
+                                    eprintln!(
+                                        "Different when the new features are enabled:\n{}",
+                                        pretty_assertions::StrComparison::new(
+                                            &current_err,
+                                            &new_err,
+                                        )
+                                    );
+                                    eprintln!("-------------------------------");
+                                }
+                            }
+                        }
+                    }
+
+                    final_tx.send(())?;
+
+                    Ok::<_, Error>(())
+                })
+        },
+        || {
+            for _ in final_rx {
+                count += 1;
+
+                if count % 100 == 0 {
+                    eprintln!("Checked {} queries", count);
+                }
+            }
+        },
+    );
+
+    r?;
+    r2?;
+
+    eprintln!("Done! Checked {} queries", count);
+
+    Ok(())
+}
+
+fn join3<A, B, C>(
+    a: impl FnOnce() -> A + Send,
+    b: impl FnOnce() -> B + Send,
+    c: impl FnOnce() -> C + Send,
+) -> (A, B, C)
+where
+    A: Send,
+    B: Send,
+    C: Send,
+{
+    let (a, (b, c)) = rayon::join(a, || rayon::join(b, c));
+    (a, b, c)
+}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,13 +12,14 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "9cddafc39c6027b1316ba0ec585730f8960cadab8017cf9f139c7002defc331f",
+	"libflux/Cargo.lock":                                                                          "67373da0755f957cf04d90fb58d9873cfafb5bef382d1535e49a5bf6c23febf0",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "3d2f484f810cb8421a8ea1b73d28cc4c7a13fcb1c94f2eadc02397832317aa91",
+	"libflux/flux-core/Cargo.toml":                                                                "b94689ddd00f579300ef6828696c80e7a29898307e2d27ab4d039ef992c27c38",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "47e06631f249715a44c9c8fa897faf142ad0fa26f67f8cfd5cd201e82cb1afc8",
 	"libflux/flux-core/src/ast/mod.rs":                                                            "4db1054af8625721300429b8ce0eacda6f8e6d8f20251874a87bb5bc884885c8",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "a74d90937d4f059800f39ff866976c68ff06c3566293aec65f1539ddc2f1de25",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
+	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "8cb0aca0eff41b28c0aff07424ae3375364a37bec0ad49fe5460e6c360735a64",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "bf275289e690236988049fc0a07cf832dbac25bb5739c02135b069dcdfab4d0f",
 	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "354a8dfd262f223412ee491a9947962f993e43c5467f8ee37c4f15528dc5b571",
 	"libflux/flux-core/src/doc/example.rs":                                                        "403a682c435c820dd37b768d5f1d5f8e117e490ca0a8c21077e7c6d4d7bccd55",


### PR DESCRIPTION
... and standard library. Extracted from https://github.com/influxdata/flux/pull/4776.
Currently this supports consuming either an sqlite database or a csv file which are the two
sources of scripts I am aware of at the moment.

```bash
cargo run --release --bin analyze_query_log --all-features -- "../../../Downloads/2022-06-28_18 30_influxdb_data.csv" --new-features unusedSymbolWarnings
```