### PR TITLE
feat(function): update function library to have its own arguments struct

### DIFF
--- a/internal/function/arguments.go
+++ b/internal/function/arguments.go
@@ -1,0 +1,309 @@
+package function
+
+import (
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+// Arguments provides access to the arguments of a function call.
+// This struct can only be created by using one of the Register functions
+// to register a function or by directly calling Invoke.
+type Arguments struct {
+	obj  values.Object
+	used map[string]bool
+}
+
+func newArguments(obj values.Object) *Arguments {
+	if obj == nil {
+		return new(Arguments)
+	}
+	return &Arguments{
+		obj:  obj,
+		used: make(map[string]bool, obj.Len()),
+	}
+}
+
+func (a *Arguments) Get(name string) (values.Value, bool) {
+	a.used[name] = true
+	v, ok := a.obj.Get(name)
+	return v, ok
+}
+
+func (a *Arguments) GetRequired(name string) (values.Value, error) {
+	a.used[name] = true
+	v, ok := a.obj.Get(name)
+	if !ok {
+		return nil, errors.Newf(codes.Invalid, "missing required keyword argument %q", name)
+	}
+	return v, nil
+}
+
+func (a *Arguments) GetString(name string) (string, bool, error) {
+	v, ok, err := a.get(name, semantic.String, false)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	return v.Str(), ok, nil
+}
+
+func (a *Arguments) GetRequiredString(name string) (string, error) {
+	v, _, err := a.get(name, semantic.String, true)
+	if err != nil {
+		return "", err
+	}
+	return v.Str(), nil
+}
+
+func (a *Arguments) GetInt(name string) (int64, bool, error) {
+	v, ok, err := a.get(name, semantic.Int, false)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	return v.Int(), ok, nil
+}
+
+func (a *Arguments) GetRequiredInt(name string) (int64, error) {
+	v, _, err := a.get(name, semantic.Int, true)
+	if err != nil {
+		return 0, err
+	}
+	return v.Int(), nil
+}
+
+func (a *Arguments) GetUInt(name string) (uint64, bool, error) {
+	v, ok, err := a.get(name, semantic.UInt, false)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	return v.UInt(), ok, nil
+}
+
+func (a *Arguments) GetRequiredUInt(name string) (uint64, error) {
+	v, _, err := a.get(name, semantic.UInt, true)
+	if err != nil {
+		return 0, err
+	}
+	return v.UInt(), nil
+}
+
+func (a *Arguments) GetFloat(name string) (float64, bool, error) {
+	v, ok, err := a.get(name, semantic.Float, false)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	return v.Float(), ok, nil
+}
+
+func (a *Arguments) GetRequiredFloat(name string) (float64, error) {
+	v, _, err := a.get(name, semantic.Float, true)
+	if err != nil {
+		return 0, err
+	}
+	return v.Float(), nil
+}
+
+func (a *Arguments) GetBool(name string) (bool, bool, error) {
+	v, ok, err := a.get(name, semantic.Bool, false)
+	if err != nil || !ok {
+		return false, ok, err
+	}
+	return v.Bool(), ok, nil
+}
+
+func (a *Arguments) GetRequiredBool(name string) (bool, error) {
+	v, _, err := a.get(name, semantic.Bool, true)
+	if err != nil {
+		return false, err
+	}
+	return v.Bool(), nil
+}
+
+func (a *Arguments) GetArray(name string, t semantic.Nature) (values.Array, bool, error) {
+	v, ok, err := a.get(name, semantic.Array, false)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	arr := v.Array()
+	et, err := arr.Type().ElemType()
+	if err != nil {
+		return nil, false, err
+	}
+	if et.Nature() != t {
+		return nil, true, errors.Newf(codes.Invalid, "keyword argument %q should be of an array of type %v, but got an array of type %v", name, t, arr.Type())
+	}
+	return v.Array(), ok, nil
+}
+
+func (a *Arguments) GetArrayAllowEmpty(name string, t semantic.Nature) (values.Array, bool, error) {
+	v, ok, err := a.get(name, semantic.Array, false)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	arr := v.Array()
+	if arr.Len() > 0 {
+		et, err := arr.Type().ElemType()
+		if err != nil {
+			return nil, false, err
+		}
+		if et.Nature() != t {
+			return nil, true, errors.Newf(codes.Invalid, "keyword argument %q should be of an array of type %v, but got an array of type %v", name, t, arr.Type())
+		}
+	}
+	return arr, ok, nil
+}
+
+func (a *Arguments) GetRequiredArray(name string, t semantic.Nature) (values.Array, error) {
+	v, _, err := a.get(name, semantic.Array, true)
+	if err != nil {
+		return nil, err
+	}
+	arr := v.Array()
+	et, err := arr.Type().ElemType()
+	if err != nil {
+		return nil, err
+	}
+	if et.Nature() != t {
+		return nil, errors.Newf(codes.Invalid, "keyword argument %q should be of an array of type %v, but got an array of type %v", name, t, arr.Type())
+	}
+	return arr, nil
+}
+
+// GetRequiredArrayAllowEmpty ensures a required array (with element type) is present,
+// but unlike GetRequiredArray, does not fail if the array is empty.
+func (a *Arguments) GetRequiredArrayAllowEmpty(name string, t semantic.Nature) (values.Array, error) {
+	v, _, err := a.get(name, semantic.Array, true)
+	if err != nil {
+		return nil, err
+	}
+	arr := v.Array()
+	if arr.Array().Len() > 0 {
+		et, err := arr.Type().ElemType()
+		if err != nil {
+			return nil, err
+		}
+		if et.Nature() != t {
+			return nil, errors.Newf(codes.Invalid, "keyword argument %q should be of an array of type %v, but got an array of type %v", name, t, arr.Type())
+		}
+	}
+	return arr, nil
+}
+
+func (a *Arguments) GetFunction(name string) (values.Function, bool, error) {
+	v, ok, err := a.get(name, semantic.Function, false)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return v.Function(), ok, nil
+}
+
+func (a *Arguments) GetRequiredFunction(name string) (values.Function, error) {
+	v, _, err := a.get(name, semantic.Function, true)
+	if err != nil {
+		return nil, err
+	}
+	return v.Function(), nil
+}
+
+func (a *Arguments) GetObject(name string) (values.Object, bool, error) {
+	v, ok, err := a.get(name, semantic.Object, false)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return v.Object(), ok, nil
+}
+
+func (a *Arguments) GetRequiredObject(name string) (values.Object, error) {
+	v, _, err := a.get(name, semantic.Object, true)
+	if err != nil {
+		return nil, err
+	}
+	return v.Object(), nil
+}
+
+func (a *Arguments) GetDictionary(name string) (values.Dictionary, bool, error) {
+	v, ok, err := a.get(name, semantic.Dictionary, false)
+	if err != nil || !ok {
+		return nil, ok, err
+	}
+	return v.Dict(), ok, nil
+}
+
+func (a *Arguments) GetRequiredDictionary(name string) (values.Dictionary, error) {
+	v, _, err := a.get(name, semantic.Dictionary, true)
+	if err != nil {
+		return nil, err
+	}
+	return v.Dict(), nil
+}
+
+func (a *Arguments) GetTime(name string) (flux.Time, bool, error) {
+	v, ok := a.Get(name)
+	if !ok {
+		return flux.Time{}, false, nil
+	}
+	qt, err := flux.ToQueryTime(v)
+	if err != nil {
+		return flux.Time{}, ok, err
+	}
+	return qt, ok, nil
+}
+
+func (a *Arguments) GetRequiredTime(name string) (flux.Time, error) {
+	qt, ok, err := a.GetTime(name)
+	if err != nil {
+		return flux.Time{}, err
+	}
+	if !ok {
+		return flux.Time{}, errors.Newf(codes.Invalid, "missing required keyword argument %q", name)
+	}
+	return qt, nil
+}
+
+func (a *Arguments) GetDuration(name string) (flux.Duration, bool, error) {
+	v, ok := a.Get(name)
+	if !ok {
+		return flux.ConvertDuration(0), false, nil
+	}
+	return v.Duration(), true, nil
+}
+
+func (a *Arguments) GetRequiredDuration(name string) (flux.Duration, error) {
+	d, ok, err := a.GetDuration(name)
+	if err != nil {
+		return flux.ConvertDuration(0), err
+	}
+	if !ok {
+		return flux.ConvertDuration(0), errors.Newf(codes.Invalid, "missing required keyword argument %q", name)
+	}
+	return d, nil
+}
+
+func (a *Arguments) get(name string, kind semantic.Nature, required bool) (values.Value, bool, error) {
+	a.used[name] = true
+	v, ok := a.obj.Get(name)
+	if !ok {
+		if required {
+			return nil, false, errors.Newf(codes.Invalid, "missing required keyword argument %q", name)
+		}
+		return nil, false, nil
+	}
+	if v.Type().Nature() != kind {
+		return nil, true, errors.Newf(codes.Invalid, "keyword argument %q should be of kind %v, but got %v", name, kind, v.Type().Nature())
+	}
+	return v, true, nil
+}
+
+func (a *Arguments) listUnused() []string {
+	var unused []string
+	if a.obj != nil {
+		a.obj.Range(func(k string, v values.Value) {
+			if !a.used[k] {
+				unused = append(unused, k)
+			}
+		})
+	}
+	return unused
+}

--- a/internal/function/function.go
+++ b/internal/function/function.go
@@ -3,7 +3,8 @@ package function
 import (
 	"context"
 
-	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/values"
 )
@@ -19,24 +20,50 @@ func ForPackage(name string) Builder {
 }
 
 type (
-	Definition        func(args interpreter.Arguments) (values.Value, error)
-	DefinitionContext func(ctx context.Context, args interpreter.Arguments) (values.Value, error)
+	Definition        func(args *Arguments) (values.Value, error)
+	DefinitionContext func(ctx context.Context, args *Arguments) (values.Value, error)
 )
 
 func (b Builder) Register(name string, fn Definition) {
-	mt := runtime.MustLookupBuiltinType(b.PackagePath, name)
-	runtime.RegisterPackageValue(b.PackagePath, name,
-		values.NewFunction(name, mt, func(ctx context.Context, args values.Object) (values.Value, error) {
-			return interpreter.DoFunctionCall(fn, args)
-		}, false),
-	)
+	b.RegisterContext(name, func(ctx context.Context, args *Arguments) (values.Value, error) {
+		return fn(args)
+	})
 }
 
 func (b Builder) RegisterContext(name string, fn DefinitionContext) {
 	mt := runtime.MustLookupBuiltinType(b.PackagePath, name)
 	runtime.RegisterPackageValue(b.PackagePath, name,
 		values.NewFunction(name, mt, func(ctx context.Context, args values.Object) (values.Value, error) {
-			return interpreter.DoFunctionCallContext(fn, ctx, args)
+			return InvokeContext(fn, ctx, args)
 		}, false),
 	)
+}
+
+// InvokeContext calls a function and returns the result.
+//
+// It passes the object as the arguments to the function and returns an error
+// if any supplied arguments are not used.
+func InvokeContext[T any](f func(ctx context.Context, args *Arguments) (T, error), ctx context.Context, argsObj values.Object) (T, error) {
+	args := newArguments(argsObj)
+	v, err := f(ctx, args)
+	if err == nil {
+		if unused := args.listUnused(); len(unused) > 0 {
+			err = errors.Newf(codes.Invalid, "unused arguments %v", unused)
+		}
+	}
+	return v, err
+}
+
+// Invoke calls a function and returns the result.
+//
+// This is the same as InvokeContext but with a background context.
+func Invoke[T any](f func(args *Arguments) (T, error), argsObj values.Object) (T, error) {
+	args := newArguments(argsObj)
+	v, err := f(args)
+	if err == nil {
+		if unused := args.listUnused(); len(unused) > 0 {
+			err = errors.Newf(codes.Invalid, "unused arguments %v", unused)
+		}
+	}
+	return v, err
 }

--- a/stdlib/bitwise/bitwise.go
+++ b/stdlib/bitwise/bitwise.go
@@ -2,11 +2,10 @@ package bitwise
 
 import (
 	"github.com/influxdata/flux/internal/function"
-	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/values"
 )
 
-func uand(args interpreter.Arguments) (values.Value, error) {
+func uand(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
@@ -17,7 +16,7 @@ func uand(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewUInt(a & b), nil
 }
-func uor(args interpreter.Arguments) (values.Value, error) {
+func uor(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
@@ -28,14 +27,14 @@ func uor(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewUInt(a | b), nil
 }
-func unot(args interpreter.Arguments) (values.Value, error) {
+func unot(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
 	}
 	return values.NewUInt(^a), nil
 }
-func uxor(args interpreter.Arguments) (values.Value, error) {
+func uxor(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
@@ -46,7 +45,7 @@ func uxor(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewUInt(a ^ b), nil
 }
-func uclear(args interpreter.Arguments) (values.Value, error) {
+func uclear(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
@@ -57,7 +56,7 @@ func uclear(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewUInt(a &^ b), nil
 }
-func ulshift(args interpreter.Arguments) (values.Value, error) {
+func ulshift(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
@@ -68,7 +67,7 @@ func ulshift(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewUInt(a << b), nil
 }
-func urshift(args interpreter.Arguments) (values.Value, error) {
+func urshift(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredUInt("a")
 	if err != nil {
 		return nil, err
@@ -80,7 +79,7 @@ func urshift(args interpreter.Arguments) (values.Value, error) {
 	return values.NewUInt(a >> b), nil
 }
 
-func sand(args interpreter.Arguments) (values.Value, error) {
+func sand(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err
@@ -91,7 +90,7 @@ func sand(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewInt(a & b), nil
 }
-func sor(args interpreter.Arguments) (values.Value, error) {
+func sor(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err
@@ -102,14 +101,14 @@ func sor(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewInt(a | b), nil
 }
-func snot(args interpreter.Arguments) (values.Value, error) {
+func snot(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err
 	}
 	return values.NewInt(^a), nil
 }
-func sxor(args interpreter.Arguments) (values.Value, error) {
+func sxor(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err
@@ -120,7 +119,7 @@ func sxor(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewInt(a ^ b), nil
 }
-func sclear(args interpreter.Arguments) (values.Value, error) {
+func sclear(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err
@@ -131,7 +130,7 @@ func sclear(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewInt(a &^ b), nil
 }
-func slshift(args interpreter.Arguments) (values.Value, error) {
+func slshift(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err
@@ -142,7 +141,7 @@ func slshift(args interpreter.Arguments) (values.Value, error) {
 	}
 	return values.NewInt(a << b), nil
 }
-func srshift(args interpreter.Arguments) (values.Value, error) {
+func srshift(args *function.Arguments) (values.Value, error) {
 	a, err := args.GetRequiredInt("a")
 	if err != nil {
 		return nil, err

--- a/stdlib/date/durations.go
+++ b/stdlib/date/durations.go
@@ -9,7 +9,6 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/function"
 	"github.com/influxdata/flux/internal/zoneinfo"
-	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -21,7 +20,7 @@ func init() {
 	pkg.Register("scale", Scale)
 }
 
-func Add(ctx context.Context, args interpreter.Arguments) (values.Value, error) {
+func Add(ctx context.Context, args *function.Arguments) (values.Value, error) {
 	d, err := args.GetRequired("d")
 	if err != nil {
 		return nil, err
@@ -39,7 +38,7 @@ func Add(ctx context.Context, args interpreter.Arguments) (values.Value, error) 
 	return addDuration(ctx, t, d.Duration(), 1, loc)
 }
 
-func Sub(ctx context.Context, args interpreter.Arguments) (values.Value, error) {
+func Sub(ctx context.Context, args *function.Arguments) (values.Value, error) {
 	d, err := args.GetRequired("d")
 	if err != nil {
 		return nil, err
@@ -101,7 +100,7 @@ func addDuration(ctx context.Context, t values.Value, d values.Duration, scale i
 	return values.NewTime(time), nil
 }
 
-func Scale(args interpreter.Arguments) (values.Value, error) {
+func Scale(args *function.Arguments) (values.Value, error) {
 	d, err := args.GetRequired("d")
 	if err != nil {
 		return nil, err

--- a/stdlib/dict/dict.go
+++ b/stdlib/dict/dict.go
@@ -4,7 +4,6 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/function"
-	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -12,7 +11,7 @@ import (
 const pkgpath = "dict"
 
 // FromList will convert a list of values into a Dictionary.
-func FromList(args interpreter.Arguments) (values.Value, error) {
+func FromList(args *function.Arguments) (values.Value, error) {
 	pairs, err := args.GetRequiredArray("pairs", semantic.Object)
 	if err != nil {
 		return nil, err
@@ -79,7 +78,7 @@ func FromList(args interpreter.Arguments) (values.Value, error) {
 }
 
 // Get will retrieve a value from a Dictionary.
-func Get(args interpreter.Arguments) (values.Value, error) {
+func Get(args *function.Arguments) (values.Value, error) {
 	from, err := args.GetRequiredDictionary("dict")
 	if err != nil {
 		return nil, err
@@ -100,7 +99,7 @@ func Get(args interpreter.Arguments) (values.Value, error) {
 // Insert will insert a value into a Dictionary and
 // return the new Dictionary. It will not modify
 // the original Dictionary.
-func Insert(args interpreter.Arguments) (values.Value, error) {
+func Insert(args *function.Arguments) (values.Value, error) {
 	dict, err := args.GetRequiredDictionary("dict")
 	if err != nil {
 		return nil, err
@@ -121,7 +120,7 @@ func Insert(args interpreter.Arguments) (values.Value, error) {
 // Remove will remove a value from a Dictionary and
 // return the new Dictionary. It will not modify
 // the original Dictionary.
-func Remove(args interpreter.Arguments) (values.Value, error) {
+func Remove(args *function.Arguments) (values.Value, error) {
 	dict, err := args.GetRequiredDictionary("dict")
 	if err != nil {
 		return nil, err

--- a/stdlib/dict/dict_test.go
+++ b/stdlib/dict/dict_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/internal/function"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/stdlib/dict"
 	"github.com/influxdata/flux/values"
 )
 
 func TestFromList(t *testing.T) {
-	args := interpreter.NewArguments(values.NewObjectWithValues(
+	args := values.NewObjectWithValues(
 		map[string]values.Value{
 			"pairs": func() values.Array {
 				vals := []values.Value{
@@ -35,9 +35,9 @@ func TestFromList(t *testing.T) {
 				return arr
 			}(),
 		},
-	))
+	)
 
-	v, err := dict.FromList(args)
+	v, err := function.Invoke(dict.FromList, args)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -69,7 +69,7 @@ func TestFromList(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	args := interpreter.NewArguments(values.NewObjectWithValues(
+	args := values.NewObjectWithValues(
 		map[string]values.Value{
 			"dict": func() values.Dictionary {
 				dictType := semantic.NewDictType(semantic.BasicString, semantic.BasicInt)
@@ -80,9 +80,9 @@ func TestGet(t *testing.T) {
 			"key":     values.NewString("a"),
 			"default": values.NewInt(0),
 		},
-	))
+	)
 
-	v, err := dict.Get(args)
+	v, err := function.Invoke(dict.Get, args)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -96,7 +96,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	args := interpreter.NewArguments(values.NewObjectWithValues(
+	args := values.NewObjectWithValues(
 		map[string]values.Value{
 			"dict": func() values.Dictionary {
 				dictType := semantic.NewDictType(semantic.BasicString, semantic.BasicInt)
@@ -107,9 +107,9 @@ func TestInsert(t *testing.T) {
 			"key":   values.NewString("b"),
 			"value": values.NewInt(8),
 		},
-	))
+	)
 
-	v, err := dict.Insert(args)
+	v, err := function.Invoke(dict.Insert, args)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -141,7 +141,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	args := interpreter.NewArguments(values.NewObjectWithValues(
+	args := values.NewObjectWithValues(
 		map[string]values.Value{
 			"dict": func() values.Dictionary {
 				dictType := semantic.NewDictType(semantic.BasicString, semantic.BasicInt)
@@ -153,9 +153,9 @@ func TestRemove(t *testing.T) {
 			}(),
 			"key": values.NewString("c"),
 		},
-	))
+	)
 
-	v, err := dict.Remove(args)
+	v, err := function.Invoke(dict.Remove, args)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/stdlib/experimental/iox/iox.go
+++ b/stdlib/experimental/iox/iox.go
@@ -4,7 +4,6 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/function"
-	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/values"
 )
 
@@ -12,7 +11,7 @@ const pkgpath = "experimental/iox"
 
 func init() {
 	b := function.ForPackage(pkgpath)
-	b.Register("from", func(args interpreter.Arguments) (values.Value, error) {
+	b.Register("from", func(args *function.Arguments) (values.Value, error) {
 		return nil, errors.New(codes.Unimplemented, "iox.from() is not implemented outside cloud 2.x")
 	})
 }

--- a/stdlib/timezone/timezone.go
+++ b/stdlib/timezone/timezone.go
@@ -5,13 +5,12 @@ import (
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/internal/function"
 	"github.com/influxdata/flux/internal/zoneinfo"
-	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/values"
 )
 
 const pkgpath = "timezone"
 
-func Location(args interpreter.Arguments) (values.Value, error) {
+func Location(args *function.Arguments) (values.Value, error) {
 	name, err := args.GetRequiredString("name")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The function package now uses its own arguments struct. This is to
eventually remove the `interpreter.Arguments` interface. An interface is
a poor choice for that type because interfaces with that many methods
cannot be changed or adapted easily.

At some point, the function package will be used for all situations
instead of the raw register methods.


### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.