### PR TITLE
fix: treat null inputs to `vectorAdd`, `vectorOr` as false

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -520,7 +520,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestAverage_test.flux":                                                     "79681d441fc0340d4f76e238f10ccc50dd2b67be62f6c5061157a4e11f634055",
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "0110e5d56e9feb926cba8097d418b08fce0a70d194aeb0bf93254272d3f4136b",
 	"stdlib/universe/lowestMin_test.flux":                                                         "823a9d836aaf31f1692eadffb46822ab12ac2d5051eafaf4ec4ffc67fb15d2d6",
-	"stdlib/universe/map_test.flux":                                                               "eb9117631941df83cc86a27ff237f4f86408eaaa1fa45b82ea48639f3841cec2",
+	"stdlib/universe/map_test.flux":                                                               "543046ab89d2e991fe1507803332e7ed590bcf015a65cd8a8005882dfcd93915",
 	"stdlib/universe/map_vectorize_conditionals_test.flux":                                        "cbe50d0dbd1b5a30c8ed8d61e1926d2e6dbdcc55dd6cde9db9cafb28835f0406",
 	"stdlib/universe/map_vectorize_const_test.flux":                                               "636889211f387eb2b56517acd090ab16340c1610bc33c1640302a84d87fb5cee",
 	"stdlib/universe/map_vectorize_equality_test.flux":                                            "b06a0cf70625e99b0503e72ae0cc445f71a0f66e77cc7110cc9369e87ed1079a",


### PR DESCRIPTION
Formerly, when the input to vectorized logical ops was a null, we'd see:

```
runtime error: cannot use vectorized or operation on non-vector invalid
```

The precedent set by the row-based logical ops is to treat incoming nulls as false.

This diff extracts the input validation to a separate function which is responsible for transitioning the incoming `values.Value` to a `values.Vector` giving it the chance to intercept the problem null case and convert them to a new vec repeat holding a boolean false.


> N.b this implementation has a slight semantic difference when compared to the row-based version.
>
> For the regular logical ops, we short-circuit when looking at the left-hand side, converting the return type to a boolean for these cases. There's still a case where the right-hand side is returned as-is, meaning the return type can be either null or bool.
>
> The vector code-path eagerly promotes null inputs (at the supposed vector-level) to vec repeats of `false`, meaning the output would be bool rather than null when the op happens to be one where the RHS would be returned.
>
> I believe it is possible to precisely pass along a null output the the same exact case, but it'll be a lot more messy (speculative).
 
### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
