### PR TITLE
fix(build): update buildinfo doc comments to match latest gofmt

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -10,6 +10,7 @@ package libflux
 // and forces the cgo library to rebuild and relink
 // the sources. This is because non-C/C++ sources
 // are not tracked by Go's build system.'
+//
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
 	"libflux/Cargo.lock":                                                                          "d22aefaaab124dba2e5bcb521d44610e400d745a36a97b29665ee3db51b4a6ca",

--- a/libflux/go/libflux/internal/buildinfo/main.go
+++ b/libflux/go/libflux/internal/buildinfo/main.go
@@ -195,6 +195,7 @@ package libflux
 // and forces the cgo library to rebuild and relink
 // the sources. This is because non-C/C++ sources
 // are not tracked by Go's build system.'
+//
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
 {{range .}}"{{.}}": "{{hexdigest .}}",

--- a/plan/heuristic_planner.go
+++ b/plan/heuristic_planner.go
@@ -112,7 +112,7 @@ func (p *heuristicPlanner) matchRules(ctx context.Context, spec *Spec, node Node
 // Traversal is repeated until a pass over the DAG results in no changes with the given rule set.
 //
 // Plan may change its argument and/or return a new instance of Spec, so the correct way to call Plan is:
-//     plan, err = plan.Plan(plan)
+// plan, err = plan.Plan(plan)
 func (p *heuristicPlanner) Plan(ctx context.Context, inputPlan *Spec) (*Spec, error) {
 	for anyChanged := true; anyChanged; {
 		visited := make(map[Node]struct{})
@@ -164,11 +164,11 @@ func (p *heuristicPlanner) Plan(ctx context.Context, inputPlan *Spec) (*Spec, er
 // and rewires them to point them at newNode.
 // Predecessors of oldNode and newNode are not touched.
 //
-//  A   B             A   B     <-- successors
-//   \ /               \ /
-//   node  becomes   newNode
-//   / \               / \
-//  D   E             D'  E'    <-- predecessors
+//	A   B             A   B     <-- successors
+//	 \ /               \ /
+//	 node  becomes   newNode
+//	 / \               / \
+//	D   E             D'  E'    <-- predecessors
 func updateSuccessors(plan *Spec, oldNode, newNode Node) error {
 	// no need to update successors if the node hasn't actually changed
 	if oldNode == newNode {


### PR DESCRIPTION
ci throws an error comparing `buildinfo.gen.go` file when my local go version is 1.19 and ci is on the previous version.
This is because `gofmt` is changed in 1.19 and now reformats doc comments with an extra line. https://tip.golang.org/doc/go1.19#go-doc So reformatted the comments itself to work with current and previous versions.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
