### PR TITLE
feat: Allow unpivot to work when the time field is missing 

### DIFF
--- a/array/array.go
+++ b/array/array.go
@@ -48,6 +48,8 @@ type Array interface {
 	// NOTE: IsValid will panic if NullBitmapBytes is not empty and 0 > i ≥ Len.
 	IsValid(i int) bool
 
+	Data() arrow.ArrayData
+
 	// Len returns the number of elements in the array.
 	Len() int
 
@@ -144,6 +146,12 @@ func (a *String) IsValid(i int) bool {
 		return a.data.IsValid(i)
 	}
 	return true
+}
+func (a *String) Data() arrow.ArrayData {
+	if a.data != nil {
+		return a.data.Data()
+	}
+	return nil
 }
 func (a *String) Len() int {
 	if a.data != nil {

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -346,9 +346,10 @@ func TestSlice(t *testing.T) {
 
 func TestCopyValid(t *testing.T) {
 	for _, tc := range []struct {
-		name  string
-		input func(memory.Allocator) *array.Int
-		want  []int64
+		name       string
+		input      func(memory.Allocator) *array.Int
+		nullBitmap func(memory.Allocator) *array.Int
+		want       []interface{}
 	}{
 		{
 			name: "nulls",
@@ -362,7 +363,55 @@ func TestCopyValid(t *testing.T) {
 				b.AppendNull()
 				return b.NewIntArray()
 			},
-			want: []int64{2, 3, 5},
+			want: []interface{}{int64(2), int64(3), int64(5)},
+		},
+		{
+			name: "nulls with nullBitmap",
+			input: func(mem memory.Allocator) *array.Int {
+				b := array.NewIntBuilder(mem)
+				b.AppendNull()
+				b.Append(2)
+				b.Append(3)
+				b.AppendNull()
+				b.Append(5)
+				b.AppendNull()
+				return b.NewIntArray()
+			},
+			nullBitmap: func(mem memory.Allocator) *array.Int {
+				b := array.NewIntBuilder(mem)
+				b.Append(1)
+				b.AppendNull()
+				b.Append(3)
+				b.AppendNull()
+				b.AppendNull()
+				b.Append(6)
+				return b.NewIntArray()
+			},
+			want: []interface{}{nil, int64(3), nil},
+		},
+		{
+			name: "all nulls in nullBitmap",
+			input: func(mem memory.Allocator) *array.Int {
+				b := array.NewIntBuilder(mem)
+				b.AppendNull()
+				b.Append(2)
+				b.Append(3)
+				b.AppendNull()
+				b.Append(5)
+				b.AppendNull()
+				return b.NewIntArray()
+			},
+			nullBitmap: func(mem memory.Allocator) *array.Int {
+				b := array.NewIntBuilder(mem)
+				b.AppendNull()
+				b.AppendNull()
+				b.AppendNull()
+				b.AppendNull()
+				b.AppendNull()
+				b.AppendNull()
+				return b.NewIntArray()
+			},
+			want: []interface{}{},
 		},
 		{
 			name: "no nulls",
@@ -374,7 +423,7 @@ func TestCopyValid(t *testing.T) {
 				b.Append(4)
 				return b.NewIntArray()
 			},
-			want: []int64{1, 2, 3, 4},
+			want: []interface{}{int64(1), int64(2), int64(3), int64(4)},
 		},
 		{
 			name: "empty",
@@ -382,7 +431,7 @@ func TestCopyValid(t *testing.T) {
 				b := array.NewIntBuilder(mem)
 				return b.NewIntArray()
 			},
-			want: nil,
+			want: []interface{}{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -390,11 +439,17 @@ func TestCopyValid(t *testing.T) {
 			defer mem.AssertSize(t, 0)
 
 			input := tc.input(mem)
+			nullBitmap := input
+			if tc.nullBitmap != nil {
+				nullBitmap = tc.nullBitmap(mem)
+				defer nullBitmap.Release()
+			}
 
-			got := array.CopyValidValues(mem, input, input).(*array.Int)
+			got := array.CopyValidValues(mem, input, nullBitmap).(*array.Int)
 
 			want := tc.want
-			if diff := cmp.Diff(want, got.Int64Values()); diff != "" {
+
+			if diff := cmp.Diff(want, arrayToInterfaceSlice(got)); diff != "" {
 				t.Errorf("unexpected value -want/+got:\n%v", diff)
 			}
 
@@ -402,6 +457,18 @@ func TestCopyValid(t *testing.T) {
 			got.Release()
 		})
 	}
+}
+
+func arrayToInterfaceSlice(array *array.Int) []interface{} {
+	out := []interface{}{}
+	for i := 0; i < array.Len(); i++ {
+		if array.IsValid(i) {
+			out = append(out, array.Value(i))
+		} else {
+			out = append(out, nil)
+		}
+	}
+	return out
 }
 
 func getValue(arr array.Array, i int) interface{} {

--- a/array/array_test.go
+++ b/array/array_test.go
@@ -391,7 +391,7 @@ func TestCopyValid(t *testing.T) {
 
 			input := tc.input(mem)
 
-			got := array.CopyValidValues(mem, input).(*array.Int)
+			got := array.CopyValidValues(mem, input, input).(*array.Int)
 
 			want := tc.want
 			if diff := cmp.Diff(want, got.Int64Values()); diff != "" {

--- a/array/builder.gen.go
+++ b/array/builder.gen.go
@@ -81,7 +81,11 @@ func (b *IntBuilder) CopyValidValues(values *Int, nullCheckArray Array) {
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.Append(values.Value(i))
+			if values.IsValid(i) {
+				b.Append(values.Value(i))
+			} else {
+				b.AppendNull()
+			}
 		}
 	}
 }
@@ -147,7 +151,11 @@ func (b *UintBuilder) CopyValidValues(values *Uint, nullCheckArray Array) {
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.Append(values.Value(i))
+			if values.IsValid(i) {
+				b.Append(values.Value(i))
+			} else {
+				b.AppendNull()
+			}
 		}
 	}
 }
@@ -213,7 +221,11 @@ func (b *FloatBuilder) CopyValidValues(values *Float, nullCheckArray Array) {
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.Append(values.Value(i))
+			if values.IsValid(i) {
+				b.Append(values.Value(i))
+			} else {
+				b.AppendNull()
+			}
 		}
 	}
 }
@@ -279,7 +291,11 @@ func (b *BooleanBuilder) CopyValidValues(values *Boolean, nullCheckArray Array) 
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.Append(values.Value(i))
+			if values.IsValid(i) {
+				b.Append(values.Value(i))
+			} else {
+				b.AppendNull()
+			}
 		}
 	}
 }

