### PR TITLE
chore: upgrade Rust toolchain to 1.63

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,7 +4,7 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-FROM rust:1.62 as RUSTBUILD
+FROM rust:1.63 as RUSTBUILD
 
 FROM golang:1.18 as PKGCONFIG
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,12 +4,7 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-#
-# Note: we are stuck on Rust version 1.58 for the time being until
-# this issue is fixed:
-#   https://github.com/rust-lang/rust/issues/97117
-# Since it blocks the ARM64 build of InfluxDB.
-FROM rust:1.58 as RUSTBUILD
+FROM rust:1.62 as RUSTBUILD
 
 FROM golang:1.18 as PKGCONFIG
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.62.1"
+channel = "1.63.0"
 components = ["rustfmt", "clippy"]
 targets = [
     "wasm32-unknown-unknown",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,5 @@
 [toolchain]
-# Note: we are stuck on Rust version 1.58 for the time being until
-# this issue is fixed:
-#   https://github.com/rust-lang/rust/issues/97117
-# Since it blocks the ARM64 build of InfluxDB.
-channel = "1.58"
+channel = "1.62"
 components = ["rustfmt", "clippy"]
 targets = [
     "wasm32-unknown-unknown",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.62"
+channel = "1.62.1"
 components = ["rustfmt", "clippy"]
 targets = [
     "wasm32-unknown-unknown",


### PR DESCRIPTION
I've worked out the issues with the InfluxDB cross-builder/build system and we can now build with new versions of the Rust toolchain.