### PR TITLE
fix: make C FFI more robust with respect to malformed input

### DIFF
--- a/libflux/flux/src/cffi.rs
+++ b/libflux/flux/src/cffi.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::anyhow;
 use fluxcore::{
-    ast,
+    ast::{self, BaseNode},
     errors::SalvageResult,
     formatter, merge_packages,
     parser::Parser,
@@ -45,8 +45,9 @@ pub struct ErrorHandle {
 
 impl From<Error> for Box<ErrorHandle> {
     fn from(err: Error) -> Self {
+        let msg = err.to_string().replace('\0', "\\0");
         Box::new(ErrorHandle {
-            message: CString::new(format!("{}", err)).unwrap(),
+            message: CString::new(msg).unwrap(),
             err,
         })
     }
@@ -123,10 +124,28 @@ pub unsafe extern "C" fn flux_parse(
     cfname: *const c_char,
     csrc: *const c_char,
 ) -> Box<ast::Package> {
-    let fname = String::from_utf8(CStr::from_ptr(cfname).to_bytes().to_vec()).unwrap();
-    let src = String::from_utf8(CStr::from_ptr(csrc).to_bytes().to_vec()).unwrap();
+    let fname = match String::from_utf8(CStr::from_ptr(cfname).to_bytes().to_vec()) {
+        Err(e) => return err_pkg(format!("flux file name: {}", e)),
+        Ok(s) => s,
+    };
+    let src = match String::from_utf8(CStr::from_ptr(csrc).to_bytes().to_vec()) {
+        Err(e) => return err_pkg(format!("flux source: {}", e)),
+        Ok(s) => s,
+    };
     let pkg = parse(fname, &src);
     Box::new(pkg)
+}
+
+fn err_pkg(msg: String) -> Box<ast::Package> {
+    Box::new(ast::Package {
+        base: BaseNode {
+            errors: vec![msg],
+            ..BaseNode::default()
+        },
+        path: "".to_string(),
+        package: "".to_string(),
+        files: vec![],
+    })
 }
 
 /// Parse the contents of a string.
@@ -215,7 +234,7 @@ pub extern "C" fn flux_free_ast_pkg(_: Option<Box<ast::Package>>) {}
 /// could occur.
 #[no_mangle]
 pub unsafe extern "C" fn flux_parse_json(
-    cstr: *mut c_char,
+    cstr: *const c_char,
     out_pkg: *mut Option<Box<ast::Package>>,
 ) -> Option<Box<ErrorHandle>> {
     catch_unwind(|| {
@@ -1094,5 +1113,51 @@ from(bucket: v.bucket)
         dbg!(&pkg);
 
         assert_eq!(identifier.unwrap().name.package(), Some("universe"));
+    }
+
+    #[test]
+    fn parse_json_with_nul() {
+        let c_str = CString::new(
+            r#"{"type":"Package","package":"main","files":[{"body":[{"type":"\u0000"}]}]}"#,
+        )
+        .expect("no interior nuls");
+        let c_char_ptr = c_str.as_ptr();
+        let mut pkg: Option<Box<ast::Package>> = None;
+        let pkg_ptr: *mut Option<Box<ast::Package>> = &mut pkg;
+
+        // Safety: both pointers are valid
+        let err_hdl = unsafe { flux_parse_json(c_char_ptr, pkg_ptr) }.expect("some error");
+        let msg = err_hdl.message.to_string_lossy();
+        assert!(
+            err_hdl
+                .message
+                .to_string_lossy()
+                .contains("unknown variant `\\0`"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_with_invalid_utf8() {
+        let cfname = CString::new("foo.flux").unwrap();
+        let cfname_ptr: *const c_char = cfname.as_ptr();
+        let v: Vec<c_char> = vec![-61, 0];
+        let csrc: *const c_char = &v[0];
+        // Safety: both pointers are valid
+        let pkg = unsafe { flux_parse(cfname_ptr, csrc) };
+        assert!(
+            pkg.base.errors[0].contains("flux source: incomplete utf-8"),
+            "did not get expected error in pkg: {:?}",
+            pkg
+        );
+
+        let (csrc, cfname_ptr) = (cfname_ptr, csrc);
+        // Safety: both pointers are valid
+        let pkg = unsafe { flux_parse(cfname_ptr, csrc) };
+        assert!(
+            pkg.base.errors[0].contains("flux file name: incomplete utf-8"),
+            "did not get expected error in pkg: {:?}",
+            pkg
+        );
     }
 }

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -62,7 +62,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/Cargo.toml":                                                                     "308c541b31f6ef25094ed4a4c2fddaf38244b0632b93c1f44b2ee4b4209d479c",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "31dcb1e825555e56b4d959244c4ea630b1d32ccddc1f8615620e0c23552d914f",
-	"libflux/flux/src/cffi.rs":                                                                    "d490e117f0e46386dee9fa35cc19209a07d1d57d7db352ab216b4d6fea1536a0",
+	"libflux/flux/src/cffi.rs":                                                                    "ada09b4330ef37de0569d6d8036e191cc583069edc79ef447de4cc280311bc35",
 	"libflux/flux/src/lib.rs":                                                                     "af2f62a02ec08ee476121e035c6587e31c1b6d5d4912ccace1e2e9ae019ad9c1",
 	"libflux/flux/templates/base.html":                                                            "a818747b9621828bb96b94291c60922db54052bbe35d5e354f8e589d2a4ebd02",
 	"libflux/flux/templates/home.html":                                                            "f9927514dd42ca7271b4817ad1ca33ec79c03a77a783581b4dcafabd246ebf3f",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -62,7 +62,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/Cargo.toml":                                                                     "308c541b31f6ef25094ed4a4c2fddaf38244b0632b93c1f44b2ee4b4209d479c",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "31dcb1e825555e56b4d959244c4ea630b1d32ccddc1f8615620e0c23552d914f",
-	"libflux/flux/src/cffi.rs":                                                                    "ada09b4330ef37de0569d6d8036e191cc583069edc79ef447de4cc280311bc35",
+	"libflux/flux/src/cffi.rs":                                                                    "d6cc56867bc475805c71cc9bc7ccd3cedf71b9cdf936973d5e30116245500802",
 	"libflux/flux/src/lib.rs":                                                                     "af2f62a02ec08ee476121e035c6587e31c1b6d5d4912ccace1e2e9ae019ad9c1",
 	"libflux/flux/templates/base.html":                                                            "a818747b9621828bb96b94291c60922db54052bbe35d5e354f8e589d2a4ebd02",
 	"libflux/flux/templates/home.html":                                                            "f9927514dd42ca7271b4817ad1ca33ec79c03a77a783581b4dcafabd246ebf3f",


### PR DESCRIPTION
An audit discovered a few places where we could be more rigorous about checking inputs for valid data. This PR addresses the issues and adds tests for them.