### PR TITLE
fix(libflux): Convert platform-dependent path separators to slashes

### DIFF
--- a/libflux/go/libflux/analyze.go
+++ b/libflux/go/libflux/analyze.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"path"
+	"path/filepath"
 	"runtime"
 	"unsafe"
 
@@ -40,7 +41,8 @@ func SemanticPackages() (map[string]*semantic.Package, error) {
 			return nil, err
 		}
 
-		k := path.Dir(pkg.Files[0].File)
+		k := path.Dir(filepath.ToSlash(pkg.Files[0].File))
+
 		m[k] = &pkg
 	}
 


### PR DESCRIPTION
Package path names may contain platform-dependent path separators, i.e. they can contain backslashes on Windows. This breaks SemanticPackages() on Windows, because it uses path.Dir() to extract a package name from a path. path.Dir() expects an all-slashes path, however.

Fix this be using filepath.ToSlash() before passing the path to path.Dir().

Fixes #5380

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
