### PR TITLE
fix: Don't lose extra precision in floats when run through the formatter

### DIFF
--- a/libflux/flux-core/src/formatter/mod.rs
+++ b/libflux/flux-core/src/formatter/mod.rs
@@ -1576,13 +1576,17 @@ impl<'doc> Formatter<'doc> {
     fn format_float_literal(&mut self, expr: &'doc ast::FloatLit) -> Doc<'doc> {
         let arena = self.arena;
 
-        docs![arena, self.format_comments(&expr.base.comments), {
-            let mut s = format!("{}", expr.value);
-            if !s.contains('.') {
-                s.push_str(".0");
-            }
-            s
-        }]
+        if let Some(text) = &expr.base.location.source {
+            docs![arena, self.format_comments(&expr.base.comments), text]
+        } else {
+            docs![arena, self.format_comments(&expr.base.comments), {
+                let mut s = format!("{}", expr.value);
+                if !s.contains('.') {
+                    s.push_str(".0");
+                }
+                s
+            }]
+        }
     }
 
     fn format_duration_literal(&mut self, n: &'doc ast::DurationLit) -> Doc<'doc> {

--- a/libflux/flux-core/src/formatter/tests.rs
+++ b/libflux/flux-core/src/formatter/tests.rs
@@ -2041,3 +2041,8 @@ a",
 
     expect![["1 + a"]].assert_eq(&format_node(Node::from_expr(&expr)).unwrap());
 }
+
+#[test]
+fn format_unrepresentable_float() {
+    assert_unchanged("0.3333333333333333333333333333333");
+}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -26,7 +26,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/doc/example.rs":                                                        "443cea4bb2a78ff0667681f42c8259829cd17c1e99ac8ac9ecf5effb48f41a76",
 	"libflux/flux-core/src/doc/mod.rs":                                                            "11c93fd68406bb36f0591d89f11bff2a7049e9ad888486431aae9418d80947bd",
 	"libflux/flux-core/src/errors.rs":                                                             "05f6c3b6db7a4d479e8e5bfa12cecefddcc6657ce40b8979f548c8ccc4149f8b",
-	"libflux/flux-core/src/formatter/mod.rs":                                                      "2887a369ecb3e6c7f5b4d3d97c2897c5c925d19617d9bd4d7f94426423cb12b8",
+	"libflux/flux-core/src/formatter/mod.rs":                                                      "b28826d33e859beb2854cdf744571006a07976ee8975c0ceb609e7e035cd49d0",
 	"libflux/flux-core/src/lib.rs":                                                                "4d03cf4a25ec4cccd09f31cffe1ac634ffb6b6bf6c9653839be01b6fbb4c9da6",
 	"libflux/flux-core/src/map.rs":                                                                "342c1cc111d343f01b97f38be10a9f1097bdd57cdc56f55e92fd3ed5028e6973",
 	"libflux/flux-core/src/parser/mod.rs":                                                         "d0d7caf1d0a540fa95bb6558adeb55c2c7b598f8e418656de2b7ba6cf957f097",


### PR DESCRIPTION
It is possible to write floating point literals which cannot be represented exactly by a `f64`. When passing source code through the formatter we lose any extra precision. This uses the literal source text to format instead (if it exists).

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
