### PR TITLE
feat(dynamic): add dynamic wrapper function

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -161,7 +161,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/date/boundaries/boundaries_test.flux":                                    "35f4198aae27017b38227a20d16ecf5c6ec81382643a36aafadda844b8d36e2b",
 	"stdlib/experimental/diff_test.flux":                                                          "b75aa4095b24d67f027b24b0c08e926824a6f68ea292821c025bcb8ac76c0339",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
-	"stdlib/experimental/dynamic/dynamic.flux":                                                    "359a37c8bc788dc4b15c3b65322debe5f995a287bf30ec9ad0a60205737142f5",
+	"stdlib/experimental/dynamic/dynamic.flux":                                                    "df57808ac79a5ef34d06a7f68c20c95e2cc31d216785df4ea19500bc4e74eb55",
 	"stdlib/experimental/dynamic/dynamic_test.flux":                                               "c1ae3567ead4e14580bc89300901675b1fcf3af5a5576b05517106adc0637811",
 	"stdlib/experimental/experimental.flux":                                                       "65b7c015a47f5f5da48d23a64d73bdf8c6e299b0530ab71af236711369104566",
 	"stdlib/experimental/experimental_test.flux":                                                  "97d2fadc0405ceef1cfa5ab768b41c1f3e00c4ee5f3e6e55e5ff29c4ad2ac340",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -161,6 +161,8 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/date/boundaries/boundaries_test.flux":                                    "35f4198aae27017b38227a20d16ecf5c6ec81382643a36aafadda844b8d36e2b",
 	"stdlib/experimental/diff_test.flux":                                                          "b75aa4095b24d67f027b24b0c08e926824a6f68ea292821c025bcb8ac76c0339",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
+	"stdlib/experimental/dynamic/dynamic.flux":                                                    "359a37c8bc788dc4b15c3b65322debe5f995a287bf30ec9ad0a60205737142f5",
+	"stdlib/experimental/dynamic/dynamic_test.flux":                                               "c1ae3567ead4e14580bc89300901675b1fcf3af5a5576b05517106adc0637811",
 	"stdlib/experimental/experimental.flux":                                                       "65b7c015a47f5f5da48d23a64d73bdf8c6e299b0530ab71af236711369104566",
 	"stdlib/experimental/experimental_test.flux":                                                  "97d2fadc0405ceef1cfa5ab768b41c1f3e00c4ee5f3e6e55e5ff29c4ad2ac340",
 	"stdlib/experimental/fill_test.flux":                                                          "3e31ca59476018a527a33d01d50c492da29f4de095df21c77abdb43c05947baf",

--- a/stdlib/experimental/dynamic/dynamic.flux
+++ b/stdlib/experimental/dynamic/dynamic.flux
@@ -10,4 +10,7 @@ package dynamic
 //
 // ## Parameters
 // - v: Value to wrap as dynamic.
+//
+// ## Metadata
+// tags: type-conversions
 builtin dynamic : (v: A) => dynamic

--- a/stdlib/experimental/dynamic/dynamic.flux
+++ b/stdlib/experimental/dynamic/dynamic.flux
@@ -10,8 +10,4 @@ package dynamic
 //
 // ## Parameters
 // - v: Value to wrap as dynamic.
-//
-// ## Examples
-//
-// TODO(onelson): need to do more work before we can really demonstrate this
 builtin dynamic : (v: A) => dynamic

--- a/stdlib/experimental/dynamic/dynamic.flux
+++ b/stdlib/experimental/dynamic/dynamic.flux
@@ -1,0 +1,17 @@
+// Package dynamic provides tools for working with values of unknown types.
+//
+// ## Metadata
+// introduced: NEXT
+//
+package dynamic
+
+
+// dynamic wraps a value so it can be used as a `dynamic` value.
+//
+// ## Parameters
+// - v: the value to wrap
+//
+// ## Examples
+//
+// TODO(onelson): need to do more work before we can really demonstrate this
+builtin dynamic : (v: A) => dynamic

--- a/stdlib/experimental/dynamic/dynamic.flux
+++ b/stdlib/experimental/dynamic/dynamic.flux
@@ -9,7 +9,7 @@ package dynamic
 // dynamic wraps a value so it can be used as a `dynamic` value.
 //
 // ## Parameters
-// - v: the value to wrap
+// - v: Value to wrap as dynamic.
 //
 // ## Examples
 //

--- a/stdlib/experimental/dynamic/dynamic.go
+++ b/stdlib/experimental/dynamic/dynamic.go
@@ -1,0 +1,30 @@
+package dynamic
+
+import (
+	"context"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/values"
+)
+
+func init() {
+	runtime.RegisterPackageValue("experimental/dynamic", "dynamic", dynamicConv)
+}
+
+var dynamicConv = values.NewFunction(
+	"dynamic",
+	runtime.MustLookupBuiltinType("experimental/dynamic", "dynamic"),
+	func(ctx context.Context, args values.Object) (values.Value, error) {
+		arguments := interpreter.NewArguments(args)
+		v, err := arguments.GetRequired("v")
+		if err != nil {
+			return nil, err
+		}
+
+		// FIXME(onelson): do we need to special case nulls here?
+		//   Ex: if the input is null, should the output be null or a
+		//   Dynamic with a null in it? My sense is the latter.
+		return values.NewDynamic(v), nil
+	},
+	false,
+)

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -1,2 +1,12 @@
 package dynamic_test
 
+
+import "testing"
+import "experimental/dynamic"
+
+testcase dynamic_not_comparable {
+    testing.shouldError(
+        fn: () => dynamic.dynamic(v: 123) == dynamic.dynamic(v: 123),
+        want: /unsupported/,
+    )
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -1,0 +1,2 @@
+package dynamic_test
+

--- a/stdlib/packages.go
+++ b/stdlib/packages.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/influxdata/flux/stdlib/experimental/bitwise"
 	_ "github.com/influxdata/flux/stdlib/experimental/csv"
 	_ "github.com/influxdata/flux/stdlib/experimental/date/boundaries"
+	_ "github.com/influxdata/flux/stdlib/experimental/dynamic"
 	_ "github.com/influxdata/flux/stdlib/experimental/geo"
 	_ "github.com/influxdata/flux/stdlib/experimental/http"
 	_ "github.com/influxdata/flux/stdlib/experimental/http/requests"


### PR DESCRIPTION
Originally planned as a part of #5143, this diff adds a new builtin to the `experimental/dynamic` package which wraps an existing value in a `Dynamic`.

This implementation is weak, probably incomplete, and hard to test without additional work since part of the contract of our "restrictive" dynamic type is you can't really do much with it until you cast it to some other value. 
_The buried lede is: we haven't implemented the dynamic support for the standard cast fns yet._

At this early stage the best I can offer in terms of testing is this short REPL session:

```
❯ go run ./cmd/flux
> import dyn "experimental/dynamic"
> dyn.dynamic(v: 123)
<unknown value>
> dyn.dynamic(v: 123) == dyn.dynamic(v: 123)
Error: unsupported binary expression dynamic == dynamic
>
```

> I went ahead and added the `==` case to the test file just so we can get the addition of the file in the repo, and to have _some sort of test_ in place. There's not a whole lot we can do right now other than prove the function is something you can import.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
