### PR TITLE
fix(array): remove 64bit refcount misalignments

### DIFF
--- a/array/array.go
+++ b/array/array.go
@@ -218,10 +218,10 @@ func (a *String) IsConstant() bool {
 }
 
 type stringValue struct {
+	rc   int64
 	data []byte
 
 	mem arrowmem.Allocator
-	rc  int64
 }
 
 func (v *stringValue) Retain() {

--- a/array/builder.go
+++ b/array/builder.go
@@ -10,13 +10,13 @@ import (
 )
 
 type StringBuilder struct {
+	refCount     int64
 	builder      *array.BinaryBuilder
 	mem          memory.Allocator
 	value        *stringValue
 	length       int
 	capacity     int
 	dataCapacity int
-	refCount     int64
 }
 
 func NewStringBuilder(mem memory.Allocator) *StringBuilder {


### PR DESCRIPTION
Invoking atomic operations in the reference counters resulted in an alignment panic in armv7, due to them not being 64bit aligned.

Declaring them first in the struct solved it.

See https://pkg.go.dev/sync/atomic#pkg-note-BUG fore more details

For context: I already fixed a similar issue at https://github.com/influxdata/flux/pull/4676

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [ ] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
