### PR TITLE
feat: add bash-like linebreak (`\` at the end of line) to the REPL

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -41,6 +41,8 @@ type REPL struct {
 	cancelMu   sync.Mutex
 	cancelFunc context.CancelFunc
 
+	lineBuf string
+
 	enableSuggestions bool
 }
 
@@ -201,6 +203,13 @@ func (r *REPL) evalWithFluxError(t string) ([]interpreter.SideEffect, *libflux.F
 // executeLine processes a line of input.
 // If the input evaluates to a valid value, that value is returned.
 func (r *REPL) executeLine(t string) (*libflux.FluxError, error) {
+	t = r.lineBuf + t
+	if strings.HasSuffix(t, "\\") {
+		r.lineBuf = t[:len(t)-1] + "\n"
+		return nil, nil
+	}
+	r.lineBuf = ""
+
 	ses, fluxError, err := r.evalWithFluxError(t)
 	if err != nil {
 		return fluxError, err

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -1,0 +1,27 @@
+package repl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/influxdata/flux/fluxinit"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplNewLine(t *testing.T) {
+	ctx := context.TODO()
+	fluxinit.FluxInit()
+
+	r := New(ctx)
+	errI, err := r.executeLine(`import "sampledata"`)
+	require.Nil(t, errI)
+	require.Nil(t, err)
+
+	errI, err = r.executeLine(`sampledata.int() \`)
+	require.Nil(t, errI)
+	require.Nil(t, err)
+
+	errI, err = r.executeLine(`|> sum()`)
+	require.Nil(t, errI)
+	require.Nil(t, err)
+}


### PR DESCRIPTION
Hello

Current REPL doesn't support multiline input. Found few issues marked as enhancement:
- #458
- #50

This PR suggests to interpret `\` at the end of the line as a limiter for a new line like in bash. 

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
