### PR TITLE
fix: check bounds using rune array instead of string len in substring

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -337,7 +337,7 @@ var sourceHashes = map[string]string{
 	"stdlib/sql/sql.flux":                                                                         "b1d5ed22a2db2046b98d8fb43b8b84e32a613681943260b8990564f12998c7a6",
 	"stdlib/sql/sql_test.flux":                                                                    "7341037a1d2633daa7dead0073502191943515d8c0e8a1372e18dd3b11a31049",
 	"stdlib/strings/strings.flux":                                                                 "15f029bbc9e907e09fdb41507df50208d5ad10c216256da68c4595d818483f2d",
-	"stdlib/strings/strings_test.flux":                                                            "38bfdd79945c5371441c09a59528482a46731762b4ea33b933360fbce6ef4d0a",
+	"stdlib/strings/strings_test.flux":                                                            "7ce13e3bbb4fa09759ca173c7582682ffa9c885a56f7eb2f8cbc867ca6385e7f",
 	"stdlib/system/system.flux":                                                                   "ce0b1ed2fa5cbf52345b3eccfd54a7637021d361a1c6c7f204b51fcfe4d9683a",
 	"stdlib/testing/chronograf/aggregate_window_count_test.flux":                                  "34e3b7f10b06926835dfb6f3ee98e17676b50942feafb73d2ac838ed78e49749",
 	"stdlib/testing/chronograf/aggregate_window_mean_test.flux":                                   "950e2c3a7e9181d82304d9d5926913cc2862f4105939c8decaee62ce8b67e42a",

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -488,7 +488,6 @@ func init() {
 				return values.NewString(strings.Join(newStringArray, argVals[1].Str())), nil
 			}, false,
 		),
-		"substring": substring,
 	}
 
 	runtime.RegisterPackageValue("strings", "joinStr", SpecialFns["joinStr"])

--- a/stdlib/strings/strings.go
+++ b/stdlib/strings/strings.go
@@ -355,13 +355,14 @@ var substring = values.NewFunction(
 			}
 
 			s := []rune(v)
+			runeCount := int64(len(s))
 			if a < 0 {
 				a = 0
-			} else if a > int64(len(v)) {
-				a = int64(len(v))
+			} else if a > runeCount {
+				a = runeCount
 			}
-			if b > int64(len(v)) {
-				b = int64(len(v))
+			if b > runeCount {
+				b = runeCount
 			} else if b < a {
 				b = a
 			}
@@ -487,6 +488,7 @@ func init() {
 				return values.NewString(strings.Join(newStringArray, argVals[1].Str())), nil
 			}, false,
 		),
+		"substring": substring,
 	}
 
 	runtime.RegisterPackageValue("strings", "joinStr", SpecialFns["joinStr"])

--- a/stdlib/strings/strings_test.flux
+++ b/stdlib/strings/strings_test.flux
@@ -70,6 +70,17 @@ testcase string_substring {
     testing.diff(got: got, want: want)
 }
 
+testcase string_substring_nbsp {
+    // XXX: Inputs of a certain sizes with trailing nbsp caused a panic
+    // <https://github.com/influxdata/EAR/issues/3494>
+    input = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx  "
+    output = strings.substring(v: input, start: 0, end: 100)
+    want = array.from(rows: [{v: input}])
+    got = array.from(rows: [{v: output}])
+
+    testing.diff(want, got)
+}
+
 // All instances of one string are replaced with another
 testcase string_replaceAll {
     want = array.from(rows: [{_value: "This is fine. Everything is fine."}])

--- a/stdlib/strings/strings_test.go
+++ b/stdlib/strings/strings_test.go
@@ -7,7 +7,6 @@ package strings_test
 
 import (
 	"context"
-
 	"testing"
 
 	"github.com/influxdata/flux/dependency"
@@ -52,26 +51,5 @@ func TestJoinStr_NullInArrParam(t *testing.T) {
 	}
 	if wantErr != gotErr.Str() {
 		t.Errorf("input %f: expected %v, gotErr %f", arr, wantErr, gotErr)
-	}
-}
-
-func TestSubstring_NbspOk(t *testing.T) {
-	fluxFunc := fluxstdlibstrings.SpecialFns["substring"]
-	fluxArg := values.NewObjectWithValues(map[string]values.Value{
-		// XXX: Inputs of a certain sizes with trailing nbsp caused a panic
-		// <https://github.com/influxdata/EAR/issues/3494>
-		"v":     values.NewString("Annual Alert Limited Event 12\u00A0\u00A0"),
-		"start": values.NewInt(0),
-		"end":   values.NewInt(1023),
-	})
-	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
-	defer deps.Finish()
-	want := "Annual Alert Limited Event 12\u00A0\u00A0"
-	got, err := fluxFunc.Call(ctx, fluxArg)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	if want != got.Str() {
-		t.Errorf("expected %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
Inputs that contain non-breaking spaces (NBSP), and assumedly a host of
other unicode characters caused `strings.substring` to panic when it
tried to index into an array of runes taken from a (seemingly larger)
string.

Failures looked like:
```
panic: runtime error: slice bounds out of range [:33] with capacity 32
```

This only seemed to panic when the inputs were "of a certain size" and
I'm not sure why that would be. Perhaps there are distinct thresholds
where the input causes the capacity to be just close enough to the
actual size of the rune count, but less than the string length in bytes.
Not sure.

The testcase added used an input seen in the wild and panicked prior to
the code change to substring.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
