### PR TITLE
refactor: Pass the context to the executor compiler

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1,13 +1,15 @@
 package compiler
 
 import (
+	"context"
+
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
-func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) (Func, error) {
+func Compile(ctx context.Context, scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) (Func, error) {
 	if scope == nil {
 		scope = NewScope()
 	}
@@ -60,7 +62,7 @@ func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) 
 		}
 	}
 
-	compiler := &compiler{}
+	compiler := &compiler{ctx}
 	root, err := compiler.compile(f.Block, subst)
 	if err != nil {
 		return nil, errors.Wrapf(err, codes.Inherit, "cannot compile @ %v", f.Location())
@@ -401,6 +403,7 @@ func apply(sub semantic.Substitutor, props []semantic.PropertyType, t semantic.M
 }
 
 type compiler struct {
+	ctx context.Context
 }
 
 // compile recursively compiles semantic nodes into evaluators.

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -60,7 +60,8 @@ func Compile(scope Scope, f *semantic.FunctionExpression, in semantic.MonoType) 
 		}
 	}
 
-	root, err := compile(f.Block, subst)
+	compiler := &compiler{}
+	root, err := compiler.compile(f.Block, subst)
 	if err != nil {
 		return nil, errors.Wrapf(err, codes.Inherit, "cannot compile @ %v", f.Location())
 	}
@@ -399,13 +400,16 @@ func apply(sub semantic.Substitutor, props []semantic.PropertyType, t semantic.M
 	panic("unknown type")
 }
 
+type compiler struct {
+}
+
 // compile recursively compiles semantic nodes into evaluators.
