### PR TITLE
feat(contrib/qxip): add contrib/qxip/env package

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,6 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
+	"stdlib/contrib/qxip/env/env.flux":                                                            "d72b887c147d1a27239098c67a35a43730958fcc04aca118f343628f4c44adc9",
 	"stdlib/contrib/qxip/hash/hash.flux":                                                          "abf7de64cbecd3f1019058be5240ba7289355df80b1771ca253f2dca857b9b1f",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,7 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
-	"stdlib/contrib/qxip/env/env.flux":                                                            "29a0f8f9763a3fb820204f9f92fd7618ddfc1023fa8c2652698004c32a45bc1a",
+	"stdlib/contrib/qxip/env/env.flux":                                                            "0160ecc4fd471b76b7fd0b679381fe3c3e0421deeb5ef12deee7dbe13340ebab",
 	"stdlib/contrib/qxip/hash/hash.flux":                                                          "abf7de64cbecd3f1019058be5240ba7289355df80b1771ca253f2dca857b9b1f",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,7 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
-	"stdlib/contrib/qxip/env/env.flux":                                                            "d72b887c147d1a27239098c67a35a43730958fcc04aca118f343628f4c44adc9",
+	"stdlib/contrib/qxip/env/env.flux":                                                            "29a0f8f9763a3fb820204f9f92fd7618ddfc1023fa8c2652698004c32a45bc1a",
 	"stdlib/contrib/qxip/hash/hash.flux":                                                          "abf7de64cbecd3f1019058be5240ba7289355df80b1771ca253f2dca857b9b1f",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",

