### PR TITLE
fix(array): use-after-free in optimized String array

### DIFF
--- a/array/array_test.go
+++ b/array/array_test.go
@@ -25,7 +25,7 @@ func TestString(t *testing.T) {
 					b.Append("a")
 				}
 			},
-			sz: 0,
+			sz: 1,
 			want: []interface{}{
 				"a", "a", "a", "a", "a",
 				"a", "a", "a", "a", "a",
@@ -165,7 +165,7 @@ func TestStringBuilder_NewArray(t *testing.T) {
 		}
 
 		arr := b.NewArray()
-		mem.AssertSize(t, 0)
+		assert.Equal(t, 1, mem.CurrentAlloc(), "unexpected memory allocation.")
 		arr.Release()
 		mem.AssertSize(t, 0)
 

--- a/array/binary.gen.go
+++ b/array/binary.gen.go
@@ -189,63 +189,6 @@ func FloatAddRConst(l *Float, r float64, mem memory.Allocator) (*Float, error) {
 	return a, nil
 }
 
-func StringAdd(l, r *String, mem memory.Allocator) (*String, error) {
-	n := l.Len()
-	if n != r.Len() {
-		return nil, errors.Newf(codes.Invalid, "vectors must have equal length for binary operations")
-	}
-	b := NewStringBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
-		if l.IsValid(i) && r.IsValid(i) {
-
-			b.Append(l.Value(i) + r.Value(i))
-
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewStringArray()
-	b.Release()
-	return a, nil
-}
-
-func StringAddLConst(l string, r *String, mem memory.Allocator) (*String, error) {
-	n := r.Len()
-	b := NewStringBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
-		if r.IsValid(i) {
-
-			b.Append(l + r.Value(i))
-
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewStringArray()
-	b.Release()
-	return a, nil
-}
-
-func StringAddRConst(l *String, r string, mem memory.Allocator) (*String, error) {
-	n := l.Len()
-	b := NewStringBuilder(mem)
-	b.Resize(n)
-	for i := 0; i < n; i++ {
-		if l.IsValid(i) {
-
-			b.Append(l.Value(i) + r)
-
-		} else {
-			b.AppendNull()
-		}
-	}
-	a := b.NewStringArray()
-	b.Release()
-	return a, nil
-}
-
 func IntSub(l, r *Int, mem memory.Allocator) (*Int, error) {
 	n := l.Len()
 	if n != r.Len() {

--- a/array/binary.go
+++ b/array/binary.go
@@ -145,3 +145,70 @@ func OrConst(fixed *bool, arr *Boolean, mem memory.Allocator) (*Boolean, error) 
 	b.Release()
 	return a, nil
 }
+
+func StringAdd(l, r *String, mem memory.Allocator) (*String, error) {
+	n := l.Len()
+	if n != r.Len() {
+		return nil, errors.Newf(codes.Invalid, "vectors must have equal length for binary operations")
+	}
+	b := NewStringBuilder(mem)
+	b.Resize(n)
+	for i := 0; i < n; i++ {
+		if l.IsValid(i) && r.IsValid(i) {
+			lb := l.ValueBytes(i)
+			rb := r.ValueBytes(i)
+			buf := make([]byte, len(lb)+len(rb))
+			copy(buf, lb)
+			copy(buf[len(lb):], rb)
+			b.AppendBytes(buf)
+
+		} else {
+			b.AppendNull()
+		}
+	}
+	a := b.NewStringArray()
+	b.Release()
+	return a, nil
+}
+
+func StringAddLConst(l string, r *String, mem memory.Allocator) (*String, error) {
+	n := r.Len()
+	b := NewStringBuilder(mem)
+	b.Resize(n)
+	for i := 0; i < n; i++ {
+		if r.IsValid(i) {
+			rb := r.ValueBytes(i)
+			buf := make([]byte, len(l)+len(rb))
+			copy(buf, l)
+			copy(buf[len(l):], rb)
+			b.AppendBytes(buf)
+
+		} else {
+			b.AppendNull()
+		}
+	}
+	a := b.NewStringArray()
+	b.Release()
+	return a, nil
+}
+
+func StringAddRConst(l *String, r string, mem memory.Allocator) (*String, error) {
+	n := l.Len()
+	b := NewStringBuilder(mem)
+	b.Resize(n)
+	for i := 0; i < n; i++ {
+		if l.IsValid(i) {
+			lb := l.ValueBytes(i)
+			buf := make([]byte, len(lb)+len(r))
+			copy(buf, lb)
+			copy(buf[len(lb):], r)
+			b.AppendBytes(buf)
+
+		} else {
+			b.AppendNull()
+		}
+	}
+	a := b.NewStringArray()
+	b.Release()
+	return a, nil
+}

--- a/array/binary.tmpldata
+++ b/array/binary.tmpldata
@@ -3,7 +3,7 @@
         {
             "Name": "Add",
             "Op": "+",
-            "Types": ["Int", "Uint", "Float", "String"]
+            "Types": ["Int", "Uint", "Float"]
         },
         {
             "Name": "Sub",

--- a/array/builder.go
+++ b/array/builder.go
@@ -198,7 +198,7 @@ func (b *StringBuilder) CopyValidValues(values *String, nullCheckArray Array) {
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.Append(values.Value(i))
+			b.AppendBytes(values.ValueBytes(i))
 		}
 	}
 }

--- a/array/repeat.go
+++ b/array/repeat.go
@@ -3,8 +3,14 @@ package array
 import "github.com/apache/arrow/go/v7/arrow/memory"
 
 func StringRepeat(v string, n int, mem memory.Allocator) *String {
+	sv := stringValue{
+		data: mem.Allocate(len(v)),
+		mem:  mem,
+		rc:   1,
+	}
+	copy(sv.data, v)
 	return &String{
-		value:  v,
+		value:  &sv,
 		length: n,
 	}
 }

--- a/array/repeat_test.go
+++ b/array/repeat_test.go
@@ -39,7 +39,7 @@ func TestRepeat(t *testing.T) {
 			name: "String",
 			t:    flux.TString,
 			v:    values.NewString("a"),
-			sz:   0, // optimized away
+			sz:   1, // optimized to a single instance
 		},
 		{
 			name: "Boolean",

--- a/execute/executetest/allocator.go
+++ b/execute/executetest/allocator.go
@@ -1,7 +1,35 @@
 package executetest
 
 import (
+	arrowmem "github.com/apache/arrow/go/v7/arrow/memory"
+
 	"github.com/influxdata/flux/memory"
 )
 
-var UnlimitedAllocator = &memory.ResourceAllocator{}
+var UnlimitedAllocator = &memory.ResourceAllocator{
+	Allocator: Allocator{},
+}
+
+// Allocator is an allocator for use in test. When a buffer is freed the
+// contents are overwritten with a predictable pattern to help detect
+// use-after-free scenarios.
+type Allocator struct{}
+
+func (Allocator) Allocate(size int) []byte {
+	return arrowmem.DefaultAllocator.Allocate(size)
+}
+
+func (a Allocator) Reallocate(size int, b []byte) []byte {
+	b1 := a.Allocate(size)
+	copy(b1, b)
+	a.Free(b)
+	return b1
+}
+
+func (a Allocator) Free(b []byte) {
+	var pattern = [...]byte{0x00, 0x33, 0xcc, 0xff}
+	for i := range b {
+		b[i] = pattern[i%len(pattern)]
+	}
+	arrowmem.DefaultAllocator.Free(b)
+}

--- a/execute/executetest/transformation.go
+++ b/execute/executetest/transformation.go
@@ -142,7 +142,7 @@ func ProcessTestHelper2(
 		}
 	}()
 
-	alloc := &memory.ResourceAllocator{}
+	alloc := UnlimitedAllocator
 	store := NewDataStore()
 	tx, d := create(RandomDatasetID(), alloc)
 	d.SetTriggerSpec(plan.DefaultTriggerSpec)

--- a/execute/format.go
+++ b/execute/format.go
@@ -251,7 +251,7 @@ func (f *Formatter) valueBuf(i, j int, typ flux.ColType, cr flux.ColReader) []by
 		}
 	case flux.TString:
 		if cr.Strings(j).IsValid(i) {
-			buf = []byte(cr.Strings(j).Value(i))
+			buf = cr.Strings(j).ValueBytes(i)
 		}
 	case flux.TTime:
 		if cr.Times(j).IsValid(i) {

--- a/stdlib/experimental/diff.go
+++ b/stdlib/experimental/diff.go
@@ -381,7 +381,7 @@ func (d *diffSchema) appendRow(builders []array.Builder, which, i int) {
 		case *array.UintBuilder:
 			b.Append(arr.(*array.Uint).Value(i))
 		case *array.StringBuilder:
-			b.Append(arr.(*array.String).Value(i))
+			b.AppendBytes(arr.(*array.String).ValueBytes(i))
 		case *array.BooleanBuilder:
 			b.Append(arr.(*array.Boolean).Value(i))
 		default:

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -427,7 +427,7 @@ func (t *groupTransformation) appendValueFromRow(b array.Builder, cr flux.ColRea
 		if vs.IsNull(i) {
 			b.AppendNull()
 		} else {
-			b.Append(vs.Value(i))
+			b.AppendBytes(vs.ValueBytes(i))
 		}
 	case flux.TBool:
 		b := b.(*array.BooleanBuilder)

--- a/stdlib/universe/moving_average.go
+++ b/stdlib/universe/moving_average.go
@@ -373,7 +373,7 @@ func (m *movingAverageState) forceValue() error {
 				b.Append(arr.Value(arr.Len() - 1))
 			case *array.StringBuilder:
 				arr := arr.(*array.String)
-				b.Append(arr.Value(arr.Len() - 1))
+				b.AppendBytes(arr.ValueBytes(arr.Len() - 1))
 			case *array.BooleanBuilder:
 				arr := arr.(*array.Boolean)
 				b.Append(arr.Value(arr.Len() - 1))


### PR DESCRIPTION
The optimized string array, which is used whan all column values are identical, was caching the string value that was passed to it. If this value came from an arrow String array then the string's data would be in the buffer backing that array. Once the array is finished with and freed the new string array containing the reference to the data buffer remains and prevents the entire buffer from being garbage collected.

The changes to the executetest package show that this is the case by scribbling over a buffer's memory when it is reported as free. This caused a number of tests to fail with strings that contain the data pattern rather than the expected result.

This could cause a correctness error if one uses a more sophisticated allocator that maintains a backing buffer. This would be a legitimate design choice in order to relieve pressure on the garbage collector.

In order to correct this the StringBuilder has been enhanced to always copy the input string into a new buffer whether it is in the optimised mode, or not. This buffer is allocated from the memory allocator. Once the builder has been converted into a string array retrieving a string from this array always makes a string copy of the data, this time allocated by the standard runtime, so that the string can be used with other structures without the possibility that it will keep a larger data buffer from being garbage collected.

These changes are likely to have an impact on the performance of certain operations. Increasing the amount of memory copying will mean that some transform heavy workloads take longer. I don't know how to ascertain the impact yet. In order to alleviate this slightly a new byte array based method (ValueBytes) has been added to the string array. This does not copy the data but instead returns a slice of the data backing the array. This is to be used when the caller knows that they will be using the data without storing a reference, or immediately copying it to a different location.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
