### PR TITLE
fix(spec): Fix duplicate definitions

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1173,19 +1173,19 @@ All such values must have a corresponding builtin statement to declare the exist
     BuiltinStatement = "builtin" identifer ":" TypeExpression .
     TypeExpression   = MonoType ["where" Constraints] .
 
-    MonoType = Tvar | Basic | Array | Record | Function .
-    Tvar     = "A" … "Z" .
-    Basic    = "int" | "uint" | "float" | "string" | "bool" | "time" | "duration" | "bytes" | "regexp" .
-    Array    = "[" MonoType "]" .
-    Record   = ( "{" [Properties] "}" ) | ( "{" Tvar "with" Properties "}" ) .
-    Function = "(" [Parameters] ")" "=>" MonoType .
+    MonoType     = Tvar | BasicType | ArrayType | RecordType | FunctionType .
+    Tvar         = "A" … "Z" .
+    BasicType    = "int" | "uint" | "float" | "string" | "bool" | "time" | "duration" | "bytes" | "regexp" .
+    ArrayType    = "[" MonoType "]" .
+    RecordType   = ( "{" [RecordTypeProperties] "}" ) | ( "{" Tvar "with" RecordTypeProperties "}" ) .
+    FunctionType = "(" [FunctionTypeParameters] ")" "=>" MonoType .
 
-    Properties = Property { "," Property } .
-    Property   = Label ":" MonoType .
-    Label      = identifier | string_lit
+    RecordTypeProperties = RecordTypeProperty { "," RecordTypeProperty } .
+    RecordTypeProperty   = Label ":" MonoType .
+    Label = identifier | string_lit
 
-    Parameters = Parameter { "," Parameter } .
-    Parameter  = [ "<-" | "?" ] identifier ":" MonoType .
+    FunctionTypeParameters = FunctionTypeParameter { "," FunctionTypeParameter } .
+    FunctionTypeParameter = [ "<-" | "?" ] identifier ":" MonoType .
 
     Constraints = Constraint { "," Constraint } .
     Constraint  = Tvar ":" Kinds .


### PR DESCRIPTION
Rename some rules for the builtin statement to avoid ambiguity.

Closes #5186.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
      N/A
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
       N/A
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated
       No feature changes, but this does update the specification.

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