--- a/array/builder.gen.go
+++ b/array/builder.gen.go
@@ -71,10 +71,13 @@ func (b *IntBuilder) NewArray() Array {
 func (b *IntBuilder) NewIntArray() *Int {
 	return b.b.NewInt64Array()
 }
-func (b *IntBuilder) CopyValidValues(values *Int) {
-	b.Reserve(values.Len() - values.NullN())
+func (b *IntBuilder) CopyValidValues(values *Int, nullCheckArray Array) {
+	if values.Len() != nullCheckArray.Len() {
+		panic("Length mismatch between the value array and the null check array")
+	}
+	b.Reserve(values.Len() - nullCheckArray.NullN())
 	for i := 0; i < values.Len(); i++ {
-		if values.IsValid(i) {
+		if nullCheckArray.IsValid(i) {
 			b.Append(values.Value(i))
 		}
 	}
@@ -131,10 +134,13 @@ func (b *UintBuilder) NewArray() Array {
 func (b *UintBuilder) NewUintArray() *Uint {
 	return b.b.NewUint64Array()
 }
-func (b *UintBuilder) CopyValidValues(values *Uint) {
-	b.Reserve(values.Len() - values.NullN())
+func (b *UintBuilder) CopyValidValues(values *Uint, nullCheckArray Array) {
+	if values.Len() != nullCheckArray.Len() {
+		panic("Length mismatch between the value array and the null check array")
+	}
+	b.Reserve(values.Len() - nullCheckArray.NullN())
 	for i := 0; i < values.Len(); i++ {
-		if values.IsValid(i) {
+		if nullCheckArray.IsValid(i) {
 			b.Append(values.Value(i))
 		}
 	}
@@ -191,10 +197,13 @@ func (b *FloatBuilder) NewArray() Array {
 func (b *FloatBuilder) NewFloatArray() *Float {
 	return b.b.NewFloat64Array()
 }
-func (b *FloatBuilder) CopyValidValues(values *Float) {
-	b.Reserve(values.Len() - values.NullN())
+func (b *FloatBuilder) CopyValidValues(values *Float, nullCheckArray Array) {
+	if values.Len() != nullCheckArray.Len() {
+		panic("Length mismatch between the value array and the null check array")
+	}
+	b.Reserve(values.Len() - nullCheckArray.NullN())
 	for i := 0; i < values.Len(); i++ {
-		if values.IsValid(i) {
+		if nullCheckArray.IsValid(i) {
 			b.Append(values.Value(i))
 		}
 	}
@@ -251,19 +260,22 @@ func (b *BooleanBuilder) NewArray() Array {
 func (b *BooleanBuilder) NewBooleanArray() *Boolean {
 	return b.b.NewBooleanArray()
 }
-func (b *BooleanBuilder) CopyValidValues(values *Boolean) {
-	b.Reserve(values.Len() - values.NullN())
+func (b *BooleanBuilder) CopyValidValues(values *Boolean, nullCheckArray Array) {
+	if values.Len() != nullCheckArray.Len() {
+		panic("Length mismatch between the value array and the null check array")
+	}
+	b.Reserve(values.Len() - nullCheckArray.NullN())
 	for i := 0; i < values.Len(); i++ {
-		if values.IsValid(i) {
+		if nullCheckArray.IsValid(i) {
 			b.Append(values.Value(i))
 		}
 	}
 }
 
-// Copies all valid (non-null) values from `values`.
+// Copies all valid (non-null) values from `values` using the bitmap of nullCheckArray.
 // If the entire array is valid a new reference to `values` is returned (as an optimization)
-func CopyValidValues(mem memory.Allocator, values Array) Array {
-	if values.NullN() == 0 {
+func CopyValidValues(mem memory.Allocator, values Array, nullCheckArray Array) Array {
+	if nullCheckArray.NullN() == 0 {
 		values.Retain()
 		return values
 	}
@@ -272,27 +284,27 @@ func CopyValidValues(mem memory.Allocator, values Array) Array {
 
 	case *Int:
 		b := NewIntBuilder(mem)
-		b.CopyValidValues(values)
+		b.CopyValidValues(values, nullCheckArray)
 		return b.NewArray()
 
 	case *Uint:
 		b := NewUintBuilder(mem)
-		b.CopyValidValues(values)
+		b.CopyValidValues(values, nullCheckArray)
 		return b.NewArray()
 
 	case *Float:
 		b := NewFloatBuilder(mem)
-		b.CopyValidValues(values)
+		b.CopyValidValues(values, nullCheckArray)
 		return b.NewArray()
 
 	case *String:
 		b := NewStringBuilder(mem)
-		b.CopyValidValues(values)
+		b.CopyValidValues(values, nullCheckArray)
 		return b.NewArray()
 
 	case *Boolean:
 		b := NewBooleanBuilder(mem)
-		b.CopyValidValues(values)
+		b.CopyValidValues(values, nullCheckArray)
 		return b.NewArray()
 
 	default:

--- a/array/builder.gen.go
+++ b/array/builder.gen.go
@@ -76,8 +76,11 @@ func (b *IntBuilder) CopyValidValues(values *Int, nullCheckArray Array) {
 		panic("Length mismatch between the value array and the null check array")
 	}
 	b.Reserve(values.Len() - nullCheckArray.NullN())
+
+	nullBitMapBytes := nullCheckArray.NullBitmapBytes()
+	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
-		if nullCheckArray.IsValid(i) {
+		if isValid(nullBitMapBytes, nullOffset, i) {
 			b.Append(values.Value(i))
 		}
 	}
@@ -139,8 +142,11 @@ func (b *UintBuilder) CopyValidValues(values *Uint, nullCheckArray Array) {
 		panic("Length mismatch between the value array and the null check array")
 	}
 	b.Reserve(values.Len() - nullCheckArray.NullN())
+
+	nullBitMapBytes := nullCheckArray.NullBitmapBytes()
+	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
-		if nullCheckArray.IsValid(i) {
+		if isValid(nullBitMapBytes, nullOffset, i) {
 			b.Append(values.Value(i))
 		}
 	}
@@ -202,8 +208,11 @@ func (b *FloatBuilder) CopyValidValues(values *Float, nullCheckArray Array) {
 		panic("Length mismatch between the value array and the null check array")
 	}
 	b.Reserve(values.Len() - nullCheckArray.NullN())
+
+	nullBitMapBytes := nullCheckArray.NullBitmapBytes()
+	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
-		if nullCheckArray.IsValid(i) {
+		if isValid(nullBitMapBytes, nullOffset, i) {
 			b.Append(values.Value(i))
 		}
 	}
@@ -265,8 +274,11 @@ func (b *BooleanBuilder) CopyValidValues(values *Boolean, nullCheckArray Array) 
 		panic("Length mismatch between the value array and the null check array")
 	}
 	b.Reserve(values.Len() - nullCheckArray.NullN())
+
+	nullBitMapBytes := nullCheckArray.NullBitmapBytes()
+	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
-		if nullCheckArray.IsValid(i) {
+		if isValid(nullBitMapBytes, nullOffset, i) {
 			b.Append(values.Value(i))
 		}
 	}

--- a/array/builder.gen.go.tmpl
+++ b/array/builder.gen.go.tmpl
@@ -64,20 +64,23 @@ func (b *{{.Name}}Builder) NewArray() Array {
 func (b *{{.Name}}Builder) New{{.Name}}Array() *{{.Name}} {
     return b.b.New{{.ArrowType}}Array()
 }
-func (b *{{.Name}}Builder) CopyValidValues(values *{{.Name}}) {
-    b.Reserve(values.Len() - values.NullN())
+func (b *{{.Name}}Builder) CopyValidValues(values *{{.Name}}, nullCheckArray Array) {
+    if values.Len() != nullCheckArray.Len() {
+        panic("Length mismatch between the value array and the null check array")
+    }
+    b.Reserve(values.Len() - nullCheckArray.NullN())
     for i := 0; i < values.Len(); i++ {
-        if values.IsValid(i) {
+        if nullCheckArray.IsValid(i) {
             b.Append(values.Value(i))
         }
     }
 }
 {{end}}{{end}}
 
-// Copies all valid (non-null) values from `values`.
+// Copies all valid (non-null) values from `values` using the bitmap of nullCheckArray.
 // If the entire array is valid a new reference to `values` is returned (as an optimization)
-func CopyValidValues(mem memory.Allocator, values Array) Array {
-    if values.NullN() == 0 {
+func CopyValidValues(mem memory.Allocator, values Array, nullCheckArray Array) Array {
+    if nullCheckArray.NullN() == 0 {
         values.Retain()
         return values
     }
@@ -86,7 +89,7 @@ func CopyValidValues(mem memory.Allocator, values Array) Array {
 {{range .}}
 	case *{{.Name}}:
         b := New{{.Name}}Builder(mem)
-        b.CopyValidValues(values)
+        b.CopyValidValues(values, nullCheckArray)
         return b.NewArray()
 {{end}}
         default:

--- a/array/builder.gen.go.tmpl
+++ b/array/builder.gen.go.tmpl
@@ -69,11 +69,14 @@ func (b *{{.Name}}Builder) CopyValidValues(values *{{.Name}}, nullCheckArray Arr
         panic("Length mismatch between the value array and the null check array")
     }
     b.Reserve(values.Len() - nullCheckArray.NullN())
-    for i := 0; i < values.Len(); i++ {
-        if nullCheckArray.IsValid(i) {
-            b.Append(values.Value(i))
-        }
-    }
+
+	nullBitMapBytes := nullCheckArray.NullBitmapBytes()
+	nullOffset := nullCheckArray.Data().Offset()
+	for i := 0; i < values.Len(); i++ {
+		if isValid(nullBitMapBytes, nullOffset, i) {
+			b.Append(values.Value(i))
+		}
+	}
 }
 {{end}}{{end}}
 

--- a/array/builder.gen.go.tmpl
+++ b/array/builder.gen.go.tmpl
@@ -74,7 +74,11 @@ func (b *{{.Name}}Builder) CopyValidValues(values *{{.Name}}, nullCheckArray Arr
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.Append(values.Value(i))
+            if values.IsValid(i) {
+			    b.Append(values.Value(i))
+            } else {
+			    b.AppendNull()
+            }
 		}
 	}
 }

--- a/array/builder.go
+++ b/array/builder.go
@@ -1,8 +1,8 @@
 package array
 
 import (
-	"github.com/apache/arrow/go/arrow/bitutil"
 	"github.com/apache/arrow/go/v7/arrow/array"
+	"github.com/apache/arrow/go/v7/arrow/bitutil"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 )
 

--- a/array/builder.go
+++ b/array/builder.go
@@ -155,10 +155,13 @@ func (b *StringBuilder) NewStringArray() *String {
 	b.reset()
 	return arr
 }
-func (b *StringBuilder) CopyValidValues(values *String) {
-	b.Reserve(values.Len() - values.NullN())
+func (b *StringBuilder) CopyValidValues(values *String, nullCheckArray Array) {
+	if values.Len() != nullCheckArray.Len() {
+		panic("Length mismatch between the value array and the null check array")
+	}
+	b.Reserve(values.Len() - nullCheckArray.NullN())
 	for i := 0; i < values.Len(); i++ {
-		if values.IsValid(i) {
+		if nullCheckArray.IsValid(i) {
 			b.Append(values.Value(i))
 		}
 	}

--- a/array/builder.go
+++ b/array/builder.go
@@ -1,6 +1,7 @@
 package array
 
 import (
+	"github.com/apache/arrow/go/arrow/bitutil"
 	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/memory"
 )
@@ -160,9 +161,17 @@ func (b *StringBuilder) CopyValidValues(values *String, nullCheckArray Array) {
 		panic("Length mismatch between the value array and the null check array")
 	}
 	b.Reserve(values.Len() - nullCheckArray.NullN())
+
+	nullBitMapBytes := nullCheckArray.NullBitmapBytes()
+	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
-		if nullCheckArray.IsValid(i) {
+		if isValid(nullBitMapBytes, nullOffset, i) {
 			b.Append(values.Value(i))
 		}
 	}
+}
+
+// Copy of Array.IsValid from arrow, allowing the IsValid check to be done without going through an interface
+func isValid(nullBitmapBytes []byte, offset int, i int) bool {
+	return len(nullBitmapBytes) == 0 || bitutil.BitIsSet(nullBitmapBytes, offset+i)
 }

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+require github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40
+
 require (
 	cloud.google.com/go/bigquery v1.8.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
@@ -72,7 +74,6 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
-	github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 	github.com/aws/aws-sdk-go v1.29.16 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.11.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-require github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40
+require github.com/apache/arrow/go/arrow v0.0.0-20211112161151-bc219186db40 // indirect
 
 require (
 	cloud.google.com/go/bigquery v1.8.0 // indirect


### PR DESCRIPTION
When pushing down aggregate functions the time field is not included in the output so we need to tweak unpivot to work without the time column. Changing the order seemed like the simplest solution however that exposed a bug in the current implementation where the full `time` column were copied over as any nulls only existed in the value column

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
