### PR TITLE
fix: Don't lose the values of non-string group keys in experimental.diff

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -159,7 +159,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/csv/csv.flux":                                                            "7f033d93ed2e456d7ee181f0afa88f8c4c81f3b1a0984e56d53d3e146db48d20",
 	"stdlib/experimental/date/boundaries/boundaries.flux":                                         "d89786ac0607574da4cd130800670907e404f9dbfea0e74dd7b2c887707feaae",
 	"stdlib/experimental/date/boundaries/boundaries_test.flux":                                    "35f4198aae27017b38227a20d16ecf5c6ec81382643a36aafadda844b8d36e2b",
-	"stdlib/experimental/diff_test.flux":                                                          "f91b8897b22fd25c6f8f631f430262dade49defd17627e6fd76cbadfcc7b4168",
+	"stdlib/experimental/diff_test.flux":                                                          "9e008f0ce38d69faa2a4ab48ffcae8090262809e24ac80625bae558b68b6554c",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
 	"stdlib/experimental/experimental.flux":                                                       "7d902e7d0a142d94a0970ba96317ccd8050f2381551da2f43039da0bb6c90a1b",
 	"stdlib/experimental/experimental_test.flux":                                                  "b417f361be23e610b6caffa266c40c421b19dedc3289ce064bb065cb0bcd825c",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -159,7 +159,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/csv/csv.flux":                                                            "7f033d93ed2e456d7ee181f0afa88f8c4c81f3b1a0984e56d53d3e146db48d20",
 	"stdlib/experimental/date/boundaries/boundaries.flux":                                         "d89786ac0607574da4cd130800670907e404f9dbfea0e74dd7b2c887707feaae",
 	"stdlib/experimental/date/boundaries/boundaries_test.flux":                                    "35f4198aae27017b38227a20d16ecf5c6ec81382643a36aafadda844b8d36e2b",
-	"stdlib/experimental/diff_test.flux":                                                          "9864f41f9c95999a071890f7ec1750b8e01cef082f7bb708443bf4f4bd59af49",
+	"stdlib/experimental/diff_test.flux":                                                          "f91b8897b22fd25c6f8f631f430262dade49defd17627e6fd76cbadfcc7b4168",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
 	"stdlib/experimental/experimental.flux":                                                       "7d902e7d0a142d94a0970ba96317ccd8050f2381551da2f43039da0bb6c90a1b",
 	"stdlib/experimental/experimental_test.flux":                                                  "b417f361be23e610b6caffa266c40c421b19dedc3289ce064bb065cb0bcd825c",

--- a/stdlib/experimental/diff.go
+++ b/stdlib/experimental/diff.go
@@ -502,9 +502,11 @@ func (d *diffTransformation) diff(key flux.GroupKey, want, got table.Chunk) (tab
 		Columns:  schema.cols,
 		Values:   make([]array.Array, 0, len(schema.cols)),
 	}
+	// `diff.NewArray()` will move the array out of `diff` and thereby zero the length so we read it here for later use
+	diffLen := diff.Len()
 	buf.Values = append(buf.Values, diff.NewArray())
 	for i, col := range key.Cols() {
-		arr := arrow.Repeat(col.Type, key.Value(i), diff.Len(), d.mem)
+		arr := arrow.Repeat(col.Type, key.Value(i), diffLen, d.mem)
 		buf.Values = append(buf.Values, arr)
 	}
 	for _, b := range builders {

--- a/stdlib/experimental/diff_test.flux
+++ b/stdlib/experimental/diff_test.flux
@@ -230,3 +230,44 @@ testcase empty_got {
         |> rename(columns: {_diff: "diff"})
         |> testing.diff(want: exp)
 }
+
+testcase mismatch_non_string_group_key {
+    want =
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _start: 2022-07-12T00:00:00Z, _time: 2022-07-12T00:00:00Z, _value: 2.0}],
+        )
+            |> group(columns: ["_measurement", "_field", "_start"])
+
+    got =
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _start: 2022-07-12T00:00:00Z, _time: 2022-07-12T00:00:00Z, _value: 3.0}],
+        )
+            |> group(columns: ["_measurement", "_field", "_start"])
+
+    exp =
+        array.from(
+            rows: [
+                {
+                    diff: "-",
+                    _measurement: "m0",
+                    _field: "f0",
+                    _start: 2022-07-12T00:00:00Z,
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: 2.0,
+                },
+                {
+                    diff: "+",
+                    _measurement: "m0",
+                    _field: "f0",
+                    _start: 2022-07-12T00:00:00Z,
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: 3.0,
+                },
+            ],
+        )
+            |> group(columns: ["_measurement", "_field", "_start"])
+
+    experimental.diff(want, got)
+        |> rename(columns: {_diff: "diff"})
+        |> testing.diff(want: exp)
+}

--- a/stdlib/experimental/diff_test.flux
+++ b/stdlib/experimental/diff_test.flux
@@ -234,13 +234,29 @@ testcase empty_got {
 testcase mismatch_non_string_group_key {
     want =
         array.from(
-            rows: [{_measurement: "m0", _field: "f0", _start: 2022-07-12T00:00:00Z, _time: 2022-07-12T00:00:00Z, _value: 2.0}],
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    _start: 2022-07-12T00:00:00Z,
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: 2.0,
+                },
+            ],
         )
             |> group(columns: ["_measurement", "_field", "_start"])
 
     got =
         array.from(
-            rows: [{_measurement: "m0", _field: "f0", _start: 2022-07-12T00:00:00Z, _time: 2022-07-12T00:00:00Z, _value: 3.0}],
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    _start: 2022-07-12T00:00:00Z,
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: 3.0,
+                },
+            ],
         )
             |> group(columns: ["_measurement", "_field", "_start"])
 


### PR DESCRIPTION
With `diff.Len()` being zero due to the `NewArray` call `arrow.Repeat` only constructed empty arrays.
The specialization of string arrays had special handling which caused it to work only for that array (and strings are the usual group keys).

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
