### PR TITLE
fix(spec): Fix typo in specification of operator precedence

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1019,8 +1019,8 @@ The operator precedence is encoded directly into the grammar as the following.
     UnaryLogicalExpression   = ComparisonExpression
                              | UnaryLogicalOperator UnaryLogicalExpression .
     UnaryLogicalOperator     = "not" | "exists" .
-    ComparisonExpression     = MultiplicativeExpression
-                             | ComparisonExpression ComparisonOperator MultiplicativeExpression .
+    ComparisonExpression     = AdditiveExpression
+                             | ComparisonExpression ComparisonOperator AdditiveExpression .
     ComparisonOperator       = "==" | "!=" | "<" | "<=" | ">" | ">=" | "=~" | "!~" .
     AdditiveExpression       = MultiplicativeExpression
                              | AdditiveExpression AdditiveOperator MultiplicativeExpression .


### PR DESCRIPTION
Fix typo in spec. Closes #5187.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
