### PR TITLE
chore: make flux test use pretty formatting for diffs

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/feature"
 	"github.com/influxdata/flux/dependencies/filesystem"
+	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
-	"github.com/influxdata/flux/execute/table"
 	"github.com/influxdata/flux/fluxinit"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/parser"
@@ -207,10 +207,8 @@ func (t *Test) consume(ctx context.Context, results flux.ResultIterator) error {
 			err := result.Tables().Do(func(tbl flux.Table) error {
 				// The data returned here is the result of `testing.diff`, so any result means that
 				// a comparison of two tables showed inequality. Capture that inequality as part of the error.
-				// XXX: rockstar (08 Dec 2020) - This could use some ergonomic work, as the diff output
-				// is not exactly "human readable."
-				_, _ = fmt.Fprint(&output, table.Stringify(tbl))
-				return nil
+				_, err := execute.NewFormatter(tbl, nil).WriteTo(&output)
+				return err
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
This just makes the output of `flux test` be more readable, e.g.,
```
failures:

	stdlib/universe/aggregate_window_test.flux: aggregate_window_predecessor_multi_successor ... fail: Table: keys: [t0]
             t0:string            _diff:string                      _time:time                  _value:int
----------------------  ----------------------  ------------------------------  --------------------------
                   a-1                       -  2019-11-25T00:01:00.000000000Z                           6
                   a-1                       +  2019-11-25T00:01:00.000000000Z                           5
Table: keys: [t0]
             t0:string            _diff:string                      _time:time                  _value:int
----------------------  ----------------------  ------------------------------  --------------------------
                   a-z                       -  2019-11-25T00:01:00.000000000Z                           5
Table: keys: [t0]
             t0:string            _diff:string                      _time:time                  _value:int
----------------------  ----------------------  ------------------------------  --------------------------
                   a-0                       +  2019-11-25T00:01:00.000000000Z                           5
```
The diff currently looks like this and I find it quite hard to parse (this is a different test than the one above but hopefully you get the idea):
```
failures:

	stdlib/universe/aggregate_window_test.flux: max_null_windows ... fail: # _field=f0,_measurement=m0 _diff=string,_time=time,_value=float,t0=string
_field=f0,_measurement=m0 _diff=,_time=2019-11-25T00:00:00Z,_value=6.000,t0=a-0
_field=f0,_measurement=m0 _diff=,_time=2019-11-25T00:00:10Z,_value=2.000,t0=a-0
_field=f0,_measurement=m0 _diff=,_time=2019-11-25T00:00:20Z,_value=0.000,t0=
_field=f0,_measurement=m0 _diff=-,_time=2019-11-25T00:00:30Z,_value=3.100,t0=a-0
_field=f0,_measurement=m0 _diff=+,_time=2019-11-25T00:00:30Z,_value=3.000,t0=a-0
_field=f0,_measurement=m0 _diff=,_time=2019-11-25T00:00:40Z,_value=4.000,t0=a-0
_field=f0,_measurement=m0 _diff=,_time=2019-11-25T00:00:50Z,_value=0.000,t0=
```

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
