### PR TITLE
poc: make planner an injected dependency

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/http"
+	"github.com/influxdata/flux/dependencies/plan"
 	"github.com/influxdata/flux/dependencies/secret"
 	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/dependency"
@@ -30,6 +31,7 @@ type Dependencies interface {
 	FilesystemService() (filesystem.Service, error)
 	SecretService() (secret.Service, error)
 	URLValidator() (url.Validator, error)
+	PlanService() (plan.Service, error)
 }
 
 // Deps implements Dependencies.
@@ -43,6 +45,7 @@ type WrappedDeps struct {
 	FilesystemService filesystem.Service
 	SecretService     secret.Service
 	URLValidator      url.Validator
+	PlanService       plan.Service
 }
 
 func (d Deps) HTTPClient() (http.Client, error) {
@@ -79,6 +82,13 @@ func (d Deps) URLValidator() (url.Validator, error) {
 		return d.Deps.URLValidator, nil
 	}
 	return nil, errors.New(codes.Unimplemented, "url validator uninitialized in dependencies")
+}
+
+func (d Deps) PlanService() (plan.Service, error) {
+	if d.Deps.PlanService != nil {
+		return d.Deps.PlanService, nil
+	}
+	return nil, errors.New(codes.Unimplemented, "plan service uninitialized in dependencies")
 }
 
 func (d Deps) Inject(ctx context.Context) context.Context {

--- a/dependencies/dependencies.go
+++ b/dependencies/dependencies.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/flux/dependencies/filesystem"
 	"github.com/influxdata/flux/dependencies/influxdb"
 	"github.com/influxdata/flux/dependencies/mqtt"
+	"github.com/influxdata/flux/plan"
 )
 
 type Dependencies struct {
@@ -27,6 +28,7 @@ func (d Dependencies) Inject(ctx context.Context) context.Context {
 func NewDefaultDependencies(defaultInfluxDBHost string) Dependencies {
 	deps := flux.NewDefaultDependencies()
 	deps.Deps.FilesystemService = filesystem.SystemFS
+	deps.Deps.PlanService = plan.DefaultPlanService()
 
 	return Dependencies{
 		Deps: deps,

--- a/dependencies/plan/service.go
+++ b/dependencies/plan/service.go
@@ -1,0 +1,11 @@
+package plan
+
+import "context"
+
+type Service interface {
+	Plan(context.Context, Spec) (Spec, error)
+}
+
+type Spec interface {
+	CheckIntegrity() error
+}

--- a/plan/builder.go
+++ b/plan/builder.go
@@ -2,8 +2,6 @@ package plan
 
 import (
 	"context"
-
-	"github.com/influxdata/flux/internal/operation"
 )
 
 // PlannerBuilder provides clients with an easy way to create planners.
@@ -37,11 +35,7 @@ type planner struct {
 	pp PhysicalPlanner
 }
 
-func (p *planner) Plan(ctx context.Context, fspec *operation.Spec) (*Spec, error) {
-	ip, err := p.lp.CreateInitialPlan(fspec)
-	if err != nil {
-		return nil, err
-	}
+func (p *planner) Plan(ctx context.Context, ip *Spec) (*Spec, error) {
 	lp, err := p.lp.Plan(ctx, ip)
 	if err != nil {
 		return nil, err

--- a/plan/clone.go
+++ b/plan/clone.go
@@ -1,0 +1,34 @@
+package plan
+
+func cloneSpec(s *Spec) (*Spec, error) {
+	nodeMap := make(map[Node]Node)
+	s.TopDownWalk(func(node Node) error {
+		nodeMap[node] = node.ShallowCopy()
+		return nil
+	})
+
+	for oldNode, newNode := range nodeMap {
+		newNode.ClearPredecessors()
+		for _, n := range oldNode.Predecessors() {
+			newNode.AddPredecessors(nodeMap[n])
+		}
+
+		newNode.ClearSuccessors()
+		for _, n := range oldNode.Successors() {
+			newNode.AddSuccessors(nodeMap[n])
+		}
+	}
+
+	newRoots := make(map[Node]struct{})
+	for r := range s.Roots {
+		newRoots[nodeMap[r]] = struct{}{}
+	}
+
+	newSpec := &Spec{
+		Roots:     newRoots,
+		Resources: s.Resources,
+		Now:       s.Now,
+	}
+
+	return newSpec, nil
+}

--- a/plan/clone_test.go
+++ b/plan/clone_test.go
@@ -1,0 +1,75 @@
+package plan_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux/plan"
+	"github.com/influxdata/flux/plan/plantest"
+)
+
+func TestClone(t *testing.T) {
+	//
+	//        sink0  sink1
+	//          |      |
+	//          2      3
+	//        /  \   /   \
+	//       /    \ /     \
+	//      5      4       8
+	//            / \
+	//           /   \
+	//          6     7
+
+	spec := &plantest.PlanSpec{
+		Nodes: []plan.Node{
+			plantest.CreatePhysicalMockNode("sink0"),
+			plantest.CreatePhysicalMockNode("sink1"),
+			plantest.CreatePhysicalMockNode("2"),
+			plantest.CreatePhysicalMockNode("3"),
+			plantest.CreatePhysicalMockNode("4"),
+			plantest.CreatePhysicalMockNode("5"),
+			plantest.CreatePhysicalMockNode("6"),
+			plantest.CreatePhysicalMockNode("7"),
+			plantest.CreatePhysicalMockNode("8"),
+		},
+		Edges: [][2]int{
+			{6, 4},
+			{7, 4},
+			{4, 2},
+			{4, 3},
+			{5, 2},
+			{8, 3},
+			{2, 0},
+			{3, 1},
+		},
+	}
+
+	inputPlan := plantest.CreatePlanSpec(spec)
+	clonedPlan, err := plan.CloneSpec(inputPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inNodes := specToSlice(inputPlan)
+	outNodes := specToSlice(clonedPlan.(*plan.Spec))
+	if want, got := len(inNodes), len(outNodes); want != got {
+		t.Fatalf("Clone() produced a graph with wrong number of nodes; want: %v, got %v", want, got)
+	}
+
+	for i, in := range inNodes {
+		if want, got := in+"_copy", outNodes[i]; want != got {
+			t.Errorf("node ID does not match expected at position %v; want: %v, got %v", i, want, got)
+		}
+	}
+
+}
+
+func specToSlice(s *plan.Spec) []plan.NodeID {
+	var nids []plan.NodeID
+	if err := s.TopDownWalk(func(node plan.Node) error {
+		nids = append(nids, node.ID())
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+	return nids
+}

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -18,7 +18,6 @@ import (
 // actual physical algorithms used to implement operations, and independent of
 // the actual data being processed.
 type LogicalPlanner interface {
-	CreateInitialPlan(spec *operation.Spec) (*Spec, error)
 	Plan(context.Context, *Spec) (*Spec, error)
 }
 
@@ -92,11 +91,6 @@ func DisableIntegrityChecks() LogicalOption {
 	})
 }
 
-// CreateInitialPlan translates the flux.Spec into an unoptimized, naive plan.
-func (l *logicalPlanner) CreateInitialPlan(spec *operation.Spec) (*Spec, error) {
-	return createLogicalPlan(spec)
-}
-
 // Plan transforms the given naive plan by applying rules.
 func (l *logicalPlanner) Plan(ctx context.Context, logicalPlan *Spec) (*Spec, error) {
 	newLogicalPlan, err := l.heuristicPlanner.Plan(ctx, logicalPlan)
@@ -166,8 +160,8 @@ func (lpn *LogicalNode) ShallowCopy() Node {
 	return newNode
 }
 
-// createLogicalPlan creates a logical query plan from a flux spec
-func createLogicalPlan(spec *operation.Spec) (*Spec, error) {
+// CreateLogicalPlan creates a logical query plan from a flux spec
+func CreateLogicalPlan(spec *operation.Spec) (*Spec, error) {
 	nodes := make(map[operation.NodeID]Node, len(spec.Operations))
 	admin := administration{now: spec.Now}
 

--- a/plan/logical.go
+++ b/plan/logical.go
@@ -154,7 +154,6 @@ func (lpn *LogicalNode) ReplaceSpec(newSpec ProcedureSpec) error {
 
 func (lpn *LogicalNode) ShallowCopy() Node {
 	newNode := new(LogicalNode)
-	newNode.edges = lpn.edges.shallowCopy()
 	newNode.id = lpn.id + "_copy"
 	newNode.Spec = lpn.Spec.Copy()
 	return newNode

--- a/plan/logical_test.go
+++ b/plan/logical_test.go
@@ -297,7 +297,7 @@ func TestPlan_LogicalPlanFromSpec(t *testing.T) {
 			thePlanner := plan.NewLogicalPlanner()
 
 			// Convert flux spec to initial logical plan
-			initPlan, err := thePlanner.CreateInitialPlan(spec)
+			initPlan, err := plan.CreateLogicalPlan(spec)
 
 			if tc.wantErr {
 				if err == nil {
@@ -645,7 +645,7 @@ func TestLogicalPlanner(t *testing.T) {
 			}
 
 			logicalPlanner := plan.NewLogicalPlanner(plan.OnlyLogicalRules(MergeFiltersRule{}, PushFilterThroughMapRule{}))
-			initPlan, err := logicalPlanner.CreateInitialPlan(fluxSpec)
+			initPlan, err := plan.CreateLogicalPlan(fluxSpec)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -684,7 +684,7 @@ from(bucket: "telegraf")
 		),
 		plan.DisableIntegrityChecks(),
 	)
-	initPlan, err := planner.CreateInitialPlan(spec)
+	initPlan, err := plan.CreateLogicalPlan(spec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ from(bucket: "telegraf")
 	// let's smash the plan
 	planner = plan.NewLogicalPlanner(
 		plan.OnlyLogicalRules(plantest.SmashPlanRule{Intruder: intruder, Kind: k}))
-	initPlan, err = planner.CreateInitialPlan(spec)
+	initPlan, err = plan.CreateLogicalPlan(spec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -708,7 +708,7 @@ from(bucket: "telegraf")
 	// let's introduce a cycle
 	planner = plan.NewLogicalPlanner(
 		plan.OnlyLogicalRules(plantest.CreateCycleRule{Kind: k}))
-	initPlan, err = planner.CreateInitialPlan(spec)
+	initPlan, err = plan.CreateLogicalPlan(spec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -76,15 +76,13 @@ func (pp *physicalPlanner) Plan(ctx context.Context, spec *Spec) (*Spec, error) 
 		return nil, err
 	}
 
-	// Ensure that the plan is valid
-	if !pp.disableValidation {
-		err := transformedSpec.CheckIntegrity()
-		if err != nil {
-			return nil, err
-		}
+	if err := transformedSpec.CheckIntegrity(); err != nil {
+		return nil, err
+	}
 
-		err = ValidatePhysicalPlan(transformedSpec)
-		if err != nil {
+	// Validate plan if requested
+	if !pp.disableValidation {
+		if ValidatePhysicalPlan(transformedSpec) != nil {
 			return nil, err
 		}
 	}

--- a/plan/physical.go
+++ b/plan/physical.go
@@ -273,7 +273,12 @@ func (ppn *PhysicalPlanNode) CallStack() []interpreter.StackEntry {
 
 func (ppn *PhysicalPlanNode) ShallowCopy() Node {
 	newNode := new(PhysicalPlanNode)
-	newNode.edges = ppn.edges.shallowCopy()
+	if ppn.bounds.value != nil {
+		newNode.bounds = bounds{value: &Bounds{
+			Start: ppn.bounds.value.Start,
+			Stop:  ppn.bounds.value.Stop,
+		}}
+	}
 	newNode.id = ppn.id + "_copy"
 	// TODO: the type assertion below... is it needed?
 	newNode.Spec = ppn.Spec.Copy().(PhysicalProcedureSpec)

--- a/plan/rules_test.go
+++ b/plan/rules_test.go
@@ -47,7 +47,7 @@ func TestRuleRegistration(t *testing.T) {
 	}
 
 	logicalPlanner := plan.NewLogicalPlanner()
-	initPlan, err := logicalPlanner.CreateInitialPlan(fluxSpec)
+	initPlan, err := plan.CreateLogicalPlan(fluxSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestRewriteWithContext(t *testing.T) {
 	}
 
 	logicalPlanner := plan.NewLogicalPlanner()
-	initPlan, err := logicalPlanner.CreateInitialPlan(fluxSpec)
+	initPlan, err := plan.CreateLogicalPlan(fluxSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestMultiRootMatch(t *testing.T) {
 	}
 
 	logicalPlanner := plan.NewLogicalPlanner()
-	initPlan, err := logicalPlanner.CreateInitialPlan(fluxSpec)
+	initPlan, err := plan.CreateLogicalPlan(fluxSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestExpectPlannerRule(t *testing.T) {
 	}
 
 	logicalPlanner := plan.NewLogicalPlanner()
-	initPlan, err := logicalPlanner.CreateInitialPlan(fluxSpec)
+	initPlan, err := plan.CreateLogicalPlan(fluxSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plan/service.go
+++ b/plan/service.go
@@ -58,3 +58,7 @@ func PlanPhysicallySkipValidation(ctx context.Context, p plan.Spec, rules ...Rul
 	}
 	return newPlan, nil
 }
+
+func CloneSpec(p plan.Spec) (plan.Spec, error) {
+	return cloneSpec(p.(*Spec))
+}

--- a/plan/service.go
+++ b/plan/service.go
@@ -1,0 +1,33 @@
+package plan
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/dependencies/plan"
+)
+
+func DefaultPlanService() plan.Service {
+	return planService{}
+}
+
+type planService struct{}
+
+func (s planService) Plan(ctx context.Context, p plan.Spec) (plan.Spec, error) {
+	pspec := p.(*Spec)
+	pb := PlannerBuilder{}
+
+	// TODO(cwolff): handle options here as before
+	//	planOptions := opts.planOptions
+	//
+	//	lopts := planOptions.logical
+	//	popts := planOptions.physical
+	//
+	//	pb.AddLogicalOptions(lopts...)
+	//	pb.AddPhysicalOptions(popts...)
+
+	ps, err := pb.Build().Plan(ctx, pspec)
+	if err != nil {
+		return nil, err
+	}
+	return ps, nil
+}

--- a/plan/service.go
+++ b/plan/service.go
@@ -7,12 +7,12 @@ import (
 )
 
 func DefaultPlanService() plan.Service {
-	return planService{}
+	return defaultPlanService{}
 }
 
-type planService struct{}
+type defaultPlanService struct{}
 
-func (s planService) Plan(ctx context.Context, p plan.Spec) (plan.Spec, error) {
+func (s defaultPlanService) Plan(ctx context.Context, p plan.Spec) (plan.Spec, error) {
 	pspec := p.(*Spec)
 	pb := PlannerBuilder{}
 
@@ -30,4 +30,31 @@ func (s planService) Plan(ctx context.Context, p plan.Spec) (plan.Spec, error) {
 		return nil, err
 	}
 	return ps, nil
+}
+
+func PlanLogically(ctx context.Context, p plan.Spec, rules ...Rule) (plan.Spec, error) {
+	lp := NewLogicalPlanner(OnlyLogicalRules(rules...))
+	newPlan, err := lp.Plan(ctx, p.(*Spec))
+	if err != nil {
+		return nil, err
+	}
+	return newPlan, nil
+}
+
+func PlanPhysically(ctx context.Context, p plan.Spec, rules ...Rule) (plan.Spec, error) {
+	pp := NewPhysicalPlanner(OnlyPhysicalRules(rules...))
+	newPlan, err := pp.Plan(ctx, p.(*Spec))
+	if err != nil {
+		return nil, err
+	}
+	return newPlan, nil
+}
+
+func PlanPhysicallySkipValidation(ctx context.Context, p plan.Spec, rules ...Rule) (plan.Spec, error) {
+	pp := NewPhysicalPlanner(OnlyPhysicalRules(rules...), DisableValidation())
+	newPlan, err := pp.Plan(ctx, p.(*Spec))
+	if err != nil {
+		return nil, err
+	}
+	return newPlan, nil
 }

--- a/plan/service.go
+++ b/plan/service.go
@@ -62,3 +62,7 @@ func PlanPhysicallySkipValidation(ctx context.Context, p plan.Spec, rules ...Rul
 func CloneSpec(p plan.Spec) (plan.Spec, error) {
 	return cloneSpec(p.(*Spec))
 }
+
+func ValidatePlan(p plan.Spec) error {
+	return ValidatePhysicalPlan(p.(*Spec))
+}

--- a/plan/types.go
+++ b/plan/types.go
@@ -206,13 +206,6 @@ func (e *edges) ClearPredecessors() {
 	e.predecessors = e.predecessors[0:0]
 }
 
-func (e *edges) shallowCopy() edges {
-	newEdges := new(edges)
-	copy(newEdges.predecessors, e.predecessors)
-	copy(newEdges.successors, e.successors)
-	return *newEdges
-}
-
 // MergeToLogicalNode merges top and bottom plan nodes into a new plan node, with the
 // given procedure spec.
 //

--- a/plan/types.go
+++ b/plan/types.go
@@ -7,13 +7,12 @@ import (
 	"time"
 
 	"github.com/influxdata/flux"
-	"github.com/influxdata/flux/internal/operation"
 	"github.com/influxdata/flux/interpreter"
 	"github.com/influxdata/flux/interval"
 )
 
 type Planner interface {
-	Plan(context.Context, *operation.Spec) (*Spec, error)
+	Plan(context.Context, *Spec) (*Spec, error)
 }
 
 // Node defines the common interface for interacting with

--- a/repl/compiler.go
+++ b/repl/compiler.go
@@ -18,14 +18,23 @@ type Compiler struct {
 }
 
 func (c Compiler) Compile(ctx context.Context, runtime flux.Runtime) (flux.Program, error) {
-	planner := plan.PlannerBuilder{}.Build()
-	ps, err := planner.Plan(ctx, c.Spec)
+	lp, err := plan.CreateLogicalPlan(c.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	planSvc, err := flux.GetDependencies(ctx).PlanService()
+	if err != nil {
+		return nil, err
+	}
+
+	pp, err := planSvc.Plan(ctx, lp)
 	if err != nil {
 		return nil, err
 	}
 
 	return &lang.Program{
-		PlanSpec: ps,
+		PlanSpec: pp.(*plan.Spec),
 	}, err
 }
 


### PR DESCRIPTION
This set of changes makes it so query planning can be tailored to its environment by injecting it as a dependency.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [ ] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
