### PR TITLE
test: Display all failures when planner rules fail to run

### DIFF
--- a/dependencies/testing/testing.go
+++ b/dependencies/testing/testing.go
@@ -89,6 +89,10 @@ type results struct {
 }
 
 func (want results) Check(got results) error {
+	// Don't report an error due to `want` being nil and `filteredGot` being {}
+	if len(got.plannerRules) == 0 {
+		return nil
+	}
 	// Only diff against the rules listed in `want`
 	filteredGot := make(map[string]int)
 	for name := range want.plannerRules {

--- a/dependencies/testing/testing_test.go
+++ b/dependencies/testing/testing_test.go
@@ -80,7 +80,7 @@ func TestExpectPlannerRule(t *testing.T) {
 			got := Check(ctx)
 			if got != nil {
 				gotErr, wantErr := got.Error(), tt.wantErr
-				if diff := cmp.Diff(gotErr, wantErr); diff != "" {
+				if diff := cmp.Diff(wantErr, gotErr); diff != "" {
 					t.Errorf("unexpected error -want/+got:\n%s", diff)
 				}
 			} else if tt.wantErr != "" {

--- a/dependencies/testing/testing_test.go
+++ b/dependencies/testing/testing_test.go
@@ -67,6 +67,11 @@ func TestExpectPlannerRule(t *testing.T) {
 			},
 			wantErr: "planner rule invoked an unexpected number of times -want/+got:\n  map[string]int{\n- \t\"A\": 3,\n+ \t\"A\": 2,\n  }\n",
 		},
+		{
+			name: "no expectation",
+			fn: func(ctx context.Context) {
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := Inject(context.Background())


### PR DESCRIPTION
`cmp.Diff` doesn't have the best output but we use it everywhere else so maybe it would be good to
display all mismatches instead of just the first failures?

Closes #5063

```
 stdlib/universe/merge_filter_test.flux: merge_filter_flag_off ... fail: planner rule invoked an unexpected number of times -want/+got:
  map[string]int{
-       "MergeFiltersRule": 1,
+       "MergeFiltersRule": 0,
  }
```

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
