### PR TITLE
feat(libflux): adds typecmp to compare Flux types

### DIFF
--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -25,6 +25,12 @@ name = "fluxc"
 test = false
 bench = false
 
+[[bin]]
+name = "typecmp"
+test = false
+bench = false
+required-features = ["doc"]
+
 [features]
 default = ["strict"]
 strict = []

--- a/libflux/flux-core/src/bin/typecmp.rs
+++ b/libflux/flux-core/src/bin/typecmp.rs
@@ -1,0 +1,144 @@
+use std::{cmp::max, fs, path::PathBuf};
+
+use anyhow::{anyhow, Result};
+use fluxcore::{
+    doc::{Doc, PackageDoc},
+    parser,
+    semantic::{
+        cmp::{self, TypeDiff},
+        convert::convert_polytype,
+        types::PolyType,
+        AnalyzerConfig,
+    },
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(about = "compare Flux types")]
+enum TypeCmp {
+    /// Diff an old and new Flux types
+    Diff {
+        /// Old Flux type
+        #[structopt(short, long, parse(from_os_str))]
+        old: PathBuf,
+        /// New Flux type
+        #[structopt(short, long, parse(from_os_str))]
+        new: PathBuf,
+        /// Versbose
+        #[structopt(short, long)]
+        verbose: bool,
+    },
+}
+fn main() -> Result<()> {
+    let app = TypeCmp::from_args();
+    match app {
+        TypeCmp::Diff { old, new, verbose } => diff(&old, &new, verbose)?,
+    };
+    Ok(())
+}
+
+struct Diagnostic {
+    pkg: String,
+    diff: TypeDiff,
+    new: Vec<String>,
+    diffs: Vec<(String, Diff)>,
+}
+
+struct Diff {
+    old: PolyType,
+    new: PolyType,
+    diff: TypeDiff,
+}
+
+fn diff(old: &PathBuf, new: &PathBuf, verbose: bool) -> Result<()> {
+    let old_contents = fs::read_to_string(old)?;
+    let old: Vec<PackageDoc> = serde_json::from_str(&old_contents)?;
+
+    let new_contents = fs::read_to_string(new)?;
+    let new: Vec<PackageDoc> = serde_json::from_str(&new_contents)?;
+
+    let mut diff = TypeDiff::Patch;
+    let mut diags = Vec::new();
+    // Check for breaking changes
+    for opkg in &old {
+        let mut diag = Diagnostic {
+            pkg: opkg.path.clone(),
+            diff: TypeDiff::Patch,
+            new: Vec::new(),
+            diffs: Vec::new(),
+        };
+        if let Some(npkg) = new.iter().find(|p| p.path == opkg.path) {
+            for (name, omember) in &opkg.members {
+                if let Some((_, nmember)) = &npkg.members.iter().find(|(k, _)| *k == name) {
+                    let old_type = type_of_doc(omember)?;
+                    let new_type = type_of_doc(*nmember)?;
+                    let d = cmp::diff(&old_type, &new_type);
+                    if verbose && d != TypeDiff::Patch {
+                        diag.diffs.push((
+                            name.to_owned(),
+                            Diff {
+                                old: old_type.clone(),
+                                new: new_type.clone(),
+                                diff: d,
+                            },
+                        ));
+                    }
+                    diag.diff = max(diag.diff, d);
+                }
+            }
+            for (name, _) in &npkg.members {
+                if !opkg.members.contains_key(name) {
+                    diag.diff = max(diag.diff, TypeDiff::Minor);
+                    diag.new.push(name.to_owned());
+                }
+            }
+        }
+        diff = max(diff, diag.diff);
+        diags.push(diag);
+    }
+    let mut new_pkgs = Vec::new();
+    // Check for new packages
+    for npkg in &new {
+        if old.iter().find(|p| p.path == npkg.path).is_none() {
+            diff = max(diff, TypeDiff::Minor);
+            new_pkgs.push(npkg.path.to_owned());
+        }
+    }
+    if verbose {
+        for diag in diags {
+            if diag.diff != TypeDiff::Patch {
+                println!("{} has a {:?} change", diag.pkg, diag.diff);
+                for (name, d) in diag.diffs {
+                    let old = format!("{}", d.old).replace("\n", "\n\t\t");
+                    let new = format!("{}", d.new).replace("\n", "\n\t\t");
+                    println!(
+                        "\t{}.{} has a {:?} change:\n\t\told: {}\n\t\tvs\n\t\tnew: {}",
+                        diag.pkg, name, d.diff, old, new
+                    );
+                }
+                for name in diag.new {
+                    println!("\t{} has new member {}", diag.pkg, name);
+                }
+            }
+        }
+        for pkg in new_pkgs {
+            println!("{} is a new package", pkg);
+        }
+    }
+    println!("{:?}", diff);
+
+    Ok(())
+}
+
+fn type_of_doc(doc: &Doc) -> Result<PolyType> {
+    match doc {
+        Doc::Package(_) => Err(anyhow!("unexpected package")),
+        Doc::Value(v) => str_to_type(v.flux_type.as_str()),
+        Doc::Function(f) => str_to_type(f.flux_type.as_str()),
+    }
+}
+
+fn str_to_type(typ: &str) -> Result<PolyType> {
+    let type_expr = parser::Parser::new(typ).parse_type_expression();
+    Ok(convert_polytype(&type_expr, &AnalyzerConfig::default())?)
+}

