### PR TITLE
chore: re-flag strict null logicals

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
+	fluxfeature "github.com/influxdata/flux/internal/feature"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
@@ -641,11 +642,13 @@ func (compiler *compiler) compile(n semantic.Node, subst semantic.Substitutor) (
 				right:    r,
 			}, nil
 		}
-		// TODO(onelson): try to select strict or regular logical here.
-		//   Need ctx to read flagger.
-		//   Currently this happens during Eval() where ctx is available and
-		//   will fallback to the regular logicalEvaluator if the flag is unset.
-		// FIXME: disabling the strict null  evaluator while looking at a perf regression...
+		if fluxfeature.Strictnulllogicalops().Enabled(compiler.ctx) {
+			return &logicalStrictNullEvaluator{
+				operator: n.Operator,
+				left:     l,
+				right:    r,
+			}, nil
+		}
 		return &logicalEvaluator{
 			operator: n.Operator,
 			left:     l,

--- a/compiler/runtime.go
+++ b/compiler/runtime.go
@@ -11,7 +11,6 @@ import (
 	"github.com/influxdata/flux/ast"
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
-	fluxfeature "github.com/influxdata/flux/internal/feature"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/flux/semantic"
@@ -332,8 +331,6 @@ func (e *logicalEvaluator) Eval(ctx context.Context, scope Scope) (values.Value,
 
 // logicalStrictNullEvaluator differs from logicalEvaluator by how it adheres to the
 // flux language spec with respect to null inputs.
-//
-//lint:ignore U1000 investigating a perf issue related to the ff check in this - not dead yet...
 type logicalStrictNullEvaluator struct {
 	operator    ast.LogicalOperatorKind
 	left, right Evaluator
@@ -344,12 +341,6 @@ func (e *logicalStrictNullEvaluator) Type() semantic.MonoType {
 }
 
 func (e *logicalStrictNullEvaluator) Eval(ctx context.Context, scope Scope) (values.Value, error) {
-	// Fallback to plain logicalEvaluator if the flag is not set.
-	if !fluxfeature.Strictnulllogicalops().Enabled(ctx) {
-		e := logicalEvaluator{operator: e.operator, left: e.left, right: e.right}
-		return e.Eval(ctx, scope)
-	}
-
 	l, err := e.left.Eval(ctx, scope)
 	if err != nil {
 		return nil, err

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -520,7 +520,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/lowestAverage_test.flux":                                                     "79681d441fc0340d4f76e238f10ccc50dd2b67be62f6c5061157a4e11f634055",
 	"stdlib/universe/lowestCurrent_test.flux":                                                     "0110e5d56e9feb926cba8097d418b08fce0a70d194aeb0bf93254272d3f4136b",
 	"stdlib/universe/lowestMin_test.flux":                                                         "823a9d836aaf31f1692eadffb46822ab12ac2d5051eafaf4ec4ffc67fb15d2d6",
-	"stdlib/universe/map_test.flux":                                                               "ca80c89e4490d1adc99e818b06cddfba76a7c27789da07ea067283dd5952edc6",
+	"stdlib/universe/map_test.flux":                                                               "268bc9cf4cc6d2adf2ff0294701febbf38733e9173b49672bbfeb7fe49fd412d",
 	"stdlib/universe/map_vectorize_conditionals_test.flux":                                        "cbe50d0dbd1b5a30c8ed8d61e1926d2e6dbdcc55dd6cde9db9cafb28835f0406",
 	"stdlib/universe/map_vectorize_const_test.flux":                                               "636889211f387eb2b56517acd090ab16340c1610bc33c1640302a84d87fb5cee",
 	"stdlib/universe/map_vectorize_equality_test.flux":                                            "b06a0cf70625e99b0503e72ae0cc445f71a0f66e77cc7110cc9369e87ed1079a",

--- a/stdlib/universe/map_test.flux
+++ b/stdlib/universe/map_test.flux
@@ -697,9 +697,6 @@ testcase logical_untyped_null_vectorized_const {
 }
 
 testcase logical_typed_null {
-    // FIXME: disabled while looking at perf regression
-    option testing.tags = ["skip"]
-
     expect.planner(rules: ["vectorizeMapRule": 0])
 
     want =
@@ -745,9 +742,6 @@ testcase logical_typed_null {
 }
 
 testcase logical_untyped_null {
-    // FIXME: disabled while looking at perf regression
-    option testing.tags = ["skip"]
-
     expect.planner(rules: ["vectorizeMapRule": 0])
 
     want =


### PR DESCRIPTION
A new version of our logical evaluator was introduced in an effort to
re-align the lang with the spec regarding nulls. 
Ref: <https://github.com/influxdata/flux/pull/5192>

The "strict null" flavor of the logical evaluator was
bypassed as part of a perf regression investigation.
Ref: <https://github.com/influxdata/flux/pull/5221>

The thought was checking the feature flag with each eval was adding
overhead and raising query latency, but with a subsequent refactor
(<https://github.com/influxdata/flux/pull/5222>) we are now able to
check the flag earlier, reducing the overhead.

This moves us closer to being able to close out #5233.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
