### PR TITLE
chore: update PR template to encourage safe stdlib additions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,11 @@
+### Checklist
 
-### Done checklist
-- [ ] docs/SPEC.md updated
-- [ ] Test cases written
+Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.
+
+- [ ] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
+- [ ] 🔗 Reference related issues
+- [ ] 🏃 Test cases are included to exercise the new code
+- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
+- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated
+
+Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.


### PR DESCRIPTION
While flux is in the pre-1.0 stage it can be difficult to make changes to APIs offered by the stdlib _once they are introduced_.

In an effort to encourage a more measured approach when introducing new packages to the flux standard library, the team discussed specifically calling this act out in the PR template. Specifically, we want _new packages_ to be introduced first under the `experimental/` directory since we have a more permissive social contract there as far as making breaking API changes go.

Checklist items that aren't relevant to the diff can be checked but should also be acknowledged by noting them as **N/A**, or otherwise making remarks in the PR description itself.

As an interesting edge case, here's the new checklist in action for a PR that doesn't actually contain any code.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues **N/A**
- [x] 🏃 Test cases are included to exercise the new code **N/A**
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` **N/A**
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated **N/A**

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
