### PR TITLE
fix: fix aggregate window rules that left plan in bad state

### DIFF
--- a/lang/query_test.go
+++ b/lang/query_test.go
@@ -332,22 +332,22 @@ guild = data
 experimental.chain(first: id, second: guild)
 `,
 			want: `[digraph {
-  array.from0
-  range1
-  filter2
+  "array.from0"
+  "range1"
+  "filter2"
   // r._field == "id"
 
-  array.from0 -> range1
-  range1 -> filter2
+  "array.from0" -> "range1"
+  "range1" -> "filter2"
 }
  digraph {
-  array.from3
-  range4
-  filter5
+  "array.from3"
+  "range4"
+  "filter5"
   // r._field == "guild"
 
-  array.from3 -> range4
-  range4 -> filter5
+  "array.from3" -> "range4"
+  "range4" -> "filter5"
 }
 ]`,
 		},
@@ -368,24 +368,24 @@ data
 |> filter(fn: (r) => r["_field"] == id)
 `,
 			want: `[digraph {
-  array.from0
-  range1
-  filter2
+  "array.from0"
+  "range1"
+  "filter2"
   // r._field == "id"
-  sort3
+  "sort3"
 
-  array.from0 -> range1
-  range1 -> filter2
-  filter2 -> sort3
+  "array.from0" -> "range1"
+  "range1" -> "filter2"
+  "filter2" -> "sort3"
 }
  digraph {
-  array.from4
-  range5
-  filter6
+  "array.from4"
+  "range5"
+  "filter6"
   // r._field == "id"
 
-  array.from4 -> range5
-  range5 -> filter6
+  "array.from4" -> "range5"
+  "range5" -> "filter6"
 }
 ]`,
 		},

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -431,7 +431,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/aggregate_window_max_test.flux":                                              "8ee5d927ef375e7ac3687ea1ea00a0e8add969c31357362d0032ee079c2ac906",
 	"stdlib/universe/aggregate_window_mean_test.flux":                                             "ba33848419748489bc330c67dfaa344fac757f8af782879c71e08b345f0f652f",
 	"stdlib/universe/aggregate_window_median_test.flux":                                           "2791ed98310aae23deab7cb79836e60539cd29810c67910c30e4b891356a2698",
-	"stdlib/universe/aggregate_window_test.flux":                                                  "79ae9443c57f613fa7917b727f80f6a3fc985fcd95006ab2804c1f5d25c9b9d3",
+	"stdlib/universe/aggregate_window_test.flux":                                                  "d415e0613744096fd7f624bdef2faf1fdae480b83feee2298b672385de14a8c8",
 	"stdlib/universe/cmo_test.flux":                                                               "3793f5cf21ae42879d6789cdc36bbcf29ddb99bf16af8a96775a9415fd8d1c09",
 	"stdlib/universe/columns_test.flux":                                                           "fe641e3e747439a15fb2f4a1e4c56da6ad6a75109db4597f1aab806931f881c7",
 	"stdlib/universe/contains_test.flux":                                                          "a1890287ebc1ad6d8c84561f7e0cb725048a1e287f49f5dceac196866a20ee01",

--- a/plan/format.go
+++ b/plan/format.go
@@ -41,6 +41,12 @@ type formatter struct {
 	p           *Spec
 }
 
+func formatAsDOT(id NodeID) string {
+	// The DOT language does not allow "." or "/" in IDs
+	// so quote the node IDs.
+	return fmt.Sprintf("%q", id)
+}
+
 func (f formatter) Format(fs fmt.State, c rune) {
 	// Panicking while producing debug output is frustrating, so catch any panics and
 	// continue if that happens.
@@ -54,7 +60,7 @@ func (f formatter) Format(fs fmt.State, c rune) {
 	_, _ = fmt.Fprintf(fs, "digraph {\n")
 	var edges []string
 	_ = f.p.BottomUpWalk(func(pn Node) error {
-		_, _ = fmt.Fprintf(fs, "  %v\n", pn.ID())
+		_, _ = fmt.Fprintf(fs, "  %v\n", formatAsDOT(pn.ID()))
 		if f.withDetails {
 			details := ""
 			if d, ok := pn.ProcedureSpec().(Detailer); ok {
@@ -78,7 +84,7 @@ func (f formatter) Format(fs fmt.State, c rune) {
 			}
 		}
 		for _, pred := range pn.Predecessors() {
-			edges = append(edges, fmt.Sprintf("  %v -> %v", pred.ID(), pn.ID()))
+			edges = append(edges, fmt.Sprintf("  %v -> %v", formatAsDOT(pred.ID()), formatAsDOT(pn.ID())))
 		}
 		return nil
 	})

--- a/plan/format_test.go
+++ b/plan/format_test.go
@@ -45,11 +45,11 @@ func TestFormatted(t *testing.T) {
 				},
 			},
 			want: `digraph {
-  from
-  filter
+  "from"
+  "filter"
   // r._value > 5.000000
 
-  from -> filter
+  "from" -> "filter"
 }
 `,
 		},
@@ -83,12 +83,12 @@ func TestFormatted(t *testing.T) {
 				},
 			},
 			want: `digraph {
-  source
-  merge
+  "source"
+  "merge"
   // *** spec details ***
   // ParallelMergeFactor: 8
 
-  source -> merge
+  "source" -> "merge"
 }
 `,
 		},

