### PR TITLE
chore: delete feature flag that removes redundant sort nodes

### DIFF
--- a/execute/executetest/dependencies.go
+++ b/execute/executetest/dependencies.go
@@ -48,7 +48,6 @@ var testFlags = map[string]interface{}{
 	"optimizeAggregateWindow":   true,
 	"optimizeStateTracking":     true,
 	"optimizeSetTransformation": true,
-	"removeRedundantSortNodes":  true,
 	"strictNullLogicalOps":      true,
 }
 

--- a/internal/feature/flags.go
+++ b/internal/feature/flags.go
@@ -125,18 +125,6 @@ func UnusedSymbolWarnings() BoolFlag {
 	return unusedSymbolWarnings
 }
 
-var removeRedundantSortNodes = feature.MakeBoolFlag(
-	"Remove Redundant Sort Nodes",
-	"removeRedundantSortNodes",
-	"Chris Wolff",
-	false,
-)
-
-// RemoveRedundantSortNodes - Planner will remove sort nodes when tables are already sorted
-func RemoveRedundantSortNodes() BoolFlag {
-	return removeRedundantSortNodes
-}
-
 var queryConcurrencyIncrease = feature.MakeIntFlag(
 	"Query Concurrency Increase",
 	"queryConcurrencyIncrease",
@@ -224,7 +212,6 @@ var all = []Flag{
 	labelPolymorphism,
 	optimizeSetTransformation,
 	unusedSymbolWarnings,
-	removeRedundantSortNodes,
 	queryConcurrencyIncrease,
 	vectorizedConditionals,
 	vectorizedFloat,
@@ -243,7 +230,6 @@ var byKey = map[string]Flag{
 	"labelPolymorphism":                labelPolymorphism,
 	"optimizeSetTransformation":        optimizeSetTransformation,
 	"unusedSymbolWarnings":             unusedSymbolWarnings,
-	"removeRedundantSortNodes":         removeRedundantSortNodes,
 	"queryConcurrencyIncrease":         queryConcurrencyIncrease,
 	"vectorizedConditionals":           vectorizedConditionals,
 	"vectorizedFloat":                  vectorizedFloat,

--- a/internal/feature/flags.yml
+++ b/internal/feature/flags.yml
@@ -64,12 +64,6 @@
   default: false
   contact: Markus Westerlind
 
-- name: Remove Redundant Sort Nodes
-  description: Planner will remove sort nodes when tables are already sorted
-  key: removeRedundantSortNodes
-  default: false
-  contact: Chris Wolff
-
 - name: Query Concurrency Increase
   description: Additional dispatcher workers to allocate on top of the minimimum allowable computed by the engine
   key: queryConcurrencyIncrease

--- a/stdlib/universe/sort.go
+++ b/stdlib/universe/sort.go
@@ -14,7 +14,6 @@ import (
 	"github.com/influxdata/flux/execute/table"
 	"github.com/influxdata/flux/internal/arrowutil"
 	"github.com/influxdata/flux/internal/errors"
-	"github.com/influxdata/flux/internal/feature"
 	"github.com/influxdata/flux/internal/mutable"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/plan"
@@ -493,10 +492,6 @@ func (r RemoveRedundantSort) Pattern() plan.Pattern {
 }
 
 func (r RemoveRedundantSort) Rewrite(ctx context.Context, node plan.Node) (plan.Node, bool, error) {
-	if !feature.RemoveRedundantSortNodes().Enabled(ctx) {
-		return node, false, nil
-	}
-
 	pred := node.Predecessors()[0]
 	inputCollation := plan.GetOutputAttribute(pred, plan.CollationKey)
 	if inputCollation == nil {


### PR DESCRIPTION
The work of #4628 was to create a planner rule that removes unnecessary sort nodes. This rule has been gated by a feature flag, and the flag has been on in production without issue for a few months now.

This PR removes the feature flag as it is no longer needed.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code (N/A)
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` (N/A)
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated (N/A)

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
