### PR TITLE
chore(dev): first attempt at a vscode devcontainer for the project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/influxdb/flux-build
+
+USER root
+RUN mkdir -p /home/builder/.cargo /home/builder/go/pkg && \
+    chown -R builder:builder /home/builder/.cargo /home/builder/go
+USER builder

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "name": "Flux Project",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "rust-lang.rust-analyzer",
+        "influxdata.flux"
+      ]
+    }
+  },
+  "mounts": [
+    {
+      "type": "volume",
+      "source": "vscode-flux-cargo",
+      "target": "/home/builder/.cargo"
+    },
+    {
+      "type": "volume",
+      "source": "vscode-flux-gopkg",
+      "target": "/home/builder/go/pkg"
+    }
+  ]
+}


### PR DESCRIPTION
This should create a standard environment for contributors to load up
the project and use vscode to modify it and have a usable environment
for compiling and running the program.

It still leaves a lot to be desired. For whatever reason, loading the
project takes forever. `rust-analyzer` takes a very long time and the go
tools aren't presently installed by default. We can iterate on the
container to make it quicker to load and a more desirable environment to
work in.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.