### PR TITLE
feat(contrib/qxip/hash): add sha1, md5, base64, hmac

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,7 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
-	"stdlib/contrib/qxip/hash/hash.flux":                                                          "abf7de64cbecd3f1019058be5240ba7289355df80b1771ca253f2dca857b9b1f",
+	"stdlib/contrib/qxip/hash/hash.flux":                                                          "85a5eda36bb6a9cc87040fb10bc22e577ed3ee91208af6070e4c1080303086a4",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",
 	"stdlib/contrib/sranka/opsgenie/opsgenie.flux":                                                "5313b78a30ffb01c606397c9bea954bdd4ca06c44663268bab1e0f706fc6d2c5",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,7 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
-	"stdlib/contrib/qxip/hash/hash.flux":                                                          "b708505c408c9706d063cf2f569ab4ef51535284c17ccdf99652f5cddb31d942",
+	"stdlib/contrib/qxip/hash/hash.flux":                                                          "25919a81b663b1f08e8f89df080c2cc5a32c40f0892ed1643d2d321e069b4fd4",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",
 	"stdlib/contrib/sranka/opsgenie/opsgenie.flux":                                                "5313b78a30ffb01c606397c9bea954bdd4ca06c44663268bab1e0f706fc6d2c5",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,7 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
-	"stdlib/contrib/qxip/hash/hash.flux":                                                          "85a5eda36bb6a9cc87040fb10bc22e577ed3ee91208af6070e4c1080303086a4",
+	"stdlib/contrib/qxip/hash/hash.flux":                                                          "b708505c408c9706d063cf2f569ab4ef51535284c17ccdf99652f5cddb31d942",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",
 	"stdlib/contrib/sranka/opsgenie/opsgenie.flux":                                                "5313b78a30ffb01c606397c9bea954bdd4ca06c44663268bab1e0f706fc6d2c5",

--- a/stdlib/contrib/qxip/hash/README.md
+++ b/stdlib/contrib/qxip/hash/README.md
@@ -11,10 +11,9 @@ Example:
     import "contrib/qxip/hash"
 
     a = hash.sha256(v: "Hello, world!")
-    // a is "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
 ```
 
-## hash.sha256
+## hash.sha1
 The `hash.sha256()` function converts a single string to a hash using sha256.
 
 Example:
@@ -34,7 +33,6 @@ Example:
     import "contrib/qxip/hash"
 
     a = hash.xxhash64(v: "Hello, world!")
-    // a is "17691043854468224118"
 ```
 
 ## hash.cityhash64
@@ -46,7 +44,6 @@ Example:
     import "contrib/qxip/hash"
 
     a = hash.cityhash64(v: "Hello, world!")
-    // a is "2359500134450972198"
 ```
 
 ## hash.md5

--- a/stdlib/contrib/qxip/hash/README.md
+++ b/stdlib/contrib/qxip/hash/README.md
@@ -10,9 +10,21 @@ Example:
 ```
     import "contrib/qxip/hash"
 
-    a = hash.sha256("Hello, world!")
+    a = hash.sha256(v: "Hello, world!")
     // a is "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
 ```
+
+## hash.sha256
+The `hash.sha256()` function converts a single string to a hash using sha256.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.sha1(v: "Hello, world!")
+```
+
 ## hash.xxhash64
 The `hash.xxhash64()` function converts a single string to a hash using xxhash64.
 
@@ -21,9 +33,10 @@ Example:
 ```
     import "contrib/qxip/hash"
 
-    a = hash.xxhash64("Hello, world!")
+    a = hash.xxhash64(v: "Hello, world!")
     // a is "17691043854468224118"
 ```
+
 ## hash.cityhash64
 The `hash.cityhash64()` function converts a single string to hash using cityhash64.
 
@@ -32,8 +45,30 @@ Example:
 ```
     import "contrib/qxip/hash"
 
-    a = hash.cityhash64("Hello, world!")
+    a = hash.cityhash64(v: "Hello, world!")
     // a is "2359500134450972198"
+```
+
+## hash.md5
+The `hash.md5()` function converts a single string to hash using MD5.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.md5(v: "Hello, world!")
+```
+
+## hash.b64
+The `hash.b64()` function converts a single string to a Base64 string.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.b64(v: "Hello, world!")
 ```
 
 ## Contact

