### PR TITLE
feat: allow physical plan attributes to contribute to formatter details

### DIFF
--- a/plan/attributes.go
+++ b/plan/attributes.go
@@ -1,5 +1,9 @@
 package plan
 
+import (
+	"fmt"
+)
+
 // Physical attributes used in specifying parallelization. The Run attribute
 // means the node executes in parallel. It accepts parallel data (a subset of
 // the source) and produces parallel data. The merge attribute means that the
@@ -24,4 +28,8 @@ type ParallelMergeAttribute struct {
 
 func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
 	return false
+}
+
+func (a ParallelMergeAttribute) PlanDetails() string {
+	return fmt.Sprintf("ParallelMergeFactor: %v", a.Factor)
 }

--- a/plan/format.go
+++ b/plan/format.go
@@ -56,9 +56,23 @@ func (f formatter) Format(fs fmt.State, c rune) {
 	_ = f.p.BottomUpWalk(func(pn Node) error {
 		_, _ = fmt.Fprintf(fs, "  %v\n", pn.ID())
 		if f.withDetails {
+			details := ""
 			if d, ok := pn.ProcedureSpec().(Detailer); ok {
-				lines := strings.Split(strings.TrimSpace(d.PlanDetails()), "\n")
-				for _, line := range lines {
+				details += d.PlanDetails() + "\n"
+			}
+
+			if ppn, ok := pn.(*PhysicalPlanNode); ok {
+				for _, attr := range ppn.OutputAttrs {
+					if d, ok := attr.(Detailer); ok {
+						details += d.PlanDetails() + "\n"
+					}
+				}
+			}
+
+			lines := strings.Split(strings.TrimSpace(details), "\n")
+
+			for _, line := range lines {
+				if len(line) > 0 {
 					_, _ = fmt.Fprintf(fs, "  // %s\n", line)
 				}
 			}


### PR DESCRIPTION
In order to determine if a query plan has been parallelized, we have been using
the presence of a `partitionMerge` node in the plan. With the emergence of a new
technique of merging in `aggregateWindow` nodes, and possibly soon `pivot` nodes as
well, we can no longer use this test.

This PR allows physical plan attributes to contribute to plan details. First
the spec is consulted, then any physical attributes that are present. Any node
with the `ParallelMerge` attribute can then indicate it is a merge node.


### Done checklist
- [ ] docs/SPEC.md updated
- [x] Test cases written
