### PR TITLE
refactor(dynamic): member expr should error when inner is not obj

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -158,7 +158,7 @@ var sourceHashes = map[string]string{
 	"stdlib/experimental/diff_test.flux":                                                          "b75aa4095b24d67f027b24b0c08e926824a6f68ea292821c025bcb8ac76c0339",
 	"stdlib/experimental/distinct_test.flux":                                                      "c7358d31972d0931aef6735ea94d901827c13fbaaeb9b02ff255391b5f95ea30",
 	"stdlib/experimental/dynamic/dynamic.flux":                                                    "4227d8f2e321ade187aadb283388e1bdec896c5b05d03ae9119eed3aae9dda0b",
-	"stdlib/experimental/dynamic/dynamic_test.flux":                                               "00c1cdf7bb5821b7896853dd7672667dcd887d1cb43eb462bd64bd87f30f758d",
+	"stdlib/experimental/dynamic/dynamic_test.flux":                                               "a6d5facd1670434fec0b2349131d23bfd72f52c29a8536ed60d90aee18cc2118",
 	"stdlib/experimental/experimental.flux":                                                       "65b7c015a47f5f5da48d23a64d73bdf8c6e299b0530ab71af236711369104566",
 	"stdlib/experimental/experimental_test.flux":                                                  "2763ee3d6f373a11ad4e77c4ecf1bbf32974f912e75043d0b7753112117a06da",
 	"stdlib/experimental/fill_test.flux":                                                          "3e31ca59476018a527a33d01d50c492da29f4de095df21c77abdb43c05947baf",

--- a/stdlib/experimental/dynamic/dynamic_test.flux
+++ b/stdlib/experimental/dynamic/dynamic_test.flux
@@ -503,24 +503,24 @@ testcase dynamic_cast_from_json_deep {
                         posX:
                             int(
                                 v:
-                                    if exists x.pos then
-                                        if exists x.pos.x then x.pos.x else debug.null()
+                                    if exists x.pos and exists x.pos.x then
+                                        x.pos.x
                                     else
                                         debug.null(),
                             ),
                         posY:
                             int(
                                 v:
-                                    if exists x.pos then
-                                        if exists x.pos.y then x.pos.y else debug.null()
+                                    if exists x.pos and exists x.pos.y then
+                                        x.pos.y
                                     else
                                         debug.null(),
                             ),
                         posZ:
                             int(
                                 v:
-                                    if exists x.pos then
-                                        if exists x.pos.z then x.pos.z else debug.null()
+                                    if exists x.pos and exists x.pos.z then
+                                        x.pos.z
                                     else
                                         debug.null(),
                             ),


### PR DESCRIPTION
Partially fixes #5276 

Member expressions on dynamic values started out very loose. Originally, any dynamic would just hand back a `dynamic(null)` when the property lookup failed. This means getting good feedback from the runtime was much harder as nulls could just bleed through.

This diff aims to ensure we give better feedback - especially for cases where the dynamic inner value is some non-object (int, float, null, and so on).
In these situations a property lookup would never make sense. This indicates the underlying data structure is probably unexpected to the script author and updates to the program will be needed.

Overall this should be a safer initial implementation at the language level since it is "more regular" and less exotic. We can add API to improve the developer experience without much sacrifice.

For cases where the inner value _is an object_ but the property doesn't exist, we will continue to hand back a `dynamic(null)` as I believe this would be expected. The key thing is to error when the overall shape of the underlying data has drifted away from the original expectations.

N.B. this change means the `dynamic_cast_from_json_deep` test had to be updated to use `exists` to dance around the nulls. It also seems like users will need to leverage `debug.null()` for alternate cases which we might not really like since it's "internal."

This likely means <https://github.com/influxdata/flux/issues/5287> or something in a similar space will be an important workflow element, ergonomically moving forward.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
