### PR TITLE
chore(pagerduty): limit length of pagerduty summary and capture response body

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -278,7 +278,7 @@ var sourceHashes = map[string]string{
 	"stdlib/kafka/kafka.flux":                                                                     "c93e5a56f16d56d69f905e8fd3b02156ccb41742bb513c9d6fd82b26187ab5e8",
 	"stdlib/math/math.flux":                                                                       "590b501bc712d134fae22c966dc8cec4722b2f5e05853474017ab4d0d93406be",
 	"stdlib/math/math_test.flux":                                                                  "1d84dabb6cb343bc6fce8968f8081a8e5b7f81d457e6c2204f764fbef0f018a4",
-	"stdlib/pagerduty/pagerduty.flux":                                                             "2ae8423b3b01e2908dc4eb8e903097ec0d6b45a9e46e29ea6755c128ddf9e664",
+	"stdlib/pagerduty/pagerduty.flux":                                                             "66279f3596df267f1f013f20ff69c312f984180baac1c537737397d796becfd7",
 	"stdlib/pagerduty/pagerduty_test.flux":                                                        "5337bf32b69869dd4cc9e4ea3abe0cc0d7fef695200bf95dc531edd57a7db2eb",
 	"stdlib/planner/aggregate_window_max_eval_test.flux":                                          "94500e1317564dc35624c2b336a97ddbd2cf55b3d5e2dc7cf59cc3291ad79aca",
 	"stdlib/planner/aggregate_window_max_push_test.flux":                                          "0f51d1bcf032ac6d6076048b633d1c5a6f460b35970ed69c47f1ed1fdbf0b618",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -278,7 +278,7 @@ var sourceHashes = map[string]string{
 	"stdlib/kafka/kafka.flux":                                                                     "c93e5a56f16d56d69f905e8fd3b02156ccb41742bb513c9d6fd82b26187ab5e8",
 	"stdlib/math/math.flux":                                                                       "590b501bc712d134fae22c966dc8cec4722b2f5e05853474017ab4d0d93406be",
 	"stdlib/math/math_test.flux":                                                                  "1d84dabb6cb343bc6fce8968f8081a8e5b7f81d457e6c2204f764fbef0f018a4",
-	"stdlib/pagerduty/pagerduty.flux":                                                             "66279f3596df267f1f013f20ff69c312f984180baac1c537737397d796becfd7",
+	"stdlib/pagerduty/pagerduty.flux":                                                             "417761b43d86a56b37a9d3a2d8eb8209d4055962bbf25a9e98b1dcd1cea1143e",
 	"stdlib/pagerduty/pagerduty_test.flux":                                                        "5337bf32b69869dd4cc9e4ea3abe0cc0d7fef695200bf95dc531edd57a7db2eb",
 	"stdlib/planner/aggregate_window_max_eval_test.flux":                                          "94500e1317564dc35624c2b336a97ddbd2cf55b3d5e2dc7cf59cc3291ad79aca",
 	"stdlib/planner/aggregate_window_max_push_test.flux":                                          "0f51d1bcf032ac6d6076048b633d1c5a6f460b35970ed69c47f1ed1fdbf0b618",

--- a/stdlib/pagerduty/pagerduty.flux
+++ b/stdlib/pagerduty/pagerduty.flux
@@ -233,12 +233,7 @@ sendEvent = (
             else
                 json.encode(v: {data with payload: {payload with custom_details: customDetails}})
 
-        return requests.do(
-            method: "POST",
-            url: pagerdutyURL,
-            body: enc,
-            headers: headers,
-        )
+        return requests.do(method: "POST", url: pagerdutyURL, body: enc, headers: headers)
     }
 
 // endpoint returns a function that sends a message to PagerDuty that includes output data.
@@ -335,6 +330,9 @@ endpoint = (url=defaultURL) =>
                                 customDetails: record.get(r: obj, key: "customDetails", default: record.any),
                             )
 
-                        return {r with _sent: string(v: 2 == response.statusCode / 100), _status: string(v: response.statusCode), _body: string(v: response.body)}
+                        return {r with _sent: string(v: 2 == response.statusCode / 100),
+                            _status: string(v: response.statusCode),
+                            _body: string(v: response.body),
+                        }
                     },
                 )

--- a/stdlib/pagerduty/pagerduty.flux
+++ b/stdlib/pagerduty/pagerduty.flux
@@ -210,7 +210,7 @@ sendEvent = (
     ) =>
     {
         payload = {
-            summary: summary,
+            summary: strings.substring(start: 0, end: 425, v: summary),
             timestamp: timestamp,
             source: source,
             component: component,

--- a/stdlib/pagerduty/pagerduty.flux
+++ b/stdlib/pagerduty/pagerduty.flux
@@ -226,7 +226,7 @@ sendEvent = (
             client: client,
             client_url: clientURL,
         }
-        headers = {"Accept": "application/vnd.pagerduty+json;version=2", "Content-Type": "application/json"}
+        headers = ["Accept": "application/vnd.pagerduty+json;version=2", "Content-Type": "application/json"]
         enc =
             if customDetails == record.any then
                 json.encode(v: data)

--- a/stdlib/pagerduty/pagerduty_test.go
+++ b/stdlib/pagerduty/pagerduty_test.go
@@ -232,6 +232,22 @@ func TestPagerdutySendEvent(t *testing.T) {
 			level:         "crit",
 		},
 		{
+			name:          "longSummary",
+			otherGroupKey: "foo",
+			pagerdutyURL:  s.URL,
+			routingKey:    "fakeRoutingKey",
+			client:        "fakeClient1",
+			clientURL:     "http://fakepagerduty.com",
+			class:         "deploy",
+			group:         "app-stack",
+			severity:      "critical",
+			source:        "monitoringtool:vendor:region",
+			summary:       strings.Repeat("l", 1048),
+			timestamp:     "2015-07-17T08:42:58.315+0000",
+			eventAction:   "trigger",
+			level:         "crit",
+		},
+		{
 			name:          "resolve",
 			otherGroupKey: "foo2",
 			pagerdutyURL:  s.URL,
@@ -396,7 +412,7 @@ data = "
 				t.Errorf("got client URL %s, expected %s", req.PostData.ClientURL, tc.clientURL)
 			}
 
-			if req.PostData.Payload.Summary != tc.summary {
+			if req.PostData.Payload.Summary != capLen(tc.summary, 1023) {
 				t.Errorf("got summary %s, expected %s", req.PostData.Payload.Summary, tc.summary)
 			}
 
@@ -438,4 +454,11 @@ data = "
 
 		})
 	}
+}
+
+func capLen(s string, i int) string {
+	if len(s) < i {
+		return s
+	}
+	return s[:i]
 }


### PR DESCRIPTION
By capturing the response body, debugging becomes easier in the case that pagerduty rejects the alert. This also truncates the summary if it is too large for pagerduty to accept, preemptively handling a failure scenario.

I have had difficulty with this working in practice (manually updating the vendored flux library and deploying), but running manual queries in query explorer with the changes to the `pagerduty.flux` file result in working/expected results. I can redact and post that query here if needed.

### Done checklist
- [x] docs/SPEC.md updated (**N/A**)
- [x] Test cases written
