### PR TITLE
fix: add salsaDatabase to list of feature passed to Rust

### DIFF
--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -56,6 +56,7 @@ func NewOptions(ctx context.Context) Options {
 	features = addFlag(ctx, features, feature.PrettyError())
 	features = addFlag(ctx, features, feature.LabelPolymorphism())
 	features = addFlag(ctx, features, feature.UnusedSymbolWarnings())
+	features = addFlag(ctx, features, feature.SalsaDatabase())
 	return Options{Features: features}
 }
 


### PR DESCRIPTION
This change just makes it so we will set the `salsaDatabase` feature based off of what's in the context when calling into Rust to analyze a Flux program. Unless I'm mistaken I think this was just an omission from #5201.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code (N/A)
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
