### PR TITLE
feat: Display yields in fluxtest

### DIFF
--- a/cmd/flux/cmd/test.go
+++ b/cmd/flux/cmd/test.go
@@ -208,22 +208,26 @@ func (t *Test) Run(executor TestExecutor) {
 
 func (t *Test) consume(ctx context.Context, results flux.ResultIterator) error {
 	var output strings.Builder
+	foundTestError := false
 	for results.More() {
 		result := results.Next()
 		if result.Name() == errorYield {
+			lenBeforeError := output.Len()
 			err := result.Tables().Do(func(tbl flux.Table) error {
 				// The data returned here is the result of `testing.diff`, so any result means that
 				// a comparison of two tables showed inequality. Capture that inequality as part of the error.
 				_, err := execute.NewFormatter(tbl, nil).WriteTo(&output)
+				foundTestError = foundTestError || output.Len() > lenBeforeError
 				return err
 			})
 			if err != nil {
 				return err
 			}
 		} else {
+			fmt.Fprintf(&output, "YIELD: %v\n", result.Name())
 			err := result.Tables().Do(func(tbl flux.Table) error {
-				tbl.Done()
-				return nil
+				_, err := execute.NewFormatter(tbl, nil).WriteTo(&output)
+				return err
 			})
 			if err != nil {
 				return err
@@ -234,7 +238,7 @@ func (t *Test) consume(ctx context.Context, results flux.ResultIterator) error {
 
 	err := results.Err()
 	if err == nil {
-		if output.Len() > 0 {
+		if foundTestError {
 			err = errors.Newf(codes.FailedPrecondition, "%s", output.String())
 		}
 	}


### PR DESCRIPTION
It is useful to be able to insert `yield(name: ...)` to inspect a test but the output of the yield were just ignored. This collects and displays the output without causing any test failures due to this extra output.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x ] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
