### PR TITLE
test: Add a parse error test for option

### DIFF
--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -947,3 +947,15 @@ fn missing_property() {
         expect: expect_test::expect![[r#"error @4:13-4:13: expected IDENT, got BUILTIN (builtin) at 4:13"#]],
     }
 }
+
+#[test]
+fn missing_identifier_in_option() {
+    test_error_msg! {
+        src: r#"
+            option =
+
+            buckets()
+        "#,
+        expect: expect_test::expect![[r#"error @2:20-2:21: expected IDENT, got ASSIGN (=) at 2:20"#]],
+    }
+}

--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -901,16 +901,14 @@ fn int_literal_zero_prefix() {
     )
 }
 
-macro_rules! test_error_msg {
-    (src: $src:expr $(,)?, expect: $expect:expr $(,)?) => {
-        let mut p = Parser::new($src);
-        let parsed = p.parse_file("".to_string());
-        $expect.assert_eq(
-            &ast::check::check(ast::walk::Node::File(&parsed))
-                .unwrap_err()
-                .to_string(),
-        );
-    };
+fn test_error_msg(src: &str, expect: expect_test::Expect) {
+    let mut p = Parser::new(src);
+    let parsed = p.parse_file("".to_string());
+    expect.assert_eq(
+        &ast::check::check(ast::walk::Node::File(&parsed))
+            .unwrap_err()
+            .to_string(),
+    );
 }
 
 #[test]
@@ -928,34 +926,36 @@ fn parse_invalid_call() {
 
 #[test]
 fn issue_4231() {
-    test_error_msg! {
-        src: r#"
+    test_error_msg(
+        r#"
             map(fn: (r) => ({ r with _value: if true and false then 1}) )
         "#,
-        expect: expect_test::expect![[r#"error @2:46-2:70: expected ELSE, got RBRACE (}) at 2:70"#]],
-    }
+        expect_test::expect![[r#"error @2:46-2:70: expected ELSE, got RBRACE (}) at 2:70"#]],
+    );
 }
 
 #[test]
 fn missing_property() {
-    test_error_msg! {
-        src: r#"
+    test_error_msg(
+        r#"
             x.
 
             builtin y : int
         "#,
-        expect: expect_test::expect![[r#"error @4:13-4:13: expected IDENT, got BUILTIN (builtin) at 4:13"#]],
-    }
+        expect_test::expect![[
+            r#"error @4:13-4:13: expected IDENT, got BUILTIN (builtin) at 4:13"#
+        ]],
+    );
 }
 
 #[test]
 fn missing_identifier_in_option() {
-    test_error_msg! {
-        src: r#"
+    test_error_msg(
+        r#"
             option =
 
             buckets()
         "#,
-        expect: expect_test::expect![[r#"error @2:20-2:21: expected IDENT, got ASSIGN (=) at 2:20"#]],
-    }
+        expect_test::expect![[r#"error @2:20-2:20: expected IDENT, got ASSIGN (=) at 2:20"#]],
+    );
 }


### PR DESCRIPTION
The error for this was changed by https://github.com/influxdata/flux/pull/4957 and was noticed downstream.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
