### PR TITLE
chore(docs): fixed reverse inputs and outputs in example

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -91,7 +91,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/bonitoo-io/victorops/victorops.flux":                                          "44d6674a86ceff7995153deca38db142fc0422b5a3526f5d0263a761d222269f",
 	"stdlib/contrib/bonitoo-io/zenoss/zenoss.flux":                                                "8f6de802b3176bf2524018e32ec5dc4eddd66db86abdeec837e9ca65ad7cc863",
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
-	"stdlib/contrib/jsternberg/aggregate/aggregate.flux":                                          "b077250cbed500bc209db468e7308572f5633e8762aef827e80999d649683b55",
+	"stdlib/contrib/jsternberg/aggregate/aggregate.flux":                                          "6bf56611ef90a88968ea193883bfd4b1b9f1278a48cce0f0b85f1556ac1de19e",
 	"stdlib/contrib/jsternberg/aggregate/table_test.flux":                                         "5e227979820698120fd6d98cfa30e47f6b8fdb2ee04445fc43a63e10fc27452b",
 	"stdlib/contrib/jsternberg/aggregate/window_test.flux":                                        "a8308af4edc31e0932ba20c40e6a6e73483a991502ca5fbc9dbe162f93ebb1e8",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -91,7 +91,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/bonitoo-io/victorops/victorops.flux":                                          "44d6674a86ceff7995153deca38db142fc0422b5a3526f5d0263a761d222269f",
 	"stdlib/contrib/bonitoo-io/zenoss/zenoss.flux":                                                "8f6de802b3176bf2524018e32ec5dc4eddd66db86abdeec837e9ca65ad7cc863",
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
-	"stdlib/contrib/jsternberg/aggregate/aggregate.flux":                                          "6bf56611ef90a88968ea193883bfd4b1b9f1278a48cce0f0b85f1556ac1de19e",
+	"stdlib/contrib/jsternberg/aggregate/aggregate.flux":                                          "3c48f5dff5972bd3feee480b92409328af44f21e68e850bdd3350a15fbfd9ffa",
 	"stdlib/contrib/jsternberg/aggregate/table_test.flux":                                         "5e227979820698120fd6d98cfa30e47f6b8fdb2ee04445fc43a63e10fc27452b",
 	"stdlib/contrib/jsternberg/aggregate/window_test.flux":                                        "a8308af4edc31e0932ba20c40e6a6e73483a991502ca5fbc9dbe162f93ebb1e8",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",

--- a/stdlib/contrib/jsternberg/aggregate/aggregate.flux
+++ b/stdlib/contrib/jsternberg/aggregate/aggregate.flux
@@ -40,16 +40,16 @@ import "contrib/jsternberg/math"
 //
 // ## Examples
 //
-// ### Compute the min of a specific column
+// ### Compute the minimum value in a specific column
 //
 // ```
 // import "sampledata"
 // import "contrib/jsternberg/aggregate"
 //
-// > sampledata.float()
+// < sampledata.float()
 //      |> aggregate.table(columns: {
 //         "min_bottom_degrees": aggregate.min(column: "_value"),
-// <    })
+// >    })
 // ```
 builtin table : (<-tables: stream[A], columns: C) => stream[B] where A: Record, B: Record, C: Record
 


### PR DESCRIPTION
Closes influxdata/docs-v2#4504

This change fixes input and output indicates that were reversed in the `aggregate.table` example.

---

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
