### PR TITLE
chore: Accept cmp.Option when diffing the RuleTestCase.ValidateError

### DIFF
--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -199,8 +199,9 @@ func PhysicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Optio
 	pp, err := physicalPlanner.Plan(ctx, before)
 	if err != nil {
 		if tc.ValidateError != nil {
-			if got, want := err, tc.ValidateError; !cmp.Equal(want, got, options...) {
-				t.Fatalf("unexpected planner error -want/+got:\n%s", cmp.Diff(want, got))
+			got, want := err, tc.ValidateError
+			if diff := cmp.Diff(want, got, options...); diff != "" {
+				t.Fatalf("unexpected planner error -want/+got:\n%s", diff)
 			}
 			return
 		}


### PR DESCRIPTION
If they aren't passed, we get confusing error messages about `cmp.Option` instead of the actual mismatch