### PR TITLE
chore(docs): add release versions to hash functions

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -93,7 +93,7 @@ var sourceHashes = map[string]string{
 	"stdlib/contrib/chobbs/discord/discord.flux":                                                  "bbda9aaee1966d67d310dc099d00476adda777394a1af279d447e4524e0d5e58",
 	"stdlib/contrib/jsternberg/influxdb/influxdb.flux":                                            "afc52f2e31d5e063e318b752d077c58189317c373494563ea0895cdcdea49074",
 	"stdlib/contrib/qxip/clickhouse/clickhouse.flux":                                              "8ad86d9c3c7a4271178d5e2fa9bb850856363cf470d92c3f5010b6de9e770db1",
-	"stdlib/contrib/qxip/hash/hash.flux":                                                          "25919a81b663b1f08e8f89df080c2cc5a32c40f0892ed1643d2d321e069b4fd4",
+	"stdlib/contrib/qxip/hash/hash.flux":                                                          "496d0ae212408a44f442bb5093fa92691d3f72927618ee1e841b52646db126c4",
 	"stdlib/contrib/qxip/logql/logql.flux":                                                        "f855e5a58efd4332c63bbdbb41efc9522c97722c44202f4b26c5226c89e7a646",
 	"stdlib/contrib/rhajek/bigpanda/bigpanda.flux":                                                "0f4d43a7ae08f0ce5e00a746082dbdae06008bcd69cb00b52f0b4f1bb10b7323",
 	"stdlib/contrib/sranka/opsgenie/opsgenie.flux":                                                "5313b78a30ffb01c606397c9bea954bdd4ca06c44663268bab1e0f706fc6d2c5",

--- a/stdlib/contrib/qxip/hash/hash.flux
+++ b/stdlib/contrib/qxip/hash/hash.flux
@@ -45,6 +45,7 @@ builtin sha256 : (v: A) => string
 //
 // ## Metadata
 // tag: type-conversion
+// introduced: 0.193.0
 builtin sha1 : (v: A) => string
 
 // xxhash64 converts a string value to a 64-bit hexadecimal hash using the xxHash algorithm.
@@ -105,6 +106,7 @@ builtin cityhash64 : (v: A) => string
 //
 // ## Metadata
 // tag: type-conversion
+// introduced: 0.193.0
 builtin b64 : (v: A) => string
 
 // md5 converts a string value to an MD5 hash.
@@ -125,6 +127,7 @@ builtin b64 : (v: A) => string
 //
 // ## Metadata
 // tag: type-conversion
+// introduced: 0.193.0
 builtin md5 : (v: A) => string
 
 // hmac converts a string value to an MD5-signed SHA-1 hash.
@@ -146,4 +149,5 @@ builtin md5 : (v: A) => string
 //
 // ## Metadata
 // tag: type-conversion
+// introduced: 0.193.0
 builtin hmac : (v: A, k: A) => string


### PR DESCRIPTION
Newly added functions in the `contrib/qxip/hash` package were missing the `introduced` metadata. This PR adds it in.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
