### PR TITLE
fix: Fix typo in SPEC.md

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -963,7 +963,7 @@ If `rec` is bounded and does *not* contain a property `k`, both `rec.k` and `rec
 If `rec` is unbounded and does *not* contain a property `k`, both `rec.k` and `rec["k"]` return _null_.
 
     MemberExpression        = DotExpression  | MemberBracketExpression
-    DotExpression           = "." identifer
+    DotExpression           = "." identifier
     MemberBracketExpression = "[" string_lit "]" .
 
 #### Conditional Expressions
@@ -1170,7 +1170,7 @@ These preassigned values are defined in the source files for the various built-i
 When a built-in value is not expressible in Flux its value may be defined by the hosting environment.
 All such values must have a corresponding builtin statement to declare the existence and type of the built-in value.
 
-    BuiltinStatement = "builtin" identifer ":" TypeExpression .
+    BuiltinStatement = "builtin" identifier ":" TypeExpression .
     TypeExpression   = MonoType ["where" Constraints] .
 
     MonoType = Tvar | Basic | Array | Record | Function .


### PR DESCRIPTION
Discovered these typos while working on describing Flux syntax in https://github.com/pierwill/flux-redex.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
