### PR TITLE
docs(SPEC): add specification of editions

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1086,7 +1086,7 @@ Attributes define a set of properties on source code elements.
     AttributeParameterList = AttributeParameter { "," AttributeParameter } .
     AttributeParameter     = PrimaryExpression
 
-The set of defined attributes and their meaning is left to the runtime to specify.
+The full set of defined attributes and their meaning is left to the runtime to specify.
 
 Example
 
@@ -1105,7 +1105,6 @@ A statement controls execution.
                    | ReturnStatement
                    | ExpressionStatement
                    | TestcaseStatement .
-
 
 
 #### Return statements
@@ -1411,6 +1410,12 @@ So, you have to:
 
 Flux provides a standard library of functions. Find documentation here https://docs.influxdata.com/flux/latest/stdlib/
 
+#### Experimental namespace
+
+Within the standard library there is an `experimental` package namespace.
+Packages within this namesapce are subject to breaking changes without notice.
+See the package documentation for more details https://docs.influxdata.com/flux/latest/stdlib/experimental/
+
 ### Composite data types
 
 A composite data type is a collection of primitive data types that together have a higher meaning.
@@ -1420,6 +1425,79 @@ A composite data type is a collection of primitive data types that together have
 A query specification defines what data and operations to perform.
 The execution model reserves the right to perform those operations as efficiently as possible.
 The execution model may rewrite the query in anyway it sees fit while maintaining correctness.
+
+## Versions and editions
+
+Flux follows a [semantic versioning scheme](https://semver.org/) such that breaking changes are clearly communicated as part of the version information.
+*Editions* allow for the introduction of breaking changes via an opt-in mechanism.
+
+Flux editions are a set of features that are enabled in Flux.
+If the edition is not enabled then the features are not enabled.
+These features would otherwise be breaking changes to Flux.
+An edition is explicitly opt-in.
+The pattern of editions allows users to migrate to new Flux versions without risk that their scripts will break.
+
+An edition is separate from a version.
+A version of Flux represents a single point in the commit history of the Flux source code.
+A user can only use a single version of Flux for a given script.
+Editions represent a set of features that are enabled for a given Flux version.
+So long as the Flux version supports all the features of the edition it can be enabled.
+A user can upgrade to a newer Flux version without being required to upgrade to the newest edition of Flux.
+
+New Flux features that require a breaking change to the syntax or semantics of Flux must always be part of a new edition.
+This means that a script can regularly update to the newest Flux version without risk of breaking because any breaking changes are explicitly opt-in.
+With editions the Flux community gets both a pattern where users can always be running the latest version of Flux and the ability to introduce new useful but otherwise breaking changes to Flux.
+
+We anticipate that there will be at most one new editions of Flux a year. A slow cadence of new editions means users have ample time to migrate to a new edition if desired.
+Even being a few years behind on editions should only mean a few migration steps in order to have access to features introduced in the newest edition.
+
+### First Edition
+
+The first edition of Flux is 2022.1.
+This first edition is the only minimum required edition of Flux.
+
+### Future Editions
+
+Editions will be named after the year in which they are created, with an added sequence number if more than one edition needs to be created in a single year.
+For example the first edition is `2022.1` because it is created in the year `2022` and is the first edition created in that year.
+
+### Editions are optional
+
+A Flux script may specify directly the edition it requires to function.
+Additionally the Flux runtime will allow for the edition to be specified out of band of the script, thus allowing for deployments of Flux to have control over the edition.
+
+#### Edition attribute
+
+The edition of the current script is specified as an `edition` attribute on the package with a single parameter, the name of the edition.
+It is an error for multiple files within a package or module to specify differing editions.
+
+Examples:
+
+Specify the edition with an explicit package clause
+
+    @edition("2022.1")
+    package math
+
+    add = (x,y) => x + y
+
+
+### Flux Editions and Modules
+
+Each Flux module may specify its own edition, therefore a Flux script on an earlier edition may import and consume a module that uses a newer edition of Flux.
+Naturally if a module exposes a new edition feature via its API, consumers of that module will be required to use at least that edition in order to directly consume the module.
+
+
+### Migrating to a new edition
+
+When a new edition is created a migration process will be provided to ease the migration from an older edition to a new edition.
+
+### Editions and Experimental
+
+Editions do not change the contract of the experimental package namespace.
+Experimental packages are still subject to breaking changes without notice.
+Most new features do not require a breaking change to Flux syntax or semantics.
+As such it will remain common for new packages to be introduced as experimental packages.
+When an API is stabilized, it can be promoted out of experimental without the need to create a new edition.
 
 ## Request and Response Formats
 


### PR DESCRIPTION
This change adds the details of how Flux editions will work and their intent. One small parser change is proposed to enable an edition directly within the script.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