--- a/stdlib/contrib/qxip/hash/README.md
+++ b/stdlib/contrib/qxip/hash/README.md
@@ -68,6 +68,17 @@ Example:
     a = hash.b64(v: "Hello, world!")
 ```
 
+## hash.hmac
+The `hash.hmac()` function converts a string and key pair to sha1 signed Base64 string.
+
+Example:
+
+```
+    import "contrib/qxip/hash"
+
+    a = hash.hmac(v: "helloworld", k: "123456")
+```
+
 ## Contact
 - Author: Lorenzo Mangani
 - Email: lorenzo.mangani@gmail.com

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -34,7 +34,7 @@ builtin sha256 : (v: A) => string
 // - v: String to hash.
 //
 // ## Examples
-// ### Convert a string to a SHA 256 hash
+// ### Convert a string to a SHA-1 hash
 // ```no_run
 // import "contrib/qxip/hash"
 //

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -114,7 +114,7 @@ builtin b64 : (v: A) => string
 // - v: String to hash.
 //
 // ## Examples
-// ### Convert a string to a 64-bit hash using CityHash64
+// ### Convert a string to an MD5 hash
 // ```no_run
 // import "contrib/qxip/hash"
 //

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -135,7 +135,7 @@ builtin md5 : (v: A) => string
 // - k: Key to sign hash.
 //
 // ## Examples
-// ### Converts a string, key to base64 signed hash for S3 auth.
+// ### Convert a string and key to a base64-signed hash
 // ```no_run
 // import "contrib/qxip/hash"
 //

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -27,6 +27,26 @@ package hash
 // tag: type-conversion
 builtin sha256 : (v: A) => string
 
+// sha1 converts a string value to a hexadecimal hash using the SHA 1 hash algorithm.
+//
+// ## Parameters
+//
+// - v: String to hash.
+//
+// ## Examples
+// ### Convert a string to a SHA 256 hash
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.sha1(v: "Hello, world!")
+//
+// // Returns 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin sha1 : (v: A) => string
+
 // xxhash64 converts a string value to a 64-bit hexadecimal hash using the xxHash algorithm.
 //
 // ## Parameters
@@ -66,3 +86,43 @@ builtin xxhash64 : (v: A) => string
 // ## Metadata
 // tag: type-conversion
 builtin cityhash64 : (v: A) => string
+
+// b64 converts a string value to Base64 string.
+//
+// ## Parameters
+//
+// - v: String to hash.
+//
+// ## Examples
+// ### Convert a string to a 64-bit hash using CityHash64
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.b64(v: "Hello, world!")
+//
+// // Returns 2359500134450972198
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin b64 : (v: A) => string
+
+// md5 converts a string value to an MD5 hash.
+//
+// ## Parameters
+//
+// - v: String to hash.
+//
+// ## Examples
+// ### Convert a string to a 64-bit hash using CityHash64
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.md5(v: "Hello, world!")
+//
+// // Returns 2359500134450972198
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin md5 : (v: A) => string

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -94,7 +94,7 @@ builtin cityhash64 : (v: A) => string
 // - v: String to hash.
 //
 // ## Examples
-// ### Convert a string to a 64-bit hash using CityHash64
+// ### Convert a string to a Base64 string
 // ```no_run
 // import "contrib/qxip/hash"
 //

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -87,7 +87,7 @@ builtin xxhash64 : (v: A) => string
 // tag: type-conversion
 builtin cityhash64 : (v: A) => string
 
-// b64 converts a string value to Base64 string.
+// b64 converts a string value to a Base64 string.
 //
 // ## Parameters
 //

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -126,3 +126,24 @@ builtin b64 : (v: A) => string
 // ## Metadata
 // tag: type-conversion
 builtin md5 : (v: A) => string
+
+// hmac converts a string value to an MD5 signed sha1 hash.
+//
+// ## Parameters
+//
+// - v: String to hash.
+// - k: Key to sign hash.
+//
+// ## Examples
+// ### Converts a string, key to base64 signed hash for S3 auth.
+// ```no_run
+// import "contrib/qxip/hash"
+//
+// hash.hmac(v: "helloworld", k: "123456")
+//
+// // Returns 75B5ueLnnGepYvh+KoevTzXCrjc=
+// ```
+//
+// ## Metadata
+// tag: type-conversion
+builtin hmac : (v: A, k: A) => string

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -27,7 +27,7 @@ package hash
 // tag: type-conversion
 builtin sha256 : (v: A) => string
 
