### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.go.tmpl]
+indent_style = tab
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
The motivation here was to avoid my editor from defaulting to space
indents in go templates.


### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [ ] Test cases written **N/A**
