### PR TITLE
refactor(execute): transition narrow state transformation to use generics

### DIFF
--- a/execute/narrow_state_transformation_test.go
+++ b/execute/narrow_state_transformation_test.go
@@ -31,9 +31,9 @@ func TestNarrowStateTransformation_ProcessChunk(t *testing.T) {
 	}
 
 	isProcessed, hasState := false, false
-	tr, _, err := execute.NewNarrowStateTransformation(
+	tr, _, err := execute.NewNarrowStateTransformation[any](
 		executetest.RandomDatasetID(),
-		&mock.NarrowStateTransformation{
+		&mock.NarrowStateTransformation[any]{
 			ProcessFn: func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, _ memory.Allocator) (interface{}, bool, error) {
 				if state != nil {
 					if want, got := int64(4), state.(int64); want != got {
@@ -109,9 +109,9 @@ func TestNarrowStateTransformation_FlushKey(t *testing.T) {
 	}
 
 	var disposeCount int
-	tr, d, err := execute.NewNarrowStateTransformation(
+	tr, d, err := execute.NewNarrowStateTransformation[any](
 		executetest.RandomDatasetID(),
-		&mock.NarrowStateTransformation{
+		&mock.NarrowStateTransformation[any]{
 			ProcessFn: func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
 				if state != nil {
 					t.Error("process unexpectedly invoked with state")
@@ -193,9 +193,9 @@ func TestNarrowStateTransformation_Process(t *testing.T) {
 	}
 
 	isProcessed := false
-	tr, _, err := execute.NewNarrowStateTransformation(
+	tr, _, err := execute.NewNarrowStateTransformation[any](
 		executetest.RandomDatasetID(),
-		&mock.NarrowStateTransformation{
+		&mock.NarrowStateTransformation[any]{
 			ProcessFn: func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, _ memory.Allocator) (interface{}, bool, error) {
 				// Memory should be allocated and should not have been improperly freed.
 				// This accounts for 64 bytes (data) + 64 bytes (null bitmap) for each column
@@ -263,9 +263,9 @@ func TestNarrowStateTransformation_Finish(t *testing.T) {
 		disposeCount int
 		isDisposed   bool
 	)
-	tr, d, err := execute.NewNarrowStateTransformation(
+	tr, d, err := execute.NewNarrowStateTransformation[any](
 		executetest.RandomDatasetID(),
-		&mock.NarrowStateTransformation{
+		&mock.NarrowStateTransformation[any]{
 			ProcessFn: func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
 				return &mockState{
 					disposeCount: &disposeCount,
@@ -358,16 +358,16 @@ func TestNarrowStateTransformation_Finish(t *testing.T) {
 // This is to prevent opentracing from showing narrowTransformation
 // as the operation.
 func TestNarrowStateTransformation_OperationType(t *testing.T) {
-	tr, _, err := execute.NewNarrowStateTransformation(
+	tr, _, err := execute.NewNarrowStateTransformation[any](
 		executetest.RandomDatasetID(),
-		&mock.NarrowStateTransformation{},
+		&mock.NarrowStateTransformation[any]{},
 		memory.DefaultAllocator,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if want, got := "*mock.NarrowStateTransformation", execute.OperationType(tr); want != got {
+	if want, got := "*mock.NarrowStateTransformation[interface {}]", execute.OperationType(tr); want != got {
 		t.Errorf("unexpected operation type -want/+got:\n\t- %s\n\t+ %s", want, got)
 	}
 }

--- a/mock/transformation.go
+++ b/mock/transformation.go
@@ -64,16 +64,16 @@ func (a *NarrowTransformation) Close() error {
 	return nil
 }
 
-type NarrowStateTransformation struct {
-	ProcessFn func(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error)
+type NarrowStateTransformation[T any] struct {
+	ProcessFn func(chunk table.Chunk, state T, d *execute.TransportDataset, mem memory.Allocator) (T, bool, error)
 	CloseFn   func() error
 }
 
-func (n *NarrowStateTransformation) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
+func (n *NarrowStateTransformation[T]) Process(chunk table.Chunk, state T, d *execute.TransportDataset, mem memory.Allocator) (T, bool, error) {
 	return n.ProcessFn(chunk, state, d, mem)
 }
 
-func (a *NarrowStateTransformation) Close() error {
+func (a *NarrowStateTransformation[T]) Close() error {
 	if a.CloseFn != nil {
 		return a.CloseFn()
 	}

--- a/stdlib/experimental/preview.go
+++ b/stdlib/experimental/preview.go
@@ -100,7 +100,7 @@ func NewPreviewTransformation(id execute.DatasetID, spec *PreviewProcedureSpec, 
 		nrows:   spec.NRows,
 		ntables: spec.NTables,
 	}
-	return execute.NewNarrowStateTransformation(id, tr, mem)
+	return execute.NewNarrowStateTransformation[any](id, tr, mem)
 }
 
 func (t *previewTransformation) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {

--- a/stdlib/universe/derivative.go
+++ b/stdlib/universe/derivative.go
@@ -158,7 +158,7 @@ func NewDerivativeTransformation(ctx context.Context, id execute.DatasetID, spec
 		timeCol:     spec.TimeColumn,
 		initialZero: spec.InitialZero,
 	}
-	return execute.NewNarrowStateTransformation(id, tr, mem)
+	return execute.NewNarrowStateTransformation[*derivativeState](id, tr, mem)
 }
 
 type derivativeTransformation struct {
@@ -169,13 +169,8 @@ type derivativeTransformation struct {
 	initialZero bool
 }
 
-func (t *derivativeTransformation) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
-	var dstate *derivativeState
-	if state != nil {
-		dstate = state.(*derivativeState)
-	}
-
-	ns, err := t.processChunk(chunk, dstate, d, mem)
+func (t *derivativeTransformation) Process(chunk table.Chunk, state *derivativeState, d *execute.TransportDataset, mem memory.Allocator) (*derivativeState, bool, error) {
+	ns, err := t.processChunk(chunk, state, d, mem)
 	if err != nil {
 		return nil, false, err
 	}

--- a/stdlib/universe/fill.go
+++ b/stdlib/universe/fill.go
@@ -285,24 +285,19 @@ func NewNarrowFillTransformation(ctx context.Context, spec *FillProcedureSpec, i
 	t := &fillTransformationAdapter{
 		fillTransformation,
 	}
-	return execute.NewNarrowStateTransformation(id, t, alloc)
+	return execute.NewNarrowStateTransformation[*fillState](id, t, alloc)
 }
 
 type fillState struct {
 	fillValue interface{}
 }
 
-func (t *fillTransformationAdapter) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem arrowmem.Allocator) (interface{}, bool, error) {
+func (t *fillTransformationAdapter) Process(chunk table.Chunk, state *fillState, d *execute.TransportDataset, mem arrowmem.Allocator) (*fillState, bool, error) {
 	return t.fillTransformation.adaptedProcess(chunk, state, d, mem)
 }
 
-func (t *fillTransformation) adaptedProcess(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem arrowmem.Allocator) (interface{}, bool, error) {
-	var dstate *fillState
-	if state != nil {
-		dstate = state.(*fillState)
-	}
-
-	if dstate == nil {
+func (t *fillTransformation) adaptedProcess(chunk table.Chunk, state *fillState, d *execute.TransportDataset, mem arrowmem.Allocator) (*fillState, bool, error) {
+	if state == nil {
 		// fill value
 		var fillValue interface{}
 		if !t.spec.UsePrevious {
@@ -310,7 +305,7 @@ func (t *fillTransformation) adaptedProcess(chunk table.Chunk, state interface{}
 		}
 
 		// populate state
-		dstate = &fillState{
+		state = &fillState{
 			fillValue: fillValue,
 		}
 	}
@@ -372,7 +367,7 @@ func (t *fillTransformation) adaptedProcess(chunk table.Chunk, state interface{}
 		Values:   make([]array.Array, len(chunk.Cols())),
 	}
 
-	if err := t.fillChunk(&buffer, chunk, colIdx, &dstate.fillValue, mem); err != nil {
+	if err := t.fillChunk(&buffer, chunk, colIdx, &state.fillValue, mem); err != nil {
 		return nil, false, err
 	}
 
@@ -380,7 +375,7 @@ func (t *fillTransformation) adaptedProcess(chunk table.Chunk, state interface{}
 	if err := d.Process(out); err != nil {
 		return nil, false, err
 	}
-	return dstate, true, nil
+	return state, true, nil
 }
 
 func (t *fillTransformationAdapter) Close() error { return nil }

--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -115,7 +115,7 @@ func NewLimitTransformation(
 		n:      int(spec.N),
 		offset: int(spec.Offset),
 	}
-	return execute.NewNarrowStateTransformation(id, t, mem)
+	return execute.NewNarrowStateTransformation[*limitState](id, t, mem)
 }
 
 type limitTransformation struct {
@@ -124,21 +124,18 @@ type limitTransformation struct {
 
 func (t *limitTransformation) Process(
 	chunk table.Chunk,
-	state interface{},
+	state *limitState,
 	dataset *execute.TransportDataset,
 	_ arrowmem.Allocator,
-) (interface{}, bool, error) {
+) (*limitState, bool, error) {
 
-	var state_ *limitState
 	// `.Process` is reentrant, so to speak. The first invocation will not
 	// include a value for `state`. Initialization happens here then is passed
 	// in/out for the subsequent calls.
 	if state == nil {
-		state_ = &limitState{n: t.n, offset: t.offset}
-	} else {
-		state_ = state.(*limitState)
+		state = &limitState{n: t.n, offset: t.offset}
 	}
-	return t.processChunk(chunk, state_, dataset)
+	return t.processChunk(chunk, state, dataset)
 }
 
 func (t *limitTransformation) processChunk(

--- a/stdlib/universe/moving_average.go
+++ b/stdlib/universe/moving_average.go
@@ -103,12 +103,11 @@ func NewMovingAverageTransformation(id execute.DatasetID, spec *MovingAveragePro
 	tr := &movingAverageTransformation{
 		n: spec.N,
 	}
-	return execute.NewNarrowStateTransformation(id, tr, mem)
+	return execute.NewNarrowStateTransformation[*movingAverageState](id, tr, mem)
 }
 
-func (m *movingAverageTransformation) Process(chunk table.Chunk, state interface{}, d *execute.TransportDataset, mem memory.Allocator) (interface{}, bool, error) {
-	s, _ := state.(*movingAverageState)
-	newState, err := m.processChunk(chunk, s, d, mem)
+func (m *movingAverageTransformation) Process(chunk table.Chunk, state *movingAverageState, d *execute.TransportDataset, mem memory.Allocator) (*movingAverageState, bool, error) {
+	newState, err := m.processChunk(chunk, state, d, mem)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
This modifies the narrow state transformation to use generics instead of
`interface{}` for its implementation. This should allow us to write code
more easily as it will remove the boilerplate to do a type cast at the
beginning of process.

None of the transformations that use this have been modified. Instead,
they use the generic method but use `interface{}` as their type
parameter.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written