### PR TITLE
chore: Don't report skips in fluxtest

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -111,9 +111,6 @@ func runFluxTests(out io.Writer, setup TestSetupFunc, flags TestFlags) (bool, er
 	reporter := TestReporter{
 		out:       out,
 		verbosity: flags.verbosity,
-		// If an explicit list of test is specified, the user is unlikely interested in all the other, skipped tests.
-		// So avoid cluttering the test report with skips.
-		reportSkips: len(flags.testNames) == 0,
 	}
 
 	runner := NewTestRunner(reporter)
@@ -968,9 +965,8 @@ func (t *TestRunner) Finish() bool {
 
 // TestReporter handles reporting of test results.
 type TestReporter struct {
-	out         io.Writer
-	verbosity   int
-	reportSkips bool
+	out       io.Writer
+	verbosity int
 }
 
 // ReportTestRun reports the result a single test run, intended to be run as
@@ -978,9 +974,6 @@ type TestReporter struct {
 func (t *TestReporter) ReportTestRun(test *Test) {
 	if t.verbosity == 0 {
 		if test.skip {
-			if t.reportSkips {
-				fmt.Fprint(t.out, color.YellowString("s"))
-			}
 		} else if test.Error() != nil {
 			fmt.Fprint(t.out, color.RedString("x"))
 		} else {
@@ -996,9 +989,6 @@ func (t *TestReporter) ReportTestRun(test *Test) {
 			}
 		}
 		if test.skip {
-			if t.reportSkips {
-				fmt.Fprintf(t.out, "%s ... %s\n", test.FullName(), color.YellowString("skip"))
-			}
 		} else if err := test.Error(); err != nil {
 			fmt.Fprintf(t.out, "%s ... %s: %s\n", test.FullName(), color.RedString("fail"), err)
 		} else {


### PR DESCRIPTION
Skips tend to bloat the test output and since tests are always skipped through explicit opt-in behavior I don't think it is very valuable.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
