### PR TITLE
refactor: improve "error package" returned when bad UTF-8

### DIFF
--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -62,7 +62,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/Cargo.toml":                                                                     "308c541b31f6ef25094ed4a4c2fddaf38244b0632b93c1f44b2ee4b4209d479c",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "31dcb1e825555e56b4d959244c4ea630b1d32ccddc1f8615620e0c23552d914f",
-	"libflux/flux/src/cffi.rs":                                                                    "d6cc56867bc475805c71cc9bc7ccd3cedf71b9cdf936973d5e30116245500802",
+	"libflux/flux/src/cffi.rs":                                                                    "ab9cca7d7ef52a5ff168430e285f7f6a15488f092bf4487e618be5611757dced",
 	"libflux/flux/src/lib.rs":                                                                     "af2f62a02ec08ee476121e035c6587e31c1b6d5d4912ccace1e2e9ae019ad9c1",
 	"libflux/flux/templates/base.html":                                                            "a818747b9621828bb96b94291c60922db54052bbe35d5e354f8e589d2a4ebd02",
 	"libflux/flux/templates/home.html":                                                            "f9927514dd42ca7271b4817ad1ca33ec79c03a77a783581b4dcafabd246ebf3f",


### PR DESCRIPTION
This PR builds upon my last PR #5408 to use the expected form of AST to hold an error produced my invalid UTF8. The function `flux_ast_get_error` wants the error to be in the base node of the first file, rather than in the package itself.

This produces a nicer error message when clients pass in Flux code with invalid UTF-8.