### PR TITLE
build: extend deadline for windows builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ jobs:
           command: go generate ./libflux/go/libflux
       - run:
           name: Build flux
+          no_output_timeout: 20m
           command: go build ./...
 
   release:


### PR DESCRIPTION
We see windows builds timeout all the time.
CircleCI has a deadline for how long a job can run without printing
anything. The default is 10m, so this diff doubles it at 20m.

Hopefully we will waste fewer CI cycles this way by reducing the number
of restarted jobs required for a green run.
