### PR TITLE
chore: disable MSSQL and Snowflake support when building with `fipsonly` build tag

### DIFF
--- a/stdlib/sql/enabled.go
+++ b/stdlib/sql/enabled.go
@@ -1,0 +1,19 @@
+//go:build !fipsonly
+
+package sql
+
+// isDriverEnabled indicates if a given database driver is enabled.
+// It is only intended to be used in test suites.
+//
+// This is a stopgap until all data base drivers can be supported
+// in a FIPS compliant manner. Once that happens, it can be removed
+// if desired.
+func isDriverEnabled(driver string) bool {
+	// All drivers are enabled in non-FIPS builds.
+	return true
+}
+
+// disabledDriverError returns the error a driver gives when it is disabled.
+func disabledDriverError(driver string) error {
+	return nil
+}

--- a/stdlib/sql/enabled_fipsonly.go
+++ b/stdlib/sql/enabled_fipsonly.go
@@ -1,0 +1,30 @@
+//go:build fipsonly
+
+package sql
+
+// isDriverEnabled indicates if a given database driver is enabled.
+// It is only intended to be used in test suites.
+//
+// This is a stopgap until all data base drivers can be supported
+// in a FIPS compliant manner. Once that happens, it can be removed
+// if desired.
+func isDriverEnabled(driver string) bool {
+	switch driver {
+	case "mssql", "sqlserver", "snowflake":
+		return false
+	default:
+		return true
+	}
+}
+
+// disabledDriverError returns the error a driver gives when it is disabled.
+func disabledDriverError(driver string) error {
+	switch driver {
+	case "mssql", "sqlserver":
+		return errMssqlDisabled
+	case "snowflake":
+		return errSnowflakeDisabled
+	default:
+		return nil
+	}
+}

--- a/stdlib/sql/errors.go
+++ b/stdlib/sql/errors.go
@@ -1,0 +1,9 @@
+package sql
+
+import (
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// ErrorDriverDisabled indicates a given database driver is disabled.
+var ErrorDriverDisabled = errors.New(codes.Unimplemented, "database driver disabled")

--- a/stdlib/sql/from_private_test.go
+++ b/stdlib/sql/from_private_test.go
@@ -169,6 +169,14 @@ func TestFromSqlUrlValidation(t *testing.T) {
 			ErrMsg: "invalid data source dsn: may not set allowAllFiles",
 		},
 	}
+	// Scan over test cases and adjust any that the driver is disabled for
+	for i, _ := range testCases {
+		if spec, ok := testCases[i].Spec.(*FromSQLProcedureSpec); ok {
+			if err := disabledDriverError(spec.DriverName); err != nil {
+				testCases[i].ErrMsg = err.Error()
+			}
+		}
+	}
 	testCases.Run(t, createFromSQLSource)
 }
 

