### PR TITLE
chore: display dynamic values

### DIFF
--- a/values/display.go
+++ b/values/display.go
@@ -29,6 +29,17 @@ func Display(w io.Writer, v Value) error {
 }
 
 func display(w *bufio.Writer, v Value, indent int) (err error) {
+	if v.Type().Nature() == semantic.Dynamic {
+		// We want a dynamic null to be displayed as
+		// dynamic(<null>) rather than just <null>
+		_, err = w.WriteString("dynamic(")
+		if err != nil {
+			return
+		}
+		display(w, v.Dynamic().Inner(), indent)
+		_, err = w.WriteString(")")
+		return
+	}
 	if v.IsNull() {
 		_, err = w.WriteString("<null>")
 		return
@@ -80,7 +91,9 @@ func display(w *bufio.Writer, v Value, indent int) (err error) {
 		if err != nil {
 			return
 		}
+		var sep = ", "
 		if multiline {
+			sep = ","
 			err = newline(w, indent+1)
 			if err != nil {
 				return
@@ -91,7 +104,7 @@ func display(w *bufio.Writer, v Value, indent int) (err error) {
 				return
 			}
 			if i != 0 {
-				_, err = w.WriteString(", ")
+				_, err = w.WriteString(sep)
 				if err != nil {
 					return
 				}

--- a/values/display_test.go
+++ b/values/display_test.go
@@ -78,7 +78,7 @@ func TestDisplay(t *testing.T) {
 					values.NewInt(4),
 				},
 			),
-			display: "[\n    1, \n    2, \n    3, \n    4\n]",
+			display: "[\n    1,\n    2,\n    3,\n    4\n]",
 		},
 		{
 			value: values.NewObjectWithValues(
@@ -136,6 +136,14 @@ func TestDisplay(t *testing.T) {
 				false,
 			),
 			display: "() => int",
+		},
+		{
+			value:   values.NewDynamic(values.NewInt(100)),
+			display: "dynamic(100)",
+		},
+		{
+			value:   values.NewDynamic(values.Null),
+			display: "dynamic(<null>)",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
These changes make it so `display` (the Flux stdlib function and also the way values are shown in the REPL) shows something meaningful for dynamic values.

I also made it so that arrays represented on multiple lines don't add a space after the comma, which makes it easier to use display output for tests.

This is part of work in progress for #5141.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` (N/A)
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated (N/A)

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
