### PR TITLE
feat(plan): generalize attributes in planner

### DIFF
--- a/execute/executor.go
+++ b/execute/executor.go
@@ -186,13 +186,13 @@ func (v *createExecutionNodeVisitor) Visit(node plan.Node) error {
 	//    predecessors. These copies merge into the node.
 
 	copies := 1
-	if attr, ok := ppn.OutputAttrs[plan.ParallelRunKey]; ok {
+	if attr := plan.GetOutputAttribute(ppn, plan.ParallelRunKey); attr != nil {
 		copies = attr.(plan.ParallelRunAttribute).Factor
 	}
 
 	isParallelMerge := false
 	predCopies := 1
-	if attr, ok := ppn.OutputAttrs[plan.ParallelMergeKey]; ok {
+	if attr := plan.GetOutputAttribute(ppn, plan.ParallelMergeKey); attr != nil {
 		isParallelMerge = true
 		predCopies = attr.(plan.ParallelMergeAttribute).Factor
 	}
@@ -397,7 +397,7 @@ func (es *executionState) chooseDefaultResources(ctx context.Context, p *plan.Sp
 				if len(node.Predecessors()) > 0 {
 					addend := 1
 					ppn := node.(*plan.PhysicalPlanNode)
-					if attr, ok := ppn.OutputAttrs[plan.ParallelRunKey]; ok {
+					if attr := plan.GetOutputAttribute(ppn, plan.ParallelRunKey); attr != nil {
 						addend = attr.(plan.ParallelRunAttribute).Factor
 					}
 					concurrencyQuota += addend

--- a/plan/attributes.go
+++ b/plan/attributes.go
@@ -2,34 +2,198 @@ package plan
 
 import (
 	"fmt"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 )
 
-// Physical attributes used in specifying parallelization. The Run attribute
-// means the node executes in parallel. It accepts parallel data (a subset of
-// the source) and produces parallel data. The merge attribute means that the
-// node accepts parallel data, merges the streams, and produces non-parallel
-// data that covers the entire data source.
-const ParallelRunKey = "parallel-run"
-const ParallelMergeKey = "parallel-merge"
+// Attributes provide a way to model different aspects of the data
+// flowing though the physical operations in a plan graph.
+//
+// For example, if a node requires its input tables to be sorted, it
+// will have the CollationAttr among its required attributes.
+// Likewise, if a node produces sorted tables, its output attributes
+// will have CollationAttr.
+//
+// Operations can require or provide attributes by implementing interfaces
+// in the corresponding PhysicalProcedureSpec:
+// - OutputAttributer is to be implemented if the procedure will provide an attribiute. E.g.,
+//   the SortProcedureSpec will provide CollationAttr for the columns on which the data is
+//   to be sorted.
+// - PassThroughAttributeris to be implemented if a procedure will not perturb a given attribute.
+//   E.g., if data with CollationAttr flows into a filter, it will still be sorted. Therefore,
+//   FilterProcedureSpec can implement PassThroughAttributer for collation.
+// - RequiredAttributer is to be implemented by procedures that require particular attreibutes.
+//   There is one set of required physical attributes for each input, since they may be different.
+//   E.g., SortMergeJoinProcedureSpec requires that the left and right inputs be sorted on the
+//   columns being joined on (and they may in fact have different names on either side).
+//
+// It's the obligation of planner rules to ensure that required attributes are satisified by
+// a procedure's inputs. If a node has required attribute that are not satisfied, it will be
+// caught by ValidatePhysicalPlan(), and an internal error will be returned.
 
-type ParallelRunAttribute struct {
-	Factor int
+// PhysicalAttr represents an attribute (collation, parallel execution)
+// of a plan node.
+type PhysicalAttr interface {
+	String() string
+	Key() string
+	SuccessorsMustRequire() bool
+	SatisfiedBy(attr PhysicalAttr) bool
 }
 
-// If a node produces parallel data, then all successors must require parallel
-// data, otherwise there will be a plan error.
-func (ParallelRunAttribute) SuccessorsMustRequire() bool {
-	return true
+// PhysicalAttributes encapsulates any physical attributes of the result produced
+// by a physical plan node, such as collation, etc.
+type PhysicalAttributes map[string]PhysicalAttr
+
+// OutputAttributer is an interface to be implemented by PhysicalProcedureSpec implementations
+// that produce output that has particular attributes.
+type OutputAttributer interface {
+	OutputAttributes() PhysicalAttributes
 }
 
-type ParallelMergeAttribute struct {
-	Factor int
+// PassThroughAttributer is an interface to be implemented by PhysicalProcedureSpec implementations
+// that allow attributes to propagate from input to output.
+type PassThroughAttributer interface {
+	PassThroughAttribute(attrKey string) bool
 }
 
-func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
-	return false
+// RequiredAttributer is an interface to be implemented by PhysicalProcedureSpec implementations
+// that require physical attributes to be provided by inputs. The return value here is a slice,
+// since each input may be required to have a different set of attributes.
+type RequiredAttributer interface {
+	RequiredAttributes() []PhysicalAttributes
 }
 
-func (a ParallelMergeAttribute) PlanDetails() string {
-	return fmt.Sprintf("ParallelMergeFactor: %v", a.Factor)
+// CheckRequiredAttributes will check that if the given node requires any
+// attributes from its predecessors, then they are provided, either directly or
+// because a predecessor passes on the attribute from one of its own predecessors.
+// If all requirements are met, nil is returned, otherwise an error
+// wil an appopriate diagnostic is produced.
+func CheckRequiredAttributes(node *PhysicalPlanNode) error {
+
+	// If there are any required attributes for this node, there should be one set of
+	// required attributes for each input.
+	reqAttrsSlice := node.requiredAttrs() // one set of required attributes for each predecessor
+	if lra, lpred := len(reqAttrsSlice), len(node.Predecessors()); lra != lpred {
+		return &flux.Error{
+			Code: codes.Internal,
+			Msg:  fmt.Sprintf("node has %d predecessors but has %d sets of required attributes", lpred, lra),
+		}
+	}
+
+	for i, reqAttrMap := range reqAttrsSlice {
+		for _, reqAttr := range reqAttrMap {
+			ppred := node.Predecessors()[i].(*PhysicalPlanNode)
+			haveAttr, n := getOutputAttributeWithNode(node.Predecessors()[i].(*PhysicalPlanNode), reqAttr.Key())
+			if haveAttr == nil {
+				return errors.Newf(codes.Internal,
+					"attribute %q, required by %q, is missing from predecessor %q",
+					reqAttr.Key(), node.ID(), n.ID(),
+				)
+			}
+
+			if !reqAttr.SatisfiedBy(haveAttr) {
+				return errors.Newf(codes.Internal,
+					"node %q requires attribute %v, which is not satisfied by predecessor %q, "+
+						"which has attribute %v",
+					node.ID(), reqAttr, ppred.ID(), haveAttr,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetOutputAttribute will return the attribute with the given key
+// provided by the given plan node, traversing backwards through predecessors
+// as needed for attributes that may pass through. E.g.,
+//   sort |> filter
+// The "filter" node will still provide the collation attribute, even though it's
+// the "sort" node that actually does the collating.
+func GetOutputAttribute(node *PhysicalPlanNode, attrKey string) PhysicalAttr {
+	attr, _ := getOutputAttributeWithNode(node, attrKey)
+	return attr
+}
+
+func getOutputAttributeWithNode(node *PhysicalPlanNode, attrKey string) (PhysicalAttr, *PhysicalPlanNode) {
+	if attr, ok := node.outputAttrs()[attrKey]; ok {
+		return attr, nil
+	}
+
+	if node.passesThroughAttr(attrKey) && len(node.Predecessors()) == 1 {
+		// TODO(cwolff): consider what it means for nodes with multiple predecessors
+		//   (e.g. join or union) to pass on attributes.
+		return getOutputAttributeWithNode(node.Predecessors()[0].(*PhysicalPlanNode), attrKey)
+	}
+
+	return nil, node
+}
+
+// CheckSuccessorsMustRequire will return an error if the node has an output attribute
+// that must be required by a successor, and nil otherwise.. E.g., the parallel-run
+// attribute is like this in that it must be required by a merge node.
+// This function will walk forward through successors to find the requiring node.
+func CheckSuccessorsMustRequire(node *PhysicalPlanNode) error {
+	for _, attr := range node.outputAttrs() {
+		if !attr.SuccessorsMustRequire() {
+			continue
+		}
+
+		if len(node.Successors()) == 0 {
+			return &flux.Error{
+				Code: codes.Internal,
+				Msg: fmt.Sprintf("node %q provides attribute %v that must be required but has no "+
+					"successors to require it", node.ID(), attr.Key()),
+			}
+		}
+		for _, succ := range node.Successors() {
+			if reqd, n := requiredBySuccessor(attr, node, succ.(*PhysicalPlanNode)); !reqd {
+				if n != nil {
+					return &flux.Error{
+						Code: codes.Internal,
+						Msg: fmt.Sprintf("plan node %q has attribute %q that must be required by successors, "+
+							"but it is not required or propagated by successor %q",
+							node.ID(), attr.Key(), n.ID(),
+						),
+					}
+				}
+				return &flux.Error{
+					Code: codes.Internal,
+					Msg: fmt.Sprintf("plan node %q has attribute %q that must be required by successors, "+
+						"but no successors require it",
+						node.ID(), attr.Key(),
+					),
+				}
+			}
+		}
+
+	}
+	return nil
+}
+
+// requiredBySuccessor returns true if the given attribute is required by succ or
+// succ passes through the attribute and one of its successors requires the attribute.
+// If the attribute is not required, this function returns false and the node that neither passes
+// along nor requires the attribute.
+func requiredBySuccessor(requiredAttr PhysicalAttr, node, succ *PhysicalPlanNode) (bool, *PhysicalPlanNode) {
+	i := indexOfNode(node, succ.Predecessors())
+	if _, ok := succ.requiredAttrs()[i][requiredAttr.Key()]; ok {
+		return true, succ
+	}
+	if succ.passesThroughAttr(requiredAttr.Key()) {
+		if len(succ.Successors()) == 0 {
+			return false, nil
+		}
+		// If this node does not require the attribute itself but passes it along,
+		// see if any successors require it.
+		for _, ssucc := range succ.Successors() {
+			if reqd, n := requiredBySuccessor(requiredAttr, succ, ssucc.(*PhysicalPlanNode)); !reqd {
+				return false, n
+			}
+		}
+		return true, succ
+	}
+	return false, succ
 }

--- a/plan/attributes_test.go
+++ b/plan/attributes_test.go
@@ -1,0 +1,314 @@
+package plan_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+	"github.com/stretchr/testify/require"
+)
+
+const mockAttrKey = "mock-attr"
+
+type mockAttr struct {
+	successorMustRequire bool
+	v                    int
+}
+
+func (m *mockAttr) String() string              { return fmt.Sprintf("%v{v: %v}", mockAttrKey, m.v) }
+func (m *mockAttr) Key() string                 { return mockAttrKey }
+func (m *mockAttr) SuccessorsMustRequire() bool { return m.successorMustRequire }
+func (m *mockAttr) SatisfiedBy(attr plan.PhysicalAttr) bool {
+	other, ok := attr.(*mockAttr)
+	if !ok {
+		return false
+	}
+	return m.v == other.v
+}
+
+func TestCheckRequiredAttributes(t *testing.T) {
+	tcs := []struct {
+		name  string
+		input *plantest.PlanSpec
+		err   string
+	}{
+		{
+			name: "valid",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("has-attr", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+					plantest.CreatePhysicalNode("require-attr", plantest.MockProcedureSpec{
+						RequiredAttributesFn: func() []plan.PhysicalAttributes {
+							return []plan.PhysicalAttributes{
+								{
+									mockAttrKey: &mockAttr{},
+								},
+							}
+						},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+		},
+		{
+			name: "wrong number of required attributes",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("pred0", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("pred1", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("require-attr", plantest.MockProcedureSpec{
+						RequiredAttributesFn: func() []plan.PhysicalAttributes {
+							return []plan.PhysicalAttributes{
+								{
+									mockAttrKey: &mockAttr{},
+								},
+							}
+						},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 2},
+					{1, 2},
+				},
+			},
+			err: "node has 2 predecessors but has 1 sets of required attributes",
+		},
+		{
+			name: "missing required attributes",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("no-attr", plantest.MockProcedureSpec{}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+					plantest.CreatePhysicalNode("require-attr", plantest.MockProcedureSpec{
+						RequiredAttributesFn: func() []plan.PhysicalAttributes {
+							return []plan.PhysicalAttributes{
+								{
+									mockAttrKey: &mockAttr{},
+								},
+							}
+						},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			err: `attribute "mock-attr", required by "require-attr", is missing from predecessor "no-attr"`,
+		},
+		{
+			name: "attribute present but not satisfied",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("has-attr", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{v: 1},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+					plantest.CreatePhysicalNode("require-attr", plantest.MockProcedureSpec{
+						RequiredAttributesFn: func() []plan.PhysicalAttributes {
+							return []plan.PhysicalAttributes{
+								{
+									mockAttrKey: &mockAttr{v: 0},
+								},
+							}
+						},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			err: `node "require-attr" requires attribute mock-attr{v: 0}, which is not satisfied ` +
+				`by predecessor "passthru", which has attribute mock-attr{v: 1}`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := plantest.CreatePlanSpec(tc.input)
+			err := spec.BottomUpWalk(func(node plan.Node) error {
+				return plan.CheckRequiredAttributes(node.(*plan.PhysicalPlanNode))
+			})
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				if err == nil {
+					t.Fatalf("expected error %q but did not get an error", tc.err)
+				}
+				require.Equal(t, tc.err, err.Error())
+			}
+		})
+	}
+}
+
+func TestCheckSuccessorsMustRequire(t *testing.T) {
+	tcs := []struct {
+		name  string
+		input *plantest.PlanSpec
+		err   string
+	}{
+		{
+			name: "valid",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("successor-must-require", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{successorMustRequire: true},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+					plantest.CreatePhysicalNode("requires-attr", plantest.MockProcedureSpec{
+						RequiredAttributesFn: func() []plan.PhysicalAttributes {
+							return []plan.PhysicalAttributes{
+								{
+									mockAttrKey: &mockAttr{successorMustRequire: true},
+								},
+							}
+						},
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+		},
+		{
+			name: "successor does not require",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("successor-does-not-require", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{successorMustRequire: false},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+					plantest.CreatePhysicalNode("requires-attr", plantest.MockProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+		},
+		{
+			name: "no successor",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("successor-must-require", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{successorMustRequire: true},
+							}
+						},
+					}),
+				},
+				Edges: [][2]int{},
+			},
+			err: `node "successor-must-require" provides attribute mock-attr that must be required but has no successors to require it`,
+		},
+		{
+			name: "no requiring successor",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("successor-must-require", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{successorMustRequire: true},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+					plantest.CreatePhysicalNode("does-not-require-attr", plantest.MockProcedureSpec{}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+					{1, 2},
+				},
+			},
+			err: `plan node "successor-must-require" has attribute "mock-attr" that must be required by successors, ` +
+				`but it is not required or propagated by successor "does-not-require-attr"`,
+		},
+		{
+			name: "no requiring successor passthru",
+			input: &plantest.PlanSpec{
+				Nodes: []plan.Node{
+					plantest.CreatePhysicalNode("successor-must-require", plantest.MockProcedureSpec{
+						OutputAttributesFn: func() plan.PhysicalAttributes {
+							return plan.PhysicalAttributes{
+								mockAttrKey: &mockAttr{successorMustRequire: true},
+							}
+						},
+					}),
+					plantest.CreatePhysicalNode("passthru", plantest.MockProcedureSpec{
+						PassThroughAttributeFn: func(attrKey string) bool { return attrKey == mockAttrKey },
+					}),
+				},
+				Edges: [][2]int{
+					{0, 1},
+				},
+			},
+			err: `plan node "successor-must-require" has attribute "mock-attr" that must be required by successors, ` +
+				`but no successors require it`,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := plantest.CreatePlanSpec(tc.input)
+			err := spec.BottomUpWalk(func(node plan.Node) error {
+				return plan.CheckSuccessorsMustRequire(node.(*plan.PhysicalPlanNode))
+			})
+			if tc.err == "" {
+				require.NoError(t, err)
+			} else {
+				if err == nil {
+					t.Fatalf("expected error %q but did not get an error", tc.err)
+				}
+				require.Equal(t, tc.err, err.Error())
+			}
+		})
+	}
+}

--- a/plan/collation.go
+++ b/plan/collation.go
@@ -1,0 +1,53 @@
+package plan
+
+import (
+	"fmt"
+)
+
+const (
+	CollationKey = "collation"
+)
+
+// CollationAttr is a physical attribute that describes the collation
+// of the rows within a table. Note: the collation attribute does not
+// say anything about how the tables in a stream are ordered.
+type CollationAttr struct {
+	Columns []string
+	Desc    bool
+}
+
+var _ PhysicalAttr = (*CollationAttr)(nil)
+
+func (ca *CollationAttr) Key() string { return CollationKey }
+
+func (ca *CollationAttr) SuccessorsMustRequire() bool {
+	return false
+}
+
+func (ca *CollationAttr) SatisfiedBy(attr PhysicalAttr) bool {
+	gotCollation, ok := attr.(*CollationAttr)
+	if !ok {
+		return false
+	}
+	if ca.Desc != gotCollation.Desc {
+		return false
+	}
+
+	if len(ca.Columns) > len(gotCollation.Columns) {
+		return false
+	}
+
+	// Note that if we are looking for collation of [a, b] and we get a collation of [a, b, c]
+	// the collation is still satisfied.
+	for i, col := range ca.Columns {
+		if gotCollation.Columns[i] != col {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (ca *CollationAttr) String() string {
+	return fmt.Sprintf("%v{Columns: %v, Desc: %v}", CollationKey, ca.Columns, ca.Desc)
+}

--- a/plan/format.go
+++ b/plan/format.go
@@ -62,7 +62,7 @@ func (f formatter) Format(fs fmt.State, c rune) {
 			}
 
 			if ppn, ok := pn.(*PhysicalPlanNode); ok {
-				for _, attr := range ppn.OutputAttrs {
+				for _, attr := range ppn.outputAttrs() {
 					if d, ok := attr.(Detailer); ok {
 						details += d.PlanDetails() + "\n"
 					}

--- a/plan/parallel.go
+++ b/plan/parallel.go
@@ -1,0 +1,70 @@
+package plan
+
+import (
+	"fmt"
+)
+
+// Physical attributes used in specifying parallelization.
+
+const ParallelRunKey = "parallel-run"
+
+// ParallelRunAttribute means the node executes in parallel when present. It accepts parallel data (a subset of
+// the source) and produces parallel data.
+type ParallelRunAttribute struct {
+	Factor int
+}
+
+var _ PhysicalAttr = ParallelRunAttribute{}
+
+func (ParallelRunAttribute) Key() string { return ParallelRunKey }
+
+// SuccessorsMustRequire implements the PhysicalAttribute interface.
+// if a node produces parallel data, then all successors must require parallel
+// data, otherwise there will be a plan error.
+func (ParallelRunAttribute) SuccessorsMustRequire() bool {
+	return true
+}
+
+func (a ParallelRunAttribute) SatisfiedBy(attr PhysicalAttr) bool {
+	other, ok := attr.(ParallelRunAttribute)
+	if !ok {
+		return false
+	}
+	return a == other
+}
+
+func (a ParallelRunAttribute) String() string {
+	return fmt.Sprintf("%v{Factor: %d}", ParallelRunKey, a.Factor)
+}
+
+const ParallelMergeKey = "parallel-merge"
+
+// ParallelMergeAttribute means that the node accepts parallel data, merges the streams, and produces non-parallel
+// data that covers the entire data source.
+type ParallelMergeAttribute struct {
+	Factor int
+}
+
+var _ PhysicalAttr = ParallelMergeAttribute{}
+
+func (ParallelMergeAttribute) Key() string { return ParallelMergeKey }
+
+func (ParallelMergeAttribute) SuccessorsMustRequire() bool {
+	return false
+}
+
+func (a ParallelMergeAttribute) SatisfiedBy(attr PhysicalAttr) bool {
+	other, ok := attr.(ParallelMergeAttribute)
+	if !ok {
+		return false
+	}
+	return a == other
+}
+
+func (a ParallelMergeAttribute) PlanDetails() string {
+	return fmt.Sprintf("ParallelMergeFactor: %v", a.Factor)
+}
+
+func (a ParallelMergeAttribute) String() string {
+	return fmt.Sprintf("%v{Factor: %d}", ParallelMergeKey, a.Factor)
+}

--- a/plan/plantest/cmp.go
+++ b/plan/plantest/cmp.go
@@ -97,31 +97,16 @@ func CompareLogicalPlanNodes(p, q plan.Node) error {
 
 // ComparePhysicalPlanNodes is a comparator function for PhysicalPlanNodes
 func ComparePhysicalPlanNodes(p, q plan.Node) error {
-	var pp, qq *plan.PhysicalPlanNode
-	var ok bool
-
-	if pp, ok = p.(*plan.PhysicalPlanNode); !ok {
+	if _, ok := p.(*plan.PhysicalPlanNode); !ok {
 		return fmt.Errorf("expected %s to be a PhysicalPlanNode", p.ID())
 	}
 
-	if qq, ok = q.(*plan.PhysicalPlanNode); !ok {
+	if _, ok := q.(*plan.PhysicalPlanNode); !ok {
 		return fmt.Errorf("expected %s to be a PhysicalPlanNode", q.ID())
 	}
 
 	if err := cmpPlanNode(p, q); err != nil {
 		return err
-	}
-
-	// Both nodes must consume the same required attributes
-	if !cmp.Equal(pp.RequiredAttrs, qq.RequiredAttrs) {
-		return fmt.Errorf("required attributes not equal -want(%s)/+got(%s) %s",
-			pp.ID(), qq.ID(), cmp.Diff(pp.RequiredAttrs, qq.RequiredAttrs))
-	}
-
-	// Both nodes must produce the same physical attributes
-	if !cmp.Equal(pp.OutputAttrs, qq.OutputAttrs) {
-		return fmt.Errorf("output attributes not equal -want(%s)/+got(%s) %s",
-			pp.ID(), qq.ID(), cmp.Diff(pp.OutputAttrs, qq.OutputAttrs))
 	}
 
 	return nil

--- a/plan/plantest/rules.go
+++ b/plan/plantest/rules.go
@@ -211,44 +211,23 @@ func PhysicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Optio
 	}
 
 	type testAttrs struct {
-		ID            plan.NodeID
-		Spec          plan.PhysicalProcedureSpec
-		RequiredAttrs plan.PhysicalAttributes
-		OutputAttrs   plan.PhysicalAttributes
+		ID   plan.NodeID
+		Spec plan.PhysicalProcedureSpec
 	}
 	want := make([]testAttrs, 0)
 	after.BottomUpWalk(func(node plan.Node) error {
-		var outputAttrs plan.PhysicalAttributes
-		var requiredAttrs plan.PhysicalAttributes
-
-		if ppn, ok := node.(*plan.PhysicalPlanNode); ok {
-			outputAttrs = ppn.OutputAttrs
-			requiredAttrs = ppn.RequiredAttrs
-		}
 		want = append(want, testAttrs{
-			ID:            node.ID(),
-			Spec:          node.ProcedureSpec().(plan.PhysicalProcedureSpec),
-			RequiredAttrs: requiredAttrs,
-			OutputAttrs:   outputAttrs,
+			ID:   node.ID(),
+			Spec: node.ProcedureSpec().(plan.PhysicalProcedureSpec),
 		})
 		return nil
 	})
 
 	got := make([]testAttrs, 0)
 	pp.BottomUpWalk(func(node plan.Node) error {
-		var outputAttrs plan.PhysicalAttributes
-		var requiredAttrs plan.PhysicalAttributes
-
-		if ppn, ok := node.(*plan.PhysicalPlanNode); ok {
-			outputAttrs = ppn.OutputAttrs
-			requiredAttrs = ppn.RequiredAttrs
-		}
-
 		got = append(got, testAttrs{
-			ID:            node.ID(),
-			Spec:          node.ProcedureSpec().(plan.PhysicalProcedureSpec),
-			RequiredAttrs: requiredAttrs,
-			OutputAttrs:   outputAttrs,
+			ID:   node.ID(),
+			Spec: node.ProcedureSpec().(plan.PhysicalProcedureSpec),
 		})
 		return nil
 	})
@@ -319,24 +298,6 @@ func LogicalRuleTestHelper(t *testing.T, tc *RuleTestCase, options ...cmp.Option
 	}
 }
 
-type PhysicalNodeOption func(*plan.PhysicalPlanNode)
-
-func WithOutputAttr(name string, attr plan.PhysicalAttr) PhysicalNodeOption {
-	return func(node *plan.PhysicalPlanNode) {
-		node.SetOutputAttr(name, attr)
-	}
-}
-
-func WithRequiredAttr(name string, attr plan.PhysicalAttr) PhysicalNodeOption {
-	return func(node *plan.PhysicalPlanNode) {
-		node.SetRequiredAttr(name, attr)
-	}
-}
-
-func CreatePhysicalNode(id plan.NodeID, spec plan.PhysicalProcedureSpec, opts ...PhysicalNodeOption) *plan.PhysicalPlanNode {
-	node := plan.CreatePhysicalNode(id, spec)
-	for _, opt := range opts {
-		opt(node)
-	}
-	return node
+func CreatePhysicalNode(id plan.NodeID, spec plan.PhysicalProcedureSpec) *plan.PhysicalPlanNode {
+	return plan.CreatePhysicalNode(id, spec)
 }

--- a/plan/plantest/spec/mock.go
+++ b/plan/plantest/spec/mock.go
@@ -21,6 +21,38 @@ func CreatePhysicalMockNode(id string) *plan.PhysicalPlanNode {
 // unit testing.
 type MockProcedureSpec struct {
 	plan.DefaultCost
+	OutputAttributesFn     func() plan.PhysicalAttributes
+	PassThroughAttributeFn func(attrKey string) bool
+	RequiredAttributesFn   func() []plan.PhysicalAttributes
+	PlanDetailsFn          func() string
+}
+
+func (s MockProcedureSpec) PlanDetails() string {
+	if s.PlanDetailsFn != nil {
+		return s.PlanDetailsFn()
+	}
+	return ""
+}
+
+func (s MockProcedureSpec) OutputAttributes() plan.PhysicalAttributes {
+	if s.OutputAttributesFn != nil {
+		return s.OutputAttributesFn()
+	}
+	return nil
+}
+
+func (s MockProcedureSpec) PassThroughAttribute(attrKey string) bool {
+	if s.PassThroughAttributeFn != nil {
+		return s.PassThroughAttributeFn(attrKey)
+	}
+	return false
+}
+
+func (s MockProcedureSpec) RequiredAttributes() []plan.PhysicalAttributes {
+	if s.RequiredAttributesFn != nil {
+		return s.RequiredAttributesFn()
+	}
+	return nil
 }
 
 func (MockProcedureSpec) Kind() plan.ProcedureKind {

--- a/plan/plantest/spec/plan.go
+++ b/plan/plantest/spec/plan.go
@@ -50,12 +50,6 @@ func copyNode(n plan.Node) plan.Node {
 		cn = plan.CreateLogicalNode(n.ID(), n.ProcedureSpec().Copy())
 	case *plan.PhysicalPlanNode:
 		pn := plan.CreatePhysicalNode(n.ID(), n.ProcedureSpec().Copy().(plan.PhysicalProcedureSpec))
-		for key, attr := range n.OutputAttrs {
-			pn.SetOutputAttr(key, attr)
-		}
-		for key, attr := range n.RequiredAttrs {
-			pn.SetRequiredAttr(key, attr)
-		}
 		cn = pn
 	}
 	return cn

--- a/plan/types.go
+++ b/plan/types.go
@@ -126,14 +126,14 @@ func (plan *Spec) CheckIntegrity() error {
 
 func symmetryCheck(node Node) error {
 	for _, pred := range node.Predecessors() {
-		if !isNodeInNodes(node, pred.Successors()) {
+		if idx := indexOfNode(node, pred.Successors()); idx == -1 {
 			return fmt.Errorf("integrity violated: %s is predecessor of %s, "+
 				"but %s is not successor of %s", pred.ID(), node.ID(), node.ID(), pred.ID())
 		}
 	}
 
 	for _, succ := range node.Successors() {
-		if !isNodeInNodes(node, succ.Predecessors()) {
+		if idx := indexOfNode(node, succ.Predecessors()); idx == -1 {
 			return fmt.Errorf("integrity violated: %s is successor of %s, "+
 				"but %s is not predecessor of %s`", succ.ID(), node.ID(), node.ID(), succ.ID())
 		}
@@ -142,14 +142,19 @@ func symmetryCheck(node Node) error {
 	return nil
 }
 
-func isNodeInNodes(node Node, nodes []Node) bool {
-	for _, n := range nodes {
+// indexOfNode is a utility function that will return the offset
+// of the given node in the slice of nodes.
+// This is useful to determine whether a node is the 1st or 2nd predecessor
+// of some other node for example.
+// Returns -1 if node not found.
+func indexOfNode(node Node, nodes []Node) int {
+	for i, n := range nodes {
 		if n == node {
-			return true
+			return i
 		}
 	}
 
-	return false
+	return -1
 }
 
 // ProcedureSpec specifies a query operation

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -441,6 +441,14 @@ type ToProcedureSpec struct {
 	Spec *ToOpSpec
 }
 
+func (o *ToProcedureSpec) PassThroughAttribute(attrKey string) bool {
+	switch attrKey {
+	case plan.ParallelRunKey, plan.CollationKey:
+		return true
+	}
+	return false
+}
+
 // Kind returns the kind for the procedure spec for the `to` flux function.
 func (o *ToProcedureSpec) Kind() plan.ProcedureKind {
 	return ToKind

--- a/stdlib/join/sort_merge_join.go
+++ b/stdlib/join/sort_merge_join.go
@@ -33,6 +33,24 @@ func (p *SortMergeJoinProcedureSpec) Copy() plan.ProcedureSpec {
 	}
 }
 
+// RequiredAttributes says that merge join must have its left input
+// sorted by the left side join keys, and the right input must be sorted
+// by the right side join keys.
+func (p *SortMergeJoinProcedureSpec) RequiredAttributes() []plan.PhysicalAttributes {
+	return []plan.PhysicalAttributes{
+		{
+			plan.CollationKey: &plan.CollationAttr{
+				Columns: getJoinKeyCols(p.On, true),
+			},
+		},
+		{
+			plan.CollationKey: &plan.CollationAttr{
+				Columns: getJoinKeyCols(p.On, false),
+			},
+		},
+	}
+}
+
 func (p *SortMergeJoinProcedureSpec) Cost(inStats []plan.Statistics) (cost plan.Cost, outStats plan.Statistics) {
 	return plan.Cost{}, plan.Statistics{}
 }

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -105,6 +105,14 @@ func newFilterProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.Pro
 	}, nil
 }
 
+func (s *FilterProcedureSpec) PassThroughAttribute(attrKey string) bool {
+	switch attrKey {
+	case plan.ParallelRunKey, plan.CollationKey:
+		return true
+	}
+	return false
+}
+
 func (s *FilterProcedureSpec) Kind() plan.ProcedureKind {
 	return FilterKind
 }

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -102,6 +102,14 @@ type GroupProcedureSpec struct {
 	GroupKeys []string
 }
 
+func (s *GroupProcedureSpec) PassThroughAttribute(attrKey string) bool {
+	switch attrKey {
+	case plan.ParallelRunKey:
+		return true
+	}
+	return false
+}
+
 func newGroupProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*GroupOpSpec)
 	if !ok {

--- a/stdlib/universe/parallel.go
+++ b/stdlib/universe/parallel.go
@@ -20,6 +20,21 @@ const (
 
 type PartitionMergeProcedureSpec struct {
 	plan.DefaultCost
+	Factor int
+}
+
+func (o *PartitionMergeProcedureSpec) OutputAttributes() plan.PhysicalAttributes {
+	return plan.PhysicalAttributes{
+		plan.ParallelMergeKey: plan.ParallelMergeAttribute{Factor: o.Factor},
+	}
+}
+
+func (o *PartitionMergeProcedureSpec) RequiredAttributes() []plan.PhysicalAttributes {
+	return []plan.PhysicalAttributes{
+		{
+			plan.ParallelRunKey: plan.ParallelRunAttribute{Factor: o.Factor},
+		},
+	}
 }
 
 func (o *PartitionMergeProcedureSpec) Kind() plan.ProcedureKind {
@@ -29,6 +44,7 @@ func (o *PartitionMergeProcedureSpec) Kind() plan.ProcedureKind {
 func (o *PartitionMergeProcedureSpec) Copy() plan.ProcedureSpec {
 	return &PartitionMergeProcedureSpec{
 		DefaultCost: o.DefaultCost,
+		Factor:      o.Factor,
 	}
 }
 

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -100,6 +100,15 @@ func (s *SortProcedureSpec) Copy() plan.ProcedureSpec {
 	return &ns
 }
 
+func (s *SortProcedureSpec) OutputAttributes() plan.PhysicalAttributes {
+	return plan.PhysicalAttributes{
+		plan.CollationKey: &plan.CollationAttr{
+			Columns: s.Columns,
+			Desc:    s.Desc,
+		},
+	}
+}
+
 // TriggerSpec implements plan.TriggerAwareProcedureSpec
 func (s *SortProcedureSpec) TriggerSpec() plan.TriggerSpec {
 	return plan.NarrowTransformationTriggerSpec{}


### PR DESCRIPTION
This set of changes creates a framework whereby plan nodes can model characteristics of the data they consume and produce. These characteristics are called `attributes` in the code and currently there are three different kinds:
- `collation` to indicate data that is collated (sorted) by particular columns
- `parallel-run` to indicate that operations are run in parallel
- `parallel-merge` to indicate a plan node that represents a merging of parallel data streams

The parallel attributes were previously existing, but with this set of changes it is the procedure specs themselves that describe whether run in parallel or if they merge parallel streams.

Different attributes being produced or required by a particular operation is expressed by implementing interfaces. The comment at the top of `attributes.go` describes this in more detail.

This change set is mostly the same as the POC that was in https://github.com/influxdata/flux/pull/4902. There is a more comprehensive description over there, which is also valid for this PR. The main differences from this PR are changes that were required to allow the tests in `parallel_test.go` to pass.

This work is part of (but does not complete) #4628.