### PR TITLE
build(windows): use patched rustup.install chocolatey package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,13 +101,18 @@ jobs:
       - run:
           name: Install system dependencies
           command: |
+            choco install git
+            git clone https://github.com/influxdata/rustup.install.git "${TMP}/rustup.install"
+            cd "${TMP}/rustup.install"
+              git checkout bump-v1.25.1
+              choco install -dvf ./rustup.install.nuspec
+            cd -
             choco upgrade golang --version=1.18 --allow-downgrade
 
             choco install \
               grep \
               llvm \
-              pkgconfiglite \
-              rustup.install
+              pkgconfiglite
 
             # rustc depends on a version of libgcc_eh that isn't present in the latest mingw.
             choco install mingw --version=8.1.0


### PR DESCRIPTION
I've got a PR open against the upstream, but in the mean time this aims
to use our patched version rather than the published one.

Ref: <https://github.com/camilohe/rustup.install/pull/7>

See this linked PR for details on what broke and steps I took to mitigate.

If/when the PR merges we can revert the change here and return to just installing `rustup.install` with the rest of our regular chocolatey packages.

---

N.b. I noticed there was some log output complaining about the `pkgconfiglite` we are installing. There might be some needed maintenance there :thinking: 

---

Testing-wise, I basically force-pushed changes to this branch until the windows build seemed to get past the rustup install.

### Done checklist
- [ ] docs/SPEC.md updated **N/A**
- [ ] Test cases written **N/A**
