### PR TITLE
feat(plan): add a rule to remove redundant sort nodes

### DIFF
--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -394,6 +394,17 @@ func (c *SimpleAggregateConfig) ReadArgs(args flux.Arguments) error {
 	return nil
 }
 
+// PassThroughAttribute implements the PassThroughAttributer interface used by
+// the planner. Aggregate functions preserve collation of their input rows,
+// albeit trivially, since there can be only one row in each output table.
+func (c SimpleAggregateConfig) PassThroughAttribute(attrKey string) bool {
+	switch attrKey {
+	case plan.CollationKey:
+		return true
+	}
+	return false
+}
+
 func NewSimpleAggregateTransformation(ctx context.Context, id DatasetID, agg SimpleAggregate, config SimpleAggregateConfig, mem memory.Allocator) (Transformation, Dataset, error) {
 	if feature.AggregateTransformationTransport().Enabled(ctx) {
 		tr := &simpleAggregateTransformation2{

--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -38,6 +38,7 @@ var testFlags = map[string]interface{}{
 	"optimizeStateTracking":     true,
 	"optimizeSetTransformation": true,
 	"experimentalTestingDiff":   true,
+	"removeRedundantSortNodes":  true,
 }
 
 type TestFlagger map[string]interface{}

--- a/execute/selector.go
+++ b/execute/selector.go
@@ -47,6 +47,16 @@ type indexSelectorTransformation struct {
 	selector IndexSelector
 }
 
+// PassThroughAttribute implements the PassThroughAttributer interface used by
+// the planner. Selector functions preserve collation of their input rows.
+func (c SelectorConfig) PassThroughAttribute(attrKey string) bool {
+	switch attrKey {
+	case plan.CollationKey:
+		return true
+	}
+	return false
+}
+
 func NewRowSelectorTransformationAndDataset(id DatasetID, mode AccumulationMode, selector RowSelector, config SelectorConfig, a memory.Allocator) (*rowSelectorTransformation, Dataset) {
 	cache := NewTableBuilderCache(a)
 	d := NewDataset(id, mode, cache)

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -197,6 +197,18 @@ func ExperimentalTestingDiff() BoolFlag {
 	return experimentalTestingDiff
 }
 
+var removeRedundantSortNodes = feature.MakeBoolFlag(
+	"Remove Redundant Sort Nodes",
+	"removeRedundantSortNodes",
+	"Chris Wolff",
+	false,
+)
+
+// RemoveRedundantSortNodes - Planner will remove sort nodes when tables are already sorted
+func RemoveRedundantSortNodes() BoolFlag {
+	return removeRedundantSortNodes
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -218,6 +230,7 @@ var all = []Flag{
 	unusedSymbolWarnings,
 	vectorizedConst,
 	experimentalTestingDiff,
+	removeRedundantSortNodes,
 }
 
 var byKey = map[string]Flag{
@@ -236,6 +249,7 @@ var byKey = map[string]Flag{
 	"unusedSymbolWarnings":             unusedSymbolWarnings,
 	"vectorizedConst":                  vectorizedConst,
 	"experimentalTestingDiff":          experimentalTestingDiff,
+	"removeRedundantSortNodes":         removeRedundantSortNodes,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -99,3 +99,9 @@
   key: experimentalTestingDiff
   default: false
   contact: Jonathan Sternberg
+
+- name: Remove Redundant Sort Nodes
+  description: Planner will remove sort nodes when tables are already sorted
+  key: removeRedundantSortNodes
+  default: false
+  contact: Chris Wolff

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -578,6 +578,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/skew_test.flux":                                                              "7782d41c563c77ba9f4176fa1b5f4f6107e418b7ea301e4896398dbcb514315a",
 	"stdlib/universe/sort2_test.flux":                                                             "1d2043c0d0b38abb8dc61fc1baa6d6052fae63fea55cc6e67fd1600911513bdb",
 	"stdlib/universe/sort_limit_test.flux":                                                        "c595da9613faf8734932d8c2e63291517b7842b5656f795b32d50e987493ec2a",
+	"stdlib/universe/sort_rules_test.flux":                                                        "8f956af4b06ea75f9b5eba19456c9c091ad39d4aeaf9459f267e2fcc87b58e13",
 	"stdlib/universe/sort_test.flux":                                                              "f69ebb5972762078e759af3c1cd3d852431a569dce74f3c379709c9e174bfa31",
 	"stdlib/universe/spread_test.flux":                                                            "1ddf25e4d86b6365da254229fc8f77bd838c24a79e6a08c9c4c50330ace0a6a3",
 	"stdlib/universe/state_count_test.flux":                                                       "c52be54b9656a2c51e1cfb5115d0a7ac4b06fefa5cd03d90f1a7e193f77b17a7",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -578,7 +578,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/skew_test.flux":                                                              "7782d41c563c77ba9f4176fa1b5f4f6107e418b7ea301e4896398dbcb514315a",
 	"stdlib/universe/sort2_test.flux":                                                             "1d2043c0d0b38abb8dc61fc1baa6d6052fae63fea55cc6e67fd1600911513bdb",
 	"stdlib/universe/sort_limit_test.flux":                                                        "c595da9613faf8734932d8c2e63291517b7842b5656f795b32d50e987493ec2a",
-	"stdlib/universe/sort_rules_test.flux":                                                        "8f956af4b06ea75f9b5eba19456c9c091ad39d4aeaf9459f267e2fcc87b58e13",
+	"stdlib/universe/sort_rules_test.flux":                                                        "0770ae42e99b04167ca5bef8340a310b224baf1ba1928997273de9663b64684a",
 	"stdlib/universe/sort_test.flux":                                                              "f69ebb5972762078e759af3c1cd3d852431a569dce74f3c379709c9e174bfa31",
 	"stdlib/universe/spread_test.flux":                                                            "1ddf25e4d86b6365da254229fc8f77bd838c24a79e6a08c9c4c50330ace0a6a3",
 	"stdlib/universe/state_count_test.flux":                                                       "c52be54b9656a2c51e1cfb5115d0a7ac4b06fefa5cd03d90f1a7e193f77b17a7",

--- a/plan/attributes.go
+++ b/plan/attributes.go
@@ -84,20 +84,24 @@ func CheckRequiredAttributes(node *PhysicalPlanNode) error {
 
 	for i, reqAttrMap := range reqAttrsSlice {
 		for _, reqAttr := range reqAttrMap {
-			ppred := node.Predecessors()[i].(*PhysicalPlanNode)
-			haveAttr, n := getOutputAttributeWithNode(node.Predecessors()[i].(*PhysicalPlanNode), reqAttr.Key())
+			pred := node.Predecessors()[i]
+			haveAttr, n := getOutputAttributeWithNode(pred, reqAttr.Key())
 			if haveAttr == nil {
-				return errors.Newf(codes.Internal,
-					"attribute %q, required by %q, is missing from predecessor %q",
+				msg := fmt.Sprintf("attribute %q, required by %q, is missing from predecessor %q",
 					reqAttr.Key(), node.ID(), n.ID(),
 				)
+				if _, ok := n.(*LogicalNode); ok {
+					// Logical nodes do not have attributes
+					msg += " which is a logical node"
+				}
+				return errors.New(codes.Internal, msg)
 			}
 
 			if !reqAttr.SatisfiedBy(haveAttr) {
 				return errors.Newf(codes.Internal,
 					"node %q requires attribute %v, which is not satisfied by predecessor %q, "+
 						"which has attribute %v",
-					node.ID(), reqAttr, ppred.ID(), haveAttr,
+					node.ID(), reqAttr, pred.ID(), haveAttr,
 				)
 			}
 		}
@@ -117,15 +121,20 @@ func GetOutputAttribute(node *PhysicalPlanNode, attrKey string) PhysicalAttr {
 	return attr
 }
 
-func getOutputAttributeWithNode(node *PhysicalPlanNode, attrKey string) (PhysicalAttr, *PhysicalPlanNode) {
-	if attr, ok := node.outputAttrs()[attrKey]; ok {
+func getOutputAttributeWithNode(node Node, attrKey string) (PhysicalAttr, Node) {
+	pn, ok := node.(*PhysicalPlanNode)
+	if !ok {
+		return nil, node
+	}
+
+	if attr, ok := pn.outputAttrs()[attrKey]; ok {
 		return attr, nil
 	}
 
-	if node.passesThroughAttr(attrKey) && len(node.Predecessors()) == 1 {
+	if pn.passesThroughAttr(attrKey) && len(pn.Predecessors()) == 1 {
 		// TODO(cwolff): consider what it means for nodes with multiple predecessors
 		//   (e.g. join or union) to pass on attributes.
-		return getOutputAttributeWithNode(node.Predecessors()[0].(*PhysicalPlanNode), attrKey)
+		return getOutputAttributeWithNode(node.Predecessors()[0], attrKey)
 	}
 
 	return nil, node
@@ -150,18 +159,22 @@ func CheckSuccessorsMustRequire(node *PhysicalPlanNode) error {
 		}
 
 		for _, succ := range node.Successors() {
-			reqd, n := requiredBySuccessor(attr, node, succ.(*PhysicalPlanNode))
+			reqd, n := requiredBySuccessor(attr, node, succ)
 			if reqd {
 				continue
 			}
 
 			if n != nil {
+				msg := fmt.Sprintf("plan node %q has attribute %q that must be required by successors, "+
+					"but it is not required or propagated by successor %q",
+					node.ID(), attr.Key(), n.ID(),
+				)
+				if _, ok := n.(*LogicalNode); ok {
+					msg += " which is a logical node"
+				}
 				return &flux.Error{
 					Code: codes.Internal,
-					Msg: fmt.Sprintf("plan node %q has attribute %q that must be required by successors, "+
-						"but it is not required or propagated by successor %q",
-						node.ID(), attr.Key(), n.ID(),
-					),
+					Msg:  msg,
 				}
 			}
 
@@ -182,19 +195,24 @@ func CheckSuccessorsMustRequire(node *PhysicalPlanNode) error {
 // succ passes through the attribute and one of its successors requires the attribute.
 // If the attribute is not required, this function returns false and the node that neither passes
 // along nor requires the attribute.
-func requiredBySuccessor(requiredAttr PhysicalAttr, node, succ *PhysicalPlanNode) (bool, *PhysicalPlanNode) {
-	i := indexOfNode(node, succ.Predecessors())
-	if _, ok := succ.requiredAttrs()[i][requiredAttr.Key()]; ok {
+func requiredBySuccessor(requiredAttr PhysicalAttr, node, succ Node) (bool, Node) {
+	psucc, ok := succ.(*PhysicalPlanNode)
+	if !ok {
+		return false, succ
+	}
+
+	i := indexOfNode(node, psucc.Predecessors())
+	if _, ok := psucc.requiredAttrs()[i][requiredAttr.Key()]; ok {
 		return true, succ
 	}
-	if succ.passesThroughAttr(requiredAttr.Key()) {
+	if psucc.passesThroughAttr(requiredAttr.Key()) {
 		if len(succ.Successors()) == 0 {
 			return false, nil
 		}
 		// If this node does not require the attribute itself but passes it along,
 		// see if any successors require it.
-		for _, ssucc := range succ.Successors() {
-			if reqd, n := requiredBySuccessor(requiredAttr, succ, ssucc.(*PhysicalPlanNode)); !reqd {
+		for _, ssucc := range psucc.Successors() {
+			if reqd, n := requiredBySuccessor(requiredAttr, succ, ssucc); !reqd {
 				return false, n
 			}
 		}

--- a/plan/attributes.go
+++ b/plan/attributes.go
@@ -116,7 +116,7 @@ func CheckRequiredAttributes(node *PhysicalPlanNode) error {
 //   sort |> filter
 // The "filter" node will still provide the collation attribute, even though it's
 // the "sort" node that actually does the collating.
-func GetOutputAttribute(node *PhysicalPlanNode, attrKey string) PhysicalAttr {
+func GetOutputAttribute(node Node, attrKey string) PhysicalAttr {
 	attr, _ := getOutputAttributeWithNode(node, attrKey)
 	return attr
 }

--- a/stdlib/internal/debug/pass.go
+++ b/stdlib/internal/debug/pass.go
@@ -63,6 +63,13 @@ func (s *PassProcedureSpec) Copy() plan.ProcedureSpec {
 	return new(PassProcedureSpec)
 }
 
+// PassThroughAttribute implements the PassThroughAttributer interface used
+// by the planner. This implementation says that any attributes provided by
+// input to this transformation are also propagated to its output.
+func (s *PassProcedureSpec) PassThroughAttribute(attrKey string) bool {
+	return true
+}
+
 // TriggerSpec implements plan.TriggerAwareProcedureSpec
 func (s *PassProcedureSpec) TriggerSpec() plan.TriggerSpec {
 	return plan.NarrowTransformationTriggerSpec{}

--- a/stdlib/join/sort_merge_join.go
+++ b/stdlib/join/sort_merge_join.go
@@ -79,7 +79,7 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 		sortProc := universe.SortProcedureSpec{
 			Columns: columns,
 		}
-		sortNode := plan.CreateUniquePhysicalNode(ctx, "sortMergeJoin", &sortProc)
+		sortNode := plan.CreateUniquePhysicalNode(ctx, name, &sortProc)
 
 		sortNode.AddPredecessors(parentNode)
 		sortNode.AddSuccessors(n)

--- a/stdlib/join/sort_merge_join.go
+++ b/stdlib/join/sort_merge_join.go
@@ -75,7 +75,7 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 	predecessors := n.Predecessors()
 	n.ClearPredecessors()
 
-	makeSortNode := func(parentNode plan.Node, columns []string) *plan.PhysicalPlanNode {
+	makeSortNode := func(name string, parentNode plan.Node, columns []string) *plan.PhysicalPlanNode {
 		sortProc := universe.SortProcedureSpec{
 			Columns: columns,
 		}
@@ -94,7 +94,7 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 	for _, pair := range spec.On {
 		columns = append(columns, pair.Left)
 	}
-	successors[0] = makeSortNode(predecessors[0], columns)
+	successors[0] = makeSortNode("sort_join_lhs", predecessors[0], columns)
 
 	successors = predecessors[1].Successors()
 
@@ -102,7 +102,7 @@ func (SortMergeJoinPredicateRule) Rewrite(ctx context.Context, n plan.Node) (pla
 	for _, pair := range spec.On {
 		columns = append(columns, pair.Right)
 	}
-	successors[0] = makeSortNode(predecessors[1], columns)
+	successors[0] = makeSortNode("sort_join_rhs", predecessors[1], columns)
 
 	// Replace the spec so we don't end up trying to apply this rewrite forever
 	x := SortMergeJoinProcedureSpec(*spec)

--- a/stdlib/universe/aggregate_window.go
+++ b/stdlib/universe/aggregate_window.go
@@ -61,13 +61,15 @@ func (s *AggregateWindowProcedureSpec) RequiredAttributes() []plan.PhysicalAttri
 
 // OutputAttributes will reflect that this operation can behave as a parallel merge,
 // and produce the parallel merge attribute if the merge factor is greater than one.
+// This operation produces tables that are sorted on _time.
 func (s *AggregateWindowProcedureSpec) OutputAttributes() plan.PhysicalAttributes {
-	if s.ParallelMergeFactor > 1 {
-		return plan.PhysicalAttributes{
-			plan.ParallelMergeKey: plan.ParallelMergeAttribute{Factor: s.ParallelMergeFactor},
-		}
+	m := plan.PhysicalAttributes{
+		plan.CollationKey: &plan.CollationAttr{Columns: []string{execute.DefaultTimeColLabel}},
 	}
-	return nil
+	if s.ParallelMergeFactor > 1 {
+		m[plan.ParallelMergeKey] = plan.ParallelMergeAttribute{Factor: s.ParallelMergeFactor}
+	}
+	return m
 }
 
 func (s *AggregateWindowProcedureSpec) Kind() plan.ProcedureKind {

--- a/stdlib/universe/pivot.gen.go
+++ b/stdlib/universe/pivot.gen.go
@@ -17,6 +17,8 @@ import (
 
 //lint:file-ignore U1000 Ignore all unused code, it's generated
 
+// mergeKeys finds all the unique values of the row key across each buffer,
+// and return them in a single array sorted in ascending order.
 func (gr *pivotTableGroup) mergeKeys(mem memory.Allocator) array.Array {
 	switch gr.rowCol.Type {
 

--- a/stdlib/universe/pivot.gen.go.tmpl
+++ b/stdlib/universe/pivot.gen.go.tmpl
@@ -13,6 +13,8 @@ import (
 
 {{ $types := . }}
 
+// mergeKeys finds all the unique values of the row key across each buffer,
+// and return them in a single array sorted in ascending order.
 func (gr *pivotTableGroup) mergeKeys(mem memory.Allocator) array.Array {
 	switch gr.rowCol.Type {
 	{{range .}}

--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -436,6 +436,16 @@ func (s *SortedPivotProcedureSpec) Copy() plan.ProcedureSpec {
 	return ns
 }
 
+// OutputAttributes implements the OutputAttributer interface used by the planner
+// to keep track of various data attributes at different points in the plan.
+// For sorted pivot, we know that the input data will be sorted on the row key, and that the
+// output of this operation will preserve that order.
+func (s *SortedPivotProcedureSpec) OutputAttributes() plan.PhysicalAttributes {
+	return plan.PhysicalAttributes{
+		plan.CollationKey: &plan.CollationAttr{Columns: s.RowKey},
+	}
+}
+
 func createSortedPivotTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
 	s, ok := spec.(*SortedPivotProcedureSpec)
 	if !ok {

--- a/stdlib/universe/range.go
+++ b/stdlib/universe/range.go
@@ -84,6 +84,14 @@ func (s *RangeProcedureSpec) TimeBounds(predecessorBounds *plan.Bounds) *plan.Bo
 	return bounds
 }
 
+func (s *RangeProcedureSpec) PassThroughAttribute(attrKey string) bool {
+	switch attrKey {
+	case plan.CollationKey:
+		return true
+	}
+	return false
+}
+
 func newRangeProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
 	spec, ok := qs.(*RangeOpSpec)
 

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -500,13 +500,7 @@ func (r RemoveRedundantSort) Rewrite(ctx context.Context, node plan.Node) (plan.
 		return node, false, nil
 	}
 
-	pred, ok := node.Predecessors()[0].(*plan.PhysicalPlanNode)
-	if !ok {
-		// Predecessor is not yet a physical node. It probably will be
-		// after another rule is applied to transform it.
-		return node, false, nil
-	}
-
+	pred := node.Predecessors()[0]
 	inputCollation := plan.GetOutputAttribute(pred, plan.CollationKey)
 	if inputCollation == nil {
 		return node, false, nil // input to sort is not already sorted

--- a/stdlib/universe/sort_rules_test.flux
+++ b/stdlib/universe/sort_rules_test.flux
@@ -103,7 +103,7 @@ testcase remove_sort_selector {
     testing.diff(want, got) |> yield()
 }
 
-testcase remove_sort_filter {
+testcase remove_sort_filter_range {
     expect.planner(rules: ["universe/RemoveRedundantSort": 1])
 
     input =
@@ -111,8 +111,10 @@ testcase remove_sort_filter {
             |> sort(columns: ["i"])
     got =
         input
+            |> range(start: -100y)
             |> filter(fn: (r) => r.i < 100)
             |> sort(columns: ["i"])
+            |> drop(columns: ["_start", "_stop"])
     want =
         input
             |> filter(fn: (r) => r.i < 100)

--- a/stdlib/universe/sort_rules_test.flux
+++ b/stdlib/universe/sort_rules_test.flux
@@ -1,0 +1,180 @@
+package universe_test
+
+
+import "array"
+import "internal/debug"
+import "join"
+import "testing"
+import "testing/expect"
+
+rows =
+    array.from(
+        rows: [
+            {_time: 2010-11-11T00:00:00Z, i: 10, desc: "cat"},
+            {_time: 2010-11-11T00:00:10Z, i: 9, desc: "dog"},
+            {_time: 2010-11-11T00:00:20Z, i: 8, desc: "tiger"},
+            {_time: 2010-11-11T00:00:30Z, i: 7, desc: "bear"},
+            {_time: 2010-11-11T00:00:40Z, i: 6, desc: "lion"},
+            {_time: 2010-11-11T00:00:50Z, i: 5, desc: "zebra"},
+            {_time: 2010-11-11T00:01:00Z, i: 4, desc: "koala"},
+            {_time: 2010-11-11T00:01:10Z, i: 3, desc: "giraffe"},
+            {_time: 2010-11-11T00:01:20Z, i: 2, desc: "canary"},
+            {_time: 2010-11-11T00:01:30Z, i: 1, desc: "gazelle"},
+        ],
+    )
+
+testcase remove_sort {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 1])
+
+    input =
+        rows
+            |> sort(columns: ["i"])
+    got =
+        input
+            // workaround for https://github.com/influxdata/flux/issues/4699
+            |> debug.pass()
+            |> sort(columns: ["i"])
+    want = input
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_more_columns {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 1])
+
+    input =
+        rows
+            |> sort(columns: ["i", "desc"])
+    got =
+        input
+            // workaround for https://github.com/influxdata/flux/issues/4699
+            |> debug.pass()
+            |> sort(columns: ["i"])
+    want = input
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_fewer_columns {
+    // sort should not be removed here because input rows
+    // are not sorted by "desc"
+    expect.planner(rules: ["universe/RemoveRedundantSort": 0])
+
+    input =
+        rows
+            |> sort(columns: ["i"])
+    got =
+        input
+            // workaround for https://github.com/influxdata/flux/issues/4699
+            |> debug.pass()
+            |> sort(columns: ["i", "desc"])
+    want = input
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_aggregate {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 1])
+
+    input =
+        rows
+            |> sort(columns: ["i"])
+    got =
+        input
+            |> sum(column: "i")
+            |> sort(columns: ["i"])
+    want = input |> sum(column: "i")
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_selector {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 1])
+
+    input =
+        rows
+            |> sort(columns: ["i"])
+    got =
+        input
+            |> min(column: "i")
+            |> sort(columns: ["i"])
+    want = input |> min(column: "i")
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_filter {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 1])
+
+    input =
+        rows
+            |> sort(columns: ["i"])
+    got =
+        input
+            |> filter(fn: (r) => r.i < 100)
+            |> sort(columns: ["i"])
+    want =
+        input
+            |> filter(fn: (r) => r.i < 100)
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_aggregate_window {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 1])
+
+    input =
+        rows
+            |> range(start: 2010-11-11T00:00:00Z, stop: 2010-11-11T00:05:00Z)
+    got =
+        input
+            // workaround for https://github.com/influxdata/flux/issues/4699
+            |> debug.pass()
+            |> aggregateWindow(every: 30s, fn: sum, column: "i")
+            |> sort(columns: ["_time"])
+    want =
+        input
+            |> debug.pass()
+            // workaround for https://github.com/influxdata/flux/issues/4699
+            |> aggregateWindow(every: 30s, fn: sum, column: "i")
+
+    testing.diff(want, got) |> yield()
+}
+
+testcase remove_sort_join {
+    expect.planner(rules: ["universe/RemoveRedundantSort": 2])
+
+    inputLeft = rows
+    inputRight = rows
+
+    sortTime = (tables=<-) => tables |> sort(columns: ["_time"])
+
+    // When join is planned, it will get sort nodes generated for each input
+    //   join(left, right)
+    // becomes
+    //   join(sort(left), sort(right))
+    //
+    // Since both inputs to the join are already sorted, the planner should remove both
+    // of the generated sort nodes, hence the rule will fire twice.
+    got =
+        join.time(
+            left: inputLeft |> sortTime(),
+            right: inputRight |> sortTime(),
+            as: (l, r) => {
+                return {_time: l._time, ldesc: l.desc, rdesc: r.desc, i: l.i}
+            },
+        )
+
+    // Neither side is sorted, so the generated sort nodes will remain,
+    // hence the rule will *not* fire four times.
+    want =
+        join.time(
+            left: inputLeft |> debug.pass(),
+            right: inputRight |> debug.pass(),
+            as: (l, r) => {
+                return {_time: l._time, ldesc: l.desc, rdesc: r.desc, i: l.i}
+            },
+        )
+
+    testing.diff(want, got) |> yield()
+}


### PR DESCRIPTION
This PR is part of #4628.

Like the title says, this adds a planner rule (behind a feature flag) and associated tests that demonstrate sort nodes being removed.

I did a quick pass over our transformations to find the ones that preserve collation, and added `PassThroughAttributer` implementations as needed. For the case of `aggregateWindow` it always generates rows sorted by `_time` so I implemented `OutputAttirbuter` for that transformation as well.

