### PR TITLE
refactor: Remove serde-aux

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -441,7 +441,6 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde",
- "serde-aux",
  "serde_derive",
  "serde_json",
  "structopt",
@@ -983,17 +982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-aux"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93abf9799c576f004252b2a05168d58527fb7c54de12e94b4d12fe3475ffad24"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -58,7 +58,6 @@ pretty = "0.11.2"
 rayon = { version = "1.5.2", optional = true }
 regex = "1.5.5"
 serde = { version = "^1.0.136", features = ["derive", "rc"] }
-serde-aux = "3.0.1"
 serde_derive = "^1.0.136"
 serde_json = "1.0.79"
 structopt = "0.3.26"

--- a/libflux/flux-core/src/ast/mod.rs
+++ b/libflux/flux-core/src/ast/mod.rs
@@ -10,7 +10,6 @@ use serde::{
     de::{Deserialize, Deserializer, Error, Visitor},
     ser::{Serialize, SerializeSeq, Serializer},
 };
-use serde_aux::prelude::*;
 
 use super::DefaultHasher;
 use crate::scanner;
@@ -1565,6 +1564,14 @@ pub struct DateTimeLit {
     #[serde(flatten)]
     pub base: BaseNode,
     pub value: chrono::DateTime<FixedOffset>,
+}
+
+fn deserialize_default_from_null<'de, T, D>(d: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
 }
 
 // The tests code exports a few helpers for writing AST related tests.

--- a/libflux/flux-core/src/ast/mod.rs
+++ b/libflux/flux-core/src/ast/mod.rs
@@ -1566,6 +1566,8 @@ pub struct DateTimeLit {
     pub value: chrono::DateTime<FixedOffset>,
 }
 
+// Re-implementation of https://github.com/vityafx/serde-aux/blob/c6f8482f51da7f187ecea62931c8f38edcf355c9/src/field_attributes.rs#L676
+// so we do not need to pull in an entire crate
 fn deserialize_default_from_null<'de, T, D>(d: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -13,11 +13,11 @@ package libflux
 //
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "d22aefaaab124dba2e5bcb521d44610e400d745a36a97b29665ee3db51b4a6ca",
+	"libflux/Cargo.lock":                                                                          "5f21e43655bf7ae60d4c59731ab1e5a74567fa9561c090555545cdaa0a09132d",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "979e410d4eef8318364ac9203bd0eedaa49ddd71043ed3402edd70ed5436286e",
+	"libflux/flux-core/Cargo.toml":                                                                "9c49e87c57b0027b7a0f525c55174eea2ddf391dadb7cb38e7f354b5b3b894b1",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "47e06631f249715a44c9c8fa897faf142ad0fa26f67f8cfd5cd201e82cb1afc8",
-	"libflux/flux-core/src/ast/mod.rs":                                                            "4db1054af8625721300429b8ce0eacda6f8e6d8f20251874a87bb5bc884885c8",
+	"libflux/flux-core/src/ast/mod.rs":                                                            "1bad512571ccedfefa0c9a15c3b52c42687360817eb1c80fecc0936498e0f2c6",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "0820db1bc097e233cfe0ece58d48e93d82a3b463be88d6937d318dff75d898db",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
 	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "8cb0aca0eff41b28c0aff07424ae3375364a37bec0ad49fe5460e6c360735a64",


### PR DESCRIPTION
~The default attribute does the same thing so no need for this dependency. (The crate seems to have been added in the original creation of the AST, maybe `default` didn't exist then or something https://github.com/influxdata/flux/pull/1418 )~

The default attribute only handles undefined fields, not null fields. But the function is so simple
to add that we do not need an dependency really.


### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
