### PR TITLE
fix: passing epsilon value from go test to test framework

### DIFF
--- a/execute/executetest/result.go
+++ b/execute/executetest/result.go
@@ -71,7 +71,7 @@ func (ti *TableIterator) Do(f func(flux.Table) error) error {
 func EqualResults(want, got []flux.Result) error {
 	wantTables := convertResults(want)
 	gotTables := convertResults(got)
-	if diff := cmp.Diff(wantTables, gotTables, floatOptions); diff != "" {
+	if diff := cmp.Diff(wantTables, gotTables, defaultFloatOptions); diff != "" {
 		return fmt.Errorf("unexpected iterator results; -want/+got\n%s", diff)
 	}
 	return nil
@@ -90,7 +90,7 @@ func EqualResultIterators(want, got flux.ResultIterator) error {
 	wantResults, wantErr := readAllIterator(want)
 	gotResults, gotErr := readAllIterator(got)
 
-	if diff := cmp.Diff(wantResults, gotResults, floatOptions); diff != "" {
+	if diff := cmp.Diff(wantResults, gotResults, defaultFloatOptions); diff != "" {
 		return fmt.Errorf("unexpected iterator results; -want/+got\n%s", diff)
 	}
 	if wantErr == nil && gotErr == nil {
@@ -127,7 +127,7 @@ func readAllIterator(iter flux.ResultIterator) ([][]*Table, error) {
 func EqualResult(w, g flux.Result) error {
 	want := ConvertResult(w)
 	got := ConvertResult(g)
-	if diff := cmp.Diff(want, got, floatOptions); diff != "" {
+	if diff := cmp.Diff(want, got, defaultFloatOptions); diff != "" {
 		return fmt.Errorf("unexpected tables -want/+got\n%s", diff)
 	}
 	return nil

--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -368,7 +368,7 @@ func RunSourceHelper(
 	sort.Sort(SortedTables(got))
 	sort.Sort(SortedTables(want))
 
-	if !cmp.Equal(want, got, floatOptions) {
+	if !cmp.Equal(want, got, defaultFloatOptions) {
 		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
 	}
 }

--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -31,7 +31,7 @@ const ulp uint = 2
 // Comparison options for floating point values.
 // NaNs are considered equal, and float64s must
 // be sufficiently close to be considered equal.
-var floatOptions = cmp.Options{
+var defaultFloatOptions = cmp.Options{
 	cmpopts.EquateNaNs(),
 	cmp.FilterValues(func(x, y float64) bool {
 		return !math.IsNaN(x) && !math.IsNaN(y)
@@ -50,12 +50,15 @@ var floatOptions = cmp.Options{
 	})),
 }
 
+// floatOptions is a list of comparison options for floating point values.
+// if not passed by the caller, defaultFloatOptions will be used
 func ProcessTestHelper(
 	t *testing.T,
 	data []flux.Table,
 	want []*Table,
 	wantErr error,
 	create func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation,
+	floatOptions ...cmp.Option,
 ) {
 	t.Helper()
 
@@ -109,17 +112,26 @@ func ProcessTestHelper(
 	sort.Sort(SortedTables(got))
 	sort.Sort(SortedTables(want))
 
-	if !cmp.Equal(want, got, floatOptions) {
+	opts := make([]cmp.Option, 0, len(defaultFloatOptions)+len(floatOptions))
+	if len(floatOptions) > 0 {
+		opts = append(opts, floatOptions...)
+	} else {
+		opts = append(opts, defaultFloatOptions...)
+	}
+	if !cmp.Equal(want, got, opts...) {
 		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
 	}
 }
 
+// floatOptions is a list of comparison options for floating point values.
+// if not passed by the caller, defaultFloatOptions will be used
 func ProcessTestHelper2(
 	t *testing.T,
 	data []flux.Table,
 	want []*Table,
 	wantErr error,
 	create func(id execute.DatasetID, alloc memory.Allocator) (execute.Transformation, execute.Dataset),
+	floatOptions ...cmp.Option,
 ) {
 	t.Helper()
 
@@ -173,7 +185,13 @@ func ProcessTestHelper2(
 	sort.Sort(SortedTables(got))
 	sort.Sort(SortedTables(want))
 
-	if !cmp.Equal(want, got, floatOptions) {
+	opts := make([]cmp.Option, 0, len(defaultFloatOptions)+len(floatOptions))
+	if len(floatOptions) > 0 {
+		opts = append(opts, floatOptions...)
+	} else {
+		opts = append(opts, defaultFloatOptions...)
+	}
+	if !cmp.Equal(want, got, opts...) {
 		t.Errorf("unexpected tables -want/+got\n%s", cmp.Diff(want, got))
 	}
 }

--- a/stdlib/universe/holt_winters_test.go
+++ b/stdlib/universe/holt_winters_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
@@ -18,6 +20,12 @@ import (
 	"github.com/influxdata/flux/stdlib/influxdata/influxdb"
 	"github.com/influxdata/flux/stdlib/universe"
 )
+
+const epsilon float64 = 1e-5
+
+var floatOptions = cmp.Options{
+	cmpopts.EquateApprox(0, epsilon),
+}
 
 func TestHoltWinters_NewQuery(t *testing.T) {
 	tests := []querytest.NewQueryTestCase{
@@ -908,6 +916,7 @@ func TestHoltWinters_Process(t *testing.T) {
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
 					return universe.NewHoltWintersTransformation(d, c, alloc, tc.spec)
 				},
+				floatOptions,
 			)
 
 			for i := 0; i < 30; i++ {
@@ -1009,6 +1018,7 @@ func TestHoltWinters_Error_Process(t *testing.T) {
 				func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
 					return universe.NewHoltWintersTransformation(d, c, alloc, tc.spec)
 				},
+				floatOptions,
 			)
 
 			for i := 0; i < 30; i++ {


### PR DESCRIPTION
Some test flakiness has been reported for the holt winter test.
```
--- FAIL: TestHoltWinters_Process (35.48s)
    --- FAIL: TestHoltWinters_Process/NOAA_water_-_with_nulls_and_missing_-_no_seasonal (17.15s)
        holt_winters_test.go:903: unexpected tables -want/+got
              []*executetest.Table{
                &{
                        ... // 2 identical fields
                        KeyValues: nil,
                        ColMeta:   {{Label: "_time", Type: s"time"}, {Label: "_value", Type: s"float"}, {Label: "minSSE", Type: s"float"}},
                        Data: [][]any{
                                {
                                        s"2015-08-27T22:13:00.000000000Z",
            -                           float64(6.517746679116747),
            +                           float64(6.517761275336982),
            -                           float64(30.52018686151099),
            +                           float64(30.520187390109854),
                                },
```

In the testing framework, we have epsilon value defaults to [1e-6](https://github.com/influxdata/flux/blob/89d78e05caee30f2ff09cd6b23bf6162c65f324d/execute/executetest/transformation.go#L25) for float operations. There is no way to change it just for one Go test. So this change is to allow Go test to pass their own value of epsilon(with default value 1e-6). 

For the holt winter, epsilon of 1e-3 should suffice, as we do not need a more precise comparison. 