### PR TITLE
chore: Remove the version range from lsp-types

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.92.1"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79d4897790e8fd2550afa6d6125821edb5716e60e0e285046e070f0f6a06e0e"
+checksum = "2368312c59425dd133cb9a327afee65be0a633a8ce471d248e2202a48f8f68ae"
 dependencies = [
  "bitflags",
  "serde",

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -49,7 +49,7 @@ fnv = "1.0.7"
 indexmap = "1"
 libflate = "1.2.0"
 log = "0.4.16"
-lsp-types = { version = ">=0.91,<=0.92", optional = true }
+lsp-types = { version = "0.91", optional = true }
 maplit = "1.0.2"
 once_cell = { version = "1.10.0", optional = true }
 pad = { version = "0.1.6", optional = true }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -12,9 +12,9 @@ package libflux
 // are not tracked by Go's build system.'
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "67373da0755f957cf04d90fb58d9873cfafb5bef382d1535e49a5bf6c23febf0",
+	"libflux/Cargo.lock":                                                                          "d22aefaaab124dba2e5bcb521d44610e400d745a36a97b29665ee3db51b4a6ca",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "b94689ddd00f579300ef6828696c80e7a29898307e2d27ab4d039ef992c27c38",
+	"libflux/flux-core/Cargo.toml":                                                                "979e410d4eef8318364ac9203bd0eedaa49ddd71043ed3402edd70ed5436286e",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "47e06631f249715a44c9c8fa897faf142ad0fa26f67f8cfd5cd201e82cb1afc8",
 	"libflux/flux-core/src/ast/mod.rs":                                                            "4db1054af8625721300429b8ce0eacda6f8e6d8f20251874a87bb5bc884885c8",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "a74d90937d4f059800f39ff866976c68ff06c3566293aec65f1539ddc2f1de25",


### PR DESCRIPTION
This does not work as I would hope (see https://github.com/rust-lang/cargo/issues/9029) so we need
to restrict this to just the same version that lspower uses (for the sake of the LSP). This is bad in its own way though as lspower does not adhere to semver which can cause its own breakages.

Personally I'd like use to remove the `From` implementations we provided here and let the LSP have its own, explicit conversions so we could avoid this churn :shrug:.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
