### PR TITLE
feat(execute): allocate memory for string content.

### DIFF
--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -148,6 +148,58 @@ func TestTablesEqual(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "string values",
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), "1"},
+					{execute.Time(2), "2"},
+					{execute.Time(3), "3"},
+				},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), "1"},
+					{execute.Time(2), "2"},
+					{execute.Time(3), "3"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "string mismatch",
+			data0: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), "1"},
+					{execute.Time(2), "2"},
+					{execute.Time(3), "3"},
+				},
+			},
+			data1: &executetest.Table{
+				ColMeta: []flux.ColMeta{
+					{Label: "_time", Type: flux.TTime},
+					{Label: "_value", Type: flux.TString},
+				},
+				Data: [][]interface{}{
+					{execute.Time(1), "1"},
+					{execute.Time(2), "2"},
+					{execute.Time(3), "4"},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
Update the string column builder to account for the memory for the string contents. This is part of an effort to reduce the prevelence of OOMs caused by unaccounted memory data See influxdata/idpe#18697.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
