### PR TITLE
fix: correct inconsistent runtime typing for `logicalVectorEvaluator`

### DIFF
--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -335,7 +335,7 @@ type logicalVectorEvaluator struct {
 }
 
 func (e *logicalVectorEvaluator) Type() semantic.MonoType {
-	return semantic.BasicBool
+	return semantic.NewVectorType(semantic.BasicBool)
 }
 
 func (e *logicalVectorEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -520,7 +520,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "0110e5d56e9feb926cba8097d418b08fce0a70d194aeb0bf93254272d3f4136b",
 	"stdlib/universe/lowestMin_test.flux":                                                         "823a9d836aaf31f1692eadffb46822ab12ac2d5051eafaf4ec4ffc67fb15d2d6",
 	"stdlib/universe/map_test.flux":                                                               "7ecbad2c73db6375056233db770624371af6bd45e836c0b8ddc9768b89e09c77",
-	"stdlib/universe/map_vectorize_conditionals_test.flux":                                        "58f9cadb545a89c66be2ac94aa7efe9308d6e397d89f65654241ce493d6af902",
+	"stdlib/universe/map_vectorize_conditionals_test.flux":                                        "cbe50d0dbd1b5a30c8ed8d61e1926d2e6dbdcc55dd6cde9db9cafb28835f0406",
 	"stdlib/universe/map_vectorize_const_test.flux":                                               "636889211f387eb2b56517acd090ab16340c1610bc33c1640302a84d87fb5cee",
 	"stdlib/universe/map_vectorize_equality_test.flux":                                            "b06a0cf70625e99b0503e72ae0cc445f71a0f66e77cc7110cc9369e87ed1079a",
 	"stdlib/universe/map_vectorize_float_test.flux":                                               "346f1bff9ade79f668de5818cad4945d35000c7968f77b6a95735cd03cdb9819",


### PR DESCRIPTION
Fixes https://github.com/influxdata/flux/issues/5155

...which shows a runtime error when nesting a logical expression inside a conditional expression.

When in the `test` position, we'd get:
```
cannot use test of type vector in conditional expression; expected boolean
```

Originally, `logicalVectorEvaluator` advertised a runtime type of bool, which is inconsistent with reality since it is actually a vector of bool.

The error message we saw in this situation stemmed from the fact we choose either the vectorized or row-based conditional evaluator with this check here:
https://github.com/influxdata/flux/blob/df2b4c404e81d39cadef7456c4a3aacf55d3638a/compiler/compiler.go#L657-L669

Since `test` in this case was a `logicalVectorEvaluator` with incorrect (bool) typing, this check failed and we fall back to the non-vectorized version for conditional.
This is why the error message states "expected boolean" -- we were calling the non-vectorized version with a vector as input.

This diff updates the impl for `logicalVectorEvaluator.Type()` such that it reports a vector of bool instead of bool.


### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` **N/A**
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated **N/A**

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
