### PR TITLE
fix: Don't error when formatting boolean literals

### DIFF
--- a/semantic/format.go
+++ b/semantic/format.go
@@ -70,6 +70,7 @@ func (v *formattingVisitor) Visit(node Node) Visitor {
 	case *StringLiteral:
 	case *FloatLiteral:
 	case *IntegerLiteral:
+	case *BooleanLiteral:
 	case *IdentifierExpression:
 	default:
 		// Do not recurse into unknown nodes, just push an error string
@@ -101,6 +102,8 @@ func (v *formattingVisitor) Done(node Node) {
 		// the difference between integers and floats in output.
 		v.push(fmt.Sprintf("%f", n.Value))
 	case *IntegerLiteral:
+		v.push(fmt.Sprintf("%v", n.Value))
+	case *BooleanLiteral:
 		v.push(fmt.Sprintf("%v", n.Value))
 	case *IdentifierExpression:
 		v.push(n.Name.Name())


### PR DESCRIPTION
Got an error for this when output the query plan. Easy enough to just handle the node

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 
Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
