### PR TITLE
refactor(deps): expose NewPrivateClient function

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -3,7 +3,6 @@ package flux
 import (
 	"context"
 	"net"
-	nethttp "net/http"
 	"syscall"
 	"time"
 
@@ -58,7 +57,7 @@ func (d Deps) PrivateHTTPClient() (http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newPrivateClient(c), nil
+	return http.NewPrivateClient(c), nil
 }
 
 func (d Deps) FilesystemService() (filesystem.Service, error) {
@@ -145,22 +144,4 @@ func GetDialer(ctx context.Context) (*net.Dialer, error) {
 		KeepAlive: 30 * time.Second,
 		Control:   control,
 	}, nil
-}
-
-// privateClient is an http client that obscures error messages that may contain
-// sensitive information
-type privateClient struct {
-	client http.Client
-}
-
-func newPrivateClient(c http.Client) http.Client {
-	return &privateClient{client: c}
-}
-
-func (c *privateClient) Do(req *nethttp.Request) (*nethttp.Response, error) {
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, codes.Internal, "an internal error has occurred")
-	}
-	return resp, nil
 }

--- a/dependencies/http/http.go
+++ b/dependencies/http/http.go
@@ -142,3 +142,21 @@ func WithTLSConfig(c Client, config *tls.Config) (Client, error) {
 	}
 	return &newClient, nil
 }
+
+// privateClient is an http client that obscures error messages that may contain
+// sensitive information
+type privateClient struct {
+	client Client
+}
+
+func NewPrivateClient(c Client) Client {
+	return &privateClient{client: c}
+}
+
+func (c *privateClient) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, codes.Internal, "an internal error has occurred")
+	}
+	return resp, nil
+}


### PR DESCRIPTION
Exposes the `newPrivateClient` function so that it can be used in external implementations of flux packages.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [ ] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
