### PR TITLE
fix: libflux build error on >= rust-1.72.0

### DIFF
--- a/libflux/flux/src/lib.rs
+++ b/libflux/flux/src/lib.rs
@@ -9,7 +9,6 @@ use fluxcore::semantic::env::Environment;
 use fluxcore::semantic::flatbuffers::semantic_generated::fbsemantic as fb;
 use fluxcore::semantic::import::Packages;
 use fluxcore::semantic::{Analyzer, AnalyzerConfig, PackageExports};
-use fluxcore::{Database, Flux};
 use once_cell::sync::Lazy;
 use thiserror::Error;
 

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -63,7 +63,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "31dcb1e825555e56b4d959244c4ea630b1d32ccddc1f8615620e0c23552d914f",
 	"libflux/flux/src/cffi.rs":                                                                    "ab9cca7d7ef52a5ff168430e285f7f6a15488f092bf4487e618be5611757dced",
-	"libflux/flux/src/lib.rs":                                                                     "af2f62a02ec08ee476121e035c6587e31c1b6d5d4912ccace1e2e9ae019ad9c1",
+	"libflux/flux/src/lib.rs":                                                                     "7e0bacaa5da218888cae12e4245d305909153bbe60cc8c17b85543563fa628cc",
 	"libflux/flux/templates/base.html":                                                            "a818747b9621828bb96b94291c60922db54052bbe35d5e354f8e589d2a4ebd02",
 	"libflux/flux/templates/home.html":                                                            "f9927514dd42ca7271b4817ad1ca33ec79c03a77a783581b4dcafabd246ebf3f",
 	"libflux/flux/templates/package.html":                                                         "635e1d638ad1a430f3894ff0a458572ca3c4dc6b9cec2c57fe771443849e1402",


### PR DESCRIPTION
Closes: #5438

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [x] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [x] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.

This a trivial patch to fix an issue with rust-1.72.0 (see linked issue). 
