### PR TITLE
feat: add new package for downsampling data

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -208,6 +208,8 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/oee/apq_test.flux":                                                       "468e6889dfb02ae4258c828d104620beadceffdef407f6f6f1ce2b2417c724d9",
 	"stdlib/experimental/oee/computeapq_test.flux":                                                "8365fa1734e8bb1336a640dfb14721d9f17e570e555594bc2a31a4dabf2ddca4",
 	"stdlib/experimental/oee/oee.flux":                                                            "9e1023aa525d30144166f32d270673920c69d924946f5aad85a2bc4caa40fec6",
+	"stdlib/experimental/polyline/polyline.flux":                                                  "847044c44c16a9f63c13f6cec2195c2106c9a1544dc55b06b1a9fbae3d6fead2",
+	"stdlib/experimental/polyline/polyline_test.flux":                                             "16473dce4f71dcdbe1e3f90b350ab1e56a513679cb5c3f872e0f2d7678d42d1f",
 	"stdlib/experimental/preview_test.flux":                                                       "cca570d25b17ed201a0ecc7ebf9e547ccff2aa0814a3ac49f12faa938cbdaf73",
 	"stdlib/experimental/prometheus/prometheus.flux":                                              "e0b3df509c8f522edee1081e5e3907ce9628f783d33b47c2e2d8ffb766f3f948",
 	"stdlib/experimental/prometheus/prometheus_histogramQuantile_test.flux":                       "37bda52e9440820c3bb278b4e9d331c0330a68f405a7623b95e15a50ee176753",

--- a/stdlib/experimental/polyline/polyline.flux
+++ b/stdlib/experimental/polyline/polyline.flux
@@ -1,0 +1,75 @@
+// Package polyline provides methods for polyline simplication, an efficient way of downsampling curves while retaining moments of variation throughout the path.
+//
+// This class of algorithms enable efficient rendering of graphs and visualizations without having to load all data into memory.
+// This is done by reducing the number of vertices that do not contribute significantly to the convexity and concavity of the shape.
+//
+// ## Metadata
+// introduced: NEXT
+//
+package polyline
+
+
+// rdp applies the Ramer Douglas Peucker (RDP) algorithm to input data to downsample curves composed
+// of line segments into visually indistinguishable curves with fewer points.
+//
+// ## Parameters
+// - valColumn: Column with Y axis values of the given curve. Default is `_value`.
+// - timeColumn: Column with X axis values of the given curve. Default is `_time`.
+// - epsilon: Maximum tolerance value that determines the amount of compression.
+//
+//   Epsilon should be greater than `0.0`.
+//
+// - retention: Percentage of points to retain after downsampling.
+//
+//   Retention rate should be between `0.0` and `100.0`.
+//
+// - tables: Input data. Default is piped-forward data (`<-`).
+//
+// ## Examples
+//
+// ### Downsample the data using the epsilon value 1.5
+// ```
+// # import "internal/gen"
+// import "experimental/polyline"
+//
+// # data = gen.tables(n: 16, seed: 1234)
+// #
+// < data
+// >     |> polyline.rdp(epsilon: 1.5)
+// ```
+//
+// ### Downsample the data using a retention rate of 90%
+// ```
+// # import "internal/gen"
+// import "experimental/polyline"
+//
+// # data = gen.tables(n: 16, seed: 1234)
+// #
+// < data
+// >     |> polyline.rdp(retention: 90.0)
+// ```
+//
+// ### Downsample the data by automatically calculating the maximum tolerance beyond which producing a visually indistingushable curve will not be possible. This can be used when both epsilon and the retention rate are tricky to be judged.
+// ```
+// # import "internal/gen"
+// import "experimental/polyline"
+//
+// # data = gen.tables(n: 16, seed: 1234)
+// #
+// < data
+// >     |> polyline.rdp()
+// ```
+//
+// ## Metadata
+// tags: transformations
+//
+builtin rdp : (
+        <-tables: stream[A],
+        ?valColumn: string,
+        ?timeColumn: string,
+        ?epsilon: float,
+        ?retention: float,
+    ) => stream[B]
+    where
+    A: Record,
+    B: Record

