### PR TITLE
fix: restore int return value for `pagerduty.sendEvent`

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -279,7 +279,7 @@ var sourceHashes = map[string]string{
 	"stdlib/kafka/kafka.flux":                                                                     "c93e5a56f16d56d69f905e8fd3b02156ccb41742bb513c9d6fd82b26187ab5e8",
 	"stdlib/math/math.flux":                                                                       "590b501bc712d134fae22c966dc8cec4722b2f5e05853474017ab4d0d93406be",
 	"stdlib/math/math_test.flux":                                                                  "1d84dabb6cb343bc6fce8968f8081a8e5b7f81d457e6c2204f764fbef0f018a4",
-	"stdlib/pagerduty/pagerduty.flux":                                                             "b7dd32513437b52808b60ec970ecb5f0367cc84b4f6746607dc945a10d8ad397",
+	"stdlib/pagerduty/pagerduty.flux":                                                             "9776c72c9380679cbadb98bc258fb0405177bb2726371cefafff43ec29dd08cd",
 	"stdlib/pagerduty/pagerduty_test.flux":                                                        "5337bf32b69869dd4cc9e4ea3abe0cc0d7fef695200bf95dc531edd57a7db2eb",
 	"stdlib/planner/aggregate_window_max_eval_test.flux":                                          "94500e1317564dc35624c2b336a97ddbd2cf55b3d5e2dc7cf59cc3291ad79aca",
 	"stdlib/planner/aggregate_window_max_push_test.flux":                                          "0f51d1bcf032ac6d6076048b633d1c5a6f460b35970ed69c47f1ed1fdbf0b618",


### PR DESCRIPTION
A recent change updated the HTTP call inside sendEvent to use requests
instead of the old http package which accidentally introduced a breaking
change by switching the return from an int (status code) to a record
(http response).

This diff will rename the new (response object) version of `sendEvent`
to `_sendEvent` so it can be used in `endpoint()`. `sendEvent` will then
call `_sendEvent` and return only the `statusCode` field to restore the
original signature.

Refs: <https://github.com/influxdata/flux/pull/5006>

Regarding tests -- I struggled to figure out a way to write a test for this which wouldn't depend on making a request to a live pagerduty. I filed #5059 which would help me today, but  maybe in the future.

The old tests continue to pass, but they also passed with the breaking change introduced so that's not great. :weary: 

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` **N/A**
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated **N/A**

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
