### PR TITLE
fix compile error with Rust 1.64

### DIFF
--- a/libflux/flux/src/cffi.rs
+++ b/libflux/flux/src/cffi.rs
@@ -97,7 +97,7 @@ pub extern "C" fn flux_free_error(_err: Option<Box<ErrorHandle>>) {}
 /// function is called twice on the same raw pointer.
 #[no_mangle]
 pub unsafe extern "C" fn flux_free_bytes(cstr: *mut c_char) {
-    Box::from_raw(cstr);
+    drop(Box::from_raw(cstr));
 }
 
 /// A buffer of flux source.

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -62,7 +62,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/Cargo.toml":                                                                     "18988dcca5d0f54bef4772d0e19a21bd656b25eb07e51b9fb52f50693a27dfc7",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "3faa8d9f04edceddf43f237e9c9b1c03f662af821ef33412691c1a6296fe66ff",
-	"libflux/flux/src/cffi.rs":                                                                    "18ac707e1b66d41945c5184e7a6cddec146bafb9755ee776f78be1c449bcf022",
+	"libflux/flux/src/cffi.rs":                                                                    "8d21c8992104c420cd49204a08646c52c02f643f56e1361bb89827c814a1f27b",
 	"libflux/flux/src/lib.rs":                                                                     "3cd7dfcf7491f5797d501a647ee92a3f66b5790f6df7ed2238f1969b4bd929ed",
 	"libflux/flux/templates/base.html":                                                            "a818747b9621828bb96b94291c60922db54052bbe35d5e354f8e589d2a4ebd02",
 	"libflux/flux/templates/home.html":                                                            "f9927514dd42ca7271b4817ad1ca33ec79c03a77a783581b4dcafabd246ebf3f",


### PR DESCRIPTION
As of rustc 1.64, Box::from_raw is #[must_use].

```
error: unused return value of `Box::<T>::from_raw` that must be used
   --> flux/src/cffi.rs:100:5
    |
100 |     Box::from_raw(cstr);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> flux/src/lib.rs:1:38
    |
1   | #![cfg_attr(feature = "strict", deny(warnings, missing_docs))]
    |                                      ^^^^^^^^
    = note: `#[deny(unused_must_use)]` implied by `#[deny(warnings)]`
    = note: call `drop(from_raw(ptr))` if you intend to drop the `Box`

error: could not compile `flux` due to previous error
```

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
