### PR TITLE
feat: Recommend valid arguments in extra argument errors

### DIFF
--- a/libflux/flux-core/src/semantic/tests.rs
+++ b/libflux/flux-core/src/semantic/tests.rs
@@ -3807,19 +3807,19 @@ test_error_msg! {
         "#,
     // Location points to call expression `match(r)`
     expect: expect![[r#"
-            error: found unexpected argument r
-              ┌─ main:3:31
-              │
-            3 │             fn = (r) => match(r)
-              │                               ^
+        error: found unexpected argument r (Expected `o`)
+          ┌─ main:3:31
+          │
+        3 │             fn = (r) => match(r)
+          │                               ^
 
-            error: missing required argument o
-              ┌─ main:3:25
-              │
-            3 │             fn = (r) => match(r)
-              │                         ^^^^^^^^
+        error: missing required argument o
+          ┌─ main:3:25
+          │
+        3 │             fn = (r) => match(r)
+          │                         ^^^^^^^^
 
-        "#]],
+    "#]],
 }
 test_error_msg! {
     test: location_points_to_call_error_2,
@@ -3829,19 +3829,19 @@ test_error_msg! {
         "#,
     // Location points to call expression `f(a: 0, c: 1)`
     expect: expect![[r#"
-            error: found unexpected argument c
-              ┌─ main:3:24
-              │
-            3 │             f(a: 0, c: 1)
-              │                        ^
+        error: found unexpected argument c (Expected `b`)
+          ┌─ main:3:24
+          │
+        3 │             f(a: 0, c: 1)
+          │                        ^
 
-            error: missing required argument b
-              ┌─ main:3:13
-              │
-            3 │             f(a: 0, c: 1)
-              │             ^^^^^^^^^^^^^
+        error: missing required argument b
+          ┌─ main:3:13
+          │
+        3 │             f(a: 0, c: 1)
+          │             ^^^^^^^^^^^^^
 
-        "#]],
+    "#]],
 }
 
 test_error_msg! {
@@ -3856,6 +3856,40 @@ test_error_msg! {
           ┌─ main:3:13
           │
         3 │             f(a: 0)
+          │             ^^^^^^^
+
+    "#]],
+}
+
+test_error_msg! {
+    test: multiple_extra_argument_recommendations,
+    src: r#"
+            f = (a, b, c) => a + b + c
+            f(d: 1)
+        "#,
+    expect: expect![[r#"
+        error: found unexpected argument d (Expected one of `a`, `b` or `c`)
+          ┌─ main:3:18
+          │
+        3 │             f(d: 1)
+          │                  ^
+
+        error: missing required argument a
+          ┌─ main:3:13
+          │
+        3 │             f(d: 1)
+          │             ^^^^^^^
+
+        error: missing required argument b
+          ┌─ main:3:13
+          │
+        3 │             f(d: 1)
+          │             ^^^^^^^
+
+        error: missing required argument c
+          ┌─ main:3:13
+          │
+        3 │             f(d: 1)
           │             ^^^^^^^
 
     "#]],
@@ -4118,7 +4152,7 @@ fn multiple_errors_in_function_call() {
             f(a: 1, b: "record", d: {})
         "#,
         expect: expect![[r#"
-            error: found unexpected argument d
+            error: found unexpected argument d (Expected `c`)
               ┌─ main:2:37
               │
             2 │             f(a: 1, b: "record", d: {})

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -53,7 +53,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/nodes.rs":                                                     "a35e2e194a0369080d413db4f1f132d5b32fd4d3cff50ce47f505cc4e31fc2b8",
 	"libflux/flux-core/src/semantic/sub.rs":                                                       "8bc05ffff0990facea2130e0faf5a837f8663d59996ff85869c6e631ac654553",
 	"libflux/flux-core/src/semantic/symbols.rs":                                                   "f061d57fe4ef7f23d0adad80d43fe1c8ae92d5e25a0da4b81e21b8087e30d253",
-	"libflux/flux-core/src/semantic/types.rs":                                                     "ff5f9b636222096415ec978f1941fabbaa6d329af48598bd3b5931cbeaba9aba",
+	"libflux/flux-core/src/semantic/types.rs":                                                     "c55bac3abc22d7868bbf3eafe821b49699f174432b2b99db6465189ce7c858d8",
 	"libflux/flux-core/src/semantic/vectorize.rs":                                                 "eda5347c1257a6541727c50d90f49f6b10876017f6c51ad98d10f90388b5dbaf",
 	"libflux/flux-core/src/semantic/walk/_walk.rs":                                                "285b7e9237e218954eddcdabeaa0a7cadd566af30ad96f714faf1b5fbcc05544",
 	"libflux/flux-core/src/semantic/walk/mod.rs":                                                  "1f8b312b728692eeea0deaa8c608b60019f5c32bd8ed3355133608102851442c",


### PR DESCRIPTION
These errors are usually because someone has made a typo or forgotten the name of an argument so reminding them of what the valid arguments are is helpful.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
