### PR TITLE
fix: vectorized division by zero should error not panic

### DIFF
--- a/array/binary.gen.go
+++ b/array/binary.gen.go
@@ -598,6 +598,10 @@ func IntDiv(l, r *Int, mem memory.Allocator) (*Int, error) {
 	for i := 0; i < n; i++ {
 		if l.IsValid(i) && r.IsValid(i) {
 
+			if r.Value(i) == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+
 			b.Append(l.Value(i) / r.Value(i))
 
 		} else {
@@ -616,6 +620,10 @@ func IntDivLConst(l int64, r *Int, mem memory.Allocator) (*Int, error) {
 	for i := 0; i < n; i++ {
 		if r.IsValid(i) {
 
+			if r.Value(i) == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+
 			b.Append(l / r.Value(i))
 
 		} else {
@@ -633,6 +641,10 @@ func IntDivRConst(l *Int, r int64, mem memory.Allocator) (*Int, error) {
 	b.Resize(n)
 	for i := 0; i < n; i++ {
 		if l.IsValid(i) {
+
+			if r == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
 
 			b.Append(l.Value(i) / r)
 
@@ -655,6 +667,10 @@ func UintDiv(l, r *Uint, mem memory.Allocator) (*Uint, error) {
 	for i := 0; i < n; i++ {
 		if l.IsValid(i) && r.IsValid(i) {
 
+			if r.Value(i) == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+
 			b.Append(l.Value(i) / r.Value(i))
 
 		} else {
@@ -673,6 +689,10 @@ func UintDivLConst(l uint64, r *Uint, mem memory.Allocator) (*Uint, error) {
 	for i := 0; i < n; i++ {
 		if r.IsValid(i) {
 
+			if r.Value(i) == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+
 			b.Append(l / r.Value(i))
 
 		} else {
@@ -690,6 +710,10 @@ func UintDivRConst(l *Uint, r uint64, mem memory.Allocator) (*Uint, error) {
 	b.Resize(n)
 	for i := 0; i < n; i++ {
 		if l.IsValid(i) {
+
+			if r == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
 
 			b.Append(l.Value(i) / r)
 

--- a/array/binary.gen.go.tmpl
+++ b/array/binary.gen.go.tmpl
@@ -88,6 +88,12 @@ func {{$type}}{{$op.Name}}(l, r *{{$type}}, mem memory.Allocator) (*{{$type}}, e
 
             {{else}}
 
+            {{if and (eq $op.Op "/") (eq $type "Int" "Uint")}}
+			if r.Value(i) == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+			{{end}}
+
 			b.Append(l.Value(i) {{$op.Op}} r.Value(i))
 
             {{end}}
@@ -112,6 +118,12 @@ func {{$type}}{{$op.Name}}LConst(l {{index $.TypeMap $type}}, r *{{$type}}, mem 
 
             {{else}}
 
+            {{if and (eq $op.Op "/") (eq $type "Int" "Uint")}}
+			if r.Value(i) == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+			{{end}}
+
 			b.Append(l {{$op.Op}} r.Value(i))
 
             {{end}}
@@ -135,6 +147,12 @@ func {{$type}}{{$op.Name}}RConst(l *{{$type}}, r {{index $.TypeMap $type}}, mem 
 			b.Append(math.Mod(l.Value(i), r))
 
             {{else}}
+
+            {{if and (eq $op.Op "/") (eq $type "Int" "Uint")}}
+			if r == 0 {
+				return nil, errors.Newf(codes.FailedPrecondition, "cannot divide by zero")
+			}
+			{{end}}
 
 			b.Append(l.Value(i) {{$op.Op}} r)
 

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -519,7 +519,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestAverage_test.flux":                                                     "79681d441fc0340d4f76e238f10ccc50dd2b67be62f6c5061157a4e11f634055",
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "0110e5d56e9feb926cba8097d418b08fce0a70d194aeb0bf93254272d3f4136b",
 	"stdlib/universe/lowestMin_test.flux":                                                         "823a9d836aaf31f1692eadffb46822ab12ac2d5051eafaf4ec4ffc67fb15d2d6",
-	"stdlib/universe/map_test.flux":                                                               "7ecbad2c73db6375056233db770624371af6bd45e836c0b8ddc9768b89e09c77",
+	"stdlib/universe/map_test.flux":                                                               "7bf5f268c00742f8c6784cbf7b320814b9ffc90e3e21b8a6902d85987734d45d",
 	"stdlib/universe/map_vectorize_conditionals_test.flux":                                        "cbe50d0dbd1b5a30c8ed8d61e1926d2e6dbdcc55dd6cde9db9cafb28835f0406",
 	"stdlib/universe/map_vectorize_const_test.flux":                                               "636889211f387eb2b56517acd090ab16340c1610bc33c1640302a84d87fb5cee",
 	"stdlib/universe/map_vectorize_equality_test.flux":                                            "b06a0cf70625e99b0503e72ae0cc445f71a0f66e77cc7110cc9369e87ed1079a",


### PR DESCRIPTION
In the row-based division, we check to see if the divisor is 0 and return an error when this is the case.

This check was missed in the vectorized division, leading to a panic.

This diff adds the check for division for uint and int. For whatever reason, zero division with float produces an `Inf+` and there is no such guard in the row-based version so no updates were made there on the vectorized side.


### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` **N/A**
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated **N/A**

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
