### PR TITLE
feat(contrib/qxip): add contrib/qxip/hash package

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,6 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "a898fc5c5079a6973be58397eb4443525c0c964ea311cdf36347582ce6fc31a6",
+	"stdlib/contrib/qxip/hash/hash.flux":                                                          "9c31d4e7409f37d2816cfd7302ae385ffacde09af63e6fbeb896a83b088eb742",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "12d8c0b46013f766b172207f6aad3cde157d06ed9aff786c921628c23a1831f1",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",
 	"stdlib/contrib/sranka/opsgenie/opsgenie.flux":                                                "5313b78a30ffb01c606397c9bea954bdd4ca06c44663268bab1e0f706fc6d2c5",

--- a/stdlib/contrib/qxip/hash/README.md
+++ b/stdlib/contrib/qxip/hash/README.md
@@ -1,0 +1,43 @@
+# Hash Package
+
+The Flux Hash Package provides functions that perform hash conversion of `string` values.
+
+## hash.sha256
+The `hash.sha256()` function converts a single string to a hash using sha256.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.sha256("Hello, world!")
+    // a is "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+```
+## hash.xxhash64
+The `hash.xxhash64()` function converts a single string to a hash using xxhash64.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.xxhash64("Hello, world!")
+    // a is "17691043854468224118"
+```
+## hash.cityhash64
+The `hash.cityhash64()` function converts a single string to hash using cityhash64.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.cityhash64("Hello, world!")
+    // a is "2359500134450972198"
+```
+
+## Contact
+- Author: Lorenzo Mangani
+- Email: lorenzo.mangani@gmail.com
+- Github: [@lmangani](https://github.com/lmangani)
+- Website: [@qryn](https://qryn.dev)

--- a/stdlib/contrib/qxip/hash/cityhash.go
+++ b/stdlib/contrib/qxip/hash/cityhash.go
@@ -1,0 +1,356 @@
+/*
+ * Go implementation of Google city hash (MIT license)
+ * https://code.google.com/p/cityhash/
+ *
+ * MIT License http://www.opensource.org/licenses/mit-license.php
+ *
+ * I don't even want to pretend to understand the details of city hash.
+ * I am only reproducing the logic in Go as faithfully as I can.
+ *
+ */
+
+package hash
+
+import (
+	"encoding/binary"
+)
+
+const (
+	k0 uint64 = 0xc3a5c85c97cb3127
+	k1 uint64 = 0xb492b66fbe98f273
+	k2 uint64 = 0x9ae16a3b2f90404f
+	k3 uint64 = 0xc949d7c7509e6557
+
+	kMul uint64 = 0x9ddfea08eb382d69
+)
+
+func fetch64(p []byte) uint64 {
+	return binary.LittleEndian.Uint64(p)
+	//return uint64InExpectedOrder(unalignedLoad64(p))
+}
+
+func fetch32(p []byte) uint32 {
+	return binary.LittleEndian.Uint32(p)
+	//return uint32InExpectedOrder(unalignedLoad32(p))
+}
+
+func rotate64(val uint64, shift uint32) uint64 {
+	if shift != 0 {
+		return ((val >> shift) | (val << (64 - shift)))
+	}
+
+	return val
+}
+
+func swap64(a, b *uint64) {
+	*a, *b = *b, *a
+}
+
+func rotate64ByAtLeast1(val uint64, shift uint32) uint64 {
+	return (val >> shift) | (val << (64 - shift))
+}
+
+func shiftMix(val uint64) uint64 {
+	return val ^ (val >> 47)
+}
+
+type Uint128 [2]uint64
+
+func (t *Uint128) setLower64(l uint64) {
+	t[0] = l
+}
+
+func (t *Uint128) setHigher64(h uint64) {
+	t[1] = h
+}
+
+func (t Uint128) Lower64() uint64 {
+	return t[0]
+}
+
+func (t Uint128) Higher64() uint64 {
+	return t[1]
+}
+
+func (t Uint128) Bytes() []byte {
+	b := make([]byte, 16)
+	binary.LittleEndian.PutUint64(b, t[0])
+	binary.LittleEndian.PutUint64(b[8:], t[1])
+	return b
+}
+
+func Hash128to64(x Uint128) uint64 {
+	// Murmur-inspired hashing.
+	var a = (x.Lower64() ^ x.Higher64()) * kMul
+	a ^= (a >> 47)
+	var b = (x.Higher64() ^ a) * kMul
+	b ^= (b >> 47)
+	b *= kMul
+	return b
+}
+
+func hashLen16(u, v uint64) uint64 {
+	return Hash128to64(Uint128{u, v})
+}
+
+func hashLen0to16(s []byte, length uint32) uint64 {
+	if length > 8 {
+		var a = fetch64(s)
+		var b = fetch64(s[length-8:])
+
+		return hashLen16(a, rotate64ByAtLeast1(b+uint64(length), length)) ^ b
+	}
+
+	if length >= 4 {
+		var a = fetch32(s)
+		return hashLen16(uint64(length)+(uint64(a)<<3), uint64(fetch32(s[length-4:])))
+	}
+
+	if length > 0 {
+		var a uint8 = uint8(s[0])
+		var b uint8 = uint8(s[length>>1])
+		var c uint8 = uint8(s[length-1])
+
+		var y uint32 = uint32(a) + (uint32(b) << 8)
+		var z uint32 = length + (uint32(c) << 2)
+
+		return shiftMix(uint64(y)*k2^uint64(z)*k3) * k2
+	}
+
+	return k2
+}
+
+// This probably works well for 16-byte strings as well, but it may be overkill
+func hashLen17to32(s []byte, length uint32) uint64 {
+	var a = fetch64(s) * k1
+	var b = fetch64(s[8:])
+	var c = fetch64(s[length-8:]) * k2
+	var d = fetch64(s[length-16:]) * k0
+
+	return hashLen16(rotate64(a-b, 43)+rotate64(c, 30)+d,
+		a+rotate64(b^k3, 20)-c+uint64(length))
+}
+
+func weakHashLen32WithSeeds(w, x, y, z, a, b uint64) Uint128 {
+	a += w
+	b = rotate64(b+a+z, 21)
+	var c uint64 = a
+	a += x
+	a += y
+	b += rotate64(a, 44)
+	return Uint128{a + z, b + c}
+}
+
+func weakHashLen32WithSeeds_3(s []byte, a, b uint64) Uint128 {
+	return weakHashLen32WithSeeds(fetch64(s), fetch64(s[8:]), fetch64(s[16:]), fetch64(s[24:]), a, b)
+}
+
+func hashLen33to64(s []byte, length uint32) uint64 {
+	var z uint64 = fetch64(s[24:])
+	var a uint64 = fetch64(s) + (uint64(length)+fetch64(s[length-16:]))*k0
+	var b uint64 = rotate64(a+z, 52)
+	var c uint64 = rotate64(a, 37)
+
+	a += fetch64(s[8:])
+	c += rotate64(a, 7)
+	a += fetch64(s[16:])
+
+	var vf uint64 = a + z
+	var vs = b + rotate64(a, 31) + c
+
+	a = fetch64(s[16:]) + fetch64(s[length-32:])
+	z = fetch64(s[length-8:])
+	b = rotate64(a+z, 52)
+	c = rotate64(a, 37)
+	a += fetch64(s[length-24:])
+	c += rotate64(a, 7)
+	a += fetch64(s[length-16:])
+
+	wf := a + z
+	ws := b + rotate64(a, 31) + c
+	r := shiftMix((vf+ws)*k2 + (wf+vs)*k0)
+	return shiftMix(r*k0+vs) * k2
+}
+
+func CityHash64(s []byte, length uint32) uint64 {
+	if length <= 32 {
+		if length <= 16 {
+			return hashLen0to16(s, length)
+		} else {
+			return hashLen17to32(s, length)
+		}
+	} else if length <= 64 {
+		return hashLen33to64(s, length)
+	}
+
+	var x uint64 = fetch64(s)
+	var y uint64 = fetch64(s[length-16:]) ^ k1
+	var z uint64 = fetch64(s[length-56:]) ^ k0
+
+	var v Uint128 = weakHashLen32WithSeeds_3(s[length-64:], uint64(length), y)
+	var w Uint128 = weakHashLen32WithSeeds_3(s[length-32:], uint64(length)*k1, k0)
+
+	z += shiftMix(v.Higher64()) * k1
+	x = rotate64(z+x, 39) * k1
+	y = rotate64(y, 33) * k1
+
+	length = (length - 1) & ^uint32(63)
+	for {
+		x = rotate64(x+y+v.Lower64()+fetch64(s[16:]), 37) * k1
+		y = rotate64(y+v.Higher64()+fetch64(s[48:]), 42) * k1
+
+		x ^= w.Higher64()
+		y ^= v.Lower64()
+
+		z = rotate64(z^w.Lower64(), 33)
+		v = weakHashLen32WithSeeds_3(s, v.Higher64()*k1, x+w.Lower64())
+		w = weakHashLen32WithSeeds_3(s[32:], z+w.Higher64(), y)
+
+		swap64(&z, &x)
+		s = s[64:]
+		length -= 64
+
+		if length == 0 {
+			break
+		}
+	}
+
+	return hashLen16(hashLen16(v.Lower64(), w.Lower64())+shiftMix(y)*k1+z, hashLen16(v.Higher64(), w.Higher64())+x)
+}
+
+func CityHash64WithSeed(s []byte, length uint32, seed uint64) uint64 {
+	return CityHash64WithSeeds(s, length, k2, seed)
+}
+
+func CityHash64WithSeeds(s []byte, length uint32, seed0, seed1 uint64) uint64 {
+	return hashLen16(CityHash64(s, length)-seed0, seed1)
+}
+
+func cityMurmur(s []byte, length uint32, seed Uint128) Uint128 {
+	var a uint64 = seed.Lower64()
+	var b uint64 = seed.Higher64()
+	var c uint64 = 0
+	var d uint64 = 0
+	var l int32 = int32(length) - 16
+
+	if l <= 0 { // len <= 16
+		a = shiftMix(a*k1) * k1
+		c = b*k1 + hashLen0to16(s, length)
+
+		if length >= 8 {
+			d = shiftMix(a + fetch64(s))
+		} else {
+			d = shiftMix(a + c)
+		}
+
+	} else { // len > 16
+		c = hashLen16(fetch64(s[length-8:])+k1, a)
+		d = hashLen16(b+uint64(length), c+fetch64(s[length-16:]))
+		a += d
+
+		for {
+			a ^= shiftMix(fetch64(s)*k1) * k1
+			a *= k1
+			b ^= a
+			c ^= shiftMix(fetch64(s[8:])*k1) * k1
+			c *= k1
+			d ^= c
+			s = s[16:]
+			l -= 16
+
+			if l <= 0 {
+				break
+			}
+		}
+	}
+	a = hashLen16(a, c)
+	b = hashLen16(d, b)
+	return Uint128{a ^ b, hashLen16(b, a)}
+}
+
+func CityHash128WithSeed(s []byte, length uint32, seed Uint128) Uint128 {
+	if length < 128 {
+		return cityMurmur(s, length, seed)
+	}
+
+	// We expect length >= 128 to be the common case.  Keep 56 bytes of state:
+	// v, w, x, y, and z.
+	var v, w Uint128
+	var x uint64 = seed.Lower64()
+	var y uint64 = seed.Higher64()
+	var z uint64 = uint64(length) * k1
+
+	var pos uint32
+	var t = s
+
+	v.setLower64(rotate64(y^k1, 49)*k1 + fetch64(s))
+	v.setHigher64(rotate64(v.Lower64(), 42)*k1 + fetch64(s[8:]))
+	w.setLower64(rotate64(y+z, 35)*k1 + x)
+	w.setHigher64(rotate64(x+fetch64(s[88:]), 53) * k1)
+
+	// This is the same inner loop as CityHash64(), manually unrolled.
+	for {
+		x = rotate64(x+y+v.Lower64()+fetch64(s[16:]), 37) * k1
+		y = rotate64(y+v.Higher64()+fetch64(s[48:]), 42) * k1
+
+		x ^= w.Higher64()
+		y ^= v.Lower64()
+		z = rotate64(z^w.Lower64(), 33)
+		v = weakHashLen32WithSeeds_3(s, v.Higher64()*k1, x+w.Lower64())
+		w = weakHashLen32WithSeeds_3(s[32:], z+w.Higher64(), y)
+		swap64(&z, &x)
+		s = s[64:]
+		pos += 64
+
+		x = rotate64(x+y+v.Lower64()+fetch64(s[16:]), 37) * k1
+		y = rotate64(y+v.Higher64()+fetch64(s[48:]), 42) * k1
+		x ^= w.Higher64()
+		y ^= v.Lower64()
+		z = rotate64(z^w.Lower64(), 33)
+		v = weakHashLen32WithSeeds_3(s, v.Higher64()*k1, x+w.Lower64())
+		w = weakHashLen32WithSeeds_3(s[32:], z+w.Higher64(), y)
+		swap64(&z, &x)
+		s = s[64:]
+		pos += 64
+		length -= 128
+
+		if length < 128 {
+			break
+		}
+	}
+
+	y += rotate64(w.Lower64(), 37)*k0 + z
+	x += rotate64(v.Lower64()+z, 49) * k0
+
+	// If 0 < length < 128, hash up to 4 chunks of 32 bytes each from the end of s.
+	var tailDone uint32
+	for tailDone = 0; tailDone < length; {
+		tailDone += 32
+		y = rotate64(y-x, 42)*k0 + v.Higher64()
+
+		//TODO why not use origin_len ?
+		w.setLower64(w.Lower64() + fetch64(t[pos+length-tailDone+16:]))
+		x = rotate64(x, 49)*k0 + w.Lower64()
+		w.setLower64(w.Lower64() + v.Lower64())
+		v = weakHashLen32WithSeeds_3(t[pos+length-tailDone:], v.Lower64(), v.Higher64())
+	}
+	// At this point our 48 bytes of state should contain more than
+	// enough information for a strong 128-bit hash.  We use two
+	// different 48-byte-to-8-byte hashes to get a 16-byte final result.
+	x = hashLen16(x, v.Lower64())
+	y = hashLen16(y, w.Lower64())
+
+	return Uint128{hashLen16(x+v.Higher64(), w.Higher64()) + y,
+		hashLen16(x+w.Higher64(), y+v.Higher64())}
+}
+
+func CityHash128(s []byte, length uint32) (result Uint128) {
+	if length >= 16 {
+		result = CityHash128WithSeed(s[16:length], length-16, Uint128{fetch64(s) ^ k3, fetch64(s[8:])})
+	} else if length >= 8 {
+		result = CityHash128WithSeed(nil, 0, Uint128{fetch64(s) ^ (uint64(length) * k0), fetch64(s[length-8:]) ^ k1})
+	} else {
+		result = CityHash128WithSeed(s, length, Uint128{k0, k1})
+	}
+	return
+}

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -1,0 +1,68 @@
+// Package hash provides functions that convert string values to hashes.
+//
+// ## Metadata
+// introduced: NEXT
+// contributors: **GitHub**: [@lmangani](https://github.com/lmangani)
+//
+package hash
+
+
+// sha256 converts a string value to a hexadecimal hash using the SHA 256 hash algorithm.
+//
+// ## Parameters
+//
+// - v: String to hash.
+//
+// ## Examples
+// ### Convert a string to a SHA 256 hash
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.sha256(v: "Hello, world!")
+//
+// // Returns 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin sha256 : (v: A) => string
+
+// xxhash64 converts a string value to a 64-bit hexadecimal hash using the xxHash algorithm.
+//
+// ## Parameters
+//
+// - v: String to hash.
+//
+// ## Examples
+// ### Convert a string to 64-bit hash using xxHash
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.xxhash64(v: "Hello, world!")
+//
+// // Returns 17691043854468224118
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin xxhash64 : (v: A) => string
+
+// cityhash64 converts a string value to a 64-bit hexadecimal hash using the CityHash64 algorithm.
+//
+// ## Parameters
+//
+// - v: String to hash.
+//
+// ## Examples
+// ### Convert a string to a 64-bit hash using CityHash64
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.cityhash64(v: "Hello, world!")
+//
+// // Returns 2359500134450972198
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin cityhash64 : (v: A) => string

--- a/stdlib/contrib/qxip/hash/hash.go
+++ b/stdlib/contrib/qxip/hash/hash.go
@@ -1,0 +1,94 @@
+package hash
+
+import (
+	"context"
+	_sha256 "crypto/sha256"
+	"encoding/hex"
+	"github.com/cespare/xxhash/v2"
+	"strconv"
+
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/semantic"
+	"github.com/influxdata/flux/values"
+)
+
+const (
+	conversionArg = "v"
+	pkgName       = "contrib/qxip/hash"
+)
+
+// function is a function definition
+type function func(args interpreter.Arguments) (values.Value, error)
+
+// makeFunction constructs a values.Function from a function definition.
+func makeFunction(name string, fn function) values.Function {
+	mt := runtime.MustLookupBuiltinType(pkgName, name)
+	return values.NewFunction(name, mt, func(ctx context.Context, args values.Object) (values.Value, error) {
+		return interpreter.DoFunctionCall(fn, args)
+	}, false)
+}
+
+func init() {
+	runtime.RegisterPackageValue(pkgName, "sha256", makeFunction("sha256", sha256))
+	runtime.RegisterPackageValue(pkgName, "xxhash64", makeFunction("xxhash64", xxhash64))
+	runtime.RegisterPackageValue(pkgName, "cityhash64", makeFunction("cityhash64", cityhash64))
+}
+
+var errMissingArg = errors.Newf(codes.Invalid, "missing argument %q", conversionArg)
+
+func sha256(args interpreter.Arguments) (values.Value, error) {
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, errMissingArg
+	} else if v.IsNull() {
+		return values.Null, nil
+	}
+	switch v.Type().Nature() {
+	case semantic.String:
+		s := v.Str()
+		hash := _sha256.Sum256([]byte(s))
+		str := hex.EncodeToString(hash[:])
+		return values.NewString(str), nil
+	default:
+		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to sha256", v.Type())
+	}
+}
+
+func xxhash64(args interpreter.Arguments) (values.Value, error) {
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, errMissingArg
+	} else if v.IsNull() {
+		return values.Null, nil
+	}
+	switch v.Type().Nature() {
+	case semantic.String:
+		s := v.Str()
+		hash := xxhash.Sum64([]byte(s))
+		str := strconv.FormatUint(hash, 10)
+		return values.NewString(str), nil
+	default:
+		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to sha256", v.Type())
+	}
+}
+
+func cityhash64(args interpreter.Arguments) (values.Value, error) {
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, errMissingArg
+	} else if v.IsNull() {
+		return values.Null, nil
+	}
+	switch v.Type().Nature() {
+	case semantic.String:
+		s := v.Str()
+		hash := CityHash64([]byte(s), uint32(len(s)))
+		str := strconv.FormatUint(hash, 10)
+		return values.NewString(str), nil
+	default:
+		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to sha256", v.Type())
+	}
+}

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -1,0 +1,138 @@
+package hash
+
+import (
+	//	"errors"
+	"testing"
+
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/values"
+)
+
+func Test_Sha256(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "sha256(v:string)",
+			v:    "Hello, world!",
+			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := sha256(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}
+
+func Test_Xxhash64(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "xxhash64(v:string)",
+			v:    "Hello, world!",
+			want: "17691043854468224118",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := xxhash64(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}
+
+func Test_Cityhash64(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "cityhash64(v:string)",
+			v:    "Hello, world!",
+			want: "2359500134450972198",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := cityhash64(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}

--- a/stdlib/packages.go
+++ b/stdlib/packages.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/influxdata/flux/stdlib/contrib/chobbs/discord"
 	_ "github.com/influxdata/flux/stdlib/contrib/jsternberg/influxdb"
 	_ "github.com/influxdata/flux/stdlib/contrib/qxip/clickhouse"
+	_ "github.com/influxdata/flux/stdlib/contrib/qxip/hash"
 	_ "github.com/influxdata/flux/stdlib/contrib/qxip/logql"
 	_ "github.com/influxdata/flux/stdlib/contrib/rhajek/bigpanda"
 	_ "github.com/influxdata/flux/stdlib/contrib/sranka/opsgenie"


### PR DESCRIPTION
This PR adds `contrib/qxip/hash` package exposing basic go hashing functions to flux scripts.
Included readme explains the functionality.

This proposal might require adaptions and is very much intended for discussion and extension as core maintainers see fit.

Done checklist:

- [x] Documentation
- [x] Basic Tests