### PR TITLE
feat: Add Stringify function to table.Chunk

### DIFF
--- a/execute/aggregate.go
+++ b/execute/aggregate.go
@@ -684,7 +684,7 @@ func (t *simpleAggregateTransformation2) Aggregate(chunk table.Chunk, state inte
 		case flux.TInt:
 			agg.(DoIntAgg).DoInt(chunk.Ints(idx))
 		case flux.TUInt:
-			agg.(DoUIntAgg).DoUInt(chunk.Uints(idx))
+			agg.(DoUIntAgg).DoUInt(chunk.UInts(idx))
 		case flux.TFloat:
 			agg.(DoFloatAgg).DoFloat(chunk.Floats(idx))
 		case flux.TString:

--- a/execute/table/chunk.go
+++ b/execute/table/chunk.go
@@ -1,6 +1,8 @@
 package table
 
 import (
+	"strings"
+
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
@@ -108,9 +110,9 @@ func (v Chunk) Ints(j int) *array.Int {
 	return v.Values(j).(*array.Int)
 }
 
-// Uints is a convenience function for retrieving an array
+// UInts is a convenience function for retrieving an array
 // as a uint array.
-func (v Chunk) Uints(j int) *array.Uint {
+func (v Chunk) UInts(j int) *array.Uint {
 	return v.Values(j).(*array.Uint)
 }
 
@@ -126,6 +128,12 @@ func (v Chunk) Strings(j int) *array.String {
 	return v.Values(j).(*array.String)
 }
 
+// Times is a convenience function for retrieving an array
+// as a time array.
+func (v Chunk) Times(j int) *array.Int {
+	return v.Ints(j)
+}
+
 // Retain will retain a reference to this Chunk.
 func (v Chunk) Retain() {
 	v.buf.Retain()
@@ -134,4 +142,11 @@ func (v Chunk) Retain() {
 // Release will release a reference to this buffer.
 func (v Chunk) Release() {
 	v.buf.Release()
+}
+
+func (v Chunk) Stringify() string {
+	var sb strings.Builder
+	stringifyKey(&sb, v.Key(), v.Cols())
+	stringifyRows(&sb, v)
+	return sb.String()
 }

--- a/execute/table/stringify.go
+++ b/execute/table/stringify.go
@@ -14,7 +14,7 @@ import (
 // Stringify will read a table and turn it into a human-readable string.
 func Stringify(table flux.Table) string {
 	var sb strings.Builder
-	stringifyKey(&sb, table)
+	stringifyKey(&sb, table.Key(), table.Cols())
 	if err := table.Do(func(cr flux.ColReader) error {
 		stringifyRows(&sb, cr)
 		return nil
@@ -41,9 +41,8 @@ func getSortedIndices(key flux.GroupKey, cols []flux.ColMeta) ([]flux.ColMeta, [
 	return cols, indices
 }
 
-func stringifyKey(sb *strings.Builder, table flux.Table) {
-	key := table.Key()
-	cols, indices := getSortedIndices(table.Key(), table.Cols())
+func stringifyKey(sb *strings.Builder, key flux.GroupKey, cols []flux.ColMeta) {
+	cols, indices := getSortedIndices(key, cols)
 
 	sb.WriteString("# ")
 	if len(cols) == 0 {

--- a/stdlib/universe/difference.go
+++ b/stdlib/universe/difference.go
@@ -483,7 +483,7 @@ func (t *differenceTransformation) processChunk(differences []*difference, first
 				values := chunk.Ints(j)
 				out = processInts(d, l, values, firstIdx, mem)
 			case flux.TUInt:
-				values := chunk.Uints(j)
+				values := chunk.UInts(j)
 				out = processUints(d, l, values, firstIdx, mem)
 			case flux.TFloat:
 				values := chunk.Floats(j)


### PR DESCRIPTION
Useful for getting a human readable view into a chunk while debugging. I tweaked `table.Chunk`s methods slightly so it implements `ColReader`, allowing it to be used with `stringifyRows`.

Should maybe use the formatting used in https://github.com/influxdata/flux/pull/5077 instead, but I am getting errors about circular depencies which I am not in the mood for untangling.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
