### PR TITLE
fix(plan): modify plan.Pat to work with no predecessors for transformations

### DIFF
--- a/plan/pattern.go
+++ b/plan/pattern.go
@@ -92,21 +92,25 @@ func (okp UnionKindPattern) Match(node Node) bool {
 		return false
 	}
 
-	if len(okp.predecessors) != len(node.Predecessors()) {
-		return false
-	}
-
-	// Check that each predecessor does not have other successors
-	for _, pred := range node.Predecessors() {
-		if len(pred.Successors()) != 1 {
+	// If we have specified predecessors, ensure that we have
+	// the proper number and that they don't have other successors.
+	if len(okp.predecessors) > 0 {
+		if len(okp.predecessors) != len(node.Predecessors()) {
 			return false
 		}
-	}
 
-	// Recursively match each predecessor
-	for i, pattern := range okp.predecessors {
-		if !pattern.Match(node.Predecessors()[i]) {
-			return false
+		// Check that each predecessor does not have other successors
+		for _, pred := range node.Predecessors() {
+			if len(pred.Successors()) != 1 {
+				return false
+			}
+		}
+
+		// Recursively match each predecessor
+		for i, pattern := range okp.predecessors {
+			if !pattern.Match(node.Predecessors()[i]) {
+				return false
+			}
 		}
 	}
 	return true

--- a/stdlib/universe/sort_limit.go
+++ b/stdlib/universe/sort_limit.go
@@ -195,7 +195,7 @@ func (s SortLimitRule) Name() string {
 }
 
 func (s SortLimitRule) Pattern() plan.Pattern {
-	return plan.Pat(LimitKind, plan.Pat(SortKind, plan.Any()))
+	return plan.Pat(LimitKind, plan.Pat(SortKind))
 }
 
 func (s SortLimitRule) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {


### PR DESCRIPTION
This modifies the pattern produced by `plan.Pat` so that it can work
when the topmost predecessor has predecessors but without requiring
those predecessors to be listed.

This allows plans like `sort |> limit` to work without using the `any`
node. The `any` node would cause the pattern to require the `any` node
to only have one successor, but it was perfectly allowable for that node
to have multiple successors. This makes writing the planner rule more
intuitive since we don't have to use `any` as the last predecessor and
it also prevents the problem of disallowing a pattern when it could have
been used.

Fixes #4699.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written