--- a/stdlib/experimental/polyline/polyline_test.flux
+++ b/stdlib/experimental/polyline/polyline_test.flux
@@ -1,0 +1,65 @@
+package polyline_test
+
+
+import "array"
+import "testing"
+import "internal/gen"
+import "internal/debug"
+import "csv"
+import "experimental/polyline"
+
+option now = () => 2030-01-01T00:00:00Z
+
+testcase polyline_rdp_with_epsilon_testcase {
+    got =
+        gen.tables(n: 16, seed: 1234)
+            |> polyline.rdp(valColumn: "_value", timeColumn: "_time", epsilon: 55.0)
+            |> drop(columns: ["_time"])
+    want =
+        array.from(
+            rows: [
+                {_value: 10.56555566168836},
+                {_value: -47.25865245658065},
+                {_value: 66.16082461651365},
+                {_value: -56.89169240573004},
+                {_value: 28.71147881415803},
+                {_value: -44.44668391211515},
+            ],
+        )
+
+    testing.diff(got: got, want: want)
+}
+testcase polyline_rdp_with_retentionrate_testcase {
+    got =
+        gen.tables(n: 16, seed: 1234)
+            |> polyline.rdp(valColumn: "_value", timeColumn: "_time", retention: 30.0)
+            |> drop(columns: ["_time"])
+    want =
+        array.from(
+            rows: [
+                {_value: 10.56555566168836},
+                {_value: -47.25865245658065},
+                {_value: -56.89169240573004},
+                {_value: -44.44668391211515},
+            ],
+        )
+
+    testing.diff(got: got, want: want)
+}
+testcase polyline_rdp_with_automatic_learning_testcase {
+    got =
+        gen.tables(n: 4, seed: 1234)
+            |> polyline.rdp(valColumn: "_value", timeColumn: "_time")
+            |> drop(columns: ["_time"])
+    want =
+        array.from(
+            rows: [
+                {_value: 10.56555566168836},
+                {_value: -29.76098586714259},
+                {_value: -67.50435038579738},
+                {_value: -16.758669047964453},
+            ],
+        )
+
+    testing.diff(got: got, want: want)
+}

