### PR TITLE
chore: add comment regarding Rust version to docker and toolchain files

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,6 +4,11 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
+#
+# Note: we are stuck on Rust version 1.58 for the time being until
+# this issue is fixed:
+#   https://github.com/rust-lang/rust/issues/97117
+# Since it blocks the ARM64 build of InfluxDB.
 FROM rust:1.58 as RUSTBUILD
 
 FROM golang:1.18 as PKGCONFIG

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,8 @@
 [toolchain]
+# Note: we are stuck on Rust version 1.58 for the time being until
+# this issue is fixed:
+#   https://github.com/rust-lang/rust/issues/97117
+# Since it blocks the ARM64 build of InfluxDB.
 channel = "1.58"
 components = ["rustfmt", "clippy"]
 targets = [


### PR DESCRIPTION
This just adds a comment to `Dockerfile_build` and `rust-toolchain.toml` about how we're blocked on this issue:
https://github.com/rust-lang/rust/issues/97117

I attempted to reproduce with Rust 1.63.0 and the issue is still occurs there.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
