### PR TITLE
feat(stdlib): switch testing.diff to use experimental.diff as its base

### DIFF
--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -37,6 +37,7 @@ var testFlags = map[string]interface{}{
 	"narrowTransformationLimit": true,
 	"optimizeStateTracking":     true,
 	"optimizeSetTransformation": true,
+	"experimentalTestingDiff":   true,
 }
 
 type TestFlagger map[string]interface{}

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -185,6 +185,18 @@ func VectorizedConst() BoolFlag {
 	return vectorizedConst
 }
 
+var experimentalTestingDiff = feature.MakeBoolFlag(
+	"Experimental Testing Diff",
+	"experimentalTestingDiff",
+	"Jonathan Sternberg",
+	false,
+)
+
+// ExperimentalTestingDiff - Switches testing.diff to use experimental.diff
+func ExperimentalTestingDiff() BoolFlag {
+	return experimentalTestingDiff
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -205,6 +217,7 @@ var all = []Flag{
 	optimizeSetTransformation,
 	unusedSymbolWarnings,
 	vectorizedConst,
+	experimentalTestingDiff,
 }
 
 var byKey = map[string]Flag{
@@ -222,6 +235,7 @@ var byKey = map[string]Flag{
 	"optimizeSetTransformation":        optimizeSetTransformation,
 	"unusedSymbolWarnings":             unusedSymbolWarnings,
 	"vectorizedConst":                  vectorizedConst,
+	"experimentalTestingDiff":          experimentalTestingDiff,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -93,3 +93,9 @@
   key: vectorizedConst
   default: false
   contact: Owen Nelson
+
+- name: Experimental Testing Diff
+  description: Switches testing.diff to use experimental.diff
+  key: experimentalTestingDiff
+  default: false
+  contact: Jonathan Sternberg

--- a/stdlib/experimental/diff.go
+++ b/stdlib/experimental/diff.go
@@ -93,7 +93,7 @@ func createDiffTransformation(id execute.DatasetID, mode execute.AccumulationMod
 	}
 
 	wantID, gotID := a.Parents()[0], a.Parents()[1]
-	return newDiffTransformation(id, pspec, wantID, gotID, a.Allocator())
+	return NewDiffTransformation(id, pspec, wantID, gotID, a.Allocator())
 }
 
 type diffTransformation struct {
@@ -107,7 +107,7 @@ type diffTransformation struct {
 	wantID, gotID execute.DatasetID
 }
 
-func newDiffTransformation(id execute.DatasetID, spec *DiffProcedureSpec, wantID, gotID execute.DatasetID, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
+func NewDiffTransformation(id execute.DatasetID, spec *DiffProcedureSpec, wantID, gotID execute.DatasetID, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	tr := &diffTransformation{
 		d:   execute.NewTransportDataset(id, mem),
 		mem: mem,


### PR DESCRIPTION
This causes the `_diff` function to use the diff implementation in
`experimental` as the base diff implementation when the feature flag is
set.

This will cause diff to use a longest common subsequence algorithm to
compute the diff.

This is behind a feature flag in case it has some unknown complication.

Fixes #924 and #4815.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written