### PR TITLE
feat: detect certain undesirable patterns so we can remove them later

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -81,6 +81,12 @@ type TableObject struct {
 		Stack []interpreter.StackEntry
 	}
 	Parents []*TableObject
+
+	// Owned is set to true when this TableObject has
+	// ownership claimed by an operation spec.
+	// A TableObject should only be owned by one spec.
+	// TableObjects are initially created unowned.
+	Owned bool
 }
 
 func (t *TableObject) Dynamic() values.Dynamic {

--- a/execute/dependencies.go
+++ b/execute/dependencies.go
@@ -35,7 +35,7 @@ type ExecutionDependencies struct {
 
 	// Metadata is passed up from any invocations of execution up to the parent
 	// execution, and out through the statistics.
-	Metadata metadata.SyncMetadata
+	Metadata *metadata.SyncMetadata
 
 	ExecutionOptions *ExecutionOptions
 }

--- a/execute/metadata.go
+++ b/execute/metadata.go
@@ -1,0 +1,18 @@
+package execute
+
+import (
+	"context"
+
+	"github.com/influxdata/flux/metadata"
+)
+
+func RecordEvent(ctx context.Context, key string) {
+	if HaveExecutionDependencies(ctx) {
+		deps := GetExecutionDependencies(ctx)
+		deps.Metadata.ReadWriteView(func(meta *metadata.Metadata) {
+			if _, ok := meta.Get(key); !ok {
+				meta.Add(key, true)
+			}
+		})
+	}
+}

--- a/internal/operation/spec.go
+++ b/internal/operation/spec.go
@@ -32,6 +32,12 @@ type Spec struct {
 	Resources  flux.ResourceManagement `json:"resources"`
 	Now        time.Time               `json:"now"`
 
+	// HasConflict is true if one of the operations in this spec
+	// was previously used in another spec. This indicates
+	// that two nodes from distinct specs relate to the same
+	// operation.
+	HasConflict bool
+
 	sorted   []*Node
 	children map[NodeID][]*Node
 	parents  map[NodeID][]*Node

--- a/stdlib/universe/window_test.go
+++ b/stdlib/universe/window_test.go
@@ -78,6 +78,7 @@ func TestFixedWindow_PassThrough(t *testing.T) {
 	w, _ := interval.NewWindow(values.ConvertDurationNsecs(time.Minute), values.ConvertDurationNsecs(time.Minute), values.MakeDuration(0, 0, false))
 	executetest.TransformationPassThroughTestHelper(t, func(d execute.Dataset, c execute.TableBuilderCache) execute.Transformation {
 		fw := universe.NewFixedWindowTransformation(
+			context.Background(),
 			d,
 			c,
 			interval.Bounds{},
@@ -836,6 +837,7 @@ func TestFixedWindow_Process(t *testing.T) {
 				t.Fatalf("unexpected error while creating window: %s", err)
 			}
 			fw := universe.NewFixedWindowTransformation(
+				context.Background(),
 				d,
 				c,
 				tc.bounds,


### PR DESCRIPTION
This detects two undesirable patterns so that we can remove them later.

The first is the `_time` parameter being in the group key when window is
used. This wasn't really intended and should have been an error, but it
may have accidentally been done and it's not explicitly an error. We
want to detect it happening so we can communicate those scripts need to
be fixed so we can turn it into an error without disruption.

The second is an undesirable interaction with table find. When table
find is used, the plan is immediately created and evaluated. But, when
this interacts with another plan evalutation, the operation will be
duplicated. This can create inconsistencies from how other parts of the
engine work. We've chosen to have this interaction be an error, but we
want to detect if it's happening so that we can make it an error and so
we can fix any scripts that may be using the interaction inadvertantly.

Related to #5248 and #5299.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.