### PR TITLE
fix: update package for `Spec` in headless repl

### DIFF
--- a/internal/cmd/headless_repl/main.go
+++ b/internal/cmd/headless_repl/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/execute/executetest"
 	"github.com/influxdata/flux/fluxinit"
+	"github.com/influxdata/flux/internal/operation"
 	"github.com/influxdata/flux/internal/spec"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/lang"
@@ -249,7 +250,7 @@ func (r *ScopeHolder) analyzeLine(t string) (*semantic.Package, *libflux.FluxErr
 	return x, nil, err
 }
 
-func (r *ScopeHolder) doQuery(ctx context.Context, spec *flux.Spec) error {
+func (r *ScopeHolder) doQuery(ctx context.Context, spec *operation.Spec) error {
 	// Setup cancel context
 	ctx, cancelFunc := context.WithCancel(ctx)
 	r.setCancel(cancelFunc)


### PR DESCRIPTION
`Spec` was moved during <https://github.com/influxdata/flux/pull/5116>.

This diff updates the import path in the headeless repl to match.

Currently there are no unit tests for this binary, so I had to manually verify the change:

```
$ go run internal/cmd/headless_repl/main.go                                                                                                                
{"jsonrpc":"2.0","method":"Service.DidOutput","params":[{"input":"now()"}]}                                                                                
{"id":null,"result":{"Result":"2022-08-26T21:07:16.304361483Z"},"error":null}                                                                              
^C^C^C^\SIGQUIT: quit
```

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code (**manually verified**)
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` **N/A**
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated **N/A**

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
