### PR TITLE
Fix documentation of sum() function

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1952,7 +1952,7 @@ from(bucket: "telegraf/autogen")
 
 ##### Sum
 
-Stddev is an aggregate operation.
+Sum is an aggregate operation.
 For each aggregated column, it outputs the sum of the non null record.
 The output column type is the same as the input column type.
 

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -601,7 +601,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "3298ba8e24903621505c78f4c48e4148f2d7c45e507e19ab46f547756a3173f4",
 	"stdlib/universe/union_test.flux":                                                             "f853a7bf588fedceee217d931733eb5f3b86b1f4717c2af24d59890b3c86f71c",
 	"stdlib/universe/unique_test.flux":                                                            "516e9fea81513c8cbb0c7a23545c9080e56c00149cc40bfc2187c649bfa4c958",
-	"stdlib/universe/universe.flux":                                                               "d95dc71b65a0674bd47ab3ab447061921a1b0a352f7a2a85ceeaac7ea8fd4ae2",
+	"stdlib/universe/universe.flux":                                                               "73096e4a8113ccae301c55db920052f657d0a71850bcc3068e8cd92b27784b61",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "cd0a1a7e788a50fa04289aa6e8b557f6c960eaf6ae95f9d8c0ff3044a48b4beb",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -2543,7 +2543,7 @@ builtin stddev : (<-tables: stream[A], ?column: string, ?mode: string) => stream
 // import "sampledata"
 //
 // < sampledata.int()
-// >     |> stddev()
+// >     |> sum()
 // ```
 //
 // ## Metadata


### PR DESCRIPTION
The documentation of the `sum()` function contained some mistaken uses of `stddev()`

### Done checklist
- [X] docs/SPEC.md updated
- [] Test cases written (N/A)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/)
