### PR TITLE
chore: create a root span for REPL input

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -27,6 +27,7 @@ import (
 	"github.com/influxdata/flux/runtime"
 	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
+	"github.com/opentracing/opentracing-go"
 )
 
 type REPL struct {
@@ -153,6 +154,11 @@ func (r *REPL) Input(t string) (*libflux.FluxError, error) {
 
 // input processes a line of input and prints the result.
 func (r *REPL) input(t string) {
+	// Create a root span
+	span := opentracing.StartSpan("REPL.input")
+	r.ctx = opentracing.ContextWithSpan(r.ctx, span)
+	defer span.Finish()
+
 	if fluxError, err := r.executeLine(t); err != nil {
 		if fluxError != nil {
 			fluxError.Print()


### PR DESCRIPTION
This just adds a root tracing span to the REPL so that any spans produced during execution have a common parent span. This makes generated traces more readable.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues (N/A)
- [x] 🏃 Test cases are included to exercise the new code (N/A)
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` (N/A)
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated (N/A)

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
