### PR TITLE
fix: "infinte" typo

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -604,7 +604,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "7d8b47b3e96b859a5fed5985c051e2a3fdc947d3d6ff9cc104e40821581fb0cb",
 	"stdlib/universe/union_test.flux":                                                             "f008260d48db70212ce64d3f51f4cf031532a9a67c1ba43242dbc4d43ef31293",
 	"stdlib/universe/unique_test.flux":                                                            "c108ab7b0e4b0b77f0a320c8c4dacb8cfbccae8b389425754e9583e69cd64ee3",
-	"stdlib/universe/universe.flux":                                                               "9c0b57102705dde576e1936abe3b389223b01ea7f434a2d0dd181e41c28307f1",
+	"stdlib/universe/universe.flux":                                                               "99965a298b08d84cd04cceee7502148be776021f824cae5afd0a6b3665fcc809",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "c8f66f7ee188bb2e979e5a8b526057b653922197ae441658f7c7f11251c96576",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -3552,7 +3552,7 @@ builtin display : (v: A) => string
 //
 builtin contains : (value: A, set: [A]) => bool where A: Nullable
 
-// inf represents an infinte float value.
+// inf represents a floating point value of infinity.
 builtin inf : duration
 
 // length returns the number of elements in an array.


### PR DESCRIPTION
the documentation generated from this file has `inf` on this line as `**inf**`, i don't know what caused that markup to be applied and cannot be sure it will still be after this change

side note: i assume this refers to either positive or negative infinity, would it be useful to state that?
though looking a bit closer (i'm not familiar with the language this is written in), it seems to be of type `duration`, rather than a float, as stated by the comment, maybe someone can clarify?

### Checklist

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
  - i hope the title suffices
- [x] 🔗 Reference related issues
  - none found
- [ ] 🏃 Test cases are included to exercise the new code
  - i'm unfamiliar with your test infrastructure, and don't know if any tests apply to this change
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.