### PR TITLE
chore: update flatc version

### DIFF
--- a/install_flatc.sh
+++ b/install_flatc.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-
-FLATBUFFERS_VERSION=2.0.0
-FLATBUFFERS_CHECKSUM=9ddb9031798f4f8754d00fca2f1a68ecf9d0f83dfac7239af1311e4fd9a565c4
+FLATBUFFERS_VERSION=22.9.29
+FLATBUFFERS_CHECKSUM=372df01795c670f6538055a7932fc7eb3e81b3653be4a216c081e9c3c26b1b6d
 curl -LS https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.tar.gz -O && \
     echo "${FLATBUFFERS_CHECKSUM} v${FLATBUFFERS_VERSION}.tar.gz" | sha256sum --check -- && \
     tar xvzf v${FLATBUFFERS_VERSION}.tar.gz && \


### PR DESCRIPTION
Update the `flatc` version referenced in `install_flatc.sh`, as well as the checksum. This should update the version of flatc our CI docker image uses so that https://github.com/influxdata/flux/pull/5296 can pass.
