### PR TITLE
chore(docs): move date.month table to correct function docs

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -107,7 +107,7 @@ var sourceHashes = map[string]string{
 	"stdlib/csv/csv.flux":                                                                         "94a1d8dd59c0e092617e9c974bad4edaf1a2c6ebb20fd185524b58cb657329b0",
 	"stdlib/csv/csv_test.flux":                                                                    "3840dd74e86252b6f91faa6ae758b064efb1b5ae9af4cd270607a5b18efcbe4c",
 	"stdlib/date/boundaries/boundaries.flux":                                                      "06360d7fedab9f7725c106ee20edbd932633f6ef97393537e951979d4dc12083",
-	"stdlib/date/date.flux":                                                                       "a9c57854ba09d5ad33df66f0fd59a89343a872e800d1f987bffde4ebfda5265a",
+	"stdlib/date/date.flux":                                                                       "77f5e4f1f0292b72ba857068cb6466086d87002993140cbf5d2a341b15f4e381",
 	"stdlib/date/date_test.flux":                                                                  "9138acd0c0072fe50b0ede6a958bbf96eea12648fb4e20cbc268869e411b6b28",
 	"stdlib/date/durations_test.flux":                                                             "06cc04f4979f1eb50a5f909f70c77fc3ff7409a902cfd46117954be293b56098",
 	"stdlib/date/hour_duration_test.flux":                                                         "d79f5a139fd4e07f40073534b44c9211b10cd9f36e9b93626a4f23fae5392826",

--- a/stdlib/date/date.flux
+++ b/stdlib/date/date.flux
@@ -252,21 +252,6 @@ builtin _monthDay : (t: T, location: {zone: string, offset: duration}) => int wh
 // monthDay returns the day of the month for a specified time.
 // Results range from `[1 - 31]`.
 //
-// | Returned value | Month     |
-// | :------------: | :-------- |
-// |       1        | January   |
-// |       2        | February  |
-// |       3        | March     |
-// |       4        | April     |
-// |       5        | May       |
-// |       6        | June      |
-// |       7        | July      |
-// |       8        | August    |
-// |       9        | September |
-// |       10       | October   |
-// |       11       | November  |
-// |       12       | December  |
-//
 // ## Parameters
 // - t: Time to operate on.
 //
@@ -363,6 +348,21 @@ yearDay = (t, location=location) => _yearDay(t, location)
 builtin _month : (t: T, location: {zone: string, offset: duration}) => int where T: Timeable
 
 // month returns the month of a specified time. Results range from `[1 - 12]`.
+//
+// | Returned value | Month     |
+// | :------------: | :-------- |
+// |       1        | January   |
+// |       2        | February  |
+// |       3        | March     |
+// |       4        | April     |
+// |       5        | May       |
+// |       6        | June      |
+// |       7        | July      |
+// |       8        | August    |
+// |       9        | September |
+// |       10       | October   |
+// |       11       | November  |
+// |       12       | December  |
 //
 // ## Parameters
 // - t: Time to operate on.


### PR DESCRIPTION
The `date.monthDay` documentation contained a table that should be in the `date.month` documentation. This PR fixes that.

Resolves #5364

---

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
