### PR TITLE
refactor: Remove type switch in schema_mutators

### DIFF
--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -342,7 +342,7 @@ func (s *RenameOpSpec) Mutator() (SchemaMutator, error) {
 }
 
 func (s *DropOpSpec) Mutator() (SchemaMutator, error) {
-	m, err := NewDropKeepMutator(s)
+	m, err := NewDropMutator(s)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (s *DropOpSpec) Mutator() (SchemaMutator, error) {
 }
 
 func (s *KeepOpSpec) Mutator() (SchemaMutator, error) {
-	m, err := NewDropKeepMutator(s)
+	m, err := NewKeepMutator(s)
 	if err != nil {
 		return nil, err
 	}

--- a/stdlib/universe/schema_functions_test.go
+++ b/stdlib/universe/schema_functions_test.go
@@ -1530,11 +1530,11 @@ func TestRenameDrop_PushDown(t *testing.T) {
 		},
 	}
 
-	m2, _ := functions.NewDropKeepMutator(&functions.DropOpSpec{
+	m2, _ := functions.NewDropMutator(&functions.DropOpSpec{
 		Cols: []string{},
 	})
 
-	m3, _ := functions.NewDropKeepMutator(&functions.KeepOpSpec{
+	m3, _ := functions.NewKeepMutator(&functions.KeepOpSpec{
 		Cols: []string{},
 	})
 

--- a/stdlib/universe/schema_mutators.go
+++ b/stdlib/universe/schema_mutators.go
@@ -191,31 +191,31 @@ type DropKeepMutator struct {
 	FlipPredicate bool
 }
 
-func NewDropKeepMutator(qs flux.OperationSpec) (*DropKeepMutator, error) {
+func NewDropMutator(s *DropOpSpec) (*DropKeepMutator, error) {
+	m := &DropKeepMutator{}
+	if s.Columns != nil {
+		m.DropCols = toStringSet(s.Columns)
+	}
+	if s.Predicate.Fn != nil {
+		if err := m.compile(s.Predicate); err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+func NewKeepMutator(s *KeepOpSpec) (*DropKeepMutator, error) {
 	m := &DropKeepMutator{}
 
-	switch s := qs.(type) {
-	case *DropOpSpec:
-		if s.Columns != nil {
-			m.DropCols = toStringSet(s.Columns)
+	if s.Columns != nil {
+		m.KeepCols = toStringSet(s.Columns)
+	}
+	if s.Predicate.Fn != nil {
+		if err := m.compile(s.Predicate); err != nil {
+			return nil, err
 		}
-		if s.Predicate.Fn != nil {
-			if err := m.compile(s.Predicate); err != nil {
-				return nil, err
-			}
-		}
-	case *KeepOpSpec:
-		if s.Columns != nil {
-			m.KeepCols = toStringSet(s.Columns)
-		}
-		if s.Predicate.Fn != nil {
-			if err := m.compile(s.Predicate); err != nil {
-				return nil, err
-			}
-			m.FlipPredicate = true
-		}
-	default:
-		return nil, errors.Newf(codes.Internal, "invalid spec type %T", qs)
+		m.FlipPredicate = true
 	}
 
 	return m, nil


### PR DESCRIPTION
No need for the type switch here when we can just type two functions precisely instead :shrug: 

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
