### PR TITLE
fix(flux-core): infinite loop protection in the parser

### DIFF
--- a/libflux/flux-core/src/parser/tests/arrow_function.rs
+++ b/libflux/flux-core/src/parser/tests/arrow_function.rs
@@ -1307,3 +1307,291 @@ fn arrow_function_as_block() {
         }
     "#]].assert_debug_eq(&parsed);
 }
+
+#[test]
+fn arrow_function_with_bad_parameter_list() {
+    let mut p = Parser::new(r#"myfun = (t=<-, fn=(r) => ({r with _field: ""}) => { }"#);
+    let parsed = p.parse_file("".to_string());
+    expect![[r#"
+    File {
+        base: BaseNode {
+            location: SourceLocation {
+                start: "line: 1, column: 1",
+                end: "line: 1, column: 54",
+                source: "myfun = (t=<-, fn=(r) => ({r with _field: \"\"}) => { }",
+            },
+        },
+        name: "",
+        metadata: "parser-type=rust",
+        package: None,
+        imports: [],
+        body: [
+            Variable(
+                VariableAssgn {
+                    base: BaseNode {
+                        location: SourceLocation {
+                            start: "line: 1, column: 1",
+                            end: "line: 1, column: 54",
+                            source: "myfun = (t=<-, fn=(r) => ({r with _field: \"\"}) => { }",
+                        },
+                    },
+                    id: Identifier {
+                        base: BaseNode {
+                            location: SourceLocation {
+                                start: "line: 1, column: 1",
+                                end: "line: 1, column: 6",
+                                source: "myfun",
+                            },
+                        },
+                        name: "myfun",
+                    },
+                    init: Function(
+                        FunctionExpr {
+                            base: BaseNode {
+                                location: SourceLocation {
+                                    start: "line: 1, column: 9",
+                                    end: "line: 1, column: 54",
+                                    source: "(t=<-, fn=(r) => ({r with _field: \"\"}) => { }",
+                                },
+                            },
+                            lparen: [],
+                            params: [
+                                Property {
+                                    base: BaseNode {
+                                        location: SourceLocation {
+                                            start: "line: 1, column: 10",
+                                            end: "line: 1, column: 14",
+                                            source: "t=<-",
+                                        },
+                                    },
+                                    key: Identifier(
+                                        Identifier {
+                                            base: BaseNode {
+                                                location: SourceLocation {
+                                                    start: "line: 1, column: 10",
+                                                    end: "line: 1, column: 11",
+                                                    source: "t",
+                                                },
+                                            },
+                                            name: "t",
+                                        },
+                                    ),
+                                    separator: [],
+                                    value: Some(
+                                        PipeLit(
+                                            PipeLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 12",
+                                                        end: "line: 1, column: 14",
+                                                        source: "<-",
+                                                    },
+                                                },
+                                            },
+                                        ),
+                                    ),
+                                    comma: [],
+                                },
+                                Property {
+                                    base: BaseNode {
+                                        location: SourceLocation {
+                                            start: "line: 1, column: 16",
+                                            end: "line: 1, column: 47",
+                                            source: "fn=(r) => ({r with _field: \"\"})",
+                                        },
+                                    },
+                                    key: Identifier(
+                                        Identifier {
+                                            base: BaseNode {
+                                                location: SourceLocation {
+                                                    start: "line: 1, column: 16",
+                                                    end: "line: 1, column: 18",
+                                                    source: "fn",
+                                                },
+                                            },
+                                            name: "fn",
+                                        },
+                                    ),
+                                    separator: [],
+                                    value: Some(
+                                        Function(
+                                            FunctionExpr {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 19",
+                                                        end: "line: 1, column: 47",
+                                                        source: "(r) => ({r with _field: \"\"})",
+                                                    },
+                                                },
+                                                lparen: [],
+                                                params: [
+                                                    Property {
+                                                        base: BaseNode {
+                                                            location: SourceLocation {
+                                                                start: "line: 1, column: 20",
+                                                                end: "line: 1, column: 21",
+                                                                source: "r",
+                                                            },
+                                                        },
+                                                        key: Identifier(
+                                                            Identifier {
+                                                                base: BaseNode {
+                                                                    location: SourceLocation {
+                                                                        start: "line: 1, column: 20",
+                                                                        end: "line: 1, column: 21",
+                                                                        source: "r",
+                                                                    },
+                                                                },
+                                                                name: "r",
+                                                            },
+                                                        ),
+                                                        separator: [],
+                                                        value: None,
+                                                        comma: [],
+                                                    },
+                                                ],
+                                                rparen: [],
+                                                arrow: [],
+                                                body: Expr(
+                                                    Paren(
+                                                        ParenExpr {
+                                                            base: BaseNode {
+                                                                location: SourceLocation {
+                                                                    start: "line: 1, column: 26",
+                                                                    end: "line: 1, column: 47",
+                                                                    source: "({r with _field: \"\"})",
+                                                                },
+                                                            },
+                                                            lparen: [],
+                                                            expression: Object(
+                                                                ObjectExpr {
+                                                                    base: BaseNode {
+                                                                        location: SourceLocation {
+                                                                            start: "line: 1, column: 27",
+                                                                            end: "line: 1, column: 46",
+                                                                            source: "{r with _field: \"\"}",
+                                                                        },
+                                                                    },
+                                                                    lbrace: [],
+                                                                    with: Some(
+                                                                        WithSource {
+                                                                            source: Identifier {
+                                                                                base: BaseNode {
+                                                                                    location: SourceLocation {
+                                                                                        start: "line: 1, column: 28",
+                                                                                        end: "line: 1, column: 29",
+                                                                                        source: "r",
+                                                                                    },
+                                                                                },
+                                                                                name: "r",
+                                                                            },
+                                                                            with: [],
+                                                                        },
+                                                                    ),
+                                                                    properties: [
+                                                                        Property {
+                                                                            base: BaseNode {
+                                                                                location: SourceLocation {
+                                                                                    start: "line: 1, column: 35",
+                                                                                    end: "line: 1, column: 45",
+                                                                                    source: "_field: \"\"",
+                                                                                },
+                                                                            },
+                                                                            key: Identifier(
+                                                                                Identifier {
+                                                                                    base: BaseNode {
+                                                                                        location: SourceLocation {
+                                                                                            start: "line: 1, column: 35",
+                                                                                            end: "line: 1, column: 41",
+                                                                                            source: "_field",
+                                                                                        },
+                                                                                    },
+                                                                                    name: "_field",
+                                                                                },
+                                                                            ),
+                                                                            separator: [],
+                                                                            value: Some(
+                                                                                StringLit(
+                                                                                    StringLit {
+                                                                                        base: BaseNode {
+                                                                                            location: SourceLocation {
+                                                                                                start: "line: 1, column: 43",
+                                                                                                end: "line: 1, column: 45",
+                                                                                                source: "\"\"",
+                                                                                            },
+                                                                                        },
+                                                                                        value: "",
+                                                                                    },
+                                                                                ),
+                                                                            ),
+                                                                            comma: [],
+                                                                        },
+                                                                    ],
+                                                                    rbrace: [],
+                                                                },
+                                                            ),
+                                                            rparen: [],
+                                                        },
+                                                    ),
+                                                ),
+                                            },
+                                        ),
+                                    ),
+                                    comma: [],
+                                },
+                                Property {
+                                    base: BaseNode {
+                                        location: SourceLocation {
+                                            start: "line: 1, column: 48",
+                                            end: "line: 1, column: 48",
+                                            source: "",
+                                        },
+                                    },
+                                    key: Identifier(
+                                        Identifier {
+                                            base: BaseNode {
+                                                location: SourceLocation {
+                                                    start: "line: 1, column: 48",
+                                                    end: "line: 1, column: 48",
+                                                    source: "",
+                                                },
+                                                errors: [
+                                                    "expected IDENT, got ARROW (=>) at 1:48",
+                                                ],
+                                            },
+                                            name: "",
+                                        },
+                                    ),
+                                    separator: [],
+                                    value: None,
+                                    comma: [],
+                                },
+                            ],
+                            rparen: [],
+                            arrow: [],
+                            body: Block(
+                                Block {
+                                    base: BaseNode {
+                                        location: SourceLocation {
+                                            start: "line: 1, column: 51",
+                                            end: "line: 1, column: 54",
+                                            source: "{ }",
+                                        },
+                                        errors: [
+                                            "expected RPAREN, got ARROW",
+                                        ],
+                                    },
+                                    lbrace: [],
+                                    body: [],
+                                    rbrace: [],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
+        ],
+        eof: [],
+    }
+    "#]].assert_debug_eq(&parsed);
+}

--- a/libflux/flux-core/src/parser/tests/attributes.rs
+++ b/libflux/flux-core/src/parser/tests/attributes.rs
@@ -1039,3 +1039,148 @@ identity = (x) => x
     "#]]
     .assert_debug_eq(&parsed);
 }
+
+#[test]
+fn parse_attribute_unfinished_parameters() {
+    let mut p = Parser::new(
+        r#"@attr1("param1", "param2"
+@attr2
+package main"#,
+    );
+    let parsed = p.parse_file("".to_string());
+    expect![[r#"
+        File {
+            base: BaseNode {
+                location: SourceLocation {
+                    start: "line: 1, column: 1",
+                    end: "line: 3, column: 13",
+                    source: "@attr1(\"param1\", \"param2\"\n@attr2\npackage main",
+                },
+            },
+            name: "",
+            metadata: "parser-type=rust",
+            package: Some(
+                PackageClause {
+                    base: BaseNode {
+                        location: SourceLocation {
+                            start: "line: 3, column: 1",
+                            end: "line: 3, column: 13",
+                            source: "package main",
+                        },
+                        attributes: [
+                            Attribute {
+                                base: BaseNode {
+                                    location: SourceLocation {
+                                        start: "line: 1, column: 1",
+                                        end: "line: 2, column: 7",
+                                        source: "@attr1(\"param1\", \"param2\"\n@attr2",
+                                    },
+                                    errors: [
+                                        "expected comma in attribute parameter list, got ATTRIBUTE",
+                                        "expected comma in attribute parameter list, got ATTRIBUTE",
+                                        "expected RPAREN, got ATTRIBUTE",
+                                    ],
+                                },
+                                name: "attr1",
+                                params: [
+                                    AttributeParam {
+                                        base: BaseNode {
+                                            location: SourceLocation {
+                                                start: "line: 1, column: 8",
+                                                end: "line: 1, column: 17",
+                                                source: "\"param1\",",
+                                            },
+                                        },
+                                        value: StringLit(
+                                            StringLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 8",
+                                                        end: "line: 1, column: 16",
+                                                        source: "\"param1\"",
+                                                    },
+                                                },
+                                                value: "param1",
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                    AttributeParam {
+                                        base: BaseNode {
+                                            location: SourceLocation {
+                                                start: "line: 1, column: 18",
+                                                end: "line: 1, column: 26",
+                                                source: "\"param2\"",
+                                            },
+                                        },
+                                        value: StringLit(
+                                            StringLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 18",
+                                                        end: "line: 1, column: 26",
+                                                        source: "\"param2\"",
+                                                    },
+                                                },
+                                                value: "param2",
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                    AttributeParam {
+                                        base: BaseNode {
+                                            location: SourceLocation {
+                                                start: "line: 2, column: 1",
+                                                end: "line: 2, column: 7",
+                                                source: "@attr2",
+                                            },
+                                        },
+                                        value: Bad(
+                                            BadExpr {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 2, column: 1",
+                                                        end: "line: 2, column: 7",
+                                                        source: "@attr2",
+                                                    },
+                                                },
+                                                text: "invalid token for primary expression: ATTRIBUTE",
+                                                expression: None,
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                ],
+                            },
+                            Attribute {
+                                base: BaseNode {
+                                    location: SourceLocation {
+                                        start: "line: 2, column: 1",
+                                        end: "line: 2, column: 7",
+                                        source: "@attr2",
+                                    },
+                                },
+                                name: "attr2",
+                                params: [],
+                            },
+                        ],
+                    },
+                    name: Identifier {
+                        base: BaseNode {
+                            location: SourceLocation {
+                                start: "line: 3, column: 9",
+                                end: "line: 3, column: 13",
+                                source: "main",
+                            },
+                        },
+                        name: "main",
+                    },
+                },
+            ),
+            imports: [],
+            body: [],
+            eof: [],
+        }
+    "#]]
+    .assert_debug_eq(&parsed);
+}

--- a/libflux/flux-core/src/parser/tests/literals.rs
+++ b/libflux/flux-core/src/parser/tests/literals.rs
@@ -1032,3 +1032,257 @@ fn integer_literal_overflow() {
         }
     "#]].assert_debug_eq(&parsed);
 }
+
+#[test]
+fn dictionary_literal() {
+    let mut p = Parser::new(r#"["a":1, "b":2]"#);
+    let parsed = p.parse_file("".to_string());
+    expect![[r#"
+        File {
+            base: BaseNode {
+                location: SourceLocation {
+                    start: "line: 1, column: 1",
+                    end: "line: 1, column: 15",
+                    source: "[\"a\":1, \"b\":2]",
+                },
+            },
+            name: "",
+            metadata: "parser-type=rust",
+            package: None,
+            imports: [],
+            body: [
+                Expr(
+                    ExprStmt {
+                        base: BaseNode {
+                            location: SourceLocation {
+                                start: "line: 1, column: 1",
+                                end: "line: 1, column: 15",
+                                source: "[\"a\":1, \"b\":2]",
+                            },
+                        },
+                        expression: Dict(
+                            DictExpr {
+                                base: BaseNode {
+                                    location: SourceLocation {
+                                        start: "line: 1, column: 1",
+                                        end: "line: 1, column: 15",
+                                        source: "[\"a\":1, \"b\":2]",
+                                    },
+                                },
+                                lbrack: [],
+                                elements: [
+                                    DictItem {
+                                        key: StringLit(
+                                            StringLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 2",
+                                                        end: "line: 1, column: 5",
+                                                        source: "\"a\"",
+                                                    },
+                                                },
+                                                value: "a",
+                                            },
+                                        ),
+                                        val: Integer(
+                                            IntegerLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 6",
+                                                        end: "line: 1, column: 7",
+                                                        source: "1",
+                                                    },
+                                                },
+                                                value: 1,
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                    DictItem {
+                                        key: StringLit(
+                                            StringLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 9",
+                                                        end: "line: 1, column: 12",
+                                                        source: "\"b\"",
+                                                    },
+                                                },
+                                                value: "b",
+                                            },
+                                        ),
+                                        val: Integer(
+                                            IntegerLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 1, column: 13",
+                                                        end: "line: 1, column: 14",
+                                                        source: "2",
+                                                    },
+                                                },
+                                                value: 2,
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                ],
+                                rbrack: [],
+                            },
+                        ),
+                    },
+                ),
+            ],
+            eof: [],
+        }
+    "#]].assert_debug_eq(&parsed);
+}
+
+#[test]
+fn unclosed_dictionary_literal() {
+    let mut p = Parser::new(r#"
+        A = ["a":1, "b":2
+        B = 100
+"#);
+    let parsed = p.parse_file("".to_string());
+    expect![[r#"
+        File {
+            base: BaseNode {
+                location: SourceLocation {
+                    start: "line: 2, column: 9",
+                    end: "line: 4, column: 1",
+                    source: "A = [\"a\":1, \"b\":2\n        B = 100\n",
+                },
+            },
+            name: "",
+            metadata: "parser-type=rust",
+            package: None,
+            imports: [],
+            body: [
+                Variable(
+                    VariableAssgn {
+                        base: BaseNode {
+                            location: SourceLocation {
+                                start: "line: 2, column: 9",
+                                end: "line: 4, column: 1",
+                                source: "A = [\"a\":1, \"b\":2\n        B = 100\n",
+                            },
+                        },
+                        id: Identifier {
+                            base: BaseNode {
+                                location: SourceLocation {
+                                    start: "line: 2, column: 9",
+                                    end: "line: 2, column: 10",
+                                    source: "A",
+                                },
+                            },
+                            name: "A",
+                        },
+                        init: Dict(
+                            DictExpr {
+                                base: BaseNode {
+                                    location: SourceLocation {
+                                        start: "line: 2, column: 13",
+                                        end: "line: 4, column: 1",
+                                        source: "[\"a\":1, \"b\":2\n        B = 100\n",
+                                    },
+                                    errors: [
+                                        "expected RBRACK, got EOF",
+                                    ],
+                                },
+                                lbrack: [],
+                                elements: [
+                                    DictItem {
+                                        key: StringLit(
+                                            StringLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 2, column: 14",
+                                                        end: "line: 2, column: 17",
+                                                        source: "\"a\"",
+                                                    },
+                                                },
+                                                value: "a",
+                                            },
+                                        ),
+                                        val: Integer(
+                                            IntegerLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 2, column: 18",
+                                                        end: "line: 2, column: 19",
+                                                        source: "1",
+                                                    },
+                                                },
+                                                value: 1,
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                    DictItem {
+                                        key: StringLit(
+                                            StringLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 2, column: 21",
+                                                        end: "line: 2, column: 24",
+                                                        source: "\"b\"",
+                                                    },
+                                                },
+                                                value: "b",
+                                            },
+                                        ),
+                                        val: Integer(
+                                            IntegerLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 2, column: 25",
+                                                        end: "line: 2, column: 26",
+                                                        source: "2",
+                                                    },
+                                                },
+                                                value: 2,
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                    DictItem {
+                                        key: Identifier(
+                                            Identifier {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 3, column: 9",
+                                                        end: "line: 3, column: 10",
+                                                        source: "B",
+                                                    },
+                                                },
+                                                name: "B",
+                                            },
+                                        ),
+                                        val: Integer(
+                                            IntegerLit {
+                                                base: BaseNode {
+                                                    location: SourceLocation {
+                                                        start: "line: 3, column: 13",
+                                                        end: "line: 3, column: 16",
+                                                        source: "100",
+                                                    },
+                                                    errors: [
+                                                        "expected COLON, got ASSIGN (=) at 3:11",
+                                                    ],
+                                                },
+                                                value: 100,
+                                            },
+                                        ),
+                                        comma: [],
+                                    },
+                                ],
+                                rbrack: [],
+                            },
+                        ),
+                    },
+                ),
+            ],
+            eof: [],
+        }
+    "#]].assert_debug_eq(&parsed);
+}

