### PR TITLE
chore(executetest): expose default test flagger

### DIFF
--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -20,9 +20,17 @@ func (d dependencyList) Inject(ctx context.Context) context.Context {
 func NewTestExecuteDependencies() flux.Dependency {
 	return dependencyList{
 		dependenciestest.Default(),
-		feature.Dependency{
-			Flagger: TestFlagger(testFlags),
-		},
+		NewDefaultTestFlagger(),
+	}
+}
+
+// NewDefaultTestFlagger gives a flagger dependency for a test harnesses to use as a baseline.
+//
+// Likely this will be made redundant by <https://github.com/influxdata/flux/issues/4777>
+// since testcases will then be able to manage their own feature selection.
+func NewDefaultTestFlagger() feature.Dependency {
+	return feature.Dependency{
+		Flagger: TestFlagger(testFlags),
 	}
 }
 


### PR DESCRIPTION
Test harnesses in other envs don't currently have good ways to "inherit" the default flagger we set here for vanilla flux.

External test harnesses like the one in OSS can configure the same flux flags we set here for vanilla flux if we make them available.

By exposing the flagger defaults with a public function, we can improve the POC here <https://github.com/influxdata/influxdb/pull/23762> which will help us avoid having to skip tests just because flags are not enabled.

This is a bit of a stop-gap and will eventually be made redundant by https://github.com/influxdata/flux/issues/4777 since the default flagger will be removed entirely. When #4777 is completed, testcases will manage their own flags.

--- 

No new tests have been added for this change since the new func is used for the existing tests. So long as the existing suite continues to pass we should be good.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
