### PR TITLE
fix: Don't include the opening parenthesis in invalid call expressions

### DIFF
--- a/libflux/flux-core/src/parser/mod.rs
+++ b/libflux/flux-core/src/parser/mod.rs
@@ -158,10 +158,12 @@ impl<'input> Parser<'input> {
     fn expect_or_skip(&mut self, exp: TokenType) -> Token {
         let t = self.scan();
         match t.tok {
-            tok if tok == exp => (),
+            tok if tok == exp => t,
             TokenType::Eof => {
                 self.errs.push(format!("expected {}, got EOF", exp));
                 self.t = Some(t.clone());
+
+                t
             }
             _ => {
                 let pos = ast::Position::from(&t.start_pos);
@@ -170,9 +172,18 @@ impl<'input> Parser<'input> {
                     exp, t.tok, t.lit, pos.line, pos.column,
                 ));
                 self.t = Some(t.clone());
+
+                Token {
+                    tok: TokenType::Illegal,
+                    lit: "".into(),
+                    start_offset: t.start_offset,
+                    end_offset: t.start_offset,
+                    start_pos: t.start_pos,
+                    end_pos: t.start_pos,
+                    comments: Vec::new(),
+                }
             }
         }
-        t
     }
 
     // open will open a new block. It will expect that the next token

--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -922,7 +922,7 @@ map(fn: (r) => ({ r with _value: if true and false then 1}) )
 "#,
     );
     let parsed = p.parse_file("".to_string());
-    expect_test::expect![[r#"error @2:34-2:59: expected ELSE, got RBRACE (}) at 2:58"#]].assert_eq(
+    expect_test::expect![[r#"error @2:34-2:58: expected ELSE, got RBRACE (}) at 2:58"#]].assert_eq(
         &ast::check::check(ast::walk::Node::File(&parsed))
             .unwrap_err()
             .to_string(),
@@ -939,7 +939,7 @@ builtin y : int
 "#,
     );
     let parsed = p.parse_file("".to_string());
-    expect_test::expect![[r#"error @4:1-4:8: expected IDENT, got BUILTIN (builtin) at 4:1"#]]
+    expect_test::expect![[r#"error @4:1-4:1: expected IDENT, got BUILTIN (builtin) at 4:1"#]]
         .assert_eq(
             &ast::check::check(ast::walk::Node::File(&parsed))
                 .unwrap_err()

--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -907,8 +907,7 @@ fn parse_invalid_call() {
     let parsed = p.parse_file("".to_string());
 
     // Checks that the identifier in the ast after the `.` does not get assigned `(` which would
-    // show up as `json.((v: r._value)`. Interferes with completion in the LSP as no identifer
-    // contains `(`
+    // show up as `json.((v: r._value)`.
     assert_eq!(
         crate::formatter::format_node(&parsed).unwrap(),
         "json.(v: r._value)\n"

--- a/libflux/flux-core/src/parser/tests/errors.rs
+++ b/libflux/flux-core/src/parser/tests/errors.rs
@@ -902,6 +902,20 @@ fn int_literal_zero_prefix() {
 }
 
 #[test]
+fn parse_invalid_call() {
+    let mut p = Parser::new("json.(v: r._value)");
+    let parsed = p.parse_file("".to_string());
+
+    // Checks that the identifier in the ast after the `.` does not get assigned `(` which would
+    // show up as `json.((v: r._value)`. Interferes with completion in the LSP as no identifer
+    // contains `(`
+    assert_eq!(
+        crate::formatter::format_node(&parsed).unwrap(),
+        "json.(v: r._value)\n"
+    );
+}
+
+#[test]
 fn issue_4231() {
     let mut p = Parser::new(
         r#"

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -29,7 +29,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "23dc650546036be5c9e1990c8a3ed79b2a4e4b4484c8dd0961a63317a821b522",
 	"libflux/flux-core/src/lib.rs":                                                                "4d03cf4a25ec4cccd09f31cffe1ac634ffb6b6bf6c9653839be01b6fbb4c9da6",
 	"libflux/flux-core/src/map.rs":                                                                "342c1cc111d343f01b97f38be10a9f1097bdd57cdc56f55e92fd3ed5028e6973",
-	"libflux/flux-core/src/parser/mod.rs":                                                         "13bc3e939f36083e327a7c4ad2351d3ef4cd820939fdf83e83f94a3a452b53ef",
+	"libflux/flux-core/src/parser/mod.rs":                                                         "b08d84b0a0244df5296e1053e2ca4c3ab38c9f7acfa7e6ab29f69d122b3e7b5e",
 	"libflux/flux-core/src/parser/strconv.rs":                                                     "ace82da40f26161ce14a5ad597fb40634f2ca044efa24d3bbb960667a12e0eb6",
 	"libflux/flux-core/src/scanner/mod.rs":                                                        "297809a7b5778363a490bc4e08add05005bdc50d7c8cd59f27390f6316aba69e",
 	"libflux/flux-core/src/scanner/scanner.rl":                                                    "e3755aed899244461e8b2a05a87ab41a89fe3d66d28f60c25ad9895f26675ba8",


### PR DESCRIPTION
Thought this would be necessary for https://github.com/influxdata/flux-lsp/pull/580 but it seems like the completions works regardless. Still, this corrects `expect_or_skip` since I'd say we shouldn't use the token if we "skip" it.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
