### PR TITLE
fix: passing context in the run source helper

### DIFF
--- a/execute/executetest/source.go
+++ b/execute/executetest/source.go
@@ -326,6 +326,7 @@ func CreateParallelFromSource(spec plan.ProcedureSpec, id execute.DatasetID, a e
 // by calling it from inside of a closure.
 func RunSourceHelper(
 	t *testing.T,
+	ctx context.Context,
 	want []*Table,
 	wantErr error,
 	create func(id execute.DatasetID) execute.Source,
@@ -342,7 +343,7 @@ func RunSourceHelper(
 	store := NewDataStore()
 	s := create(RandomDatasetID())
 	s.AddTransformation(store)
-	s.Run(context.Background())
+	s.Run(ctx)
 
 	gotErr := store.Err()
 	if gotErr == nil && wantErr != nil {

--- a/stdlib/csv/from_test.go
+++ b/stdlib/csv/from_test.go
@@ -168,6 +168,7 @@ func TestFromCSV_ReturnSingleResult(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			executetest.RunSourceHelper(t,
+				context.Background(),
 				test.want,
 				test.wantErr,
 				func(id execute.DatasetID) execute.Source {
@@ -329,6 +330,7 @@ func TestFromCSV_Run(t *testing.T) {
 		},
 	}
 	executetest.RunSourceHelper(t,
+		context.Background(),
 		want,
 		nil,
 		func(id execute.DatasetID) execute.Source {


### PR DESCRIPTION
This change is to pass context param in the `runSourceHelper` so that `Run` method can use the passed context rather overwriting to default`context.Background()`

Required for writing go test in https://github.com/influxdata/idpe/pull/15867

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
