### PR TITLE
chore(query_analyzer): Add an option to just print the source for each logged query

### DIFF
--- a/libflux/flux-core/src/bin/analyze_query_log.rs
+++ b/libflux/flux-core/src/bin/analyze_query_log.rs
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
             imports,
             new_prelude,
             new_imports,
-            new_config: new_config.clone(),
+            new_config,
             report_already_failing_scripts: app.report_already_failing_scripts,
         })
     };
@@ -237,7 +237,7 @@ impl Analysis for FeatureDiff {
         };
 
         let current_result = match std::panic::catch_unwind(|| {
-            analyzer().analyze_source("".into(), "".into(), &source)
+            analyzer().analyze_source("".into(), "".into(), source)
         }) {
             Ok(x) => x,
             Err(_) => panic!("Panic at source {}: {}", i, source),
@@ -251,7 +251,7 @@ impl Analysis for FeatureDiff {
             )
         };
         let new_result = match std::panic::catch_unwind(|| {
-            new_analyzer().analyze_source("".into(), "".into(), &source)
+            new_analyzer().analyze_source("".into(), "".into(), source)
         }) {
             Ok(x) => x,
             Err(_) => panic!("Panic at source {}: {}", i, source),
@@ -265,7 +265,7 @@ impl Analysis for FeatureDiff {
 
                 eprintln!(
                     "Missing errors when the features are enabled: {}",
-                    err.error.pretty(&source)
+                    err.error.pretty(source)
                 );
                 eprintln!("-------------------------------");
             }
@@ -275,14 +275,14 @@ impl Analysis for FeatureDiff {
 
                 eprintln!(
                     "New errors when the features are enabled: {}",
-                    err.error.pretty(&source)
+                    err.error.pretty(source)
                 );
                 eprintln!("-------------------------------");
             }
             (Err(current_err), Err(new_err)) => {
                 if self.report_already_failing_scripts {
-                    let current_err = current_err.error.pretty(&source);
-                    let new_err = new_err.error.pretty(&source);
+                    let current_err = current_err.error.pretty(source);
+                    let new_err = new_err.error.pretty(source);
                     if current_err != new_err {
                         eprintln!("{}", source);
 

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -20,7 +20,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/mod.rs":                                                            "78b485774e015a2c73419fb91c750b58295c71027e722e80239d43827aed6a4b",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "76b93aa401766a680474141c280fab35af096efb0686f9560d54ffd66187b37d",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
-	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "8cb0aca0eff41b28c0aff07424ae3375364a37bec0ad49fe5460e6c360735a64",
+	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "83d91f8fff049c8d4f8da705f639409caa273339e2daabe5b8ecf861301f4de6",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "bf275289e690236988049fc0a07cf832dbac25bb5739c02135b069dcdfab4d0f",
 	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "930809716897510e8b804026fc3428b7b0a7d69038905c5da5a891da61a20fa1",
 	"libflux/flux-core/src/doc/example.rs":                                                        "443cea4bb2a78ff0667681f42c8259829cd17c1e99ac8ac9ecf5effb48f41a76",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -20,7 +20,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/ast/mod.rs":                                                            "78b485774e015a2c73419fb91c750b58295c71027e722e80239d43827aed6a4b",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "76b93aa401766a680474141c280fab35af096efb0686f9560d54ffd66187b37d",
 	"libflux/flux-core/src/bin/README.md":                                                         "c1245a4938c923d065647b4dc4f7e19486e85c93d868ef2f7f47ddff62ec81df",
-	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "83d91f8fff049c8d4f8da705f639409caa273339e2daabe5b8ecf861301f4de6",
+	"libflux/flux-core/src/bin/analyze_query_log.rs":                                              "8fb616be4c9473e8347d34ceb4051695c1922590caa60958c7318d8e52cddc58",
 	"libflux/flux-core/src/bin/fluxc.rs":                                                          "bf275289e690236988049fc0a07cf832dbac25bb5739c02135b069dcdfab4d0f",
 	"libflux/flux-core/src/bin/fluxdoc.rs":                                                        "930809716897510e8b804026fc3428b7b0a7d69038905c5da5a891da61a20fa1",
 	"libflux/flux-core/src/doc/example.rs":                                                        "443cea4bb2a78ff0667681f42c8259829cd17c1e99ac8ac9ecf5effb48f41a76",


### PR DESCRIPTION
Adds the capability to just print the queries run through `analyze_query_log` since the input formats (csv or sqlite) aren't as easy to read.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
