### PR TITLE
fix(stdlib): ignore unknown messages rather than erroring

### DIFF
--- a/execute/transport.go
+++ b/execute/transport.go
@@ -24,6 +24,11 @@ import (
 // Transport is an interface for handling raw messages.
 type Transport interface {
 	// ProcessMessage will process a message in the Transport.
+	//
+	// Messages sent to the Transport may be one of many types.
+	// Known message should be handled as is appropriate, but
+	// unknown messages should be acked but otherwise ignored.
+	// An error should not be returned for unknown messages.
 	ProcessMessage(m Message) error
 }
 

--- a/stdlib/join/merge_join.go
+++ b/stdlib/join/merge_join.go
@@ -128,8 +128,6 @@ func (t *MergeJoinTransformation) ProcessMessage(m execute.Message) error {
 			})
 			t.d.Finish(err)
 		}
-	default:
-		return errors.New(codes.Internal, "invalid message")
 	}
 	return nil
 }


### PR DESCRIPTION
The process message method is intended to ignore messages it does not
understand rather than actively return an error. This removes the error
from join for an invalid message.

### Done checklist
- [x] docs/SPEC.md updated
- [x] Test cases written