### PR TITLE
fix: update iox.sql to detect midstream errors

### DIFF
--- a/dependencies/iox/client.go
+++ b/dependencies/iox/client.go
@@ -42,11 +42,18 @@ func GetProvider(ctx context.Context) Provider {
 	return p.(Provider)
 }
 
+// RecordReader is similar to the RecordReader interface provided by Arrow's array
+// package, but includes a method for detecting errors that are sent mid-stream.
+type RecordReader interface {
+	array.RecordReader
+	Err() error
+}
+
 // Client provides a way to query an iox instance.
 type Client interface {
 	// Query will initiate a query using the given query string, parameters, and memory allocator
 	// against the iox instance. It returns an array.RecordReader from the arrow flight api.
-	Query(ctx context.Context, query string, params []interface{}, mem memory.Allocator) (array.RecordReader, error)
+	Query(ctx context.Context, query string, params []interface{}, mem memory.Allocator) (RecordReader, error)
 
 	// GetSchema will retrieve a schema for the given table if this client supports that capability.
 	// If this Client doesn't support this capability, it should return a flux error with the code


### PR DESCRIPTION
This updates the IOx client abstraction to produce a reader that has an `Err()` method (which the Flight implementation does), and updates the implementation of `iox.sql` to check it for errors.

Prior to this change, midstream errors would be ignored and the result would be truncated.

These changes address a defect found in the cloud product, with tests added to the PR there.

BREAKING CHANGE: breaks the Go API for the IOx client dependency.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code (see above)
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/` (N/A)
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
