### PR TITLE
docs: update docs with windowing caveats

### DIFF
--- a/interpreter/interpreter_test.go
+++ b/interpreter/interpreter_test.go
@@ -883,8 +883,8 @@ func TestStack(t *testing.T) {
 			FunctionName: "window",
 			Location: ast.SourceLocation{
 				File:   "universe/universe.flux",
-				Start:  ast.Position{Line: 3889, Column: 12},
-				End:    ast.Position{Line: 3889, Column: 51},
+				Start:  ast.Position{Line: 3895, Column: 12},
+				End:    ast.Position{Line: 3895, Column: 51},
 				Source: `window(every: inf, timeColumn: timeDst)`,
 			},
 		},

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -602,7 +602,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "7d8b47b3e96b859a5fed5985c051e2a3fdc947d3d6ff9cc104e40821581fb0cb",
 	"stdlib/universe/union_test.flux":                                                             "f008260d48db70212ce64d3f51f4cf031532a9a67c1ba43242dbc4d43ef31293",
 	"stdlib/universe/unique_test.flux":                                                            "c108ab7b0e4b0b77f0a320c8c4dacb8cfbccae8b389425754e9583e69cd64ee3",
-	"stdlib/universe/universe.flux":                                                               "99965a298b08d84cd04cceee7502148be776021f824cae5afd0a6b3665fcc809",
+	"stdlib/universe/universe.flux":                                                               "c0109d185acbe159d9b2b0f4c1d9a47dea5aa0d4fd5f182c969981e1caf84550",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "c8f66f7ee188bb2e979e5a8b526057b653922197ae441658f7c7f11251c96576",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -602,7 +602,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "7d8b47b3e96b859a5fed5985c051e2a3fdc947d3d6ff9cc104e40821581fb0cb",
 	"stdlib/universe/union_test.flux":                                                             "f008260d48db70212ce64d3f51f4cf031532a9a67c1ba43242dbc4d43ef31293",
 	"stdlib/universe/unique_test.flux":                                                            "c108ab7b0e4b0b77f0a320c8c4dacb8cfbccae8b389425754e9583e69cd64ee3",
-	"stdlib/universe/universe.flux":                                                               "c0109d185acbe159d9b2b0f4c1d9a47dea5aa0d4fd5f182c969981e1caf84550",
+	"stdlib/universe/universe.flux":                                                               "d9933a5e9318c06a68351dcc31f5fc38f0c54c7e2657d41ab44a2915ef26eaf3",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "c8f66f7ee188bb2e979e5a8b526057b653922197ae441658f7c7f11251c96576",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -602,7 +602,7 @@ var sourceHashes = map[string]string{
 	"stdlib/universe/union_heterogeneous_test.flux":                                               "7d8b47b3e96b859a5fed5985c051e2a3fdc947d3d6ff9cc104e40821581fb0cb",
 	"stdlib/universe/union_test.flux":                                                             "f008260d48db70212ce64d3f51f4cf031532a9a67c1ba43242dbc4d43ef31293",
 	"stdlib/universe/unique_test.flux":                                                            "c108ab7b0e4b0b77f0a320c8c4dacb8cfbccae8b389425754e9583e69cd64ee3",
-	"stdlib/universe/universe.flux":                                                               "d9933a5e9318c06a68351dcc31f5fc38f0c54c7e2657d41ab44a2915ef26eaf3",
+	"stdlib/universe/universe.flux":                                                               "060426aa8c8caf89187489f3bbd077cdba9efa389d76a09d3346636b4ba35e61",
 	"stdlib/universe/universe_truncateTimeColumn_test.flux":                                       "8acb700c612e9eba87c0525b33fd1f0528e6139cc912ed844932caef25d37b56",
 	"stdlib/universe/window_aggregate_test.flux":                                                  "c8f66f7ee188bb2e979e5a8b526057b653922197ae441658f7c7f11251c96576",
 	"stdlib/universe/window_default_start_align_test.flux":                                        "0aaf612796fbb5ac421579151ad32a8861f4494a314ea615d0ccedd18067b980",

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -2789,7 +2789,6 @@ builtin _window : (
 //
 // This function is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
 // If `timeColumn` _is_ in the group key, resulting output is confusing and generally not useful.
-// In a future release, `window()` may produce an error for this case.
 //
 // #### Window by calendar months and years
 // `every`, `period`, and `offset` parameters support all valid duration units,
@@ -3745,7 +3744,6 @@ _fillEmpty = (tables=<-, createEmpty) =>
 //
 // This function is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
 // If `timeColumn` _is_ in the group key, resulting output is confusing and generally not useful.
-// In a future release, `aggregateWindow()` may produce an error for this case.
 //
 // #### Downsample by calendar months and years
 // `every`, `period`, and `offset` parameters support all valid duration units,

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -2787,6 +2787,10 @@ builtin _window : (
 // A single input row may be placed into zero or more output tables depending on
 // the parameters passed into `window()`.
 //
+// This funcion is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
+// If `timeColumn` _is_ in the group key, resulting output is confusing and generally not useful.
+// In a future release, `window()` may produce an error for this case.
+//
 // #### Window by calendar months and years
 // `every`, `period`, and `offset` parameters support all valid duration units,
 // including calendar months (`1mo`) and years (`1y`).
@@ -3738,6 +3742,10 @@ _fillEmpty = (tables=<-, createEmpty) =>
 //
 // `aggregateWindow()` requires `_start` and `_stop` columns in input data.
 // Use `range()` to assign `_start` and `_stop` values.
+//
+// This funcion is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
+// If `timeColumn` _is_ in the group key, resulting output is confusing and generally not useful.
+// In a future release, `aggregateWindow()` may produce an error for this case.
 //
 // #### Downsample by calendar months and years
 // `every`, `period`, and `offset` parameters support all valid duration units,

--- a/stdlib/universe/universe.flux
+++ b/stdlib/universe/universe.flux
@@ -2787,7 +2787,7 @@ builtin _window : (
 // A single input row may be placed into zero or more output tables depending on
 // the parameters passed into `window()`.
 //
-// This funcion is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
+// This function is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
 // If `timeColumn` _is_ in the group key, resulting output is confusing and generally not useful.
 // In a future release, `window()` may produce an error for this case.
 //
@@ -3743,7 +3743,7 @@ _fillEmpty = (tables=<-, createEmpty) =>
 // `aggregateWindow()` requires `_start` and `_stop` columns in input data.
 // Use `range()` to assign `_start` and `_stop` values.
 //
-// This funcion is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
+// This function is intended to be used when `timeColumn` (`_time` by default) is not in the group key.
 // If `timeColumn` _is_ in the group key, resulting output is confusing and generally not useful.
 // In a future release, `aggregateWindow()` may produce an error for this case.
 //


### PR DESCRIPTION
Discourage use of `window` and `aggregateWindow` when `_time` is in the group key.

The reason is that even when we get a right answer, the output is confusing. At other times we hit this bug:
https://github.com/influxdata/flux/issues/5260

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code (N/A)
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