--- a/plan/types.go
+++ b/plan/types.go
@@ -343,6 +343,23 @@ func ReplaceNode(oldNode, newNode Node) {
 	oldNode.ClearPredecessors()
 }
 
+// ReplacePhysicalNodes accepts a connected group of nodes that has a single output and
+// a single input, and replaces them with a single node with the predecessors of the old input node.
+// Note that the planner has a convention of connecting successors itself
+// (rather than having the rules doing it) so the old output's successors
+// remain unconnected.
+func ReplacePhysicalNodes(ctx context.Context, oldOutputNode, oldInputNode Node, name string, newSpec PhysicalProcedureSpec) Node {
+	newNode := CreateUniquePhysicalNode(ctx, name, newSpec)
+
+	newNode.AddPredecessors(oldInputNode.Predecessors()...)
+	for _, pred := range oldInputNode.Predecessors() {
+		i := IndexOfNode(oldInputNode, pred.Successors())
+		pred.Successors()[i] = newNode
+	}
+
+	return newNode
+}
+
 type WindowSpec struct {
 	Every    flux.Duration
 	Period   flux.Duration

--- a/stdlib/universe/aggregate_window.go
+++ b/stdlib/universe/aggregate_window.go
@@ -872,18 +872,14 @@ func (a AggregateWindowRule) Rewrite(ctx context.Context, node plan.Node) (plan.
 	if !a.isValidWindowSpec(windowSpec) {
 		return node, false, nil
 	}
-	parentNode := windowNode.Predecessors()[0]
-
-	parentNode.ClearSuccessors()
-	newNode := plan.CreateUniquePhysicalNode(ctx, "aggregateWindow", &AggregateWindowProcedureSpec{
+	newSpec := &AggregateWindowProcedureSpec{
 		WindowSpec:     windowSpec,
 		AggregateKind:  aggregateNode.Kind(),
 		ValueCol:       valueCol,
 		UseStart:       useStart,
 		ForceAggregate: false,
-	})
-	parentNode.AddSuccessors(newNode)
-	newNode.AddPredecessors(parentNode)
+	}
+	newNode := plan.ReplacePhysicalNodes(ctx, node, windowNode, "aggregateWindow", newSpec)
 	return newNode, true, nil
 }
 
@@ -995,17 +991,14 @@ func (a AggregateWindowCreateEmptyRule) Rewrite(ctx context.Context, node plan.N
 	if !a.isValidWindowSpec(windowSpec) {
 		return node, false, nil
 	}
-	parentNode := windowNode.Predecessors()[0]
 
-	parentNode.ClearSuccessors()
-	newNode := plan.CreateUniquePhysicalNode(ctx, "aggregateWindow", &AggregateWindowProcedureSpec{
+	newSpec := &AggregateWindowProcedureSpec{
 		WindowSpec:     windowSpec,
 		AggregateKind:  aggregateNode.Kind(),
 		ValueCol:       valueCol,
 		UseStart:       useStart,
 		ForceAggregate: true,
-	})
-	parentNode.AddSuccessors(newNode)
-	newNode.AddPredecessors(parentNode)
+	}
+	newNode := plan.ReplacePhysicalNodes(ctx, node, windowNode, "aggregateWindow", newSpec)
 	return newNode, true, nil
 }


### PR DESCRIPTION
This PR fixes an issue with the planner rules that replace the composite `aggregateWindow` operation (composed of `window |> fill |> agg |> duplicate |> window(inf)`) with a unified `aggregateWindow` operation.

This rule was assuming that the predecessor to the pattern had just one successor. If this was not the case, the plan would become corrupt and planning would fail. This was being hidden before #5047 merged because a pattern that had a predecessor with multiple successors would never be reported as a match.

There are also some changes in this PR to improve diagnostics when things go wrong in the planner, and to improve the DOT representation of query plans.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` (N/A)
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated (N/A)

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
