### PR TITLE
fix: logical null handling

### DIFF
--- a/array/binary.go
+++ b/array/binary.go
@@ -15,42 +15,60 @@ func And(l, r *Boolean, mem memory.Allocator) (*Boolean, error) {
 	b := NewBooleanBuilder(mem)
 	b.Resize(n)
 	for i := 0; i < n; i++ {
-		if l.IsValid(i) && r.IsValid(i) {
-			b.Append(l.Value(i) && r.Value(i))
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewBooleanArray()
-	b.Release()
-	return a, nil
-}
-
-func AndLConst(l bool, r *Boolean, mem memory.Allocator) (*Boolean, error) {
-	n := r.Len()
-	b := NewBooleanBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
-		if r.IsValid(i) {
-			b.Append(l && r.Value(i))
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewBooleanArray()
-	b.Release()
-	return a, nil
-}
-
-func AndRConst(l *Boolean, r bool, mem memory.Allocator) (*Boolean, error) {
-	n := l.Len()
-	b := NewBooleanBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
+		var elmL *bool
 		if l.IsValid(i) {
-			b.Append(l.Value(i) && r)
-		} else {
+			x := l.Value(i)
+			elmL = &x
+		}
+		var elmR *bool
+		if r.IsValid(i) {
+			x := r.Value(i)
+			elmR = &x
+		}
+
+		if elmL == nil && elmR == nil {
+			// both sides are null
 			b.AppendNull()
+		} else if elmL == nil || elmR == nil {
+			// one side is null, the other is false
+			if (elmL != nil && !*elmL) || (elmR != nil && !*elmR) {
+				b.Append(false)
+			} else {
+				b.AppendNull()
+			}
+		} else {
+			// no nulls
+			b.Append(*elmL && *elmR)
+		}
+	}
+	a := b.NewBooleanArray()
+	b.Release()
+	return a, nil
+}
+
+func AndConst(fixed *bool, arr *Boolean, mem memory.Allocator) (*Boolean, error) {
+	n := arr.Len()
+	b := NewBooleanBuilder(mem)
+	b.Resize(n)
+	for i := 0; i < n; i++ {
+		var elm *bool
+		if arr.IsValid(i) {
+			x := arr.Value(i)
+			elm = &x
+		}
+		if fixed == nil && elm == nil {
+			// both sides are null
+			b.AppendNull()
+		} else if fixed == nil || elm == nil {
+			// one side is null, the other is false
+			if (fixed != nil && !*fixed) || (elm != nil && !*elm) {
+				b.Append(false)
+			} else {
+				b.AppendNull()
+			}
+		} else {
+			// no nulls
+			b.Append(*fixed && *elm)
 		}
 	}
 	a := b.NewBooleanArray()
@@ -67,42 +85,60 @@ func Or(l, r *Boolean, mem memory.Allocator) (*Boolean, error) {
 	b := NewBooleanBuilder(mem)
 	b.Resize(n)
 	for i := 0; i < n; i++ {
-		if l.IsValid(i) && r.IsValid(i) {
-			b.Append(l.Value(i) || r.Value(i))
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewBooleanArray()
-	b.Release()
-	return a, nil
-}
-
-func OrLConst(l bool, r *Boolean, mem memory.Allocator) (*Boolean, error) {
-	n := r.Len()
-	b := NewBooleanBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
-		if r.IsValid(i) {
-			b.Append(l || r.Value(i))
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewBooleanArray()
-	b.Release()
-	return a, nil
-}
-
-func OrRConst(l *Boolean, r bool, mem memory.Allocator) (*Boolean, error) {
-	n := l.Len()
-	b := NewBooleanBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
+		var elmL *bool
 		if l.IsValid(i) {
-			b.Append(l.Value(i) || r)
-		} else {
+			x := l.Value(i)
+			elmL = &x
+		}
+		var elmR *bool
+		if r.IsValid(i) {
+			x := r.Value(i)
+			elmR = &x
+		}
+
+		if elmL == nil && elmR == nil {
+			// both sides are null
 			b.AppendNull()
+		} else if elmL == nil || elmR == nil {
+			// one side is null, the other is true
+			if (elmL != nil && *elmL) || (elmR != nil && *elmR) {
+				b.Append(true)
+			} else {
+				b.AppendNull()
+			}
+		} else {
+			// no nulls
+			b.Append(*elmL || *elmR)
+		}
+	}
+	a := b.NewBooleanArray()
+	b.Release()
+	return a, nil
+}
+
+func OrConst(fixed *bool, arr *Boolean, mem memory.Allocator) (*Boolean, error) {
+	n := arr.Len()
+	b := NewBooleanBuilder(mem)
+	b.Resize(n)
+	for i := 0; i < n; i++ {
+		var elm *bool
+		if arr.IsValid(i) {
+			x := arr.Value(i)
+			elm = &x
+		}
+		if fixed == nil && elm == nil {
+			// both sides are null
+			b.AppendNull()
+		} else if fixed == nil || elm == nil {
+			// one side is null, the other is true
+			if (fixed != nil && *fixed) || (elm != nil && *elm) {
+				b.Append(true)
+			} else {
+				b.AppendNull()
+			}
+		} else {
+			// no nulls
+			b.Append(*fixed || *elm)
 		}
 	}
 	a := b.NewBooleanArray()

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -634,8 +634,11 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 				right:    r,
 			}, nil
 		}
-
-		return &logicalEvaluator{
+		// TODO(onelson): try to select strict or regular logical here.
+		//   Need ctx to read flagger.
+		//   Currently this happens during Eval() where ctx is available and
+		//   will fallback to the regular logicalEvaluator if the flag is unset.
+		return &logicalStrictNullEvaluator{
 			operator: n.Operator,
 			left:     l,
 			right:    r,

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -475,13 +475,15 @@ func vectorAnd(l, r values.Vector, mem memory.Allocator) (values.Vector, error) 
 		b := (*rvr).Bool()
 		return values.NewVectorRepeatValue(values.NewBool(a && b)), nil
 	} else if lvr != nil {
-		res, err := array.AndLConst((*lvr).Bool(), r.Arr().(*array.Boolean), mem)
+		fixed := (*lvr).Bool()
+		res, err := array.AndConst(&fixed, r.Arr().(*array.Boolean), mem)
 		if err != nil {
 			return nil, err
 		}
 		return values.NewVectorValue(res, semantic.BasicBool), nil
 	} else if rvr != nil {
-		res, err := array.AndRConst(l.Arr().(*array.Boolean), (*rvr).Bool(), mem)
+		fixed := (*rvr).Bool()
+		res, err := array.AndConst(&fixed, l.Arr().(*array.Boolean), mem)
 		if err != nil {
 			return nil, err
 		}
@@ -513,13 +515,15 @@ func vectorOr(l, r values.Vector, mem memory.Allocator) (values.Vector, error) {
 		b := (*rvr).Bool()
 		return values.NewVectorRepeatValue(values.NewBool(a || b)), nil
 	} else if lvr != nil {
-		res, err := array.OrLConst((*lvr).Bool(), r.Arr().(*array.Boolean), mem)
+		fixed := (*lvr).Bool()
+		res, err := array.OrConst(&fixed, r.Arr().(*array.Boolean), mem)
 		if err != nil {
 			return nil, err
 		}
 		return values.NewVectorValue(res, semantic.BasicBool), nil
 	} else if rvr != nil {
-		res, err := array.OrRConst(l.Arr().(*array.Boolean), (*rvr).Bool(), mem)
+		fixed := (*rvr).Bool()
+		res, err := array.OrConst(&fixed, l.Arr().(*array.Boolean), mem)
 		if err != nil {
 			return nil, err
 		}

--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -42,6 +42,7 @@ var testFlags = map[string]interface{}{
 	"optimizeStateTracking":     true,
 	"optimizeSetTransformation": true,
 	"removeRedundantSortNodes":  true,
+	"strictNullLogicalOps":      true,
 }
 
 type TestFlagger map[string]interface{}

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -209,6 +209,18 @@ func VectorizedUnaryOps() BoolFlag {
 	return vectorizedUnaryOps
 }
 
+var strictNullLogicalOps = feature.MakeBoolFlag(
+	"StrictNullLogicalOps",
+	"strictNullLogicalOps",
+	"Owen Nelson",
+	false,
+)
+
+// Strictnulllogicalops - When enabled, nulls in logical expressions should match the behavior language spec.
+func Strictnulllogicalops() BoolFlag {
+	return strictNullLogicalOps
+}
+
 // Inject will inject the Flagger into the context.
 func Inject(ctx context.Context, flagger Flagger) context.Context {
 	return feature.Inject(ctx, flagger)
@@ -231,6 +243,7 @@ var all = []Flag{
 	vectorizedConst,
 	vectorizedFloat,
 	vectorizedUnaryOps,
+	strictNullLogicalOps,
 }
 
 var byKey = map[string]Flag{
@@ -250,6 +263,7 @@ var byKey = map[string]Flag{
 	"vectorizedConst":                  vectorizedConst,
 	"vectorizedFloat":                  vectorizedFloat,
 	"vectorizedUnaryOps":               vectorizedUnaryOps,
+	"strictNullLogicalOps":             strictNullLogicalOps,
 }
 
 // Flags returns all feature flags.

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -105,3 +105,9 @@
   key: vectorizedUnaryOps
   default: false
   contact: Owen Nelson
+
+- name: StrictNullLogicalOps
+  description: When enabled, nulls in logical expressions should match the behavior language spec.
+  key: strictNullLogicalOps
+  default: false
+  contact: Owen Nelson

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -520,7 +520,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestAverage_test.flux":                                                     "79681d441fc0340d4f76e238f10ccc50dd2b67be62f6c5061157a4e11f634055",
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "0110e5d56e9feb926cba8097d418b08fce0a70d194aeb0bf93254272d3f4136b",
 	"stdlib/universe/lowestMin_test.flux":                                                         "823a9d836aaf31f1692eadffb46822ab12ac2d5051eafaf4ec4ffc67fb15d2d6",
-	"stdlib/universe/map_test.flux":                                                               "eb9117631941df83cc86a27ff237f4f86408eaaa1fa45b82ea48639f3841cec2",
+	"stdlib/universe/map_test.flux":                                                               "268bc9cf4cc6d2adf2ff0294701febbf38733e9173b49672bbfeb7fe49fd412d",
 	"stdlib/universe/map_vectorize_conditionals_test.flux":                                        "cbe50d0dbd1b5a30c8ed8d61e1926d2e6dbdcc55dd6cde9db9cafb28835f0406",
 	"stdlib/universe/map_vectorize_const_test.flux":                                               "636889211f387eb2b56517acd090ab16340c1610bc33c1640302a84d87fb5cee",
 	"stdlib/universe/map_vectorize_equality_test.flux":                                            "b06a0cf70625e99b0503e72ae0cc445f71a0f66e77cc7110cc9369e87ed1079a",

--- a/stdlib/universe/map_test.flux
+++ b/stdlib/universe/map_test.flux
@@ -592,6 +592,9 @@ testcase logical_untyped_null_vectorized {
 
     got =
         array.from(rows: [{_true: true, _false: false}])
+            // N.b. The "untyped" null here is introduced by hiding the type
+            // information from flux via `debug.opaque()` then accessing the
+            // undefined field `_null` inside our map func.
             |> debug.opaque()
             |> map(
                 fn: (r) =>
@@ -669,6 +672,9 @@ testcase logical_untyped_null {
 
     got =
         array.from(rows: [{_true: true, _false: false}])
+            // N.b. The "untyped" null here is introduced by hiding the type
+            // information from flux via `debug.opaque()` then accessing the
+            // undefined field `_null` inside our map func.
             |> debug.opaque()
             |> map(
                 fn: (r) =>


### PR DESCRIPTION
Fixes #5188

During an earlier attempt #5181 to fix a type-error problem in the vectorized logical operator implementation, we identified some deviation from the spec in how it worked with respect to `null` inputs. We also found the standard row-based version of logical ops _also deviated_ but in different ways.

This diff attempts to align all logical operator implementations (vectorized, row-based, as well as "in the interpreter") to be representative of what we have in the spec.

In addition to adhering to the spec re: nulls, this diff also adds short-circuiting support to the vectorized implementation in a similar fashion to vectorized conditionals.
This is achieved by checking the left-hand-side vector to see if all the elements are a single value. When this is the case and the value happens to be a short-circuit for the given op, we can skip evaluating the right-hand side entirely.

> In cases where all the elements are the same, but are not useful for short-circuiting, we can still use this information to select a "const" implementation for the op (where one side is fixed throughout), just like in the case of a `VectorRepeatValue`.

## Feature Flagging

Since the null handling aspect changes the behavior of _all logical op_ implementations in flux, the modifications to the conventional row-based and interpreter impls have been guarded with a new feature flag: `strictNullLogicalOps`.

The vectorized impl will use the newly aligned code with or without the `strictNullLogicalOps` flag set.

Since the status quo behavior is not aligned with the spec, we could consider this a "bug fix" but it is a **breaking change** nonetheless. Should there be users who relied on the prior behavior, the flag is our escape hatch to give the affected users a respite to update their scripts if needed.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
