### PR TITLE
chore(docs): fix typo and example in aggregateWindow

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -608,7 +608,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "7d8b47b3e96b859a5fed5985c051e2a3fdc947d3d6ff9cc104e40821581fb0cb",
 	"stdlib/universe/union_test.flux":                                                             "f008260d48db70212ce64d3f51f4cf031532a9a67c1ba43242dbc4d43ef31293",
 	"stdlib/universe/unique_test.flux":                                                            "2471d3a7aa6aac3e18def5736dc2352ae59e160edf033d3ceffe8fc91fe6492f",
-	"stdlib/universe/universe.flux":                                                               "e097972d87839974adbb6b86585b592343049f9a71b78a1b9141fc8748e4b742",
+	"stdlib/universe/universe.flux":                                                               "53d6c2ca39d677192dc7de26f3004e12120227180cf0f0042d84ae20b76b8dad",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "c8f66f7ee188bb2e979e5a8b526057b653922197ae441658f7c7f11251c96576",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -608,7 +608,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "7d8b47b3e96b859a5fed5985c051e2a3fdc947d3d6ff9cc104e40821581fb0cb",
 	"stdlib/universe/union_test.flux":                                                             "f008260d48db70212ce64d3f51f4cf031532a9a67c1ba43242dbc4d43ef31293",
 	"stdlib/universe/unique_test.flux":                                                            "2471d3a7aa6aac3e18def5736dc2352ae59e160edf033d3ceffe8fc91fe6492f",
-	"stdlib/universe/universe.flux":                                                               "53d6c2ca39d677192dc7de26f3004e12120227180cf0f0042d84ae20b76b8dad",
+	"stdlib/universe/universe.flux":                                                               "1e9d883758dfa1ba4ced1d46ba84c1207013fac13a2e92106d17c8b5167b3cc5",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "c8f66f7ee188bb2e979e5a8b526057b653922197ae441658f7c7f11251c96576",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -3751,7 +3751,7 @@ _fillEmpty = (tables=<-, createEmpty) =>
 //   Default is `_stop`.
 // - timeDst: Column to store time values for aggregate values in.
 //   Default is `_time`.
-// - createEmpty: Create empty tables for empty window. Default is `false`.
+// - createEmpty: Create empty tables for empty window. Default is `true`.
 //
 //   **Note:** When using `createEmpty: true`, aggregate functions return empty
 //   tables, but selector functions do not. By design, selectors drop empty tables.

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -3744,7 +3744,7 @@ _fillEmpty = (tables=<-, createEmpty) =>
 //
 //   `offset` can be negative, indicating that the offset goes backwards in time.
 //
-// - fn: Aggreate or selector function to apply to each time window.
+// - fn: Aggregate or selector function to apply to each time window.
 // - location: Location used to determine timezone. Default is the `location` option.
 // - column: Column to operate on.
 // - timeSrc: Column to use as the source of the new time value for aggregate values.
@@ -3819,7 +3819,7 @@ _fillEmpty = (tables=<-, createEmpty) =>
 // | Saturday   |   2d   |
 // | Sunday     |   3d   |
 //
-// ```js
+// ```
 // # import "array"
 // #
 // # data =


### PR DESCRIPTION
Related to https://github.com/influxdata/docs-v2/pull/4373

Fixes a typo and removes code block syntax from aggregateWindow documentation. The `js` code block syntax was preventing the example from rendering correctly in the generated docs.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated