### PR TITLE
fix: add wasmbind feature to chrono

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -120,11 +120,13 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
+ "js-sys",
  "libc",
  "num-integer",
  "num-traits",
  "serde",
  "time",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["doc"]
 [features]
 default = ["strict"]
 strict = []
-lsp = ["lsp-types"]
+lsp = ["lsp-types", "chrono/wasmbind"]
 doc = ["csv", "once_cell", "pad", "pulldown-cmark", "rayon", "tempfile"]
 
 [dependencies]


### PR DESCRIPTION
When targeting wasm, `chrono` will panic in certain code paths,
particularly doing things like `now()`. This presents itself in the
browser version of the lsp with errors in the console. In a few cases,
it causes the lsp to crash, though most cases the lsp continues after
the error.