### PR TITLE
fix(plan): fix logic bug in planner helper method

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -581,7 +581,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/simple_max_test.flux":                                                        "a63b3f530e4d81451e3c71a1abeea50cff02e743c9313ab3ffd5bc3b3ce9ad2e",
 	"stdlib/universe/skew_test.flux":                                                              "7782d41c563c77ba9f4176fa1b5f4f6107e418b7ea301e4896398dbcb514315a",
 	"stdlib/universe/sort2_test.flux":                                                             "1d2043c0d0b38abb8dc61fc1baa6d6052fae63fea55cc6e67fd1600911513bdb",
-	"stdlib/universe/sort_limit_test.flux":                                                        "dc987d52f993ae11c8f0643af17c86471a75c6a9677899996182645fc86a4ee8",
+	"stdlib/universe/sort_limit_test.flux":                                                        "32825b6b789c5b3287ae72967687a63fa3fee783e6626426c9b1cc7f39306dc8",
 	"stdlib/universe/sort_rules_test.flux":                                                        "0770ae42e99b04167ca5bef8340a310b224baf1ba1928997273de9663b64684a",
 	"stdlib/universe/sort_test.flux":                                                              "f69ebb5972762078e759af3c1cd3d852431a569dce74f3c379709c9e174bfa31",
 	"stdlib/universe/spread_test.flux":                                                            "1ddf25e4d86b6365da254229fc8f77bd838c24a79e6a08c9c4c50330ace0a6a3",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -581,7 +581,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/simple_max_test.flux":                                                        "a63b3f530e4d81451e3c71a1abeea50cff02e743c9313ab3ffd5bc3b3ce9ad2e",
 	"stdlib/universe/skew_test.flux":                                                              "7782d41c563c77ba9f4176fa1b5f4f6107e418b7ea301e4896398dbcb514315a",
 	"stdlib/universe/sort2_test.flux":                                                             "1d2043c0d0b38abb8dc61fc1baa6d6052fae63fea55cc6e67fd1600911513bdb",
-	"stdlib/universe/sort_limit_test.flux":                                                        "c595da9613faf8734932d8c2e63291517b7842b5656f795b32d50e987493ec2a",
+	"stdlib/universe/sort_limit_test.flux":                                                        "dc987d52f993ae11c8f0643af17c86471a75c6a9677899996182645fc86a4ee8",
 	"stdlib/universe/sort_rules_test.flux":                                                        "0770ae42e99b04167ca5bef8340a310b224baf1ba1928997273de9663b64684a",
 	"stdlib/universe/sort_test.flux":                                                              "f69ebb5972762078e759af3c1cd3d852431a569dce74f3c379709c9e174bfa31",
 	"stdlib/universe/spread_test.flux":                                                            "1ddf25e4d86b6365da254229fc8f77bd838c24a79e6a08c9c4c50330ace0a6a3",

--- a/plan/types.go
+++ b/plan/types.go
@@ -265,8 +265,8 @@ func mergePlanNodes(top, bottom, merged Node) (Node, error) {
 	}
 
 	merged.AddPredecessors(bottom.Predecessors()...)
-	for i, pred := range merged.Predecessors() {
-		for _, succ := range pred.Successors() {
+	for _, pred := range merged.Predecessors() {
+		for i, succ := range pred.Successors() {
 			if succ == bottom {
 				pred.Successors()[i] = merged
 			}

--- a/stdlib/universe/sort_limit_test.flux
+++ b/stdlib/universe/sort_limit_test.flux
@@ -138,3 +138,37 @@ testcase sort_limit_zero_row_table {
 
     testing.diff(got, want)
 }
+
+testcase sort_limit_multi_successor {
+    input =
+        array.from(
+            rows: [
+                {_time: 2022-01-11T00:00:00Z, _value: 10.0},
+                {_time: 2022-01-11T01:00:00Z, _value: 12.0},
+                {_time: 2022-01-11T02:00:00Z, _value: 18.0},
+                {_time: 2022-01-11T03:00:00Z, _value: 4.0},
+                {_time: 2022-01-11T04:00:00Z, _value: 8.0},
+            ],
+        )
+    in0 =
+        input
+            |> bottom(n: 2)
+    in1 =
+        input
+            |> top(n: 2)
+    got =
+        union(tables: [in0, in1])
+            |> sort(columns: ["_time"])
+
+    want =
+        array.from(
+            rows: [
+                {_time: 2022-01-11T01:00:00Z, _value: 12.0},
+                {_time: 2022-01-11T02:00:00Z, _value: 18.0},
+                {_time: 2022-01-11T03:00:00Z, _value: 4.0},
+                {_time: 2022-01-11T04:00:00Z, _value: 8.0},
+            ],
+        )
+
+    testing.diff(got: got, want: want)
+}


### PR DESCRIPTION
Fixes #5114.

This PR addresses an issue that has existed for a long time, but did not manifest until #5047 was merged. 

The issue was in a `plan` helper method that merges two nodes. If the predecessor to one of the nodes had a predecessor with multiple successors, we were not updating edges correctly and we put the plan graph into an inconsistent state.

Previously this issue could not be hit because we did not allow many rules to match in multi-successor scenarios, and this bug is particular to that situation.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` (N/A)
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated (N/A)

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
