### PR TITLE
chore: Downgrade rust to 1.58 again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,10 @@ test: test-go test-rust test-flux
 test-go: libflux-go
 	$(GO_TEST) $(GO_TEST_FLAGS) ./...
 
-test-rust:
+test-rust: lint-rust
 	cd libflux && $(CARGO) test $(CARGO_ARGS) --all-features && \
 	$(CARGO) doc --no-deps && \
-	$(CARGO) test --doc && \
-	$(CARGO) clippy $(CARGO_ARGS) --all-features --all-targets -- -Dclippy::all -Dclippy::undocumented_unsafe_blocks
+	$(CARGO) test --doc
 
 test-flux:
 	$(GO_RUN) ./cmd/flux test -p stdlib -v --parallel 8
@@ -144,6 +143,9 @@ test-bench: libflux-go
 
 vet: libflux-go
 	$(GO_VET) ./...
+
+lint-rust:
+	cd libflux && $(CARGO) clippy $(CARGO_ARGS) --all-features --all-targets -- -Dclippy::all -Dclippy::undocumented_unsafe_blocks
 
 bench: libflux-go
 	$(GO_TEST) -bench=. -run=^$$ ./...
@@ -221,6 +223,7 @@ checkdocs: $(STDLIB_SOURCES) libflux/target/release/fluxc libflux/target/release
 	libflux \
 	libflux-go \
 	libflux-wasm \
+	lint-rust \
 	publish-wasm \
 	release \
 	staticcheck \

--- a/libflux/flux/src/cffi.rs
+++ b/libflux/flux/src/cffi.rs
@@ -898,6 +898,8 @@ from(bucket: v.bucket)
     }
 
     #[test]
+    // TODO Remove once rust is updated (see https://github.com/rust-lang/rust-clippy/pull/8450)
+    #[allow(clippy::undocumented_unsafe_blocks)]
     fn test_ast_get_error() {
         let ast = crate::parser::parse_string("test".to_string(), "x = 3 + / 10 - \"");
         let ast = Box::new(ast.into());

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -62,7 +62,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/Cargo.toml":                                                                     "9fae0ee886a5c5278ad6b4606c36d9e929ab9529995856a333a618caae35c210",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "6f2a4da51744a174ab13a1ebcb18ea39c0acfc2c720e7a61ea3e326fb0649529",
-	"libflux/flux/src/cffi.rs":                                                                    "26ff804cf82aac53557cfc7b9add51c2d8caeb9ea2d456fc857a65ec34ec7532",
+	"libflux/flux/src/cffi.rs":                                                                    "9d664309e2542f4320e285ac3f5aeb6f835ae6e1f102a8318943ceb0d8a55e68",
 	"libflux/flux/src/lib.rs":                                                                     "3cd7dfcf7491f5797d501a647ee92a3f66b5790f6df7ed2238f1969b4bd929ed",
 	"libflux/flux/templates/base.html":                                                            "a818747b9621828bb96b94291c60922db54052bbe35d5e354f8e589d2a4ebd02",
 	"libflux/flux/templates/home.html":                                                            "f9927514dd42ca7271b4817ad1ca33ec79c03a77a783581b4dcafabd246ebf3f",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.62"
+channel = "1.58"
 components = ["rustfmt", "clippy"]
 targets = [
     "wasm32-unknown-unknown",


### PR DESCRIPTION
Didn't think about us being locked to 1.58 when I created https://github.com/influxdata/flux/pull/4939 so I updated rust to fix the bug with the `undocumented_unsafe_blocks` lint. This downgrades rust again and adds an allow to work around it.

cc https://github.com/influxdata/flux/pull/5084#issuecomment-1216836856

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