--- a/stdlib/sql/mssql.go
+++ b/stdlib/sql/mssql.go
@@ -1,3 +1,5 @@
+//go:build !fipsonly
+
 package sql
 
 import (

--- a/stdlib/sql/mssql_azure.go
+++ b/stdlib/sql/mssql_azure.go
@@ -1,3 +1,5 @@
+//go:build !fipsonly
+
 package sql
 
 import (

--- a/stdlib/sql/mssql_azure_fipsonly.go
+++ b/stdlib/sql/mssql_azure_fipsonly.go
@@ -1,0 +1,9 @@
+//go:build fipsonly
+
+package sql
+
+import "database/sql"
+
+func mssqlOpenFunction(driverName, dataSourceName string) openFunc {
+	return func() (*sql.DB, error) { return nil, errMssqlDisabled }
+}

--- a/stdlib/sql/mssql_fipsonly.go
+++ b/stdlib/sql/mssql_fipsonly.go
@@ -1,0 +1,73 @@
+//go:build fipsonly
+
+package sql
+
+// This file contains code to effectively disable mssql support in flux.
+// This is simply a stopgap until flux can be modified to avoid making
+// connections that will use NTLM. Once that happens, most of the code in
+// this file will go away and be replaced by a function to check if
+// NTLM is required.
+
+import (
+	"database/sql"
+	neturl "net/url"
+	"strings"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+// mssqlConfig is copied from mssql.go. This copy will go away when the NTLM check is added.
+type mssqlConfig struct {
+	Scheme   string
+	Host     string
+	User     string
+	Password string
+	Database string
+	// Azure auth
+	//AzureAuth string
+	//*AzureConfig
+}
+
+// errMssqlDisabled indicates MSSQL support has been disabled because of FIPS.
+var errMssqlDisabled = errors.Wrap(ErrorDriverDisabled, codes.Unimplemented, "mssql driver disabled for FIPS")
+
+// mssqlParseDSN will go away once NTLM check is added.
+func mssqlParseDSN(dsn string) (cfg *mssqlConfig, err error) {
+	return nil, errMssqlDisabled
+}
+
+// NewMssqlRowReader will go away once NTLM check is added.
+func NewMssqlRowReader(r *sql.Rows) (execute.RowReader, error) {
+	return nil, errMssqlDisabled
+}
+
+// MssqlColumnTranslateFunc will go away once NTLM check is added.
+func MssqlColumnTranslateFunc() translationFunc {
+	return func(f flux.ColType, colname string) (string, error) {
+		return "", errMssqlDisabled
+	}
+}
+
+// isMssqlDriver is copied from mssql.go. This copy will go away once NTLM check is added.
+func isMssqlDriver(driverName string) bool {
+	return driverName == "mssql" || driverName == "sqlserver"
+}
+
+// These constants are copied from mssql.go and will go away when NTLM check is added.
+const (
+	// SQL Server cannot insert into table with IDENTITY set unless explicitly enabled.
+	// https://docs.microsoft.com/en-us/sql/t-sql/statements/set-identity-insert-transact-sql
+	mssqlIdentityInsertEnabled = "identity insert=on"
+)
+
+// mssqlCheckParameter is copied from mssql.go. This copy will go away once NTLM check is added.
+func mssqlCheckParameter(dsn string, option string) bool {
+	raw, err := neturl.QueryUnescape(dsn)
+	if err != nil {
+		raw = dsn
+	}
+	return strings.Contains(strings.ToLower(raw), option)
+}

--- a/stdlib/sql/snowflake.go
+++ b/stdlib/sql/snowflake.go
@@ -1,3 +1,5 @@
+//go:build !fipsonly
+
 package sql
 
 import (
@@ -33,11 +35,17 @@ type SnowflakeRowReader struct {
 	CloseFunc   func() error
 }
 
+type snowflakeConfig snowflake.Config
+
 const (
 	layoutDate         = "2006-01-02"
 	layoutTime         = "15:04:05"
 	layoutTimeStampNtz = "2006-01-02T15:04:05.0000000000"
 )
+
+func snowflakeParseDSN(dsn string) (cfg *snowflakeConfig, err error) {
+	return snowflake.ParseDSN(dsn)
+}
 
 // Next prepares SnowflakeRowReader to return rows
 func (m *SnowflakeRowReader) Next() bool {

--- a/stdlib/sql/snowflake.go
+++ b/stdlib/sql/snowflake.go
@@ -12,7 +12,7 @@ import (
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/values"
-	_ "github.com/influxdata/gosnowflake"
+	"github.com/influxdata/gosnowflake"
 )
 
 // Snowflake DB support.
@@ -35,7 +35,7 @@ type SnowflakeRowReader struct {
 	CloseFunc   func() error
 }
 
-type snowflakeConfig snowflake.Config
+type snowflakeConfig gosnowflake.Config
 
 const (
 	layoutDate         = "2006-01-02"
@@ -44,7 +44,8 @@ const (
 )
 
 func snowflakeParseDSN(dsn string) (cfg *snowflakeConfig, err error) {
-	return snowflake.ParseDSN(dsn)
+	gsConfig, err := gosnowflake.ParseDSN(dsn)
+	return (*snowflakeConfig)(gsConfig), err
 }
 
 // Next prepares SnowflakeRowReader to return rows

--- a/stdlib/sql/snowflake_fipsonly.go
+++ b/stdlib/sql/snowflake_fipsonly.go
@@ -1,0 +1,44 @@
+//go:build fipsonly
+
+package sql
+
+import (
+	"database/sql"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/internal/errors"
+)
+
+type snowflakeConfig struct {
+	User     string
+	Password string
+	Protocol string
+	Host     string
+}
+
+// How did these end up in the snowflake implementation?
+const (
+	layoutDate         = "2006-01-02"
+	layoutTime         = "15:04:05"
+	layoutTimeStampNtz = "2006-01-02T15:04:05.0000000000"
+)
+
+// errSnowflakeDisabled indicates Snowflake support has been disabled because of FIPS.
+var errSnowflakeDisabled = errors.Wrap(ErrorDriverDisabled, codes.Unimplemented, "snowflake support disabled for FIPS")
+
+func snowflakeParseDSN(dsn string) (cfg *snowflakeConfig, err error) {
+	return nil, errSnowflakeDisabled
+}
+
+func NewSnowflakeRowReader(r *sql.Rows) (execute.RowReader, error) {
+	return nil, errSnowflakeDisabled
+}
+
+// SnowflakeColumnTranslateFunc will go away once gosnowflake's OCSP implementation is updated.
+func SnowflakeColumnTranslateFunc() translationFunc {
+	return func(f flux.ColType, colname string) (string, error) {
+		return "", errMssqlDisabled
+	}
+}

--- a/stdlib/sql/source_validator.go
+++ b/stdlib/sql/source_validator.go
@@ -9,7 +9,6 @@ import (
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/dependencies/url"
 	"github.com/influxdata/flux/internal/errors"
-	"github.com/influxdata/gosnowflake"
 )
 
 // helper function to validate the data source url (postgres, sqlmock) / dsn (mysql, snowflake) using the URLValidator.
@@ -74,7 +73,7 @@ func validateDataSource(validator url.Validator, driverName string, dataSourceNa
 		}
 	case "snowflake":
 		// an example is: username:password@accountname/dbname/testschema?warehouse=mywh
-		cfg, err := gosnowflake.ParseDSN(dataSourceName)
+		cfg, err := snowflakeParseDSN(dataSourceName)
 		if err != nil {
 			return errors.Newf(codes.Invalid, "invalid data source dsn: %v", err)
 		}

--- a/stdlib/sql/sql_test.go
+++ b/stdlib/sql/sql_test.go
@@ -323,6 +323,10 @@ func TestSQLiteParsing(t *testing.T) {
 }
 
 func TestSnowflakeParsing(t *testing.T) {
+	if !isDriverEnabled("snowflake") {
+		t.Skip("snowflake driver is disabled")
+	}
+
 	// here we want to build a mocked representation of what's in our Snowflake db, and then run our RowReader over it, then verify that the results
 	// are as expected.
 	testCases := []struct {
@@ -389,6 +393,9 @@ func TestSnowflakeParsing(t *testing.T) {
 }
 
 func TestMssqlParsing(t *testing.T) {
+	if !isDriverEnabled("mssql") {
+		t.Skip("mssql is disabled")
+	}
 	// here we want to build a mocked representation of what's in our SQLServer db, and then run our RowReader over it, then verify that the results
 	// are as expected.
 	testCases := []struct {

--- a/stdlib/sql/to_privates_test.go
+++ b/stdlib/sql/to_privates_test.go
@@ -160,6 +160,9 @@ func TestMysqlTranslation(t *testing.T) {
 }
 
 func TestSnowflakeTranslation(t *testing.T) {
+	if !isDriverEnabled("snowflake") {
+		t.Skip("snowflake is disabled, skipping test")
+	}
 	snowflakeTypeTranslations := map[string]flux.ColType{
 		"FLOAT":         flux.TFloat,
 		"NUMBER":        flux.TInt,
@@ -188,6 +191,9 @@ func TestSnowflakeTranslation(t *testing.T) {
 }
 
 func TestMssqlTranslation(t *testing.T) {
+	if !isDriverEnabled("sqlserver") {
+		t.Skip("mssql is disabled")
+	}
 	mssqlTypeTranslations := map[string]flux.ColType{
 		"FLOAT":          flux.TFloat,
 		"BIGINT":         flux.TInt,


### PR DESCRIPTION
The InfluxDB Enterprise FIPS build will pull in non-FIPS approved cryptographic algorithms and implementations if flux MSSQL and Snowflake support are built. As a work-around for this, the MSSQL and Snowflake support are disabled when the `fipsonly` build tag is used. Attempting to use either of these databases will result in errors indicating that the database support is diabled.

In the future, upgrades or modifications to the underlying MSSQL and Snowflake libraries may allow these database drivers to be re-enabled in the FIPS builds.

closes: #5362

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
