### PR TITLE
fix(fill): correct type for fillValueTime

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -501,7 +501,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/integral_test.flux":                                                          "7206d881f059f0e6009fe3f0cfeb18b5fcec9ba192b607f63d375541851fcb85",
 	"stdlib/universe/join_across_measurements_test.flux":                                          "4362913c852740d1e55dc13d2b9ac798ffde4263a4b78ca0c96bd5a1333278ad",
 	"stdlib/universe/join_agg_test.flux":                                                          "94c4de77895501644c9fd100dda93d85a76e35b39e97bd801f59f3e6179b337c",
-	"stdlib/universe/join_fill_panic_test.flux":                                                   "4b1706d3ac001bb9bffe5f26bfa7d26e3149a4a15b048cb48cd7657eb4643f2b",
+	"stdlib/universe/join_fill_panic_test.flux":                                                   "60976aa9a75b79ccb03d2403df3f644f8f70abf0da71d066a3d03bcc1cc9904f",
 	"stdlib/universe/join_mismatched_schema_test.flux":                                            "4a50ae64612961f8fc9decc0ad87305eb937931d9608f8a9796cedad35699ff8",
 	"stdlib/universe/join_missing_on_col_test.flux":                                               "477ddf1b38200ff1d3ff63b020e5a89c6b0c9adb4f468d69f56176669c4363e3",
 	"stdlib/universe/join_panic_test.flux":                                                        "1397a1c71a1efb7efe0a5a3e057e7543c59cf405707e637c0073f48b6c28cc03",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -501,6 +501,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/integral_test.flux":                                                          "7206d881f059f0e6009fe3f0cfeb18b5fcec9ba192b607f63d375541851fcb85",
 	"stdlib/universe/join_across_measurements_test.flux":                                          "4362913c852740d1e55dc13d2b9ac798ffde4263a4b78ca0c96bd5a1333278ad",
 	"stdlib/universe/join_agg_test.flux":                                                          "94c4de77895501644c9fd100dda93d85a76e35b39e97bd801f59f3e6179b337c",
+	"stdlib/universe/join_fill_panic_test.flux":                                                   "4b1706d3ac001bb9bffe5f26bfa7d26e3149a4a15b048cb48cd7657eb4643f2b",
 	"stdlib/universe/join_mismatched_schema_test.flux":                                            "4a50ae64612961f8fc9decc0ad87305eb937931d9608f8a9796cedad35699ff8",
 	"stdlib/universe/join_missing_on_col_test.flux":                                               "477ddf1b38200ff1d3ff63b020e5a89c6b0c9adb4f468d69f56176669c4363e3",
 	"stdlib/universe/join_panic_test.flux":                                                        "1397a1c71a1efb7efe0a5a3e057e7543c59cf405707e637c0073f48b6c28cc03",

--- a/stdlib/universe/fill.gen.go
+++ b/stdlib/universe/fill.gen.go
@@ -210,7 +210,7 @@ func (t *fillTransformation) fillTimeColumn(arr *array.Int, fillValue *interface
 		}
 	}
 	if t.spec.UsePrevious && !fillValueNull {
-		*fillValue = fillValueTime
+		*fillValue = values.Time(fillValueTime)
 	}
 	return b.NewArray()
 }

--- a/stdlib/universe/fill.gen.go.tmpl
+++ b/stdlib/universe/fill.gen.go.tmpl
@@ -45,7 +45,7 @@ func (t *fillTransformation) fill{{.Name}}Column(arr *{{.ArrowType}}, fillValue 
         }
     }
     if t.spec.UsePrevious && !fillValueNull {
-        *fillValue = fillValue{{.Name}}
+        *fillValue = {{if eq .Name "Time"}}values.Time(fillValue{{.Name}}){{else}}fillValue{{.Name}}{{end}}
     }
     return b.NewArray()
 }

--- a/stdlib/universe/join_fill_panic_test.flux
+++ b/stdlib/universe/join_fill_panic_test.flux
@@ -1,0 +1,40 @@
+package universe_test
+
+
+import "testing"
+import "internal/debug"
+import "array"
+import "join"
+
+testcase fill_time_previous {
+    left =
+        array.from(rows: [{_time: 2022-01-01T00:00:00Z, _value: 2}, {_time: 2022-01-01T00:00:15Z, _value: 1}])
+            |> map(fn: (r) => ({r with myStart: r._time}))
+
+    right = array.from(rows: [{_time: 2022-01-01T00:00:30Z, _value: 0}])
+    got =
+        join.full(
+            left: left,
+            right: right,
+            on: (l, r) => l._time == r._time,
+            as: (l, r) => {
+                time = if exists l._time then l._time else r._time
+                value = if exists l._value then l._value else r._value
+
+                return {_time: time, value: value, myStart: l.myStart}
+            },
+        )
+            // Adding debug.slurp avoids the panic and the test passes
+            // |> debug.slurp()
+            |> fill(column: "myStart", usePrevious: true)
+    want =
+        array.from(
+            rows: [
+                {_time: 2022-01-01T00:00:00Z, myStart: 2022-01-01T00:00:00Z, value: 2},
+                {_time: 2022-01-01T00:00:15Z, myStart: 2022-01-01T00:00:15Z, value: 1},
+                {_time: 2022-01-01T00:00:30Z, myStart: 2022-01-01T00:00:15Z, value: 0},
+            ],
+        )
+
+    testing.diff(got, want)
+}

--- a/stdlib/universe/join_fill_panic_test.flux
+++ b/stdlib/universe/join_fill_panic_test.flux
@@ -8,7 +8,12 @@ import "join"
 
 testcase fill_time_previous {
     left =
-        array.from(rows: [{_time: 2022-01-01T00:00:00Z, _value: 2}, {_time: 2022-01-01T00:00:15Z, _value: 1}])
+        array.from(
+            rows: [
+                {_time: 2022-01-01T00:00:00Z, _value: 2},
+                {_time: 2022-01-01T00:00:15Z, _value: 1},
+            ],
+        )
             |> map(fn: (r) => ({r with myStart: r._time}))
 
     right = array.from(rows: [{_time: 2022-01-01T00:00:30Z, _value: 0}])


### PR DESCRIPTION
Closes #5127

`fill()` was incorrectly setting `fillValueTime` as an int64, which caused a panic the next time `fillTimeColumn` was called and tried to coerce `fillValueTime` into a `values.Time`. This only manifested when processing a table that spanned multiple table chunks (i.e., when `fillTimeColumn` was called with a `fillValue` that was already set).

This patch sets `fillValueTime` to be a `values.Time`, which avoids the bad type coercion and thereby also avoids the panic.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
