### PR TITLE
test: Display which planner rule ran an unexpected number of times

### DIFF
--- a/dependencies/testing/testing.go
+++ b/dependencies/testing/testing.go
@@ -91,7 +91,7 @@ func (want results) Check(got results) error {
 	for name, want := range want.plannerRules {
 		got := got.plannerRules[name]
 		if want != got {
-			return errors.Newf(codes.Invalid, "planner rule invoked an unexpected number of times: %d (want) != %d (got)", want, got)
+			return errors.Newf(codes.Invalid, "planner rule `%s` invoked an unexpected number of times: %d (want) != %d (got)", name, want, got)
 		}
 	}
 	return nil

--- a/dependencies/testing/testing_test.go
+++ b/dependencies/testing/testing_test.go
@@ -63,7 +63,7 @@ func TestExpectPlannerRule(t *testing.T) {
 				MarkInvokedPlannerRule(ctx, "A")
 				MarkInvokedPlannerRule(ctx, "A")
 			},
-			wantErr: "planner rule invoked an unexpected number of times: 3 (want) != 2 (got)",
+			wantErr: "planner rule `A` invoked an unexpected number of times: 3 (want) != 2 (got)",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -140,7 +140,7 @@ func TestQuery_TestingCheck(t *testing.T) {
 	if q.Err() == nil {
 		t.Fatalf("expected error from query execution about failed testing checks")
 	}
-	if !strings.Contains(q.Err().Error(), "planner rule invoked an unexpected number of times") {
+	if !strings.Contains(q.Err().Error(), "planner rule `NonExistantRule` invoked an unexpected number of times") {
 		t.Errorf("expected error about failed testing checks got error: %v", q.Err())
 	}
 }


### PR DESCRIPTION
I am surprised no-one has ran into this before, wondering which plan did not run correctly.

Closes #5064 (Because I do not understand why the test becomes flaky in that PR)

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
