### PR TITLE
fix(stdlib): to function should skip empty tag values

### DIFF
--- a/dependencies/influxdb/http.go
+++ b/dependencies/influxdb/http.go
@@ -542,6 +542,10 @@ func (h *httpWriter) encodeMetric(enc *lineprotocol.Encoder, m Metric) ([]byte, 
 
 	// Encode the tags.
 	for _, tag := range tags {
+		// Skip tags with an empty value.
+		if tag.Value == "" {
+			continue
+		}
 		enc.AddTag(tag.Key, tag.Value)
 	}
 

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -230,9 +230,15 @@ outer:
 					return errors.New(codes.Invalid, "invalid type for tag column")
 				}
 
+				value := er.Strings(j).Value(i)
+				if value == "" {
+					// Skip tag value if it is empty.
+					continue
+				}
+
 				metric.Tags = append(metric.Tags, &Tag{
 					Key:   col.Label,
-					Value: er.Strings(j).Value(i),
+					Value: value,
 				})
 			}
 		}

--- a/stdlib/influxdata/influxdb/wide_to.go
+++ b/stdlib/influxdata/influxdb/wide_to.go
@@ -230,9 +230,15 @@ func getTablePointsMetadata(tbl flux.Table) (md tablePointsMetadata, err error) 
 				return md, errors.Newf(codes.FailedPrecondition, "group key column %q has type %v; type %v is required", col.Label, col.Type, flux.TString)
 			}
 			isTag[col.Label] = true
+
+			value := tbl.Key().ValueString(j)
+			if value == "" {
+				// Skip tag value if it is empty.
+				continue
+			}
 			md.Tags = append(md.Tags, &influxdb.Tag{
 				Key:   col.Label,
-				Value: tbl.Key().ValueString(j),
+				Value: value,
 			})
 		}
 	}


### PR DESCRIPTION
The to function is intended to skip tags that are empty since that is
how tags with an empty value are represented in influxdb.

The old implementation would also skip keys that are empty, but I think
this behavior isn't correct so this will retain the behavior of erroring
on the tag key being invalid.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written