### PR TITLE
refactor(deps): Add private http client

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -160,7 +160,7 @@ func newPrivateClient(c http.Client) http.Client {
 func (c *privateClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.Wrap(codes.Internal, "an internal error has occurred", err)
+		return nil, errors.Wrap(err, codes.Internal, "an internal error has occurred")
 	}
 	return resp, nil
 }

--- a/dependencies.go
+++ b/dependencies.go
@@ -160,7 +160,7 @@ func newPrivateClient(c http.Client) http.Client {
 func (c *privateClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, errors.New(codes.Internal, "an internal error has occurred")
+		return nil, errors.Wrap(codes.Internal, "an internal error has occurred", err)
 	}
 	return resp, nil
 }

--- a/dependencies/influxdb/http_provider_test.go
+++ b/dependencies/influxdb/http_provider_test.go
@@ -38,7 +38,7 @@ func TestPrivateClient(t *testing.T) {
 	}
 	_, err = c.Client.Do(&nethttp.Request{})
 	if err != nil {
-		if err.Error() != "an internal error has occurred" {
+		if err.Error() != "an internal error has occurred: mock error" {
 			t.Fatalf("got unexpected error: %s", err)
 		}
 	} else {

--- a/dependencies/influxdb/http_provider_test.go
+++ b/dependencies/influxdb/http_provider_test.go
@@ -1,0 +1,47 @@
+package influxdb
+
+import (
+	"context"
+	nethttp "net/http"
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/dependencies/http"
+	fluxurl "github.com/influxdata/flux/dependencies/url"
+	"github.com/influxdata/flux/dependency"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+type mockClient struct{}
+
+var _ http.Client = mockClient{}
+
+func (c mockClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
+	return nil, errors.New(codes.Internal, "mock error")
+}
+
+func TestPrivateClient(t *testing.T) {
+	h := HttpProvider{
+		DefaultConfig: Config{
+			Host: "http://myhost.com:8085",
+		},
+	}
+	deps := flux.Deps{Deps: flux.WrappedDeps{
+		HTTPClient:   mockClient{},
+		URLValidator: fluxurl.PrivateIPValidator{},
+	}}
+	ctx, _ := dependency.Inject(context.Background(), deps)
+	c, err := h.clientFor(ctx, Config{})
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = c.Client.Do(&nethttp.Request{})
+	if err != nil {
+		if err.Error() != "an internal error has occurred" {
+			t.Fatalf("got unexpected error: %s", err)
+		}
+	} else {
+		t.Fatal("expected error but got none")
+	}
+}


### PR DESCRIPTION
Adds the `PrivateClient` struct which wraps the default client. Behaves identically to the default client except that it obscures error messages that may contain sensitive information.

Also exposes a `PrivateHTTPClient()` method to the `Dependencies` struct. If an `HttpProvider` is created and no host is specified in the config, this method is called in place of `HTTPClient()`.