-func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
+func (compiler *compiler) compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 	switch n := n.(type) {
 	case *semantic.Block:
 		body := make([]Evaluator, len(n.Body))
 		for i, s := range n.Body {
-			node, err := compile(s, subst)
+			node, err := compiler.compile(s, subst)
 			if err != nil {
 				return nil, err
 			}
@@ -418,7 +422,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 	case *semantic.ExpressionStatement:
 		return nil, errors.New(codes.Internal, "statement does nothing, side effects are not supported by the compiler")
 	case *semantic.ReturnStatement:
-		node, err := compile(n.Argument, subst)
+		node, err := compiler.compile(n.Argument, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -430,7 +434,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 		if err != nil {
 			return nil, err
 		}
-		node, err := compile(n.Init, subst)
+		node, err := compiler.compile(n.Init, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -444,7 +448,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 		properties := make(map[string]Evaluator, len(n.Properties))
 
 		for _, p := range n.Properties {
-			node, err := compile(p.Value, subst)
+			node, err := compiler.compile(p.Value, subst)
 			if err != nil {
 				return nil, err
 			}
@@ -453,7 +457,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 
 		var extends *identifierEvaluator
 		if n.With != nil {
-			node, err := compile(n.With, subst)
+			node, err := compiler.compile(n.With, subst)
 			if err != nil {
 				return nil, err
 			}
@@ -475,7 +479,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 		if len(n.Elements) > 0 {
 			elements = make([]Evaluator, len(n.Elements))
 			for i, e := range n.Elements {
-				node, err := compile(e, subst)
+				node, err := compiler.compile(e, subst)
 				if err != nil {
 					return nil, err
 				}
@@ -492,11 +496,11 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			Val Evaluator
 		}, len(n.Elements))
 		for i, item := range n.Elements {
-			key, err := compile(item.Key, subst)
+			key, err := compiler.compile(item.Key, subst)
 			if err != nil {
 				return nil, err
 			}
-			val, err := compile(item.Val, subst)
+			val, err := compiler.compile(item.Val, subst)
 			if err != nil {
 				return nil, err
 			}
@@ -515,7 +519,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			name: n.Name.Name(),
 		}, nil
 	case *semantic.MemberExpression:
-		object, err := compile(n.Object, subst)
+		object, err := compiler.compile(n.Object, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -527,11 +531,11 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			nullable: isNullable(t),
 		}, nil
 	case *semantic.IndexExpression:
-		arr, err := compile(n.Array, subst)
+		arr, err := compiler.compile(n.Array, subst)
 		if err != nil {
 			return nil, err
 		}
-		idx, err := compile(n.Index, subst)
+		idx, err := compiler.compile(n.Index, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -543,7 +547,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 	case *semantic.StringExpression:
 		parts := make([]Evaluator, len(n.Parts))
 		for i, p := range n.Parts {
-			e, err := compile(p, subst)
+			e, err := compiler.compile(p, subst)
 			if err != nil {
 				return nil, err
 			}
@@ -557,7 +561,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			value: n.Value,
 		}, nil
 	case *semantic.InterpolatedPart:
-		e, err := compile(n.Expression, subst)
+		e, err := compiler.compile(n.Expression, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -601,7 +605,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			duration: v,
 		}, nil
 	case *semantic.UnaryExpression:
-		node, err := compile(n.Argument, subst)
+		node, err := compiler.compile(n.Argument, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -618,11 +622,11 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			op:   n.Operator,
 		}, nil
 	case *semantic.LogicalExpression:
-		l, err := compile(n.Left, subst)
+		l, err := compiler.compile(n.Left, subst)
 		if err != nil {
 			return nil, err
 		}
-		r, err := compile(n.Right, subst)
+		r, err := compiler.compile(n.Right, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -645,15 +649,15 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			right:    r,
 		}, nil
 	case *semantic.ConditionalExpression:
-		test, err := compile(n.Test, subst)
+		test, err := compiler.compile(n.Test, subst)
 		if err != nil {
 			return nil, err
 		}
-		c, err := compile(n.Consequent, subst)
+		c, err := compiler.compile(n.Consequent, subst)
 		if err != nil {
 			return nil, err
 		}
-		a, err := compile(n.Alternate, subst)
+		a, err := compiler.compile(n.Alternate, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -672,12 +676,12 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			alternate:  a,
 		}, nil
 	case *semantic.BinaryExpression:
-		l, err := compile(n.Left, subst)
+		l, err := compiler.compile(n.Left, subst)
 		if err != nil {
 			return nil, err
 		}
 		lt := l.Type().Nature()
-		r, err := compile(n.Right, subst)
+		r, err := compiler.compile(n.Right, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -716,7 +720,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 			f:     g,
 		}, nil
 	case *semantic.CallExpression:
-		args, err := compile(n.Arguments, subst)
+		args, err := compiler.compile(n.Arguments, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -739,13 +743,13 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 				// This should be caught during type inference
 				return nil, errors.Newf(codes.Internal, "callee lacks a pipe argument, but one was provided")
 			}
-			pipe, err := compile(n.Pipe, subst)
+			pipe, err := compiler.compile(n.Pipe, subst)
 			if err != nil {
 				return nil, err
 			}
 			args.(*objEvaluator).properties[string(pipeArg.Name())] = pipe
 		}
-		callee, err := compile(n.Callee, subst)
+		callee, err := compiler.compile(n.Callee, subst)
 		if err != nil {
 			return nil, err
 		}
@@ -779,7 +783,7 @@ func compile(n semantic.Node, subst semantic.Substitutor) (Evaluator, error) {
 				// Search for default value
 				for _, d := range n.Defaults.Properties {
 					if d.Key.Key() == k {
-						d, err := compile(d.Value, subst)
+						d, err := compiler.compile(d.Value, subst)
 						if err != nil {
 							return nil, err
 						}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -586,7 +586,7 @@ func TestCompileAndEval(t *testing.T) {
 
 			stmt := pkg.Files[0].Body[0].(*semantic.ExpressionStatement)
 			fn := stmt.Expression.(*semantic.FunctionExpression)
-			f, err := compiler.Compile(nil, fn, tc.inType)
+			f, err := compiler.Compile(ctx, nil, fn, tc.inType)
 			if err != nil {
 				if !tc.wantCompileErr {
 					t.Fatalf("unexpected error: %s", err)
@@ -784,7 +784,7 @@ func TestRuntimeTypeErrors(t *testing.T) {
 
 			stmt := pkg.Files[0].Body[0].(*semantic.ExpressionStatement)
 			fn := stmt.Expression.(*semantic.FunctionExpression)
-			f, err := compiler.Compile(sc, fn, inType)
+			f, err := compiler.Compile(ctx, sc, fn, inType)
 			if err != nil {
 				t.Fatalf("unexpected error during compilation: %s", err)
 			}
@@ -844,7 +844,7 @@ func TestCompiler_ReturnType(t *testing.T) {
 
 			stmt := pkg.Files[0].Body[0].(*semantic.ExpressionStatement)
 			fn := stmt.Expression.(*semantic.FunctionExpression)
-			f, err := compiler.Compile(nil, fn, tc.inType)
+			f, err := compiler.Compile(ctx, nil, fn, tc.inType)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -1301,7 +1301,7 @@ func (f *functionValue) Call(ctx context.Context, args values.Object) (values.Va
 	}
 	defer releaseScope(scope)
 
-	fn, err := Compile(scope, f.fn, args.Type())
+	fn, err := Compile(ctx, scope, f.fn, args.Type())
 	if err != nil {
 		return nil, err
 	}

--- a/compiler/vectorized_test.go
+++ b/compiler/vectorized_test.go
@@ -798,7 +798,7 @@ func TestVectorizedFns(t *testing.T) {
 				return
 			}
 
-			f, err := compiler.Compile(nil, fn, tc.inType)
+			f, err := compiler.Compile(ctx, nil, fn, tc.inType)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
 			}

--- a/execute/row_fn_test.go
+++ b/execute/row_fn_test.go
@@ -128,7 +128,7 @@ func TestRowMapFn_Eval(t *testing.T) {
 
 			stmt := pkg.Files[0].Body[0].(*semantic.ExpressionStatement)
 			fn := stmt.Expression.(*semantic.FunctionExpression)
-			f, err := execute.NewRowMapFn(fn, nil).Prepare(tc.data.ColMeta)
+			f, err := execute.NewRowMapFn(fn, nil).Prepare(ctx, tc.data.ColMeta)
 			if err != nil {
 				if tc.prepareErr != nil {
 					if !cmp.Equal(tc.prepareErr.Error(), err.Error()) {
@@ -246,12 +246,13 @@ func testRowPredicateFn_EvalRow(t *testing.T, scope compiler.Scope) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := gt2F().Prepare(tc.data.ColMeta)
+			// ctx := dependenciestest.Default().Inject(context.Background())
+			ctx := context.TODO()
+
+			f, err := gt2F().Prepare(ctx, tc.data.ColMeta)
 			if err != nil {
 				t.Fatal(err)
 			}
-			// ctx := dependenciestest.Default().Inject(context.Background())
-			ctx := context.TODO()
 			got := make([]bool, 0, len(tc.data.Data))
 			tc.data.Do(func(cr flux.ColReader) error {
 				for i := 0; i < cr.Len(); i++ {

--- a/execute/vector_fn.go
+++ b/execute/vector_fn.go
@@ -22,8 +22,8 @@ func NewVectorMapFn(fn *semantic.FunctionExpression, scope compiler.Scope) *Vect
 	}
 }
 
-func (f *VectorMapFn) Prepare(cols []flux.ColMeta) (*VectorMapPreparedFn, error) {
-	fn, err := f.prepare(cols, nil, true)
+func (f *VectorMapFn) Prepare(ctx context.Context, cols []flux.ColMeta) (*VectorMapPreparedFn, error) {
+	fn, err := f.prepare(ctx, cols, nil, true)
 	if err != nil {
 		return nil, err
 	} else if k := fn.returnType().Nature(); k != semantic.Object {

--- a/stdlib/array/array.go
+++ b/stdlib/array/array.go
@@ -90,7 +90,7 @@ func init() {
 					inputType := semantic.NewObjectType([]semantic.PropertyType{
 						{Key: []byte("x"), Value: elementType},
 					})
-					f, err := compiler.Compile(compiler.ToScope(fn.Scope), fn.Fn, inputType)
+					f, err := compiler.Compile(ctx, compiler.ToScope(fn.Scope), fn.Fn, inputType)
 					if err != nil {
 						return nil, err
 					}
@@ -149,7 +149,7 @@ func init() {
 					inputType := semantic.NewObjectType([]semantic.PropertyType{
 						{Key: []byte("x"), Value: elementType},
 					})
-					f, err := compiler.Compile(compiler.ToScope(fn.Scope), fn.Fn, inputType)
+					f, err := compiler.Compile(ctx, compiler.ToScope(fn.Scope), fn.Fn, inputType)
 					if err != nil {
 						return nil, err
 					}

--- a/stdlib/experimental/join.go
+++ b/stdlib/experimental/join.go
@@ -308,7 +308,7 @@ func (c *mergeJoinCache) SetTriggerSpec(spec plan.TriggerSpec) {
 
 func (c *mergeJoinCache) join(key flux.GroupKey, a, b *RowIterator) (flux.Table, error) {
 	// Compile row fn for the input rows
-	if err := c.fn.Prepare(a.columns, b.columns); err != nil {
+	if err := c.fn.Prepare(c.ctx, a.columns, b.columns); err != nil {
 		return nil, err
 	}
 
@@ -498,7 +498,7 @@ func newRowJoinFn(fn *semantic.FunctionExpression, scope compiler.Scope) *rowJoi
 	}
 }
 
-func (fn *rowJoinFn) Prepare(left, right []flux.ColMeta) error {
+func (fn *rowJoinFn) Prepare(ctx context.Context, left, right []flux.ColMeta) error {
 	// Check the left and right types to make sure required properties are
 	// columns in their respective ColMeta.
 	fntype := fn.fn.TypeOf()
@@ -570,7 +570,7 @@ func (fn *rowJoinFn) Prepare(left, right []flux.ColMeta) error {
 		{Key: []byte("left"), Value: semantic.NewObjectType(l)},
 		{Key: []byte("right"), Value: semantic.NewObjectType(r)},
 	})
-	f, err := compiler.Compile(fn.scope, fn.fn, in)
+	f, err := compiler.Compile(ctx, fn.scope, fn.fn, in)
 	if err != nil {
 		return err
 	}

--- a/stdlib/generate/from.go
+++ b/stdlib/generate/from.go
@@ -114,7 +114,7 @@ func createFromGeneratorSource(prSpec plan.ProcedureSpec, dsid execute.DatasetID
 	s.Start = spec.Start
 	s.Stop = spec.Stop
 	s.Count = spec.Count
-	fn, err := compiler.Compile(compiler.ToScope(spec.Fn.Scope), spec.Fn.Fn, semantic.NewObjectType(
+	fn, err := compiler.Compile(a.Context(), compiler.ToScope(spec.Fn.Scope), spec.Fn.Fn, semantic.NewObjectType(
 		[]semantic.PropertyType{
 			{Key: []byte("n"), Value: semantic.BasicInt},
 		},

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -198,7 +198,7 @@ func (t *toTransformation) writeTable(chunk table.Chunk) (err error) {
 	var fn *execute.RowMapPreparedFn
 	if spec.FieldFn.Fn != nil {
 		var err error
-		if fn, err = t.fn.Prepare(columns); err != nil {
+		if fn, err = t.fn.Prepare(t.ctx, columns); err != nil {
 			return err
 		}
 	}

--- a/stdlib/join/join_fn.go
+++ b/stdlib/join/join_fn.go
@@ -32,7 +32,7 @@ func NewJoinFn(fn interpreter.ResolvedFunction) *JoinFn {
 	}
 }
 
-func (f *JoinFn) Prepare(lcols, rcols []flux.ColMeta) error {
+func (f *JoinFn) Prepare(ctx context.Context, lcols, rcols []flux.ColMeta) error {
 	typ := f.Type()
 	args, err := typ.SortedArguments()
 	if err != nil {
@@ -61,6 +61,7 @@ func (f *JoinFn) Prepare(lcols, rcols []flux.ColMeta) error {
 	})
 	f.args = values.NewObject(in)
 	prepared, err := f.fn.Prepare(
+		ctx,
 		lcols,
 		map[string]semantic.MonoType{"r": *f.rtyp},
 		false,

--- a/stdlib/join/merge_join.go
+++ b/stdlib/join/merge_join.go
@@ -417,7 +417,7 @@ func (s *joinState) join(
 	} else {
 		rschema = defaultRight
 	}
-	err := fn.Prepare(lschema, rschema)
+	err := fn.Prepare(ctx, lschema, rschema)
 	if err != nil {
 		return nil, err
 	}

--- a/stdlib/universe/filter.go
+++ b/stdlib/universe/filter.go
@@ -162,7 +162,7 @@ type filterTransformation struct {
 func (t *filterTransformation) Process(chunk table.Chunk, d *execute.TransportDataset, mem arrowmem.Allocator) error {
 	// Prepare the function for the column types.
 	cols := chunk.Cols()
-	fn, err := t.fn.Prepare(cols)
+	fn, err := t.fn.Prepare(t.ctx, cols)
 	if err != nil {
 		// TODO(nathanielc): Should we not fail the query for failed compilation?
 		return err

--- a/stdlib/universe/map.go
+++ b/stdlib/universe/map.go
@@ -139,7 +139,7 @@ func (m *mapTransformation) Process(
 
 	// Prepare the compiled function for the set of columns.
 	cols := chunk.Cols()
-	fn, err := m.fn.Prepare(cols)
+	fn, err := m.fn.Prepare(m.ctx, cols)
 	if err != nil {
 		return err
 	}
@@ -324,7 +324,7 @@ func (m *mapTransformation) Close() error {
 }
 
 type mapFunc interface {
-	Prepare(cols []flux.ColMeta) (mapPreparedFunc, error)
+	Prepare(ctx context.Context, cols []flux.ColMeta) (mapPreparedFunc, error)
 }
 
 type mapPreparedFunc interface {
@@ -335,8 +335,8 @@ type mapRowFunc struct {
 	fn *execute.RowMapFn
 }
 
-func (m *mapRowFunc) Prepare(cols []flux.ColMeta) (mapPreparedFunc, error) {
-	fn, err := m.fn.Prepare(cols)
+func (m *mapRowFunc) Prepare(ctx context.Context, cols []flux.ColMeta) (mapPreparedFunc, error) {
+	fn, err := m.fn.Prepare(ctx, cols)
 	if err != nil {
 		return nil, err
 	}

--- a/stdlib/universe/map_vectorized.go
+++ b/stdlib/universe/map_vectorized.go
@@ -91,8 +91,8 @@ type mapVectorFunc struct {
 	fn *execute.VectorMapFn
 }
 
-func (m *mapVectorFunc) Prepare(cols []flux.ColMeta) (mapPreparedFunc, error) {
-	fn, err := m.fn.Prepare(cols)
+func (m *mapVectorFunc) Prepare(ctx context.Context, cols []flux.ColMeta) (mapPreparedFunc, error) {
+	fn, err := m.fn.Prepare(ctx, cols)
 	if err != nil {
 		return nil, err
 	}

--- a/stdlib/universe/reduce.go
+++ b/stdlib/universe/reduce.go
@@ -128,7 +128,7 @@ func NewReduceTransformation(ctx context.Context, spec *ReduceProcedureSpec, d e
 func (t *reduceTransformation) Process(id execute.DatasetID, tbl flux.Table) error {
 	// Prepare the function with the column types list.
 	cols := tbl.Cols()
-	fn, err := t.fn.Prepare(cols, map[string]semantic.MonoType{"accumulator": t.identity.Type()})
+	fn, err := t.fn.Prepare(t.ctx, cols, map[string]semantic.MonoType{"accumulator": t.identity.Type()})
 	if err != nil {
 		return err
 	}

--- a/stdlib/universe/schema_functions.go
+++ b/stdlib/universe/schema_functions.go
@@ -333,31 +333,31 @@ func (s *DuplicateOpSpec) Copy() SchemaMutation {
 	}
 }
 
-func (s *RenameOpSpec) Mutator() (SchemaMutator, error) {
-	m, err := NewRenameMutator(s)
+func (s *RenameOpSpec) Mutator(ctx context.Context) (SchemaMutator, error) {
+	m, err := NewRenameMutator(ctx, s)
 	if err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (s *DropOpSpec) Mutator() (SchemaMutator, error) {
-	m, err := NewDropMutator(s)
+func (s *DropOpSpec) Mutator(ctx context.Context) (SchemaMutator, error) {
+	m, err := NewDropMutator(ctx, s)
 	if err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (s *KeepOpSpec) Mutator() (SchemaMutator, error) {
-	m, err := NewKeepMutator(s)
+func (s *KeepOpSpec) Mutator(ctx context.Context) (SchemaMutator, error) {
+	m, err := NewKeepMutator(ctx, s)
 	if err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (s *DuplicateOpSpec) Mutator() (SchemaMutator, error) {
+func (s *DuplicateOpSpec) Mutator(ctx context.Context) (SchemaMutator, error) {
 	m, err := NewDuplicateMutator(s)
 	if err != nil {
 		return nil, err
@@ -415,7 +415,7 @@ func createSchemaMutationTransformation(id execute.DatasetID, mode execute.Accum
 func NewSchemaMutationTransformation(ctx context.Context, spec *SchemaMutationProcedureSpec, id execute.DatasetID, mem memory.Allocator) (execute.Transformation, execute.Dataset, error) {
 	mutators := make([]SchemaMutator, len(spec.Mutations))
 	for i, mutation := range spec.Mutations {
-		m, err := mutation.Mutator()
+		m, err := mutation.Mutator(ctx)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/stdlib/universe/state_tracking.go
+++ b/stdlib/universe/state_tracking.go
@@ -186,7 +186,7 @@ func (n *stateTrackingTransformation) Process(chunk table.Chunk, state *trackedS
 		}
 		mod = true
 	}
-	mod, err := n.processChunk(chunk, state, d, mem, mod)
+	mod, err := n.processChunk(n.ctx, chunk, state, d, mem, mod)
 	return state, mod, err
 }
 
@@ -195,8 +195,8 @@ func (n *stateTrackingTransformation) Close() error { return nil }
 // Updates the state object for each row in the chunk, creates a new chunk with
 // columns tracking counts and/or durations, and passes that chunk to the next
 // transport node.
-func (n *stateTrackingTransformation) processChunk(chunk table.Chunk, state *trackedState, d *execute.TransportDataset, mem memory.Allocator, mod bool) (bool, error) {
-	fn, err := n.fn.Prepare(chunk.Cols())
+func (n *stateTrackingTransformation) processChunk(ctx context.Context, chunk table.Chunk, state *trackedState, d *execute.TransportDataset, mem memory.Allocator, mod bool) (bool, error) {
+	fn, err := n.fn.Prepare(ctx, chunk.Cols())
 	if err != nil {
 		return mod, err
 	}

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -113,7 +113,7 @@ func tableFind(ctx context.Context, to *flux.TableObject, fn *execute.TablePredi
 				return nil
 			}
 
-			preparedFn, err := fn.Prepare(tbl)
+			preparedFn, err := fn.Prepare(ctx, tbl)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Should make it possible to enable the strict null logical ops when compiling the executor instead of branching inside the executor itself.


### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
