### PR TITLE
fix: Indent long testcase headers

### DIFF
--- a/libflux/flux-core/src/formatter/mod.rs
+++ b/libflux/flux-core/src/formatter/mod.rs
@@ -828,9 +828,9 @@ impl<'doc> Formatter<'doc> {
         let arena = self.arena;
 
         let comment = self.format_comments(&n.base.comments);
-        let prefix = docs![
+        let prefix = docs![arena, "testcase"];
+        let prefix2 = docs![
             arena,
-            "testcase",
             arena.line(),
             self.format_identifier(&n.id),
             if let Some(extends) = &n.extends {
@@ -844,11 +844,13 @@ impl<'doc> Formatter<'doc> {
             } else {
                 arena.nil()
             },
-            arena.line(),
-        ];
+        ]
+        .group();
 
         let mut hang_doc = self.hang_block(&n.block);
-        hang_doc.affixes.push(affixes(prefix, arena.nil()).nest());
+        hang_doc.add_prefix(arena.line());
+        hang_doc.affixes.push(affixes(prefix2, arena.nil()).nest());
+        hang_doc.affixes.push(affixes(prefix, arena.nil()));
         docs![
             arena,
             // Do not put the leading comment into the hang_doc so that

--- a/libflux/flux-core/src/formatter/tests.rs
+++ b/libflux/flux-core/src/formatter/tests.rs
@@ -905,17 +905,18 @@ testcase x {
 #[test]
 fn testcase_indentation() {
     assert_unchanged(
-        r#"testcase basic {
-    inData =
-        "
+        r#"testcase basic
+    {
+        inData =
+            "
 #datatype,string,long,dateTime:RFC3339,long,string,string,string
 #group,false,false,false,false,true,true,true
 #default,_result,,,,,,
 ,result,table,_time,_value,_field,_measurement,host
 ,,0,2018-05-22T19:53:26Z,100,load1,system,host.local
 "
-    outData =
-        "
+        outData =
+            "
 #datatype,string,long,double
 #group,false,false,false
 #default,_result,,
@@ -923,15 +924,15 @@ fn testcase_indentation() {
 ,,0,100.0
 "
 
-    got =
-        csv.from(csv: inData)
-            |> testing.load()
-            |> range(start: 2018-05-22T19:53:26Z)
-            |> map(fn: (r) => ({newValue: float(v: r._value)}))
-    want = csv.from(csv: outData)
+        got =
+            csv.from(csv: inData)
+                |> testing.load()
+                |> range(start: 2018-05-22T19:53:26Z)
+                |> map(fn: (r) => ({newValue: float(v: r._value)}))
+        want = csv.from(csv: outData)
 
-    testing.diff(want: want, got: got) |> yield()
-}"#,
+        testing.diff(want: want, got: got) |> yield()
+    }"#,
     );
 }
 
@@ -2040,4 +2041,24 @@ a",
     let expr = p.parse_expression();
 
     expect![["1 + a"]].assert_eq(&format_node(Node::from_expr(&expr)).unwrap());
+}
+
+#[test]
+fn format_long_extends_testcase() {
+    expect_format(
+        r#"
+testcase iox_tagValues_with_predicate extends "flux/influxdata/influxdb/schema/schema_test.tagValues_with_predicate" {
+
+    super()
+}
+"#,
+        expect![[r#"
+            testcase
+                iox_tagValues_with_predicate
+                extends
+                "flux/influxdata/influxdb/schema/schema_test.tagValues_with_predicate"
+                {
+                    super()
+                }"#]],
+    );
 }


### PR DESCRIPTION
Testcases with long names and extends clauses currently get split up without indentation which doesn't look great, I seem to have some problems describing it correctly to the formatter though so I need to dig a bit more to fix the unwanted changes this currently makes.

```flux
testcase
iox_tagValues_with_predicate
extends
"flux/influxdata/influxdb/schema/schema_test.tagValues_with_predicate"
{
    super()
}
```

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [ ] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
