### PR TITLE
Support non-uniformly spaced data in regression

### DIFF
--- a/stdlib/contrib/anaisdg/statsmodels/linearreg.flux
+++ b/stdlib/contrib/anaisdg/statsmodels/linearreg.flux
@@ -52,7 +52,7 @@ linearRegression = (tables=<-) => {
     renameAndSum =
         tables
             |> rename(columns: {_value: "y"})
-            // calculate x as difference from first value (in seconds)
+            // calculate x as difference from first value (in nanoseconds)
             |> map(fn: (r) => ({ r with x : float(v: uint(v: r._time)  - uint(v: firstRecord._time)) }))
     t =
         renameAndSum


### PR DESCRIPTION
Prior to this change, the statsmodels linear regression calculation assumed that the input table data was uniformly spaced (the "x" column was just a uniformly increasing integer). This resulted in incorrect "slope" calculations on data that was nonuniformly-spaced. This change modifies the function's behavior to map the input `_time` columns to a time difference in nanoseconds, and use that value for the calculation of the regression, meaning its output now matches other tools such as Excel's or Libreoffice Calc's "trend lines" analysis.

I'm a very basic user of Influx and am totally unfamiliar with its development, so I'm not sure how or where to put test cases and will need some direction on that.

@Anaisdg will probably want to take a look

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 ~~Reference related issues~~ (did not create one)
- [ ] 🏃 Test cases are included to exercise the new code (I'm not really sure how to do this)

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