--- a/libflux/flux-core/src/parser/tests/literals.rs
+++ b/libflux/flux-core/src/parser/tests/literals.rs
@@ -1134,15 +1134,18 @@ fn dictionary_literal() {
             ],
             eof: [],
         }
-    "#]].assert_debug_eq(&parsed);
+    "#]]
+    .assert_debug_eq(&parsed);
 }
 
 #[test]
 fn unclosed_dictionary_literal() {
-    let mut p = Parser::new(r#"
+    let mut p = Parser::new(
+        r#"
         A = ["a":1, "b":2
         B = 100
-"#);
+"#,
+    );
     let parsed = p.parse_file("".to_string());
     expect![[r#"
         File {
@@ -1284,5 +1287,6 @@ fn unclosed_dictionary_literal() {
             ],
             eof: [],
         }
-    "#]].assert_debug_eq(&parsed);
+    "#]]
+    .assert_debug_eq(&parsed);
 }

--- a/libflux/flux-core/src/parser/tests/types.rs
+++ b/libflux/flux-core/src/parser/tests/types.rs
@@ -1944,7 +1944,8 @@ fn test_parse_parameters_unclosed_error() {
 
         error @1:22-1:22: expected RPAREN, got EOF
 
-        error @1:22-1:22: expected ARROW, got EOF"#]].assert_eq(
+        error @1:22-1:22: expected ARROW, got EOF"#]]
+    .assert_eq(
         &ast::check::check(ast::walk::Node::TypeExpression(&parsed))
             .unwrap_err()
             .to_string(),

--- a/libflux/flux-core/src/parser/tests/types.rs
+++ b/libflux/flux-core/src/parser/tests/types.rs
@@ -1930,3 +1930,23 @@ fn test_parse_record_unclosed_error() {
             .to_string(),
     );
 }
+
+#[test]
+fn test_parse_parameters_unclosed_error() {
+    let mut p = Parser::new(r#"(a:int, b:int: => int"#);
+    let parsed = p.parse_type_expression();
+    expect_test::expect![[r#"
+        error @1:14-1:14: expected IDENT, got COLON (:) at 1:14
+
+        error @1:16-1:16: expected IDENT, got ARROW (=>) at 1:16
+
+        error @1:19-1:22: expected COLON, got ARROW (=>) at 1:16
+
+        error @1:22-1:22: expected RPAREN, got EOF
+
+        error @1:22-1:22: expected ARROW, got EOF"#]].assert_eq(
+        &ast::check::check(ast::walk::Node::TypeExpression(&parsed))
+            .unwrap_err()
+            .to_string(),
+    );
+}

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -29,7 +29,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/formatter/mod.rs":                                                      "6aaf87b945bbbfd8acc7a680aae6d3f4c84f8964a9ed6cb50b99122bb240fd45",
 	"libflux/flux-core/src/lib.rs":                                                                "487c5b2db051f7ed5276c566a9a6b2ee75d6a13459443cf94b51b6d90d20edd2",
 	"libflux/flux-core/src/map.rs":                                                                "342c1cc111d343f01b97f38be10a9f1097bdd57cdc56f55e92fd3ed5028e6973",
-	"libflux/flux-core/src/parser/mod.rs":                                                         "2d6b2c6b86b2921e8e68b6588f4c873632a7eaa1e645f3167efbf14aa3b4da58",
+	"libflux/flux-core/src/parser/mod.rs":                                                         "abc9f7fe02d4252c4046bf1f680916f328b5f04a73509413ef37b55a0daa1420",
 	"libflux/flux-core/src/parser/strconv.rs":                                                     "2e288c83dcc9cf6e1b6a503219108cd3ed74446f9a2906b551480fa298e14531",
 	"libflux/flux-core/src/scanner/mod.rs":                                                        "eb7afb2eff162080046ddda7d1e9d01ffd4ec3a165bbcc95a001bf7edefa5e9c",
 	"libflux/flux-core/src/scanner/scanner.rl":                                                    "34e1f306994b8f69d0551110ce22efa75e0081b7c5f498ad293a739970bbcbc2",


### PR DESCRIPTION
Update all loops using self.more in the parser to detect if they get stuck attempting to process the same token multiple times. This has been observed to cause the parser to get into an infinite loop with some erroneus inputs.

The protection code was copied from the parse_array_items_rest and applied everywhere the parser could conceivably get stuck. It is not clear that it is possible to get stuck in all the places that the protection was added.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