-// sha1 converts a string value to a hexadecimal hash using the SHA 1 hash algorithm.
+// sha1 converts a string value to a hexadecimal hash using the SHA-1 hash algorithm.
 //
 // ## Parameters
 //

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -127,7 +127,7 @@ builtin b64 : (v: A) => string
 // tag: type-conversion
 builtin md5 : (v: A) => string
 
-// hmac converts a string value to an MD5 signed sha1 hash.
+// hmac converts a string value to an MD5-signed SHA-1 hash.
 //
 // ## Parameters
 //

--- a/stdlib/contrib/qxip/hash/hash.go
+++ b/stdlib/contrib/qxip/hash/hash.go
@@ -2,9 +2,9 @@ package hash
 
 import (
 	"context"
-	_sha256 "crypto/sha256"
-	_sha1 "crypto/sha1"
 	_md5 "crypto/md5"
+	_sha1 "crypto/sha1"
+	_sha256 "crypto/sha256"
 	_b64 "encoding/base64"
 	"encoding/hex"
 	"github.com/cespare/xxhash/v2"

--- a/stdlib/contrib/qxip/hash/hash.go
+++ b/stdlib/contrib/qxip/hash/hash.go
@@ -3,6 +3,9 @@ package hash
 import (
 	"context"
 	_sha256 "crypto/sha256"
+	_sha1 "crypto/sha1"
+	_md5 "crypto/md5"
+	_b64 "encoding/base64"
 	"encoding/hex"
 	"github.com/cespare/xxhash/v2"
 	"strconv"
@@ -33,8 +36,11 @@ func makeFunction(name string, fn function) values.Function {
 
 func init() {
 	runtime.RegisterPackageValue(pkgName, "sha256", makeFunction("sha256", sha256))
+	runtime.RegisterPackageValue(pkgName, "sha1", makeFunction("sha1", sha1))
 	runtime.RegisterPackageValue(pkgName, "xxhash64", makeFunction("xxhash64", xxhash64))
 	runtime.RegisterPackageValue(pkgName, "cityhash64", makeFunction("cityhash64", cityhash64))
+	runtime.RegisterPackageValue(pkgName, "md5", makeFunction("md5", md5))
+	runtime.RegisterPackageValue(pkgName, "b64", makeFunction("b64", b64))
 }
 
 var errMissingArg = errors.Newf(codes.Invalid, "missing argument %q", conversionArg)
@@ -54,6 +60,59 @@ func sha256(args interpreter.Arguments) (values.Value, error) {
 		return values.NewString(str), nil
 	default:
 		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to sha256", v.Type())
+	}
+}
+
+func sha1(args interpreter.Arguments) (values.Value, error) {
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, errMissingArg
+	} else if v.IsNull() {
+		return values.Null, nil
+	}
+	switch v.Type().Nature() {
+	case semantic.String:
+		s := v.Str()
+		hash := _sha1.Sum([]byte(s))
+		str := hex.EncodeToString(hash[:])
+		return values.NewString(str), nil
+	default:
+		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to sha1", v.Type())
+	}
+}
+
+func md5(args interpreter.Arguments) (values.Value, error) {
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, errMissingArg
+	} else if v.IsNull() {
+		return values.Null, nil
+	}
+	switch v.Type().Nature() {
+	case semantic.String:
+		s := v.Str()
+		hash := _md5.Sum([]byte(s))
+		str := hex.EncodeToString(hash[:])
+		return values.NewString(str), nil
+	default:
+		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to md5", v.Type())
+	}
+}
+
+func b64(args interpreter.Arguments) (values.Value, error) {
+	v, ok := args.Get(conversionArg)
+	if !ok {
+		return nil, errMissingArg
+	} else if v.IsNull() {
+		return values.Null, nil
+	}
+	switch v.Type().Nature() {
+	case semantic.String:
+		s := v.Str()
+		str := _b64.URLEncoding.EncodeToString([]byte(s))
+		return values.NewString(str), nil
+	default:
+		return nil, errors.Newf(codes.Invalid, "hash cannot convert %v to b64", v.Type())
 	}
 }
 

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -62,7 +62,7 @@ func Test_Sha1(t *testing.T) {
 		{
 			name: "sha1(v:string)",
 			v:    "Hello, world!",
-			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+			want: "943a702d06f34599aee1f8da8ef9f7296031d699",
 		},
 	}
 	for _, tc := range testCases {
@@ -191,7 +191,7 @@ func Test_Base64(t *testing.T) {
 		{
 			name: "b64(v:string)",
 			v:    "Hello, world!",
-			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+			want: "SGVsbG8sIHdvcmxkIQ",
 		},
 	}
 	for _, tc := range testCases {
@@ -234,7 +234,7 @@ func Test_MD5(t *testing.T) {
 		{
 			name: "md5(v:string)",
 			v:    "Hello, world!",
-			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+			want: "6cd3556deb0da54bca060b4c39479839",
 		},
 	}
 	for _, tc := range testCases {

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -270,6 +270,7 @@ func Test_HMac(t *testing.T) {
 	testCases := []struct {
 		name      string
 		v         interface{}
+		k         interface{}
 		want      string
 		wantNull  bool
 		expectErr error

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -71,7 +71,7 @@ func Test_Sha1(t *testing.T) {
 				"v": values.New(tc.v),
 			}
 			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
-			got, err := sha256(args)
+			got, err := sha1(args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -200,7 +200,7 @@ func Test_Base64(t *testing.T) {
 				"v": values.New(tc.v),
 			}
 			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
-			got, err := sha256(args)
+			got, err := b64(args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
@@ -243,7 +243,7 @@ func Test_MD5(t *testing.T) {
 				"v": values.New(tc.v),
 			}
 			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
-			got, err := sha256(args)
+			got, err := md5(args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -51,6 +51,49 @@ func Test_Sha256(t *testing.T) {
 	}
 }
 
+func Test_Sha1(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "sha1(v:string)",
+			v:    "Hello, world!",
+			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := sha256(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}
+
 func Test_Xxhash64(t *testing.T) {
 	testCases := []struct {
 		name      string
@@ -115,6 +158,92 @@ func Test_Cityhash64(t *testing.T) {
 			}
 			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
 			got, err := cityhash64(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}
+
+func Test_Base64(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "b64(v:string)",
+			v:    "Hello, world!",
+			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := sha256(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}
+
+func Test_MD5(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "md5(v:string)",
+			v:    "Hello, world!",
+			want: "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := sha256(args)
 			if err != nil {
 				if tc.expectErr == nil {
 					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -265,3 +265,48 @@ func Test_MD5(t *testing.T) {
 		})
 	}
 }
+
+func Test_HMac(t *testing.T) {
+	testCases := []struct {
+		name      string
+		v         interface{}
+		want      string
+		wantNull  bool
+		expectErr error
+	}{
+		{
+			name: "hmac(v:string, k: key)",
+			v:    "helloworld",
+			k:    "123456",
+			want: "75B5ueLnnGepYvh+KoevTzXCrjc=",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			myMap := map[string]values.Value{
+				"v": values.New(tc.v),
+				"k": values.New(tc.k),
+			}
+			args := interpreter.NewArguments(values.NewObjectWithValues(myMap))
+			got, err := hmac(args)
+			if err != nil {
+				if tc.expectErr == nil {
+					t.Errorf("unexpected error - want: <nil>, got: %s", err.Error())
+				} else if want, got := tc.expectErr.Error(), err.Error(); got != want {
+					t.Errorf("unexpected error - want: %s, got: %s", want, got)
+				}
+				return
+			}
+			if !tc.wantNull {
+				want := values.NewString(tc.want)
+				if !got.Equal(want) {
+					t.Errorf("Wanted: %s, got: %v", want, got)
+				}
+			} else {
+				if !got.IsNull() {
+					t.Errorf("Wanted: %v, got: %v", values.Null, got)
+				}
+			}
+		})
+	}
+}

--- a/stdlib/contrib/qxip/hash/hash_test.go
+++ b/stdlib/contrib/qxip/hash/hash_test.go
@@ -191,7 +191,7 @@ func Test_Base64(t *testing.T) {
 		{
 			name: "b64(v:string)",
 			v:    "Hello, world!",
-			want: "SGVsbG8sIHdvcmxkIQ",
+			want: "SGVsbG8sIHdvcmxkIQ==",
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR extends the `contrib/qxip/hash` package with additional functions for `sha1`, `base64`, `md5`, `hmac`

Note: The primary goal of this extension is powering flux native extensions dealing with auth token calculation etc. _(ie: s3 client we're working on)_ without having to use or import additional go code. 

- [x] Updated Documentation
- [x] Extended Test Converage


