### PR TITLE
feat(csv): add download headers within csv dialect

### DIFF
--- a/csv/dialect.go
+++ b/csv/dialect.go
@@ -2,6 +2,7 @@ package csv
 
 import (
 	"fmt"
+	"mime"
 	"net/http"
 
 	"github.com/influxdata/flux"
@@ -27,7 +28,12 @@ func (d Dialect) SetHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 	w.Header().Set("Transfer-Encoding", "chunked")
 	if d.ResultEncoderConfig.AttachmentFilename != "" {
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q; filename*=UTF-8''%q", d.ResultEncoderConfig.AttachmentFilename, d.ResultEncoderConfig.AttachmentFilename))
+		mediatype := "attachment"
+		params := map[string]string{
+			"filename":  d.ResultEncoderConfig.AttachmentFilename,
+			"filename*": fmt.Sprintf("UTF-8''%s", d.ResultEncoderConfig.AttachmentFilename),
+		}
+		w.Header().Set("Content-Disposition", mime.FormatMediaType(mediatype, params))
 	}
 }
 

--- a/csv/dialect.go
+++ b/csv/dialect.go
@@ -1,7 +1,9 @@
 package csv
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/influxdata/flux"
 )
@@ -25,6 +27,10 @@ type Dialect struct {
 func (d Dialect) SetHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 	w.Header().Set("Transfer-Encoding", "chunked")
+	if d.ResultEncoderConfig.DownloadHeader {
+		timestamp := time.Now().Format(time.RFC3339)
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"influxdata_%s.csv\"; filename*=UTF-8''influxdata_%s.csv", timestamp, timestamp))
+	}
 }
 
 func (d Dialect) Encoder() flux.MultiResultEncoder {

--- a/csv/dialect.go
+++ b/csv/dialect.go
@@ -3,7 +3,6 @@ package csv
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/influxdata/flux"
 )
@@ -27,9 +26,8 @@ type Dialect struct {
 func (d Dialect) SetHeaders(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
 	w.Header().Set("Transfer-Encoding", "chunked")
-	if d.ResultEncoderConfig.DownloadHeader {
-		timestamp := time.Now().Format(time.RFC3339)
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"influxdata_%s.csv\"; filename*=UTF-8''influxdata_%s.csv", timestamp, timestamp))
+	if d.ResultEncoderConfig.AttachmentFilename != "" {
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q; filename*=UTF-8''%q", d.ResultEncoderConfig.AttachmentFilename, d.ResultEncoderConfig.AttachmentFilename))
 	}
 }
 

--- a/csv/result.go
+++ b/csv/result.go
@@ -794,8 +794,8 @@ type ResultEncoderConfig struct {
 	// NoHeader indicates whether a header row should be added.
 	NoHeader bool
 
-	// Indicates whether http headers for download should be added.
-	DownloadHeader bool
+	// If present, add the download header matching this AttachmentFilename.
+	AttachmentFilename string
 
 	// Delimiter is the character to delimite columns.
 	// It must not be \r, \n, or the Unicode replacement character (0xFFFD).

--- a/csv/result.go
+++ b/csv/result.go
@@ -794,6 +794,9 @@ type ResultEncoderConfig struct {
 	// NoHeader indicates whether a header row should be added.
 	NoHeader bool
 
+	// Indicates whether http headers for download should be added.
+	DownloadHeader bool
+
 	// Delimiter is the character to delimite columns.
 	// It must not be \r, \n, or the Unicode replacement character (0xFFFD).
 	Delimiter rune


### PR DESCRIPTION
Part of https://github.com/influxdata/idpe/issues/16210

Per feedback from the automation team (see this PR https://github.com/influxdata/idpe/pull/16212), and with approval of @nathanielc , making changes to the csv Dialect to add download headers.

### Background:
* we are doing direct filesystem download of data in the UI, bypassing browser memory.
* With this approach, the download filename is only configured with content-disposition headers.
* Made changes in queryrouterd to add the headers.
* Per automation team's request, pushing the header change into the csv Dialect.


### Checklist
- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code --> test cases are in idpe.
        * did not add Headers test to this repo, since I didn't see other headers tested.
        * Did add an idpe test case, which has already been successfully run with local changes in this package. Confirmed works.