--- a/stdlib/experimental/polyline/rdp.go
+++ b/stdlib/experimental/polyline/rdp.go
@@ -1,0 +1,290 @@
+package polyline
+
+import (
+	"fmt"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	fluxarrow "github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/stdlib/experimental/polyline/rdp"
+)
+
+const RdpKind = "rdp"
+
+type RdpOpSpec struct {
+	ValColumn  string  `json:"valcolumn"`
+	TimeColumn string  `json:"timecolumn"`
+	Epsilon    float64 `json:"epsilon"`
+	Retention  float64 `json:"retentionpercent"`
+}
+
+func init() {
+	rdpSignature := runtime.MustLookupBuiltinType("experimental/polyline", "rdp")
+	runtime.RegisterPackageValue("experimental/polyline", RdpKind, flux.MustValue(flux.FunctionValue(RdpKind, createRdpOpSpec, rdpSignature)))
+	plan.RegisterProcedureSpec(RdpKind, newRdpProcedure, RdpKind)
+	execute.RegisterTransformation(RdpKind, createRdpTransformation)
+}
+
+// Creating the operational spec for the RDP function
+
+func createRdpOpSpec(args flux.Arguments, a *flux.Administration) (flux.OperationSpec, error) {
+	if err := a.AddParentFromArgs(args); err != nil {
+		return nil, err
+	}
+	spec := new(RdpOpSpec)
+	if col, ok, err := args.GetString("valColumn"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.ValColumn = col
+	} else {
+		spec.ValColumn = execute.DefaultValueColLabel
+	}
+	if col, ok, err := args.GetString("timeColumn"); err != nil {
+		return nil, err
+	} else if ok {
+		spec.TimeColumn = col
+	} else {
+		spec.TimeColumn = execute.DefaultTimeColLabel
+	}
+	if s, ok, err := args.GetFloat("epsilon"); err != nil {
+		return nil, err
+	} else if ok {
+		if s <= 0.0 {
+			return nil, errors.New(codes.Invalid, "Epsilon values need to be greater than 0.0")
+		}
+		spec.Epsilon = s
+	}
+	if sp, ok, err := args.GetFloat("retention"); err != nil {
+		return nil, err
+	} else if ok {
+		if sp <= 0.0 || sp >= 100.0 {
+			return nil, errors.New(codes.Invalid, "Retention percentage should be between 0.0 and 100.0")
+		}
+		spec.Retention = sp
+	}
+	return spec, nil
+}
+
+func (s *RdpOpSpec) Kind() flux.OperationKind {
+	return RdpKind
+}
+
+// Definition of RDP procedure spec
+
+type RdpProcedureSpec struct {
+	plan.DefaultCost
+	valColumn  string
+	TimeColumn string
+	Epsilon    float64
+	Retention  float64
+}
+
+func newRdpProcedure(qs flux.OperationSpec, pa plan.Administration) (plan.ProcedureSpec, error) {
+	spec, ok := qs.(*RdpOpSpec)
+	if !ok {
+		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
+	}
+	return &RdpProcedureSpec{
+		valColumn:  spec.ValColumn,
+		TimeColumn: spec.TimeColumn,
+		Epsilon:    spec.Epsilon,
+		Retention:  spec.Retention,
+	}, nil
+}
+
+func (s *RdpProcedureSpec) Kind() plan.ProcedureKind {
+	return RdpKind
+}
+func (s *RdpProcedureSpec) Copy() plan.ProcedureSpec {
+	ns := new(RdpProcedureSpec)
+	*ns = *s
+	return ns
+}
+
+func (s *RdpProcedureSpec) TriggerSpec() plan.TriggerSpec {
+	return plan.NarrowTransformationTriggerSpec{}
+}
+
+// Defining RDP as a narrow transformation.
+
+func createRdpTransformation(id execute.DatasetID, mode execute.AccumulationMode, spec plan.ProcedureSpec, a execute.Administration) (execute.Transformation, execute.Dataset, error) {
+	s, ok := spec.(*RdpProcedureSpec)
+	if !ok {
+		return nil, nil, errors.Newf(codes.Internal, "invalid spec type %T", spec)
+	}
+	cache := execute.NewTableBuilderCache(a.Allocator())
+	d := execute.NewDataset(id, mode, cache)
+	t := NewRdpTransformation(d, cache, a.Allocator(), s)
+	return t, d, nil
+}
+
+type RdpTransformation struct {
+	execute.ExecutionNode
+	d                execute.Dataset
+	cache            execute.TableBuilderCache
+	alloc            memory.Allocator
+	valColumn        string
+	timeColumn       string
+	epsilon          float64
+	retentionPercent float64
+}
+
+func NewRdpTransformation(d execute.Dataset, cache execute.TableBuilderCache, alloc memory.Allocator, spec *RdpProcedureSpec) *RdpTransformation {
+	return &RdpTransformation{
+		d:                d,
+		cache:            cache,
+		alloc:            alloc,
+		valColumn:        spec.valColumn,
+		timeColumn:       spec.TimeColumn,
+		epsilon:          spec.Epsilon,
+		retentionPercent: spec.Retention,
+	}
+}
+
+// Transformation logic
+func (rdpt *RdpTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
+	// Sanity checks.
+	builder, created := rdpt.cache.TableBuilder(tbl.Key())
+	if !created {
+		return errors.Newf(codes.FailedPrecondition, "Rdp found duplicate table with key: %v", tbl.Key())
+	}
+	cols := tbl.Cols()
+	timeIdx := execute.ColIdx(rdpt.timeColumn, cols)
+	if timeIdx < 0 {
+		return errors.Newf(codes.FailedPrecondition, "cannot find time column %s", rdpt.timeColumn)
+	}
+	colIdx := execute.ColIdx(rdpt.valColumn, cols)
+	if colIdx < 0 {
+		return errors.Newf(codes.FailedPrecondition, "cannot find column %s", rdpt.valColumn)
+	}
+	typ := cols[colIdx].Type
+	if typ != flux.TInt &&
+		typ != flux.TUInt &&
+		typ != flux.TFloat {
+		return errors.Newf(codes.FailedPrecondition, "rdp can work only on numerical types, got %s", typ.String())
+	}
+
+	// Building schema.
+	if err := execute.AddTableKeyCols(tbl.Key(), builder); err != nil {
+		return err
+	}
+	newTimeIdx, err := builder.AddCol(flux.ColMeta{
+		Label: execute.DefaultTimeColLabel,
+		Type:  flux.TTime,
+	})
+	if err != nil {
+		return err
+	}
+	newValueIdx, err := builder.AddCol(flux.ColMeta{
+		Label: execute.DefaultValueColLabel,
+		Type:  flux.TFloat,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Cleaning data for RDP input.
+	vs, ts, err := rdpt.getCleanData(tbl, colIdx, timeIdx)
+	if err != nil {
+		return err
+	}
+
+	// Passing the cleaned input data to the main RDP function
+
+	rdp_obj := rdp.New(rdpt.timeColumn, rdpt.valColumn, rdpt.epsilon, rdpt.retentionPercent, fluxarrow.NewAllocator(rdpt.alloc))
+	newTs, newVs, errors := rdp_obj.Do(vs, ts)
+	if errors != nil {
+		return errors
+	}
+	// don't need vs and ts anymore
+	vs.Release()
+	ts.Release()
+
+	defer func() {
+		newVs.Release()
+		newTs.Release()
+	}()
+
+	// Appending columns.
+	if err := builder.AppendTimes(newTimeIdx, newTs); err != nil {
+		return err
+	}
+	if err := builder.AppendFloats(newValueIdx, newVs); err != nil {
+		return err
+	}
+	if err := execute.AppendKeyValuesN(tbl.Key(), builder, newVs.Len()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// getCleanData handles NULL values effectively, drops invalid timestamps and returns two arrow arrays containing X values and Y values.
+
+func (rdpt *RdpTransformation) getCleanData(tbl flux.Table, colIdx, timeIdx int) (*array.Float, *array.Float, error) {
+	vs := array.NewFloatBuilder(fluxarrow.NewAllocator(rdpt.alloc))
+	ts := array.NewFloatBuilder(fluxarrow.NewAllocator(rdpt.alloc))
+	appendV := func(cr flux.ColReader, i int) {
+		switch typ := tbl.Cols()[colIdx].Type; typ {
+		case flux.TInt:
+			c := cr.Ints(colIdx)
+			if c.IsNull(i) {
+				vs.AppendNull()
+			} else {
+				vs.Append(float64(c.Value(i)))
+			}
+		case flux.TUInt:
+			c := cr.UInts(colIdx)
+			if c.IsNull(i) {
+				vs.AppendNull()
+			} else {
+				vs.Append(float64(c.Value(i)))
+			}
+		case flux.TFloat:
+			c := cr.Floats(colIdx)
+			if c.IsNull(i) {
+				vs.AppendNull()
+			} else {
+				vs.Append(float64(c.Value(i)))
+			}
+		default:
+			panic(fmt.Sprintf("cannot append non-numerical type %s", typ.String()))
+		}
+
+	}
+	if err := tbl.Do(func(cr flux.ColReader) error {
+		// we work row-wise
+		for i := 0; i < cr.Len(); i++ {
+			// drop values with invalid timestamp
+			if cts := cr.Times(timeIdx); cts.IsValid(i) {
+				trueT := cts.Value(i)
+				ts.Append(float64(trueT))
+				appendV(cr, i)
+
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+	return vs.NewFloatArray(), ts.NewFloatArray(), nil
+}
+
+func (rdpt *RdpTransformation) RetractTable(id execute.DatasetID, key flux.GroupKey) error {
+	return rdpt.d.RetractTable(key)
+}
+
+func (rdpt *RdpTransformation) UpdateWatermark(id execute.DatasetID, mark execute.Time) error {
+	return rdpt.d.UpdateWatermark(mark)
+}
+func (rdpt *RdpTransformation) UpdateProcessingTime(id execute.DatasetID, pt execute.Time) error {
+	return rdpt.d.UpdateProcessingTime(pt)
+}
+func (rdpt *RdpTransformation) Finish(id execute.DatasetID, err error) {
+	rdpt.d.Finish(err)
+}

--- a/stdlib/experimental/polyline/rdp/rdp.go
+++ b/stdlib/experimental/polyline/rdp/rdp.go
@@ -1,0 +1,227 @@
+package rdp
+
+import (
+	"math"
+	"sort"
+
+	"github.com/apache/arrow/go/v7/arrow/memory"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+type Rdp struct {
+	timeColumn       string
+	valColumn        string
+	epsilon          float64
+	retentionPercent float64
+	vs               *array.Float
+	ts               *array.Float
+	alloc            memory.Allocator
+}
+
+func New(timeColumn string, valColumn string, threshold float64, retentionPercent float64, alloc memory.Allocator) *Rdp {
+	return &Rdp{
+		timeColumn:       timeColumn,
+		valColumn:        valColumn,
+		epsilon:          threshold,
+		retentionPercent: retentionPercent,
+		alloc:            alloc,
+	}
+}
+
+type Point struct {
+	xCoordinate float64
+	yCoordinate float64
+}
+
+type ConnectLine struct {
+	Starting Point
+	Ending   Point
+}
+
+// Finds the perpendicular distance from a given 2D point to a line
+
+func (l ConnectLine) perpendicularDistanceFromPointToLine(pt Point) float64 {
+	a, b, c := l.Coefficients()
+	return math.Abs(a*pt.xCoordinate+b*pt.yCoordinate+c) / math.Sqrt(a*a+b*b)
+}
+
+func (l ConnectLine) Coefficients() (a, b, c float64) {
+	a = l.Starting.yCoordinate - l.Ending.yCoordinate
+	b = l.Ending.xCoordinate - l.Starting.xCoordinate
+	c = l.Starting.xCoordinate*l.Ending.yCoordinate - l.Ending.xCoordinate*l.Starting.yCoordinate
+	return a, b, c
+}
+
+// Finds the farthest 2D point from a given line
+
+func FindFarthestPoint(line ConnectLine, ipdata []Point) (farthestPointIndex int, farthestPointDistanceFromLine float64) {
+	for i := 0; i < len(ipdata); i++ {
+		distance := line.perpendicularDistanceFromPointToLine(ipdata[i])
+		if distance > farthestPointDistanceFromLine {
+			farthestPointDistanceFromLine = distance
+			farthestPointIndex = i
+		}
+	}
+	return farthestPointIndex, farthestPointDistanceFromLine
+}
+
+// Uses the times array and values array to build a single array containing 2D points
+
+func (r *Rdp) ToPoints() []Point {
+	points := make([]Point, 0, r.vs.Len())
+	for i := 0; i < r.vs.Len(); i++ {
+		points = append(points, Point{xCoordinate: r.ts.Value(i), yCoordinate: r.vs.Value(i)})
+	}
+
+	return points
+}
+
+// Recursive implementation of the RDP Algorithm given the epsilon value
+
+func DownSampleIpdata(ipdata []Point, epsilon float64) []Point {
+	if len(ipdata) <= 2 {
+		return ipdata
+	}
+	line := ConnectLine{Starting: ipdata[0], Ending: ipdata[len(ipdata)-1]}
+
+	farthestPointIndex, farthestPointDistanceFromLine := FindFarthestPoint(line, ipdata)
+
+	if farthestPointDistanceFromLine >= epsilon {
+		leftSplit := DownSampleIpdata(ipdata[:farthestPointIndex+1], epsilon)
+		rightSplit := DownSampleIpdata(ipdata[farthestPointIndex:], epsilon)
+		return append(leftSplit[:len(leftSplit)-1], rightSplit...)
+	}
+
+	return []Point{ipdata[0], ipdata[len(ipdata)-1]}
+
+}
+
+//Iterative implementation of the RDP algorithm for the given retention rate
+
+func DownSampleRetention(ipdata []Point, startIndex int64, endIndex int64, weights []float64) []float64 {
+	var stack [][]int64
+	globalStartIndex := startIndex
+	globalEndIndex := endIndex
+	stack = append(stack, []int64{startIndex, endIndex})
+	for len(stack) > 0 {
+		n := len(stack) - 1
+		lineOfInterest := stack[n]
+		stack = stack[:n]
+		startIndex := lineOfInterest[0]
+		endIndex := lineOfInterest[1]
+		maxDistance := 0.0
+		index := startIndex
+		line := ConnectLine{Starting: ipdata[startIndex], Ending: ipdata[endIndex]}
+		for i := index + 1; i < endIndex; i++ {
+
+			distance := line.perpendicularDistanceFromPointToLine(ipdata[i])
+			if distance > maxDistance {
+				index = i
+				maxDistance = distance
+			}
+
+		}
+		if maxDistance > 0.0 {
+			weights[index] = maxDistance
+			stack = append(stack, []int64{startIndex, index})
+			stack = append(stack, []int64{index, endIndex})
+		}
+	}
+	weights[globalStartIndex] = math.Inf(1)
+	weights[globalEndIndex] = math.Inf(1)
+	return weights
+}
+
+//Learning the value of epsilon (maxTolerance) automatically if both the epsilon value and the retention rate have not been given
+
+func DownSampleIpdataAuto(ipdata []Point) []Point {
+	if len(ipdata) <= 2 {
+		return ipdata
+	}
+	line := ConnectLine{Starting: ipdata[0], Ending: ipdata[len(ipdata)-1]}
+
+	farthestPointIndex, farthestPointDistanceFromLine := FindFarthestPoint(line, ipdata)
+	x1 := ipdata[0].xCoordinate
+	x2 := ipdata[len(ipdata)-1].xCoordinate
+	y1 := ipdata[0].yCoordinate
+	y2 := ipdata[len(ipdata)-1].yCoordinate
+	lengthOfLine := math.Sqrt(math.Pow((x2-x1), 2) + math.Pow((y2-y1), 2))
+	slope := 0.0
+	if (x2 - x1) != 0 {
+		slope = (y2 - y1) / (x2 - x1)
+	}
+	phi := math.Atan(slope) //Phi is the angle between the digitized line and the continuous 2D line made with the X-axis
+	tmax := (1 / lengthOfLine) * (math.Abs(math.Sin(phi)) + math.Abs(math.Cos(phi)))
+	dophimaxone := math.Atan((1 / lengthOfLine) * (math.Abs(math.Sin(phi) + math.Cos(phi))) * (1 - tmax + math.Pow(tmax, 2)))
+	dophimaxtwo := math.Atan((1 / lengthOfLine) * (math.Abs(math.Sin(phi) - math.Cos(phi))) * (1 - tmax + math.Pow(tmax, 2)))
+	dophimax := math.Max(dophimaxone, dophimaxtwo) //Maximum deviation
+	window_threshold := lengthOfLine * dophimax
+	if farthestPointDistanceFromLine >= window_threshold {
+		leftSplit := DownSampleIpdataAuto(ipdata[:farthestPointIndex+1])
+		rightSplit := DownSampleIpdataAuto(ipdata[farthestPointIndex:])
+		return append(leftSplit[:len(leftSplit)-1], rightSplit...)
+	}
+
+	return []Point{ipdata[0], ipdata[len(ipdata)-1]}
+
+}
+
+// Given the array of 2D points split them into separate x and y arrays
+
+func (r *Rdp) SplitCoordinates(sampledPoints []Point) (*array.Int, *array.Float) {
+	newts := array.NewIntBuilder(r.alloc)
+	newvs := array.NewFloatBuilder(r.alloc)
+	for i := range sampledPoints {
+		newts.Append(int64(sampledPoints[i].xCoordinate))
+		newvs.Append(sampledPoints[i].yCoordinate)
+	}
+	return newts.NewIntArray(), newvs.NewFloatArray()
+}
+
+// Main implementation
+
+func (r *Rdp) Do(vs *array.Float, ts *array.Float) (*array.Int, *array.Float, error) {
+	r.vs = vs
+	r.ts = ts
+	points := r.ToPoints()
+	var sampledPoints []Point
+	// if both epsilon and retention rate is given together
+
+	if r.epsilon != 0.0 && r.retentionPercent != 0.0 {
+		return nil, nil, errors.New(codes.Invalid, "Please provide either epsilon or retention rate and not both")
+	}
+	// If epsilon has been given
+
+	if r.epsilon != 0.0 {
+		sampledPoints = DownSampleIpdata(points, r.epsilon)
+		Newts, Newvs := r.SplitCoordinates(sampledPoints)
+		return Newts, Newvs, nil
+	} else if r.retentionPercent != 0.0 { // if the retention percent is given
+		numOfPoints := int64(vs.Len())
+		retention := r.retentionPercent
+		weights := make([]float64, numOfPoints)
+		pointsToKeep := math.Floor((retention / 100) * float64(numOfPoints))
+		if pointsToKeep >= 1.0 {
+			weightsUpdated := DownSampleRetention(points, 0, numOfPoints-1, weights)
+			weightsDescending := make([]float64, len(weightsUpdated))
+			copy(weightsDescending, weightsUpdated)
+			sort.Sort(sort.Reverse(sort.Float64Slice(weightsDescending)))
+			maxTolerance := weightsDescending[int64(pointsToKeep)-1]
+			for i := range points {
+				if weightsUpdated[i] >= maxTolerance {
+					sampledPoints = append(sampledPoints, points[i])
+				}
+			}
+			Newts, Newvs := r.SplitCoordinates(sampledPoints)
+			return Newts, Newvs, nil
+		} else {
+			return nil, nil, errors.New(codes.Invalid, "The number of points to retain is less than 1. Please consider increasing the retention rate")
+		}
+	} else { // if both epsilon and retention rate is not given then we try to learn the maximum tolerance by ourselves.
+		sampledPoints := DownSampleIpdataAuto(points)
+		Newts, Newvs := r.SplitCoordinates(sampledPoints)
+		return Newts, Newvs, nil
+	}
+}

--- a/stdlib/packages.go
+++ b/stdlib/packages.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/influxdata/flux/stdlib/experimental/json"
 	_ "github.com/influxdata/flux/stdlib/experimental/mqtt"
 	_ "github.com/influxdata/flux/stdlib/experimental/oee"
+	_ "github.com/influxdata/flux/stdlib/experimental/polyline"
 	_ "github.com/influxdata/flux/stdlib/experimental/prometheus"
 	_ "github.com/influxdata/flux/stdlib/experimental/query"
 	_ "github.com/influxdata/flux/stdlib/experimental/record"


### PR DESCRIPTION
Added a new package containing functions for polyline simplification. The RDP algorithm enables the downsampling of data by retaining the variations in the curve to create visually indistinguishable graphs.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
