### PR TITLE
fix(join): Make join resilient to schema changes

### DIFF
--- a/stdlib/join/merge_join_test.go
+++ b/stdlib/join/merge_join_test.go
@@ -1580,6 +1580,226 @@ func TestMergeJoin(t *testing.T) {
 				},
 			),
 		},
+		{
+			name:   "schema change extra column",
+			method: "full",
+			on: []join.ColumnPair{
+				{Left: "label", Right: "id"},
+				{Left: "_time", Right: "_time"},
+			},
+			as: `(l, r) => {
+        label = if exists l.label then l.label else r.id
+        time = if exists l._time then l._time else r._time
+
+        return {
+            label: label,
+            lv: l._value,
+            group: l.group,
+            rv: r._value,
+            _time: time,
+        }
+			}`,
+			left: func() []table.Chunk {
+				s1 := constructChunks(
+					[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+					[]flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "label", Type: flux.TString},
+						{Label: "group", Type: flux.TUInt},
+					},
+					[]map[string]interface{}{
+						{"_time": execute.Time(1), "_value": 1.2, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(2), "_value": 3.4, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(3), "_value": 5.6, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(4), "_value": 7.8, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(1), "_value": 9.0, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(2), "_value": 1.9, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(3), "_value": 2.8, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(4), "_value": 3.7, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(1), "_value": 4.6, "label": "d", "group": uint64(1)},
+						{"_time": execute.Time(2), "_value": 5.5, "label": "d", "group": uint64(1)},
+						{"_time": execute.Time(3), "_value": 1.3, "label": "d", "group": uint64(1)},
+						{"_time": execute.Time(4), "_value": 2.4, "label": "d", "group": uint64(1)},
+					},
+				)
+				s2 := constructChunks(
+					[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+					[]flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "label", Type: flux.TString},
+						{Label: "group", Type: flux.TUInt},
+						{Label: "extra", Type: flux.TBool},
+					},
+					[]map[string]interface{}{
+						{"_time": execute.Time(6), "_value": 1.2, "label": "e", "group": uint64(1), "extra": true},
+					},
+				)
+				return append(s1, s2...)
+			}(),
+			right: constructChunks(
+				[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+				[]flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "id", Type: flux.TString},
+					{Label: "group", Type: flux.TUInt},
+				},
+				[]map[string]interface{}{
+					{"_time": execute.Time(1), "_value": int64(1), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(2), "_value": int64(2), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(3), "_value": int64(3), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(4), "_value": int64(4), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(1), "_value": int64(5), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(2), "_value": int64(6), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(3), "_value": int64(7), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(4), "_value": int64(8), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(1), "_value": int64(9), "id": "d", "group": uint64(1)},
+					{"_time": execute.Time(2), "_value": int64(10), "id": "d", "group": uint64(1)},
+					{"_time": execute.Time(3), "_value": int64(11), "id": "d", "group": uint64(1)},
+					{"_time": execute.Time(4), "_value": int64(12), "id": "d", "group": uint64(1)},
+				},
+			),
+			wantTables: constructChunks(
+				[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+				[]flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "lv", Type: flux.TFloat},
+					{Label: "rv", Type: flux.TInt},
+					{Label: "label", Type: flux.TString},
+					{Label: "group", Type: flux.TUInt},
+				},
+				[]map[string]interface{}{
+					{"_time": execute.Time(1), "lv": 1.2, "rv": int64(1), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": 3.4, "rv": int64(2), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": 5.6, "rv": int64(3), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": 7.8, "rv": int64(4), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(1), "lv": 9.0, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": 1.9, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": 2.8, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": 3.7, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(1), "lv": values.Null, "rv": int64(5), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": values.Null, "rv": int64(6), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": values.Null, "rv": int64(7), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": values.Null, "rv": int64(8), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(1), "lv": 4.6, "rv": int64(9), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": 5.5, "rv": int64(10), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": 1.3, "rv": int64(11), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": 2.4, "rv": int64(12), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(6), "lv": 1.2, "rv": values.Null, "label": "e", "group": uint64(1)},
+				},
+			),
+		},
+		{
+			name:   "schema change missing column",
+			method: "full",
+			on: []join.ColumnPair{
+				{Left: "label", Right: "id"},
+				{Left: "_time", Right: "_time"},
+			},
+			as: `(l, r) => {
+				label = if exists l.label then l.label else r.id
+				time = if exists l._time then l._time else r._time
+
+				return {
+						label: label,
+						lv: l._value,
+						group: l.group,
+						rv: r._value,
+						_time: time,
+				}
+			}`,
+			left: func() []table.Chunk {
+				s1 := constructChunks(
+					[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+					[]flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "label", Type: flux.TString},
+						{Label: "group", Type: flux.TUInt},
+					},
+					[]map[string]interface{}{
+						{"_time": execute.Time(1), "_value": 1.2, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(2), "_value": 3.4, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(3), "_value": 5.6, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(4), "_value": 7.8, "label": "a", "group": uint64(1)},
+						{"_time": execute.Time(1), "_value": 9.0, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(2), "_value": 1.9, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(3), "_value": 2.8, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(4), "_value": 3.7, "label": "b", "group": uint64(1)},
+						{"_time": execute.Time(1), "_value": 4.6, "label": "d", "group": uint64(1)},
+						{"_time": execute.Time(2), "_value": 5.5, "label": "d", "group": uint64(1)},
+						{"_time": execute.Time(3), "_value": 1.3, "label": "d", "group": uint64(1)},
+						{"_time": execute.Time(4), "_value": 2.4, "label": "d", "group": uint64(1)},
+					},
+				)
+				s2 := constructChunks(
+					[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+					[]flux.ColMeta{
+						{Label: "_time", Type: flux.TTime},
+						{Label: "_value", Type: flux.TFloat},
+						{Label: "group", Type: flux.TUInt},
+					},
+					[]map[string]interface{}{
+						{"_time": execute.Time(6), "_value": 1.2, "group": uint64(1)},
+					},
+				)
+				return append(s1, s2...)
+			}(),
+			right: constructChunks(
+				[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+				[]flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TInt},
+					{Label: "id", Type: flux.TString},
+					{Label: "group", Type: flux.TUInt},
+				},
+				[]map[string]interface{}{
+					{"_time": execute.Time(1), "_value": int64(1), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(2), "_value": int64(2), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(3), "_value": int64(3), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(4), "_value": int64(4), "id": "a", "group": uint64(1)},
+					{"_time": execute.Time(1), "_value": int64(5), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(2), "_value": int64(6), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(3), "_value": int64(7), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(4), "_value": int64(8), "id": "c", "group": uint64(1)},
+					{"_time": execute.Time(1), "_value": int64(9), "id": "d", "group": uint64(1)},
+					{"_time": execute.Time(2), "_value": int64(10), "id": "d", "group": uint64(1)},
+					{"_time": execute.Time(3), "_value": int64(11), "id": "d", "group": uint64(1)},
+					{"_time": execute.Time(4), "_value": int64(12), "id": "d", "group": uint64(1)},
+				},
+			),
+			wantTables: constructChunks(
+				[]flux.ColMeta{{Label: "group", Type: flux.TUInt}},
+				[]flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "lv", Type: flux.TFloat},
+					{Label: "rv", Type: flux.TInt},
+					{Label: "label", Type: flux.TString},
+					{Label: "group", Type: flux.TUInt},
+				},
+				[]map[string]interface{}{
+					{"_time": execute.Time(1), "lv": 1.2, "rv": int64(1), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": 3.4, "rv": int64(2), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": 5.6, "rv": int64(3), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": 7.8, "rv": int64(4), "label": "a", "group": uint64(1)},
+					{"_time": execute.Time(1), "lv": 9.0, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": 1.9, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": 2.8, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": 3.7, "rv": values.Null, "label": "b", "group": uint64(1)},
+					{"_time": execute.Time(1), "lv": values.Null, "rv": int64(5), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": values.Null, "rv": int64(6), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": values.Null, "rv": int64(7), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": values.Null, "rv": int64(8), "label": "c", "group": uint64(1)},
+					{"_time": execute.Time(1), "lv": 4.6, "rv": int64(9), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(2), "lv": 5.5, "rv": int64(10), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(3), "lv": 1.3, "rv": int64(11), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(4), "lv": 2.4, "rv": int64(12), "label": "d", "group": uint64(1)},
+					{"_time": execute.Time(6), "lv": 1.2, "rv": values.Null, "label": values.Null, "group": uint64(1)},
+				},
+			),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Adds a 2 new types, `RowJoinFn` and `RowJoinPreparedFn`, which are used by `JoinFn` in an effort to leverage the function caching logic from the `execute` package.

Also modifies some code in the join transformation to better handle schema changes between tables.

Closes #4883 