### PR TITLE
feat(dynamic): add support dynamic support for standard type conversion functions

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -158,7 +158,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/diff_test.flux":                                                          "b75aa4095b24d67f027b24b0c08e926824a6f68ea292821c025bcb8ac76c0339",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
 	"stdlib/experimental/dynamic/dynamic.flux":                                                    "4227d8f2e321ade187aadb283388e1bdec896c5b05d03ae9119eed3aae9dda0b",
-	"stdlib/experimental/dynamic/dynamic_test.flux":                                               "d989fd19517c63ff6c3c326bb6a73fd6897772989595ccaf5cb72372b7d042be",
+	"stdlib/experimental/dynamic/dynamic_test.flux":                                               "8b893e1283edfdec71bfc2f0d74170c2214966b0516b68adb94b61a8e04e146e",
 	"stdlib/experimental/experimental.flux":                                                       "65b7c015a47f5f5da48d23a64d73bdf8c6e299b0530ab71af236711369104566",
 	"stdlib/experimental/experimental_test.flux":                                                  "97d2fadc0405ceef1cfa5ab768b41c1f3e00c4ee5f3e6e55e5ff29c4ad2ac340",
 	"stdlib/experimental/fill_test.flux":                                                          "3e31ca59476018a527a33d01d50c492da29f4de095df21c77abdb43c05947baf",

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -314,3 +314,11 @@ testcase dynamic_isType_dictionary {
 testcase dynamic_isType_null_should_not_panic {
     testing.assertEqualValues(want: false, got: dynamic.isType(v: debug.null(), type: "int"))
 }
+
+testcase dynamic_cast_bool_to_bool {
+    testing.assertEqualValues(want: true, got: bool(v: dynamic.dynamic(v: true)))
+}
+
+testcase dynamic_cast_float_to_bool_error {
+    testing.shouldError(fn: () => bool(v: dynamic.dynamic(v: 1.1)), want: /cannot convert float/)
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -417,6 +417,14 @@ testcase dynamic_cast_from_json {
 }
 
 testcase dynamic_cast_from_json_deep {
+    // FIXME(onelson): inference seems off for dynamic here.
+    // Test fails with:
+    // ```
+    // expected dynamic (dynamic) but found
+    //   {A with pos: {C with z: F, y: E, x: D}, name: B} (record) (argument x) (argument fn)
+    // ```
+    // Seems like `array.map()` expects `x` to have known fields here, but shouldn't.
+    option testing.tags = ["skip"]
     data =
         "
     {

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -379,3 +379,17 @@ testcase dynamic_cast_string_to_int_error {
         want: /cannot convert string/,
     )
 }
+
+testcase dynamic_cast_int_to_string {
+    testing.assertEqualValues(
+        want: "123",
+        got: string(v: dynamic.dynamic(v: 123)),
+    )
+}
+
+testcase dynamic_cast_function_to_string_error {
+    testing.shouldError(
+        fn: () => string(v: dynamic.dynamic(v: () => true)),
+        want: /cannot convert \(\) => bool to string/,
+    )
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -407,3 +407,17 @@ testcase dynamic_cast_string_to_time_error {
         want: /cannot convert string/,
     )
 }
+
+testcase dynamic_cast_int_to_uint {
+    testing.assertEqualValues(
+        want: uint(v:123),
+        got: uint(v: dynamic.dynamic(v: 123)),
+    )
+}
+
+testcase dynamic_cast_string_to_uint_error {
+    testing.shouldError(
+        fn: () => uint(v: dynamic.dynamic(v: "not a uint")),
+        want: /cannot convert string/,
+    )
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -335,3 +335,19 @@ testcase dynamic_cast_string_to_bytes {
 testcase dynamic_cast_int_to_bytes_error {
     testing.shouldError(fn: () => bytes(v: dynamic.dynamic(v: 1)), want: /cannot convert int/)
 }
+
+testcase dynamic_cast_int_to_duration {
+    // duration can't be used as column data so we need to use `display()` to
+    // convert to string before we compare.
+    testing.assertEqualValues(
+        want: "18ms",
+        got: display(v: duration(v: dynamic.dynamic(v: 18000000))),
+    )
+}
+
+testcase dynamic_cast_string_to_duration_error {
+    testing.shouldError(
+        fn: () => duration(v: dynamic.dynamic(v: "not a duration")),
+        want: /cannot convert string/,
+    )
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -353,10 +353,7 @@ testcase dynamic_cast_string_to_duration_error {
 }
 
 testcase dynamic_cast_int_to_float {
-    testing.assertEqualValues(
-        want: 123.0,
-        got: float(v: dynamic.dynamic(v: 123)),
-    )
+    testing.assertEqualValues(want: 123.0, got: float(v: dynamic.dynamic(v: 123)))
 }
 
 testcase dynamic_cast_string_to_float_error {
@@ -367,10 +364,7 @@ testcase dynamic_cast_string_to_float_error {
 }
 
 testcase dynamic_cast_float_to_int {
-    testing.assertEqualValues(
-        want: 123,
-        got: int(v: dynamic.dynamic(v: 123.0)),
-    )
+    testing.assertEqualValues(want: 123, got: int(v: dynamic.dynamic(v: 123.0)))
 }
 
 testcase dynamic_cast_string_to_int_error {
@@ -381,10 +375,7 @@ testcase dynamic_cast_string_to_int_error {
 }
 
 testcase dynamic_cast_int_to_string {
-    testing.assertEqualValues(
-        want: "123",
-        got: string(v: dynamic.dynamic(v: 123)),
-    )
+    testing.assertEqualValues(want: "123", got: string(v: dynamic.dynamic(v: 123)))
 }
 
 testcase dynamic_cast_function_to_string_error {
@@ -395,10 +386,7 @@ testcase dynamic_cast_function_to_string_error {
 }
 
 testcase dynamic_cast_int_to_time {
-    testing.assertEqualValues(
-        want: 1970-01-01T00:00:00.000000000Z,
-        got: time(v: dynamic.dynamic(v: 0)),
-    )
+    testing.assertEqualValues(want: 1970-01-01T00:00:00Z, got: time(v: dynamic.dynamic(v: 0)))
 }
 
 testcase dynamic_cast_string_to_time_error {
@@ -409,10 +397,7 @@ testcase dynamic_cast_string_to_time_error {
 }
 
 testcase dynamic_cast_int_to_uint {
-    testing.assertEqualValues(
-        want: uint(v:123),
-        got: uint(v: dynamic.dynamic(v: 123)),
-    )
+    testing.assertEqualValues(want: uint(v: 123), got: uint(v: dynamic.dynamic(v: 123)))
 }
 
 testcase dynamic_cast_string_to_uint_error {

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -351,3 +351,16 @@ testcase dynamic_cast_string_to_duration_error {
         want: /cannot convert string/,
     )
 }
+testcase dynamic_cast_int_to_float {
+    testing.assertEqualValues(
+        want: 123.0,
+        got: float(v: dynamic.dynamic(v: 123)),
+    )
+}
+
+testcase dynamic_cast_string_to_float_error {
+    testing.shouldError(
+        fn: () => float(v: dynamic.dynamic(v: "not a float")),
+        want: /cannot convert string/,
+    )
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -393,3 +393,17 @@ testcase dynamic_cast_function_to_string_error {
         want: /cannot convert \(\) => bool to string/,
     )
 }
+
+testcase dynamic_cast_int_to_time {
+    testing.assertEqualValues(
+        want: 1970-01-01T00:00:00.000000000Z,
+        got: time(v: dynamic.dynamic(v: 0)),
+    )
+}
+
+testcase dynamic_cast_string_to_time_error {
+    testing.shouldError(
+        fn: () => time(v: dynamic.dynamic(v: "not a time")),
+        want: /cannot convert string/,
+    )
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -425,6 +425,7 @@ testcase dynamic_cast_from_json_deep {
     // ```
     // Seems like `array.map()` expects `x` to have known fields here, but shouldn't.
     option testing.tags = ["skip"]
+
     data =
         "
     {

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -322,3 +322,16 @@ testcase dynamic_cast_bool_to_bool {
 testcase dynamic_cast_float_to_bool_error {
     testing.shouldError(fn: () => bool(v: dynamic.dynamic(v: 1.1)), want: /cannot convert float/)
 }
+
+testcase dynamic_cast_string_to_bytes {
+    // bytes can't be used as column data so we need to use `display()` to
+    // convert to string before we compare.
+    testing.assertEqualValues(
+        want: "0x616263",
+        got: display(v: bytes(v: dynamic.dynamic(v: "abc"))),
+    )
+}
+
+testcase dynamic_cast_int_to_bytes_error {
+    testing.shouldError(fn: () => bytes(v: dynamic.dynamic(v: 1)), want: /cannot convert int/)
+}

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -351,6 +351,7 @@ testcase dynamic_cast_string_to_duration_error {
         want: /cannot convert string/,
     )
 }
+
 testcase dynamic_cast_int_to_float {
     testing.assertEqualValues(
         want: 123.0,
@@ -361,6 +362,20 @@ testcase dynamic_cast_int_to_float {
 testcase dynamic_cast_string_to_float_error {
     testing.shouldError(
         fn: () => float(v: dynamic.dynamic(v: "not a float")),
+        want: /cannot convert string/,
+    )
+}
+
+testcase dynamic_cast_float_to_int {
+    testing.assertEqualValues(
+        want: 123,
+        got: int(v: dynamic.dynamic(v: 123.0)),
+    )
+}
+
+testcase dynamic_cast_string_to_int_error {
+    testing.shouldError(
+        fn: () => int(v: dynamic.dynamic(v: "not an int")),
         want: /cannot convert string/,
     )
 }

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -319,6 +319,13 @@ testcase dynamic_cast_bool_to_bool {
     testing.assertEqualValues(want: true, got: bool(v: dynamic.dynamic(v: true)))
 }
 
+testcase dynamic_cast_null_to_bool {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: bool(v: dynamic.dynamic(v: debug.null()))),
+    )
+}
+
 testcase dynamic_cast_float_to_bool_error {
     testing.shouldError(fn: () => bool(v: dynamic.dynamic(v: 1.1)), want: /cannot convert float/)
 }
@@ -329,6 +336,14 @@ testcase dynamic_cast_string_to_bytes {
     testing.assertEqualValues(
         want: "0x616263",
         got: display(v: bytes(v: dynamic.dynamic(v: "abc"))),
+    )
+}
+
+// The rest of the cast fns propagate nulls, but bytes treats them as an error.
+testcase dynamic_cast_null_to_bytes_error {
+    testing.shouldError(
+        fn: () => bytes(v: dynamic.dynamic(v: debug.null())),
+        want: /cannot convert null to bytes/,
     )
 }
 
@@ -345,6 +360,13 @@ testcase dynamic_cast_int_to_duration {
     )
 }
 
+testcase dynamic_cast_null_to_duration {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: duration(v: dynamic.dynamic(v: debug.null()))),
+    )
+}
+
 testcase dynamic_cast_string_to_duration_error {
     testing.shouldError(
         fn: () => duration(v: dynamic.dynamic(v: "not a duration")),
@@ -354,6 +376,13 @@ testcase dynamic_cast_string_to_duration_error {
 
 testcase dynamic_cast_int_to_float {
     testing.assertEqualValues(want: 123.0, got: float(v: dynamic.dynamic(v: 123)))
+}
+
+testcase dynamic_cast_null_to_float {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: float(v: dynamic.dynamic(v: debug.null()))),
+    )
 }
 
 testcase dynamic_cast_string_to_float_error {
@@ -367,6 +396,13 @@ testcase dynamic_cast_float_to_int {
     testing.assertEqualValues(want: 123, got: int(v: dynamic.dynamic(v: 123.0)))
 }
 
+testcase dynamic_cast_null_to_int {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: int(v: dynamic.dynamic(v: debug.null()))),
+    )
+}
+
 testcase dynamic_cast_string_to_int_error {
     testing.shouldError(
         fn: () => int(v: dynamic.dynamic(v: "not an int")),
@@ -376,6 +412,13 @@ testcase dynamic_cast_string_to_int_error {
 
 testcase dynamic_cast_int_to_string {
     testing.assertEqualValues(want: "123", got: string(v: dynamic.dynamic(v: 123)))
+}
+
+testcase dynamic_cast_null_to_string {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: string(v: dynamic.dynamic(v: debug.null()))),
+    )
 }
 
 testcase dynamic_cast_function_to_string_error {
@@ -389,6 +432,13 @@ testcase dynamic_cast_int_to_time {
     testing.assertEqualValues(want: 1970-01-01T00:00:00Z, got: time(v: dynamic.dynamic(v: 0)))
 }
 
+testcase dynamic_cast_null_to_time {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: time(v: dynamic.dynamic(v: debug.null()))),
+    )
+}
+
 testcase dynamic_cast_string_to_time_error {
     testing.shouldError(
         fn: () => time(v: dynamic.dynamic(v: "not a time")),
@@ -398,6 +448,13 @@ testcase dynamic_cast_string_to_time_error {
 
 testcase dynamic_cast_int_to_uint {
     testing.assertEqualValues(want: uint(v: 123), got: uint(v: dynamic.dynamic(v: 123)))
+}
+
+testcase dynamic_cast_null_to_uint {
+    testing.assertEqualValues(
+        want: "<null>",
+        got: display(v: uint(v: dynamic.dynamic(v: debug.null()))),
+    )
 }
 
 testcase dynamic_cast_string_to_uint_error {

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -329,6 +329,12 @@ var durationConv = values.NewFunction(
 		} else if v.IsNull() {
 			return values.Null, nil
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			n, err := values.ParseDuration(v.Str())

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -217,6 +217,11 @@ var floatConv = values.NewFunction(
 			return values.Null, nil
 		}
 
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		return toFloatValue(v)
 	},
 	false,

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -358,6 +358,12 @@ var byteConv = values.NewFunction(
 		if !ok {
 			return nil, errMissingArg
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			return values.NewBytes([]byte(v.Str())), nil

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -159,6 +159,12 @@ var uintConv = values.NewFunction(
 		} else if v.IsNull() {
 			return values.Null, nil
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			n, err := strconv.ParseUint(v.Str(), 10, 64)

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -105,6 +105,12 @@ var intConv = values.NewFunction(
 		} else if v.IsNull() {
 			return values.Null, nil
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			n, err := strconv.ParseInt(v.Str(), 10, 64)

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -314,6 +314,12 @@ var timeConv = values.NewFunction(
 		} else if v.IsNull() {
 			return values.Null, nil
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			ts, err := parser.ParseTime(v.Str())

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -233,6 +233,12 @@ var boolConv = values.NewFunction(
 		} else if v.IsNull() {
 			return values.Null, nil
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			switch s := v.Str(); s {

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -58,6 +58,12 @@ var stringConv = values.NewFunction(
 		} else if v.IsNull() {
 			return values.Null, nil
 		}
+
+		// When the incoming value is Dynamic, pull out the inner value.
+		if v.Type().Nature() == semantic.Dynamic {
+			v = v.Dynamic().Inner()
+		}
+
 		switch v.Type().Nature() {
 		case semantic.String:
 			str = v.Str()

--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -57,10 +57,7 @@ var stringConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -110,10 +107,7 @@ var intConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -158,10 +152,7 @@ var uintConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -233,10 +224,7 @@ var floatConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -255,10 +243,7 @@ var boolConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -319,10 +304,7 @@ var timeConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -357,10 +339,7 @@ var durationConv = values.NewFunction(
 			return nil, errMissingArg
 		} else if v.IsNull() {
 			return values.Null, nil
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 
@@ -392,10 +371,7 @@ var byteConv = values.NewFunction(
 		v, ok := args.Get(conversionArg)
 		if !ok {
 			return nil, errMissingArg
-		}
-
-		// When the incoming value is Dynamic, pull out the inner value.
-		if v.Type().Nature() == semantic.Dynamic {
+		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
 


### PR DESCRIPTION
Fixes #5143

By adding a branch at the top of the following functions we can pull out the inner value of a dynamic and then run the rest of the default implementation as is:

- `bool()`
- `bytes()`
- `duration()`
- `float()`
- `int()`
- `string()`
- `time()`
- `uint()`

The tests added look to make sure at least one conversion or extraction works as expected and at least one error case is hit reliably. The dynamic code path relies on the current behavior of `Dynamic.IsNull` for null propagation so I added a test for each function to show `dynamic(null)` does in fact produce a `null`.
Otherwise, I didn't think we should need to chase total coverage of the original function, just that the dynamic is indeed being unwrapped.

Since #5143 is the last piece of planned work for this initial push towards adding dynamic support, I also added a couple tests targeting the initial use case shown in #5139.

`dynamic_cast_from_json_deep` demonstrates verbatim the input shown during that early problem space definition, and sadly it is currently failing. Looks like we have a little bit more work to do on the inference side before we can deliver our MVP.

For now the test is skipped, but I'll take a quick look at see if I can resolve the issue as a part of this PR.

---

**Update:** planning to work the outstanding inference gap as a separate PR. Not sure how deep a rabbit hole it'll be. I'll leave affected tests skipped until the gap is closed.

---

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
