### PR TITLE
test: Add debug.null()

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -262,7 +262,7 @@ var sourceHashes = map[string]string{
 	"stdlib/influxdata/influxdb/to_test.flux":                                                     "fcf5253c42f7668988e6b951d4ec11c5ba754ee19ba1fcc67ec3e0b3c0d3d579",
 	"stdlib/influxdata/influxdb/v1/v1.flux":                                                       "86ffb049a2b5d7568a8c8791ad7ccc0a9b62b564ce9009384267cdbc77f1a275",
 	"stdlib/internal/boolean/boolean.flux":                                                        "3d4d27a591d9063bfbc79a9302463e5715b6481748708a98df8a54e53871ab69",
-	"stdlib/internal/debug/debug.flux":                                                            "36a7ac5023719f5d72f3b467b80fe4f1fefc754422f9e81463e721ed39e53c27",
+	"stdlib/internal/debug/debug.flux":                                                            "b4088e47938b9860472eb32f70d957ed56e61d1ba034ad490d3a00d76c722f00",
 	"stdlib/internal/debug/debug_test.flux":                                                       "673fa36e1fb36aa55ec2e76f08bf2600faa61c1904e4c0a7229b7680d1f0228f",
 	"stdlib/internal/gen/gen.flux":                                                                "14e379521d3c003e92fcf51d47a8c36d2f91730fb0d8301a3f4b2638865a00c5",
 	"stdlib/internal/gen/tables_test.flux":                                                        "14a3d3542aa0815bf3fb912b045c23161322acff731bfa04ce380c5da9866654",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -262,7 +262,7 @@ var sourceHashes = map[string]string{
 	"stdlib/influxdata/influxdb/to_test.flux":                                                     "fcf5253c42f7668988e6b951d4ec11c5ba754ee19ba1fcc67ec3e0b3c0d3d579",
 	"stdlib/influxdata/influxdb/v1/v1.flux":                                                       "86ffb049a2b5d7568a8c8791ad7ccc0a9b62b564ce9009384267cdbc77f1a275",
 	"stdlib/internal/boolean/boolean.flux":                                                        "3d4d27a591d9063bfbc79a9302463e5715b6481748708a98df8a54e53871ab69",
-	"stdlib/internal/debug/debug.flux":                                                            "c4bd609c21ab708139fe39f0551003ea592cf426b4cf5f9763f7a5bf67a395f4",
+	"stdlib/internal/debug/debug.flux":                                                            "36a7ac5023719f5d72f3b467b80fe4f1fefc754422f9e81463e721ed39e53c27",
 	"stdlib/internal/debug/debug_test.flux":                                                       "673fa36e1fb36aa55ec2e76f08bf2600faa61c1904e4c0a7229b7680d1f0228f",
 	"stdlib/internal/gen/gen.flux":                                                                "14e379521d3c003e92fcf51d47a8c36d2f91730fb0d8301a3f4b2638865a00c5",
 	"stdlib/internal/gen/tables_test.flux":                                                        "14a3d3542aa0815bf3fb912b045c23161322acff731bfa04ce380c5da9866654",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -262,7 +262,7 @@ var sourceHashes = map[string]string{
 	"stdlib/influxdata/influxdb/to_test.flux":                                                     "fcf5253c42f7668988e6b951d4ec11c5ba754ee19ba1fcc67ec3e0b3c0d3d579",
 	"stdlib/influxdata/influxdb/v1/v1.flux":                                                       "86ffb049a2b5d7568a8c8791ad7ccc0a9b62b564ce9009384267cdbc77f1a275",
 	"stdlib/internal/boolean/boolean.flux":                                                        "3d4d27a591d9063bfbc79a9302463e5715b6481748708a98df8a54e53871ab69",
-	"stdlib/internal/debug/debug.flux":                                                            "c94c8f729e1051d2c85b535238fd2dc6e5080a92ad46918c445490a26645e856",
+	"stdlib/internal/debug/debug.flux":                                                            "c4bd609c21ab708139fe39f0551003ea592cf426b4cf5f9763f7a5bf67a395f4",
 	"stdlib/internal/debug/debug_test.flux":                                                       "673fa36e1fb36aa55ec2e76f08bf2600faa61c1904e4c0a7229b7680d1f0228f",
 	"stdlib/internal/gen/gen.flux":                                                                "14e379521d3c003e92fcf51d47a8c36d2f91730fb0d8301a3f4b2638865a00c5",
 	"stdlib/internal/gen/tables_test.flux":                                                        "14a3d3542aa0815bf3fb912b045c23161322acff731bfa04ce380c5da9866654",

--- a/stdlib/internal/debug/debug.flux
+++ b/stdlib/internal/debug/debug.flux
@@ -54,7 +54,14 @@ builtin getOption : (pkg: string, name: string) => A
 builtin feature : (key: string) => A
 
 // Null returns the null value with the given type
-builtin null : (?type: string) => A
+//
+// ## Parameters
+// - type: Which type to give the null
+//
+// ```
+// array.from(rows: [{a: 1, b: 2, c: 3}, {a: debug.null("int"), b: 5, c: 6}])
+// ``
+builtin null : (?type: string) => A where A: Basic
 
 // vectorize controls whether the compiler attempts to vectorize Flux functions.
 option vectorize = false

--- a/stdlib/internal/debug/debug.flux
+++ b/stdlib/internal/debug/debug.flux
@@ -53,5 +53,8 @@ builtin getOption : (pkg: string, name: string) => A
 //
 builtin feature : (key: string) => A
 
+// Null returns the null value with the given type
+builtin null : (?type: string) => A
+
 // vectorize controls whether the compiler attempts to vectorize Flux functions.
 option vectorize = false

--- a/stdlib/internal/debug/debug.flux
+++ b/stdlib/internal/debug/debug.flux
@@ -53,7 +53,7 @@ builtin getOption : (pkg: string, name: string) => A
 //
 builtin feature : (key: string) => A
 
-// Null returns the null value with the given type
+// null returns the null value with the given type
 //
 // ## Parameters
 // - type: Which type to give the null

--- a/stdlib/internal/debug/null.go
+++ b/stdlib/internal/debug/null.go
@@ -1,0 +1,58 @@
+package debug
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+func init() {
+	mt := runtime.MustLookupBuiltinType("internal/debug", "null")
+	runtime.RegisterPackageValue("internal/debug", "null",
+		values.NewFunction("null", mt, func(ctx context.Context, args values.Object) (values.Value, error) {
+			return interpreter.DoFunctionCallContext(Null, ctx, args)
+		}, false),
+	)
+}
+
+func Null(ctx context.Context, args interpreter.Arguments) (values.Value, error) {
+	typ, ok, err := args.GetString("type")
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return values.Null, nil
+	}
+
+	var semanticType semantic.MonoType
+	switch typ {
+	case "string":
+		semanticType = semantic.BasicString
+	case "bytes":
+		semanticType = semantic.BasicBytes
+	case "int":
+		semanticType = semantic.BasicInt
+	case "uint":
+		semanticType = semantic.BasicUint
+	case "float":
+		semanticType = semantic.BasicFloat
+	case "bool":
+		semanticType = semantic.BasicBool
+	case "time":
+		semanticType = semantic.BasicTime
+	case "duration":
+		semanticType = semantic.BasicDuration
+	case "regexp":
+		semanticType = semantic.BasicRegexp
+	default:
+		return nil, errors.Newf(codes.Invalid, "Invalid null type `%s`", typ)
+	}
+
+	return values.NewNull(semanticType), nil
+}


### PR DESCRIPTION
Allow null values to be created explicitly in flux code. We could always create nulls by using `csv.from` however that format is pretty hard to read compared to `array.from` but since the latter could not create streams with nulls we were forced to use `csv.from`. With this we can use `array.from` in cases where nulls are needed in the test.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
