### PR TITLE
fix: sort columns when printing group key

### DIFF
--- a/internal/execute/groupkey/groupkey.go
+++ b/internal/execute/groupkey/groupkey.go
@@ -92,11 +92,11 @@ func (k *groupKey) Less(o flux.GroupKey) bool {
 func (k *groupKey) String() string {
 	var b strings.Builder
 	b.WriteRune('{')
-	for j, c := range k.cols {
-		if j != 0 {
+	for i, idx := range k.sorted {
+		if i != 0 {
 			b.WriteRune(',')
 		}
-		fmt.Fprintf(&b, "%s=%v", c.Label, k.values[j])
+		fmt.Fprintf(&b, "%s=%v", k.cols[idx].Label, k.values[idx])
 	}
 	b.WriteRune('}')
 	return b.String()

--- a/internal/execute/groupkey/groupkey_test.go
+++ b/internal/execute/groupkey/groupkey_test.go
@@ -3,6 +3,7 @@ package groupkey_test
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/semantic"
@@ -338,6 +339,50 @@ func TestGroupKey_Less(t *testing.T) {
 			}
 			if want, got := tt.want[1], tt.right.Less(tt.left); want != got {
 				t.Errorf("unexpected result for right < left: want=%v got=%v", want, got)
+			}
+		})
+	}
+}
+
+func TestGroupKey_String(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		gk   flux.GroupKey
+		want string
+	}{
+		{
+			name: "simple",
+			gk: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "a", Type: flux.TString},
+					{Label: "b", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("a0"),
+					values.NewString("b0"),
+				},
+			),
+			want: "{a=a0,b=b0}",
+		},
+		{
+			name: "unordered columns",
+			gk: execute.NewGroupKey(
+				[]flux.ColMeta{
+					{Label: "b", Type: flux.TString},
+					{Label: "a", Type: flux.TString},
+				},
+				[]values.Value{
+					values.NewString("b0"),
+					values.NewString("a0"),
+				},
+			),
+			want: "{a=a0,b=b0}",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			want, got := tt.want, tt.gk.String()
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Fatalf("did not get expected value for String(); -want/+got:\n%v", diff)
 			}
 		})
 	}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -551,7 +551,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/moving_average_test.flux":                                                    "a9d6ffe7093521f01d6000bdc09b569c7d3978b8b4ab1b247b6744ab9981dbed",
 	"stdlib/universe/multiple_range_test.flux":                                                    "d01a115a15408039f7eb36fec1f8bfcb0b1a96a6b203ba03e1b0fc42838a7c71",
 	"stdlib/universe/parse_regex_test.flux":                                                       "992b3a1e2885dc844d0b7d3e3040aa61252b1d000cd16ab90659890fdb4765e1",
-	"stdlib/universe/pivot_col_order_test.flux":                                                   "df230a979da15d93390ce897639b79c7c394cc89fc77b436093d3c1c1587e129",
+	"stdlib/universe/pivot_col_order_test.flux":                                                   "c02eff2056c7dff2614a1167bcf56f2be689cfdf1819c35aa05826cc02330af1",
 	"stdlib/universe/pivot_fields_test.flux":                                                      "1a1517c9f7dd624600f3f3c1c9d01073ed24967975245833a18a20f0e506c0ad",
 	"stdlib/universe/pivot_mean_test.flux":                                                        "ecab0e8a5567172b6afefe62ed5900746e60c96d6ac78ab10c3c2cd6b48f1f48",
 	"stdlib/universe/pivot_table_test.flux":                                                       "52947b9aa9e499e9d750b6a5e41c5b67e2a0e7f3307b49103651cae525bb0072",


### PR DESCRIPTION
The flux pivot() function uses a string representation of
the group key to keep track of what columns it has seen.
Sometimes the columns of the group key can appear in a different order
even if the set of columns and their values are the same. when this
happens, pivot() panics as it uses a map that assumes all group
keys have a canonical representation.

So the `groupKeyString` that is computed here:
https://github.com/influxdata/flux/blob/cf5caf06789c3e6995998a077ffc411f80582c2f/stdlib/universe/pivot.go#L264

Is later used here to access a map in a map-of-maps:
https://github.com/influxdata/flux/blob/cf5caf06789c3e6995998a077ffc411f80582c2f/stdlib/universe/pivot.go#L307

And sometimes it may happen that the string value used to create an entry in the
outer map may be different than the string value used to access that entry later on.

The fix here is to make `groupKey.String()` use the sorted order
of the group columns when returning its result, so that the group key string
is always the same.

Fixes #5104.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