--- a/stdlib/contrib/qxip/env/README.md
+++ b/stdlib/contrib/qxip/env/README.md
@@ -1,0 +1,37 @@
+# Env Package
+
+The env package provides methods to access system ENV variables.
+
+To prevent leaking undesired keys, the package requires using the `FLUX_` prefix.
+
+## env.get
+Retrive a key from system ENV variables.
+
+Example:
+
+```no_run
+import "contrib/qxip/env"
+env.get(key: "FLUX_KEY_NAME")
+```
+
+### Populate sensitive credentials with ENV variables
+```no_run
+import "sql"
+import "contrib/qxip/env"
+
+username = env.get(key: "FLUX_USERNAME")
+password = env.get(key: "FLUX_PASSWORD")
+
+sql.from(
+    driverName: "postgres",
+    dataSourceName: "postgresql://${username}:${password}@localhost",
+    query: "SELECT * FROM example-table",
+)
+```
+
+
+## Contact
+- Author: Lorenzo Mangani
+- Email: lorenzo.mangani@gmail.com
+- Github: [@lmangani](https://github.com/lmangani)
+- Website: [@qryn](https://qryn.dev)

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -1,0 +1,39 @@
+// Package env provides a function for reading ENV variables starting with the FLUX_ prefix.
+//
+// ## Metadata
+// introduced: NEXT
+// tags: secrets,security,env
+//
+package env
+
+
+// get retrieves a key variable from the process ENV.
+//
+// ## Parameters
+// - key: ENV key to retrieve.
+//
+// ## Examples
+//
+// ### Retrive a key from ENV variables
+// ```no_run
+// import "contrib/qxip/env"
+//
+// env.get(key: "KEY_NAME")
+// ```
+//
+// ### Populate sensitive credentials with ENV variables//
+// ```no_run
+// import "sql"
+// import "contrib/qxip/env"
+//
+// username = env.get(key: "FLUX_USERNAME")
+// password = env.get(key: "FLUX_PASSWORD")
+//
+// sql.from(
+//     driverName: "postgres",
+//     dataSourceName: "postgresql://${username}:${password}@localhost",
+//     query: "SELECT * FROM example-table",
+// )
+// ```
+//
+builtin get : (key: string) => string

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -14,7 +14,7 @@ package env
 //
 // ## Examples
 //
-// ### Retrive a key from ENV variables
+// ### Retrieve an environment variable
 // ```no_run
 // import "contrib/qxip/env"
 //

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -18,7 +18,7 @@ package env
 // ```no_run
 // import "contrib/qxip/env"
 //
-// env.get(key: "KEY_NAME")
+// env.get(key: "FLUX_KEY_NAME")
 // ```
 //
 // ### Populate sensitive credentials with ENV variables//

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -21,7 +21,7 @@ package env
 // env.get(key: "FLUX_KEY_NAME")
 // ```
 //
-// ### Populate sensitive credentials with ENV variables//
+// ### Populate sensitive credentials with ENV variables
 // ```no_run
 // import "sql"
 // import "contrib/qxip/env"

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -10,7 +10,7 @@ package env
 // get retrieves an environment variable from the process ENV.
 //
 // ## Parameters
-// - key: ENV key to retrieve.
+// - key: Environment variable key to retrieve.
 //
 // ## Examples
 //

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -1,4 +1,4 @@
-// Package env provides a function for reading ENV variables starting with the FLUX_ prefix.
+// Package env provides a function for reading environment variables starting with the `FLUX_` prefix.
 //
 // ## Metadata
 // introduced: NEXT

--- a/stdlib/contrib/qxip/env/env.flux
+++ b/stdlib/contrib/qxip/env/env.flux
@@ -7,7 +7,7 @@
 package env
 
 
-// get retrieves a key variable from the process ENV.
+// get retrieves an environment variable from the process ENV.
 //
 // ## Parameters
 // - key: ENV key to retrieve.

--- a/stdlib/contrib/qxip/env/env.go
+++ b/stdlib/contrib/qxip/env/env.go
@@ -1,0 +1,42 @@
+package env
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/influxdata/flux/interpreter"
+	"github.com/influxdata/flux/runtime"
+	"github.com/influxdata/flux/values"
+)
+
+const GetKind = "get"
+
+func init() {
+	runtime.RegisterPackageValue("contrib/qxip/env", GetKind, GetFunc)
+}
+
+// GetFunc is a function that calls Get.
+var GetFunc = makeGetFunc()
+
+func makeGetFunc() values.Function {
+	sig := runtime.MustLookupBuiltinType("contrib/qxip/env", "get")
+	return values.NewFunction("get", sig, Get, false)
+}
+
+// Get retrieves the key variable for a given ENV. The key must start with FLUX_.
+func Get(ctx context.Context, args values.Object) (values.Value, error) {
+	fargs := interpreter.NewArguments(args)
+	key, err := fargs.GetRequiredString("key")
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(key, "FLUX_") {
+		return nil, err
+	}
+	value := os.Getenv(key)
+	if len(value) < 1 {
+		return nil, err
+	}
+	return values.NewString(value), nil
+}

--- a/stdlib/packages.go
+++ b/stdlib/packages.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/influxdata/flux/stdlib/contrib/chobbs/discord"
 	_ "github.com/influxdata/flux/stdlib/contrib/jsternberg/influxdb"
 	_ "github.com/influxdata/flux/stdlib/contrib/qxip/clickhouse"
+	_ "github.com/influxdata/flux/stdlib/contrib/qxip/env"
 	_ "github.com/influxdata/flux/stdlib/contrib/qxip/hash"
 	_ "github.com/influxdata/flux/stdlib/contrib/qxip/logql"
 	_ "github.com/influxdata/flux/stdlib/contrib/rhajek/bigpanda"


### PR DESCRIPTION
This PR adds `contrib/qxip/env` package exposing a limited scope of OS `ENV` variables to flux scripts.

Included readme explains the functionality.

#### PR Note
The original ENV reading functionality available in Secretservice seems to have been intentionally [removed](https://github.com/influxdata/flux/issues/1764) due to various [security concerns](https://github.com/influxdata/flux/pull/1753#issuecomment-524838180) such as allowing scripts to read InfluxDB Cloud ENVs, etc. This package limits the allowed ENV scope _(`FLUX_` or any other prefix considered safe by the Influx Team)_ to attempt complying with the previous criteria. 

Done checklist:

- [x]  Documentation
