### PR TITLE
feat: Don't display nulls as 0 in diff

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -159,7 +159,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/csv/csv.flux":                                                            "7f033d93ed2e456d7ee181f0afa88f8c4c81f3b1a0984e56d53d3e146db48d20",
 	"stdlib/experimental/date/boundaries/boundaries.flux":                                         "d89786ac0607574da4cd130800670907e404f9dbfea0e74dd7b2c887707feaae",
 	"stdlib/experimental/date/boundaries/boundaries_test.flux":                                    "35f4198aae27017b38227a20d16ecf5c6ec81382643a36aafadda844b8d36e2b",
-	"stdlib/experimental/diff_test.flux":                                                          "9e008f0ce38d69faa2a4ab48ffcae8090262809e24ac80625bae558b68b6554c",
+	"stdlib/experimental/diff_test.flux":                                                          "b75aa4095b24d67f027b24b0c08e926824a6f68ea292821c025bcb8ac76c0339",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
 	"stdlib/experimental/experimental.flux":                                                       "24cf87d3a5ce2f7cb6534856c1cee16047721f313eaa6e981c826caa611fd2a0",
 	"stdlib/experimental/experimental_test.flux":                                                  "b417f361be23e610b6caffa266c40c421b19dedc3289ce064bb065cb0bcd825c",

--- a/stdlib/experimental/diff.go
+++ b/stdlib/experimental/diff.go
@@ -361,13 +361,19 @@ func (d *diffSchema) appendRow(builders []array.Builder, which, i int) {
 	}
 
 	for j, idx := range idxs {
+		builder := builders[j]
 		if idx < 0 {
-			builders[j].AppendNull()
+			builder.AppendNull()
 			continue
 		}
 
 		arr := chunk.Values(idx)
-		switch b := builders[j].(type) {
+		if arr.IsNull(i) {
+			builder.AppendNull()
+			continue
+		}
+
+		switch b := builder.(type) {
 		case *array.FloatBuilder:
 			b.Append(arr.(*array.Float).Value(i))
 		case *array.IntBuilder:

--- a/stdlib/experimental/diff_test.flux
+++ b/stdlib/experimental/diff_test.flux
@@ -4,6 +4,7 @@ package experimental_test
 import "testing"
 import "array"
 import "experimental"
+import "internal/debug"
 
 testcase match {
     rows = [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}]
@@ -21,15 +22,11 @@ testcase match {
 
 testcase mismatch {
     want =
-        array.from(
-            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
-        )
+        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
             |> group(columns: ["_measurement", "_field"])
 
     got =
-        array.from(
-            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 3.0}],
-        )
+        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 3.0}])
             |> group(columns: ["_measurement", "_field"])
 
     exp =
@@ -163,9 +160,7 @@ testcase partial_match {
 
 testcase empty_want {
     want =
-        array.from(
-            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
-        )
+        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
             |> group(columns: ["_measurement", "_field"])
 
     got =
@@ -207,9 +202,7 @@ testcase empty_got {
             |> group(columns: ["_measurement", "_field"])
 
     got =
-        array.from(
-            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
-        )
+        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
             |> group(columns: ["_measurement", "_field"])
 
     exp =
@@ -282,6 +275,41 @@ testcase mismatch_non_string_group_key {
             ],
         )
             |> group(columns: ["_measurement", "_field", "_start"])
+
+    experimental.diff(want, got)
+        |> rename(columns: {_diff: "diff"})
+        |> testing.diff(want: exp)
+}
+
+testcase mismatch_null {
+    want =
+        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
+            |> group(columns: ["_measurement", "_field"])
+
+    got =
+        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: debug.null(type: "float")}])
+            |> group(columns: ["_measurement", "_field"])
+
+    exp =
+        array.from(
+            rows: [
+                {
+                    diff: "-",
+                    _measurement: "m0",
+                    _field: "f0",
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: 2.0,
+                },
+                {
+                    diff: "+",
+                    _measurement: "m0",
+                    _field: "f0",
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: debug.null(type: "float"),
+                },
+            ],
+        )
+            |> group(columns: ["_measurement", "_field"])
 
     experimental.diff(want, got)
         |> rename(columns: {_diff: "diff"})

--- a/stdlib/experimental/diff_test.flux
+++ b/stdlib/experimental/diff_test.flux
@@ -22,11 +22,15 @@ testcase match {
 
 testcase mismatch {
     want =
-        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
+        )
             |> group(columns: ["_measurement", "_field"])
 
     got =
-        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 3.0}])
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 3.0}],
+        )
             |> group(columns: ["_measurement", "_field"])
 
     exp =
@@ -160,7 +164,9 @@ testcase partial_match {
 
 testcase empty_want {
     want =
-        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
+        )
             |> group(columns: ["_measurement", "_field"])
 
     got =
@@ -202,7 +208,9 @@ testcase empty_got {
             |> group(columns: ["_measurement", "_field"])
 
     got =
-        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
+        )
             |> group(columns: ["_measurement", "_field"])
 
     exp =
@@ -283,11 +291,22 @@ testcase mismatch_non_string_group_key {
 
 testcase mismatch_null {
     want =
-        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}])
+        array.from(
+            rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: 2.0}],
+        )
             |> group(columns: ["_measurement", "_field"])
 
     got =
-        array.from(rows: [{_measurement: "m0", _field: "f0", _time: 2022-07-12T00:00:00Z, _value: debug.null(type: "float")}])
+        array.from(
+            rows: [
+                {
+                    _measurement: "m0",
+                    _field: "f0",
+                    _time: 2022-07-12T00:00:00Z,
+                    _value: debug.null(type: "float"),
+                },
+            ],
+        )
             |> group(columns: ["_measurement", "_field"])
 
     exp =


### PR DESCRIPTION
Before they would be displayed as the zero-value of whatever type the column is which is rather confusing. Now it is left empty instead (or should we display `<nil>` or something instead?)

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
