### PR TITLE
feat: Accept flux feature flags to the test command

### DIFF
--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -2,17 +2,14 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 
-	"github.com/influxdata/flux/cmd/flux/cmd"
+	fluxcmd "github.com/influxdata/flux/cmd/flux/cmd"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies"
-	"github.com/influxdata/flux/dependencies/feature"
 	"github.com/influxdata/flux/dependency"
-	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/repl"
@@ -59,13 +56,10 @@ func runE(cmd *cobra.Command, args []string) error {
 	ctx, span := injectDependencies(ctx)
 	defer span.Finish()
 
-	flagger := executetest.TestFlagger{}
-	if len(flags.Features) != 0 {
-		if err := json.Unmarshal([]byte(flags.Features), &flagger); err != nil {
-			return errors.Newf(codes.Invalid, "Unable to unmarshal features as json: %s", err)
-		}
+	ctx, err = fluxcmd.WithFeatureFlags(ctx, flags.Features)
+	if err != nil {
+		return err
 	}
-	ctx = feature.Dependency{Flagger: flagger}.Inject(ctx)
 
 	var opts []repl.Option
 	if flags.EnableSuggestions {
@@ -143,7 +137,7 @@ func main() {
 	fmtCmd.Flags().BoolVarP(&fmtFlags.AnalyzeCurrentDirectory, "analyze-current-directory", "c", false, "analyze the current <directory | file> and report if file(s) are not formatted")
 	fluxCmd.AddCommand(fmtCmd)
 
-	testCmd := cmd.TestCommand(NewTestExecutor)
+	testCmd := fluxcmd.TestCommand(NewTestExecutor)
 	fluxCmd.AddCommand(testCmd)
 
 	if err := fluxCmd.Execute(); err != nil {

--- a/cmd/flux/main.go
+++ b/cmd/flux/main.go
@@ -130,7 +130,7 @@ func main() {
 	fluxCmd.Flags().StringVar(&flags.Trace, "trace", "", "Trace query execution")
 	fluxCmd.Flags().StringVarP(&flags.Format, "format", "", "cli", "Output format one of: cli,csv. Defaults to cli")
 	fluxCmd.Flag("trace").NoOptDefVal = "jaeger"
-	fluxCmd.Flags().StringVar(&flags.Features, "feature", "", "JSON object specifying the features to execute with. See internal/feature/flags.yml for a list of the current features")
+	fluxCmd.Flags().StringVar(&flags.Features, "features", "", "JSON object specifying the features to execute with. See internal/feature/flags.yml for a list of the current features")
 
 	fmtCmd := &cobra.Command{
 		Use:   "fmt",

--- a/libflux/flux-core/src/bin/fluxdoc.rs
+++ b/libflux/flux-core/src/bin/fluxdoc.rs
@@ -300,7 +300,7 @@ impl<'a> example::Executor for CLIExecutor<'a> {
         cmd.arg("--format")
             .arg("csv")
             .arg(tmpfile.path())
-            .arg("--feature")
+            .arg("--features")
             .arg(r#"{"labelPolymorphism": true}"#);
         log::debug!("Executing {:?}", cmd);
         let output = cmd

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -21,7 +21,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
 	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "8cb0aca0eff41b28c0aff07424ae3375364a37bec0ad49fe5460e6c360735a64",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "bf275289e690236988049fc0a07cf832dbac25bb5739c02135b069dcdfab4d0f",
-	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "354a8dfd262f223412ee491a9947962f993e43c5467f8ee37c4f15528dc5b571",
+	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "930809716897510e8b804026fc3428b7b0a7d69038905c5da5a891da61a20fa1",
 	"libflux/flux-core/src/doc/example.rs":                                                        "403a682c435c820dd37b768d5f1d5f8e117e490ca0a8c21077e7c6d4d7bccd55",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "764b5a2802558aae1ce2457e2d0f5107e155abbc0de79e13771ee0053e3358ce",
 	"libflux/flux-core/src/errors.rs":                                                             "f499fbb9aff1736c8fa65fe1e6663a1f77e7d0d8003b4fdecd8ea009b02569fb",


### PR DESCRIPTION
Matches how features can be passed to the flux REPL/script runner. I don't really need this as but I didn't realize that until after I had this written already :shrug: Seems useful/consistent with the REPL at least.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
