### PR TITLE
test: Don't report skips when --test is used

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -108,7 +108,14 @@ func runFluxTests(out io.Writer, setup TestSetupFunc, flags TestFlags) (bool, er
 		flags.paths = []string{"."}
 	}
 
-	reporter := NewTestReporter(out, flags.verbosity)
+	reporter := TestReporter{
+		out:       out,
+		verbosity: flags.verbosity,
+		// If an explicit list of test is specified, the user is unlikely interested in all the other, skipped tests.
+		// So avoid cluttering the test report with skips.
+		reportSkips: len(flags.testNames) == 0,
+	}
+
 	runner := NewTestRunner(reporter)
 	if err := runner.Gather(flags.paths); err != nil {
 		return false, err
@@ -917,13 +924,9 @@ func (t *TestRunner) Finish() bool {
 
 // TestReporter handles reporting of test results.
 type TestReporter struct {
-	out       io.Writer
-	verbosity int
-}
-
-// NewTestReporter creates a new TestReporter with a provided verbosity.
-func NewTestReporter(out io.Writer, verbosity int) TestReporter {
-	return TestReporter{out: out, verbosity: verbosity}
+	out         io.Writer
+	verbosity   int
+	reportSkips bool
 }
 
 // ReportTestRun reports the result a single test run, intended to be run as
@@ -931,7 +934,9 @@ func NewTestReporter(out io.Writer, verbosity int) TestReporter {
 func (t *TestReporter) ReportTestRun(test *Test) {
 	if t.verbosity == 0 {
 		if test.skip {
-			fmt.Fprint(t.out, color.YellowString("s"))
+			if t.reportSkips {
+				fmt.Fprint(t.out, color.YellowString("s"))
+			}
 		} else if test.Error() != nil {
 			fmt.Fprint(t.out, color.RedString("x"))
 		} else {
@@ -947,7 +952,9 @@ func (t *TestReporter) ReportTestRun(test *Test) {
 			}
 		}
 		if test.skip {
-			fmt.Fprintf(t.out, "%s ... %s\n", test.FullName(), color.YellowString("skip"))
+			if t.reportSkips {
+				fmt.Fprintf(t.out, "%s ... %s\n", test.FullName(), color.YellowString("skip"))
+			}
 		} else if err := test.Error(); err != nil {
 			fmt.Fprintf(t.out, "%s ... %s: %s\n", test.FullName(), color.RedString("fail"), err)
 		} else {


### PR DESCRIPTION
Personally if I have specified `--test` I am only interested in the test(s) I have
specified so seeing 800 other lines reporting all the skipped tests is just noise.
The final summary still reports the number of success/skip/failures so skips are still reported, just not as heavily

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