--- a/libflux/flux-core/src/semantic/cmp.rs
+++ b/libflux/flux-core/src/semantic/cmp.rs
@@ -1,0 +1,265 @@
+//! Utility to compare Flux types with each other.
+
+use std::cmp::max;
+
+use crate::semantic::types::{collect_record, MonoType, PolyType};
+
+/// Represents a difference between two types.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Copy)]
+pub enum TypeDiff {
+    /// Represents a backwards incomptible change to the types
+    Major = 2,
+    /// Represents a backwards comptible change to type
+    Minor = 1,
+    /// Represents no change to the types
+    Patch = 0,
+}
+
+/// Report the difference between the old and new polytypes.
+pub fn diff(old: &PolyType, new: &PolyType) -> TypeDiff {
+    println!("{} {}", old, new);
+    if old.vars != new.vars {
+        return TypeDiff::Major;
+    }
+    if old.cons != new.cons {
+        return TypeDiff::Major;
+    }
+    diff_monotype(&old.expr, &new.expr)
+}
+
+fn diff_monotype(old: &MonoType, new: &MonoType) -> TypeDiff {
+    match (old, new) {
+        (MonoType::Error, MonoType::Error) => TypeDiff::Patch,
+        (MonoType::Builtin(o), MonoType::Builtin(n)) => {
+            if o == n {
+                TypeDiff::Patch
+            } else {
+                TypeDiff::Major
+            }
+        }
+        (MonoType::Label(o), MonoType::Label(n)) => {
+            if o == n {
+                TypeDiff::Patch
+            } else {
+                TypeDiff::Major
+            }
+        }
+        (MonoType::Var(o), MonoType::Var(n)) => {
+            if o == n {
+                TypeDiff::Patch
+            } else {
+                TypeDiff::Major
+            }
+        }
+        (MonoType::BoundVar(o), MonoType::BoundVar(n)) => {
+            if o == n {
+                TypeDiff::Patch
+            } else {
+                TypeDiff::Major
+            }
+        }
+        (MonoType::Collection(old), MonoType::Collection(new)) => {
+            if old.collection != new.collection {
+                TypeDiff::Major
+            } else {
+                diff_monotype(&old.arg, &new.arg)
+            }
+        }
+        (MonoType::Record(old), MonoType::Record(new)) => {
+            let mut diff = TypeDiff::Patch;
+            let (ofields, otail) = collect_record(old);
+            let (nfields, ntail) = collect_record(new);
+            for (key, ofield) in ofields.iter() {
+                if let Some(nfield) = nfields.get(key) {
+                    if ofield.len() != nfield.len() {
+                        return diff;
+                    }
+                    for (i, of) in ofield.iter().enumerate() {
+                        let nf = nfield[i];
+                        diff = max(diff, diff_monotype(&of, &nf));
+                        if diff == TypeDiff::Major {
+                            return diff;
+                        }
+                    }
+                } else {
+                    return TypeDiff::Major;
+                }
+            }
+            match (otail, ntail) {
+                (Some(old), Some(new)) => {
+                    diff = max(diff, diff_monotype(old, new));
+                    if diff == TypeDiff::Major {
+                        return diff;
+                    }
+                }
+                (None, None) => {}
+                (_, _) => {
+                    return TypeDiff::Major;
+                }
+            };
+            for (key, _) in nfields.iter() {
+                if ofields.get(key).is_none() {
+                    // Adding a new field to a record is a major change
+                    return TypeDiff::Major;
+                }
+            }
+            diff
+        }
+        (MonoType::Dict(ref old), MonoType::Dict(ref new)) => max(
+            diff_monotype(&old.key, &new.key),
+            diff_monotype(&old.val, &new.val),
+        ),
+        (MonoType::Fun(old), MonoType::Fun(new)) => {
+            let mut diff = TypeDiff::Patch;
+            // Check for missing old required args
+            for (ok, ov) in &old.req {
+                if let Some((_, nv)) = new.req.iter().find(|(nk, _)| *nk == ok) {
+                    diff = max(diff, diff_monotype(ov, nv));
+                    if diff == TypeDiff::Major {
+                        return diff;
+                    }
+                } else {
+                    return TypeDiff::Major;
+                }
+            }
+            // Check for new required args
+            for (nk, _) in &new.req {
+                if old.req.iter().find(|(ok, _)| *ok == nk).is_none() {
+                    return TypeDiff::Major;
+                }
+            }
+            // Check for missing old optional args
+            for (ok, ov) in &old.opt {
+                if let Some((_, nv)) = new.opt.iter().find(|(nk, _)| *nk == ok) {
+                    match (ov.default.as_ref(), nv.default.as_ref()) {
+                        (Some(old), Some(new)) => {
+                            diff = max(diff, diff_monotype(&old, &new));
+                            if diff == TypeDiff::Major {
+                                return diff;
+                            }
+                        }
+                        (None, None) => {}
+                        (_, _) => {
+                            return TypeDiff::Major;
+                        }
+                    }
+                    diff = max(diff, diff_monotype(&ov.typ, &nv.typ));
+                    if diff == TypeDiff::Major {
+                        return diff;
+                    }
+                } else {
+                    return TypeDiff::Major;
+                }
+            }
+            // Check for new optional args
+            for (nk, _) in &new.opt {
+                if old.opt.iter().find(|(ok, _)| *ok == nk).is_none() {
+                    diff = max(diff, TypeDiff::Minor);
+                }
+            }
+            match (old.pipe.as_ref(), new.pipe.as_ref()) {
+                (Some(old), Some(new)) => {
+                    if old.k != new.k {
+                        return TypeDiff::Major;
+                    }
+                    diff = max(diff, diff_monotype(&old.v, &new.v));
+                    if diff == TypeDiff::Major {
+                        return diff;
+                    }
+                }
+                (None, None) => {}
+                (_, _) => {
+                    return TypeDiff::Major;
+                }
+            };
+            max(diff, diff_monotype(&old.retn, &new.retn))
+        }
+        // If the core monotype is different its a major change
+        (_, _) => TypeDiff::Major,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{diff, TypeDiff};
+    use crate::{
+        parser,
+        semantic::{convert::convert_polytype, types::PolyType, AnalyzerConfig},
+    };
+
+    fn str_to_type(typ: &str) -> PolyType {
+        let type_expr = parser::Parser::new(typ).parse_type_expression();
+        convert_polytype(&type_expr, &AnalyzerConfig::default()).unwrap()
+    }
+    macro_rules! test {
+        ($o:expr, $n:expr, $d:expr) => {
+            let old = str_to_type($o);
+            let new = str_to_type($n);
+
+            assert_eq!($d, diff(&old, &new));
+        };
+    }
+
+    #[test]
+    fn test_basic() {
+        test!("int", "int", TypeDiff::Patch);
+        test!("int", "float", TypeDiff::Major);
+    }
+    #[test]
+    fn test_record() {
+        test!("{a:int}", "{a:int}", TypeDiff::Patch);
+        test!("{a:int}", "{a:float}", TypeDiff::Major);
+        test!("{a:int,b:int}", "{a:int}", TypeDiff::Major);
+        test!("{a:int,b:int}", "{a:int,b:int}", TypeDiff::Patch);
+        test!("{a:int,b:int | C}", "{a:int,b:int | C}", TypeDiff::Patch);
+        test!("{a:int,b:int}", "{a:int,b:int | C}", TypeDiff::Major);
+    }
+
+    #[test]
+    fn test_function() {
+        test!("() => int", "() => int", TypeDiff::Patch);
+        test!("() => int", "() => float", TypeDiff::Major);
+        test!("(a:int) => int", "(a:int) => int", TypeDiff::Patch);
+        test!("(<-a:int) => int", "(<-a:int) => int", TypeDiff::Patch);
+        test!(
+            "(<-a:int,b:float) => int",
+            "(<-a:int,b:float) => int",
+            TypeDiff::Patch
+        );
+        test!(
+            "(<-a:int,b:float) => int",
+            "(a:int,<-b:float) => int",
+            TypeDiff::Major
+        );
+        test!("(a:int) => int", "(a:int,?b:int) => int", TypeDiff::Minor);
+        test!("(a:int) => int", "() => int", TypeDiff::Major);
+        test!("(a:int) => int", "(a:int, b:float) => int", TypeDiff::Major);
+        test!("(a:int,?b:float) => int", "(a:int, b:float) => int", TypeDiff::Major);
+    }
+
+    #[test]
+    fn test_constraints() {
+        test!("A where A: Record", "A where A: Record", TypeDiff::Patch);
+        test!("A where A: Record", "A where A: Addable", TypeDiff::Major);
+    }
+
+    #[test]
+    fn test_collection() {
+        test!("[int]", "[int]", TypeDiff::Patch);
+        test!("[int]", "[float]", TypeDiff::Major);
+
+        test!("stream[int]", "stream[int]", TypeDiff::Patch);
+        test!("stream[int]", "stream[float]", TypeDiff::Major);
+
+        test!("vector[int]", "vector[int]", TypeDiff::Patch);
+        test!("vector[int]", "vector[float]", TypeDiff::Major);
+
+        test!("stream[int]", "vector[float]", TypeDiff::Major);
+    }
+
+    #[test]
+    fn test_dict() {
+        test!("[int:int]", "[int:int]", TypeDiff::Patch);
+        test!("[int:int]", "[int:float]", TypeDiff::Major);
+    }
+}

--- a/libflux/flux-core/src/semantic/mod.rs
+++ b/libflux/flux-core/src/semantic/mod.rs
@@ -12,6 +12,7 @@ pub mod types;
 
 pub mod bootstrap;
 pub mod check;
+pub mod cmp;
 pub mod env;
 pub mod formatter;
 pub mod fresh;

--- a/libflux/flux-core/src/semantic/types.rs
+++ b/libflux/flux-core/src/semantic/types.rs
@@ -1336,7 +1336,11 @@ impl fmt::Display for Record {
     }
 }
 
-fn collect_record(record: &Record) -> (RefMonoTypeVecMap<'_, RecordLabel>, Option<&MonoType>) {
+/// Creates map of the records fields and its tail.
+/// Useful for comparing two records as its possible fields repeat.
+pub(crate) fn collect_record(
+    record: &Record,
+) -> (RefMonoTypeVecMap<'_, RecordLabel>, Option<&MonoType>) {
     let mut a = RefMonoTypeVecMap::new();
 
     let mut fields = record.fields();


### PR DESCRIPTION
WIP

TODO:

- [x] Choose a better name
- [x] Write tests
- [ ] Document rules
- [x] Report specifics about changes instead of just the aggregate Major,Minor,Patch diff
- [ ] Determine how we would like to use this in CI, i.e. compare master against most recent Flux release? Then what?

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [ ] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
