### PR TITLE
feat(array): less leaky string array

### DIFF
--- a/array/array.go
+++ b/array/array.go
@@ -2,11 +2,11 @@ package array
 
 import (
 	"strconv"
-	"sync/atomic"
 
 	"github.com/apache/arrow/go/v7/arrow"
 	"github.com/apache/arrow/go/v7/arrow/array"
 	arrowmem "github.com/apache/arrow/go/v7/arrow/memory"
+
 	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
@@ -103,10 +103,23 @@ type Builder interface {
 	NewArray() Array
 }
 
+type binaryArray interface {
+	NullN() int
+	NullBitmapBytes() []byte
+	IsNull(i int) bool
+	IsValid(i int) bool
+	Data() arrow.ArrayData
+	Len() int
+	ValueBytes() []byte
+	ValueLen(i int) int
+	ValueOffset(i int) int
+	ValueString(i int) string
+	Retain()
+	Release()
+}
+
 type String struct {
-	length int
-	data   *array.Binary
-	value  *stringValue
+	binaryArray
 }
 
 // NewStringFromBinaryArray creates an instance of String from
@@ -118,140 +131,90 @@ type String struct {
 func NewStringFromBinaryArray(data *array.Binary) *String {
 	data.Retain()
 	return &String{
-		data: data,
+		binaryArray: data,
 	}
 }
 
 func (a *String) DataType() DataType {
 	return StringType
 }
-func (a *String) NullN() int {
-	if a.data != nil {
-		return a.data.NullN()
-	}
-	return 0
-}
-func (a *String) NullBitmapBytes() []byte {
-	if a.data != nil {
-		return a.data.NullBitmapBytes()
-	}
-	return nil
-}
-func (a *String) IsNull(i int) bool {
-	if a.data != nil {
-		return a.data.IsNull(i)
-	}
-	return false
-}
-func (a *String) IsValid(i int) bool {
-	if a.data != nil {
-		return a.data.IsValid(i)
-	}
-	return true
-}
-func (a *String) Data() arrow.ArrayData {
-	if a.data != nil {
-		return a.data.Data()
-	}
-	return nil
-}
-func (a *String) Len() int {
-	if a.data != nil {
-		return a.data.Len()
-	}
-	return a.length
-}
-func (a *String) Retain() {
-	if a.data != nil {
-		a.data.Retain()
-		return
-	}
-	a.value.Retain()
-}
-func (a *String) Release() {
-	if a.data != nil {
-		a.data.Release()
-		return
-	}
-	a.value.Release()
-}
+
 func (a *String) Slice(i, j int) Array {
-	if a.data != nil {
-		data := array.NewSliceData(a.data.Data(), int64(i), int64(j))
-		defer data.Release()
-		return &String{
-			data: array.NewBinaryData(data),
-		}
+	slice, ok := a.binaryArray.(interface{ Slice(i, j int) binaryArray })
+	if ok {
+		return &String{binaryArray: slice.Slice(i, j)}
 	}
-	a.value.Retain()
+	data := array.NewSliceData(a.binaryArray.Data(), int64(i), int64(j))
+	defer data.Release()
 	return &String{
-		value:  a.value,
-		length: j - i,
+		binaryArray: array.NewBinaryData(data),
 	}
 }
 
-// ValueBytes returns a byte slice containing the value of this string
-// at index i. This slice points to the contents of the data buffer and
-// is only valid for the lifetime of the array.
-func (a *String) ValueBytes(i int) []byte {
-	if a.data != nil {
-		return a.data.Value(i)
-	}
-	return a.value.Bytes()
-}
-
-// Value returns a string copy of the value stored at index i. The
-// returned value will outlive the array and is safe to use like any
-// other go string. The memory backing the string will be allocated by
-// the runtime, rather than any provided allocator.
+// Value returns a string view of the bytes in the array. The string
+// is only valid for the lifetime of the array. Care should be taken not
+// to store this string without also retaining the array.
 func (a *String) Value(i int) string {
-	return string(a.ValueBytes(i))
+	return a.ValueString(i)
 }
-func (a *String) ValueLen(i int) int {
-	if a.data != nil {
-		return a.data.ValueLen(i)
+
+// ValueRef returns a reference to the memory buffer and location that
+// stores the value at i. The reference is only valid for as long as the
+// array is, the buffer needs to be retained if further access is
+// required.
+func (a *String) ValueRef(i int) StringRef {
+	if vr, ok := a.binaryArray.(interface{ ValueRef(int) StringRef }); ok {
+		return vr.ValueRef(i)
 	}
-	return a.value.Len()
+	return StringRef{
+		buf: a.Data().Buffers()[2],
+		off: a.ValueOffset(i),
+		len: a.ValueLen(i),
+	}
 }
+
+// ValueCopy returns the value at the requested position copied into a
+// new memory location. This value will remain valid after the array is
+// released, but is not tracked by the memory allocator.
+//
+// This function is intended to be temporary while changes are being
+// made to reduce the amount of unaccounted data memory.
+func (a *String) ValueCopy(i int) string {
+	return string(a.ValueRef(i).Bytes())
+}
+
 func (a *String) IsConstant() bool {
-	return a.data == nil
+	ic, ok := a.binaryArray.(interface{ IsConstant() bool })
+	return ok && ic.IsConstant()
 }
 
-type stringValue struct {
-	rc   int64
-	data []byte
-
-	mem arrowmem.Allocator
+// StringRef contains a referenct to the storage for a value.
+type StringRef struct {
+	buf *arrowmem.Buffer
+	off int
+	len int
 }
 
-func (v *stringValue) Retain() {
-	if v == nil {
-		return
-	}
-	atomic.AddInt64(&v.rc, 1)
+// Buffer returns the memory buffer that contains the value.
+func (r StringRef) Buffer() *arrowmem.Buffer {
+	return r.buf
 }
 
-func (v *stringValue) Release() {
-	if v == nil {
-		return
-	}
-	if atomic.AddInt64(&v.rc, -1) == 0 {
-		v.mem.Free(v.data)
-	}
+// Offset returns the offset into the memory buffer at which the value
+// starts.
+func (r StringRef) Offset() int {
+	return r.off
 }
 
-func (v *stringValue) Bytes() []byte {
-	if v == nil {
-		return nil
-	}
-	return v.data
+// Len returns the length of the value.
+func (r StringRef) Len() int {
+	return r.len
 }
 
-func (v *stringValue) Len() int {
-	if v == nil {
-		return 0
-	}
-	return len(v.data)
+// Bytes returns the bytes from the memory buffer that contain the
+// value.
+func (r StringRef) Bytes() []byte {
+	return r.buf.Bytes()[r.off : r.off+r.len]
 }
 
 type sliceable interface {

--- a/array/binary.go
+++ b/array/binary.go
@@ -155,11 +155,11 @@ func StringAdd(l, r *String, mem memory.Allocator) (*String, error) {
 	b.Resize(n)
 	for i := 0; i < n; i++ {
 		if l.IsValid(i) && r.IsValid(i) {
-			lb := l.ValueBytes(i)
-			rb := r.ValueBytes(i)
-			buf := make([]byte, len(lb)+len(rb))
-			copy(buf, lb)
-			copy(buf[len(lb):], rb)
+			ls := l.Value(i)
+			rs := r.Value(i)
+			buf := make([]byte, len(ls)+len(rs))
+			copy(buf, ls)
+			copy(buf[len(ls):], rs)
 			b.AppendBytes(buf)
 
 		} else {
@@ -177,10 +177,10 @@ func StringAddLConst(l string, r *String, mem memory.Allocator) (*String, error)
 	b.Resize(n)
 	for i := 0; i < n; i++ {
 		if r.IsValid(i) {
-			rb := r.ValueBytes(i)
-			buf := make([]byte, len(l)+len(rb))
+			rs := r.Value(i)
+			buf := make([]byte, len(l)+len(rs))
 			copy(buf, l)
-			copy(buf[len(l):], rb)
+			copy(buf[len(l):], rs)
 			b.AppendBytes(buf)
 
 		} else {
@@ -198,10 +198,10 @@ func StringAddRConst(l *String, r string, mem memory.Allocator) (*String, error)
 	b.Resize(n)
 	for i := 0; i < n; i++ {
 		if l.IsValid(i) {
-			lb := l.ValueBytes(i)
-			buf := make([]byte, len(lb)+len(r))
-			copy(buf, lb)
-			copy(buf[len(lb):], r)
+			ls := l.Value(i)
+			buf := make([]byte, len(ls)+len(r))
+			copy(buf, ls)
+			copy(buf[len(ls):], r)
 			b.AppendBytes(buf)
 
 		} else {

--- a/array/builder.go
+++ b/array/builder.go
@@ -2,7 +2,6 @@ package array
 
 import (
 	"bytes"
-	"sync/atomic"
 
 	"github.com/apache/arrow/go/v7/arrow/array"
 	"github.com/apache/arrow/go/v7/arrow/bitutil"
@@ -10,101 +9,38 @@ import (
 )
 
 type StringBuilder struct {
-	refCount     int64
-	builder      *array.BinaryBuilder
-	mem          memory.Allocator
-	value        *stringValue
-	length       int
-	capacity     int
-	dataCapacity int
+	mem      memory.Allocator
+	builder  *array.BinaryBuilder
+	constant bool
 }
 
 func NewStringBuilder(mem memory.Allocator) *StringBuilder {
 	return &StringBuilder{
 		mem:      mem,
-		refCount: 1,
+		builder:  array.NewBinaryBuilder(mem, StringType),
+		constant: true,
 	}
 }
-func (b *StringBuilder) init() {
-	if b.builder != nil {
-		return
-	}
-	builder := array.NewBinaryBuilder(b.mem, StringType)
-	if capacity := b.Cap(); capacity > 0 {
-		builder.Resize(capacity)
-		dataCapacity := b.value.Len() * capacity
-		if dataCapacity < b.dataCapacity {
-			dataCapacity = b.dataCapacity
-		}
-		builder.ReserveData(dataCapacity)
-	}
-	if b.length > 0 {
-		for i := 0; i < b.length; i++ {
-			builder.Append(b.value.Bytes())
-		}
-	}
-	b.builder = builder
-	b.value.Release()
-	b.value = nil
-}
-func (b *StringBuilder) reset() {
-	b.builder = nil
-	b.length = 0
-	b.value = nil
-	b.capacity = 0
-	b.dataCapacity = 0
-}
+
 func (b *StringBuilder) Retain() {
-	atomic.AddInt64(&b.refCount, 1)
+	b.builder.Retain()
 }
 func (b *StringBuilder) Release() {
-	if atomic.AddInt64(&b.refCount, -1) != 0 {
-		return
-	}
-	if b.builder != nil {
-		b.builder.Release()
-		b.builder = nil
-	}
-	if b.value != nil {
-		b.value.Release()
-		b.value = nil
-	}
+	b.builder.Release()
 }
 func (b *StringBuilder) Len() int {
-	if b.builder != nil {
-		return b.builder.Len()
-	}
-	return b.length
+	return b.builder.Len()
 }
 func (b *StringBuilder) Cap() int {
-	if b.builder != nil {
-		return b.builder.Cap()
-	}
-
-	capacity := b.capacity
-	if capacity < b.length {
-		capacity = b.length
-	}
-	return capacity
+	return b.builder.Cap()
 }
 func (b *StringBuilder) NullN() int {
-	if b.builder != nil {
-		return b.builder.NullN()
-	}
-	return 0
+	return b.builder.NullN()
 }
 
 func (b *StringBuilder) AppendBytes(buf []byte) {
-	if b.builder == nil && (b.length == 0 || bytes.Equal(buf, b.value.Bytes())) {
-		if b.value == nil {
-			b.initValue(len(buf))
-			copy(b.value.data, buf)
-		}
-		b.length++
-		return
-	}
-	if b.value != nil {
-		b.init()
+	if b.builder.Len() > 0 {
+		b.constant = b.constant && bytes.Equal(buf, b.builder.Value(0))
 	}
 	b.builder.Append(buf)
 }
@@ -112,26 +48,7 @@ func (b *StringBuilder) AppendBytes(buf []byte) {
 // Append appends a string to the array being built. The input string
 // will always be copied.
 func (b *StringBuilder) Append(v string) {
-	if b.builder == nil && (b.length == 0 || v == string(b.value.Bytes())) {
-		if b.value == nil {
-			b.initValue(len(v))
-			copy(b.value.data, v)
-		}
-		b.length++
-		return
-	}
-	if b.value != nil {
-		b.init()
-	}
-	b.builder.AppendString(v)
-}
-
-func (b *StringBuilder) initValue(size int) {
-	b.value = &stringValue{
-		data: b.mem.Allocate(size),
-		mem:  b.mem,
-		rc:   1,
-	}
+	b.AppendBytes([]byte(v))
 }
 
 func (b *StringBuilder) AppendValues(v []string, valid []bool) {
@@ -144,50 +61,40 @@ func (b *StringBuilder) AppendValues(v []string, valid []bool) {
 	}
 }
 func (b *StringBuilder) AppendNull() {
-	b.init()
+	b.constant = false
 	b.builder.AppendNull()
 }
+
 func (b *StringBuilder) UnsafeAppendBoolToBitmap(isValid bool) {
-	b.init()
 	b.builder.UnsafeAppendBoolToBitmap(isValid)
 }
+
 func (b *StringBuilder) Reserve(n int) {
-	if b.builder != nil {
-		b.builder.Reserve(n)
-		return
-	}
-	b.capacity = n
+	b.builder.Reserve(n)
 }
+
 func (b *StringBuilder) ReserveData(n int) {
-	if b.builder != nil {
-		b.builder.ReserveData(n)
-		return
-	}
-	b.dataCapacity = n
+	b.builder.ReserveData(n)
 }
+
 func (b *StringBuilder) Resize(n int) {
-	if b.builder != nil {
-		b.builder.Resize(n)
-		return
-	}
-	// In arrow, resize and reserve both affect
-	// the capacity. Neither of them change the
-	// length of the built array.
-	b.capacity = n
+	b.builder.Resize(n)
 }
+
 func (b *StringBuilder) NewArray() Array {
 	return b.NewStringArray()
 }
+
 func (b *StringBuilder) NewStringArray() *String {
-	arr := &String{}
-	if b.builder == nil {
-		arr.value, arr.length = b.value, b.length
-	} else {
-		arr.data = b.builder.NewBinaryArray()
+	arr := b.builder.NewBinaryArray()
+	if !b.constant || arr.Len() < 1 {
+		b.constant = true
+		return &String{arr}
 	}
-	b.reset()
-	return arr
+	defer arr.Release()
+	return StringRepeat(arr.ValueString(0), arr.Len(), b.mem)
 }
+
 func (b *StringBuilder) CopyValidValues(values *String, nullCheckArray Array) {
 	if values.Len() != nullCheckArray.Len() {
 		panic("Length mismatch between the value array and the null check array")
@@ -198,7 +105,7 @@ func (b *StringBuilder) CopyValidValues(values *String, nullCheckArray Array) {
 	nullOffset := nullCheckArray.Data().Offset()
 	for i := 0; i < values.Len(); i++ {
 		if isValid(nullBitMapBytes, nullOffset, i) {
-			b.AppendBytes(values.ValueBytes(i))
+			b.Append(values.Value(i))
 		}
 	}
 }

--- a/array/repeat.go
+++ b/array/repeat.go
@@ -1,16 +1,93 @@
 package array
 
-import "github.com/apache/arrow/go/v7/arrow/memory"
+import (
+	"unsafe"
+
+	"github.com/apache/arrow/go/v7/arrow"
+	"github.com/apache/arrow/go/v7/arrow/memory"
+)
 
 func StringRepeat(v string, n int, mem memory.Allocator) *String {
-	sv := stringValue{
-		data: mem.Allocate(len(v)),
-		mem:  mem,
-		rc:   1,
-	}
-	copy(sv.data, v)
+	buf := memory.NewResizableBuffer(mem)
+	buf.Resize(len(v))
+	copy(buf.Bytes(), v)
 	return &String{
-		value:  &sv,
-		length: n,
+		binaryArray: &repeatedBinary{
+			len: n,
+			buf: buf,
+		},
+	}
+}
+
+type repeatedBinary struct {
+	len int
+	buf *memory.Buffer
+}
+
+func (*repeatedBinary) Data() arrow.ArrayData {
+	return nil
+}
+
+func (*repeatedBinary) NullN() int {
+	return 0
+}
+
+func (*repeatedBinary) NullBitmapBytes() []byte {
+	return nil
+}
+
+func (*repeatedBinary) IsNull(i int) bool {
+	return false
+}
+
+func (b *repeatedBinary) IsValid(i int) bool {
+	return i < b.len
+}
+
+func (b *repeatedBinary) Len() int {
+	return b.len
+}
+
+func (b *repeatedBinary) ValueBytes() []byte {
+	return b.buf.Bytes()
+}
+
+func (b *repeatedBinary) ValueLen(int) int {
+	return b.buf.Len()
+}
+
+func (*repeatedBinary) ValueOffset(int) int {
+	return 0
+}
+
+func (b *repeatedBinary) ValueString(int) string {
+	return unsafe.String(unsafe.SliceData(b.buf.Bytes()), b.buf.Len())
+}
+
+func (b *repeatedBinary) Retain() {
+	b.buf.Retain()
+}
+
+func (b *repeatedBinary) Release() {
+	b.buf.Release()
+}
+
+func (b *repeatedBinary) IsConstant() bool {
+	return true
+}
+
+func (b *repeatedBinary) Slice(i, j int) binaryArray {
+	b.buf.Retain()
+	return &repeatedBinary{
+		len: j - i,
+		buf: b.buf,
+	}
+}
+
+func (b *repeatedBinary) ValueRef(int) StringRef {
+	return StringRef{
+		buf: b.buf,
+		off: 0,
+		len: b.buf.Len(),
 	}
 }

--- a/array/repeat_test.go
+++ b/array/repeat_test.go
@@ -39,7 +39,7 @@ func TestRepeat(t *testing.T) {
 			name: "String",
 			t:    flux.TString,
 			v:    values.NewString("a"),
-			sz:   1, // optimized to a single instance
+			sz:   64, // optimized to a single instance - 64 bytes
 		},
 		{
 			name: "Boolean",

--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -472,7 +472,7 @@ func TestSlice_String(t *testing.T) {
 
 	vs := make([]string, l)
 	for i := 0; i < l; i++ {
-		vs[i] = arr.Value(i)
+		vs[i] = arr.ValueCopy(i)
 	}
 
 	if !cmp.Equal(values, vs) {
@@ -540,7 +540,7 @@ func TestSlice_String(t *testing.T) {
 
 			vs = vs[:0]
 			for i := 0; i < l; i++ {
-				vs = append(vs, arr.Value(i))
+				vs = append(vs, arr.ValueCopy(i))
 			}
 
 			if !cmp.Equal(tc.want, vs) {

--- a/csv/result.go
+++ b/csv/result.go
@@ -1257,7 +1257,7 @@ func encodeValueFrom(i, j int, c colMeta, cr flux.ColReader) (string, error) {
 		}
 	case flux.TString:
 		if cr.Strings(j).IsValid(i) {
-			v = cr.Strings(j).Value(i)
+			v = cr.Strings(j).ValueCopy(i)
 		}
 	case flux.TTime:
 		if cr.Times(j).IsValid(i) {

--- a/execute/executetest/table.go
+++ b/execute/executetest/table.go
@@ -544,7 +544,7 @@ func ConvertTable(tbl flux.Table) (*Table, error) {
 					}
 				case flux.TString:
 					if col := cr.Strings(j); col.IsValid(i) {
-						row[j] = col.Value(i)
+						row[j] = col.ValueCopy(i)
 					}
 				case flux.TTime:
 					if col := cr.Times(j); col.IsValid(i) {

--- a/execute/format.go
+++ b/execute/format.go
@@ -251,7 +251,7 @@ func (f *Formatter) valueBuf(i, j int, typ flux.ColType, cr flux.ColReader) []by
 		}
 	case flux.TString:
 		if cr.Strings(j).IsValid(i) {
-			buf = cr.Strings(j).ValueBytes(i)
+			buf = []byte(cr.Strings(j).Value(i))
 		}
 	case flux.TTime:
 		if cr.Times(j).IsValid(i) {

--- a/execute/table.go
+++ b/execute/table.go
@@ -437,7 +437,7 @@ func ValueForRow(cr flux.ColReader, i, j int) values.Value {
 		if cr.Strings(j).IsNull(i) {
 			return values.NewNull(semantic.BasicString)
 		}
-		return values.NewString(cr.Strings(j).Value(i))
+		return values.NewString(cr.Strings(j).ValueCopy(i))
 	case flux.TInt:
 		if cr.Ints(j).IsNull(i) {
 			return values.NewNull(semantic.BasicInt)

--- a/execute/table/stringify.go
+++ b/execute/table/stringify.go
@@ -124,7 +124,7 @@ func valueForRow(cr flux.ColReader, i, j int) values.Value {
 		if cr.Strings(j).IsNull(i) {
 			return values.NewNull(semantic.BasicString)
 		}
-		return values.NewString(cr.Strings(j).Value(i))
+		return values.NewString(cr.Strings(j).ValueCopy(i))
 	case flux.TInt:
 		if cr.Ints(j).IsNull(i) {
 			return values.NewNull(semantic.BasicInt)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/flux
 
-go 1.18
+go 1.20
 
 require (
 	cloud.google.com/go v0.110.0

--- a/internal/arrowutil/array_values.gen.go
+++ b/internal/arrowutil/array_values.gen.go
@@ -498,7 +498,7 @@ func (v StringArrayValue) Get(i int) values.Value {
 	if v.arr.IsNull(i) {
 		return values.Null
 	}
-	return values.New(v.arr.Value(i))
+	return values.New(v.arr.ValueCopy(i))
 }
 
 func (v StringArrayValue) Set(i int, value values.Value) {

--- a/internal/arrowutil/compare.gen.go
+++ b/internal/arrowutil/compare.gen.go
@@ -237,7 +237,7 @@ func StringCompare(x, y *array.String, i, j int) int {
 		return 1
 	}
 
-	if l, r := x.Value(i), y.Value(j); l < r {
+	if l, r := x.ValueCopy(i), y.ValueCopy(j); l < r {
 		return -1
 	} else if l == r {
 		return 0
@@ -256,7 +256,7 @@ func StringCompareDesc(x, y *array.String, i, j int) int {
 		return 1
 	}
 
-	if l, r := x.Value(i), y.Value(j); l > r {
+	if l, r := x.ValueCopy(i), y.ValueCopy(j); l > r {
 		return -1
 	} else if l == r {
 		return 0

--- a/internal/arrowutil/copy.gen.go
+++ b/internal/arrowutil/copy.gen.go
@@ -284,7 +284,7 @@ func CopyStringsTo(b *array.StringBuilder, arr *array.String) {
 			b.AppendNull()
 			continue
 		}
-		b.Append(arr.Value(i))
+		b.Append(arr.ValueCopy(i))
 	}
 }
 
@@ -315,7 +315,7 @@ func CopyStringsByIndexTo(b *array.StringBuilder, arr *array.String, indices *ar
 			b.AppendNull()
 			continue
 		}
-		b.Append(arr.Value(offset))
+		b.Append(arr.ValueCopy(offset))
 	}
 }
 
@@ -324,5 +324,5 @@ func CopyStringValue(b *array.StringBuilder, arr *array.String, i int) {
 		b.AppendNull()
 		return
 	}
-	b.Append(arr.Value(i))
+	b.Append(arr.ValueCopy(i))
 }

--- a/internal/arrowutil/filter.gen.go
+++ b/internal/arrowutil/filter.gen.go
@@ -108,7 +108,7 @@ func FilterStrings(arr *array.String, bitset []byte, mem memory.Allocator) *arra
 	for i := 0; i < len(bitset); i++ {
 		if bitutil.BitIsSet(bitset, i) {
 			if arr.IsValid(i) {
-				b.Append(arr.Value(i))
+				b.Append(arr.ValueCopy(i))
 			} else {
 				b.AppendNull()
 			}

--- a/internal/arrowutil/iterator.gen.go
+++ b/internal/arrowutil/iterator.gen.go
@@ -289,10 +289,10 @@ func IterateStrings(arrs []array.Array) StringIterator {
 	return StringIterator{Values: values}
 }
 
-// Value returns the current value in the iterator.
+// ValueCopy returns the current value in the iterator.
 func (i *StringIterator) Value() string {
 	vs := i.Values[0]
-	return vs.Value(i.i)
+	return vs.ValueCopy(i.i)
 }
 
 // IsValid returns if the current value is valid.

--- a/internal/arrowutil/iterator.gen.go.tmpl
+++ b/internal/arrowutil/iterator.gen.go.tmpl
@@ -20,7 +20,7 @@ func Iterate{{.Name}}s(arrs []array.Array) {{.Name}}Iterator {
 	return {{.Name}}Iterator{Values: values}
 }
 
-// {{.Value}} returns the current value in the iterator.
+// Value returns the current value in the iterator.
 func (i *{{.Name}}Iterator) Value() {{.PrimitiveType}} {
 	vs := i.Values[0]
 	return vs.{{.Value}}(i.i)

--- a/internal/arrowutil/iterator.gen.go.tmpl
+++ b/internal/arrowutil/iterator.gen.go.tmpl
@@ -21,7 +21,7 @@ func Iterate{{.Name}}s(arrs []array.Array) {{.Name}}Iterator {
 }
 
 // {{.Value}} returns the current value in the iterator.
-func (i *{{.Name}}Iterator) {{.Value}}() {{.PrimitiveType}} {
+func (i *{{.Name}}Iterator) Value() {{.PrimitiveType}} {
 	vs := i.Values[0]
 	return vs.{{.Value}}(i.i)
 }

--- a/internal/arrowutil/iterator.gen_test.go.tmpl
+++ b/internal/arrowutil/iterator.gen_test.go.tmpl
@@ -36,7 +36,7 @@ func TestIterate{{.Name}}s(t *testing.T) {
 		if want, got := arr.IsValid(i%100), itr.IsValid(); !cmp.Equal(want, got) {
 			t.Fatalf("unexpected valid value at index %d -want/+got:\n%s", i, cmp.Diff(want, got))
 		} else if want && got {
-			if want, got := arr.{{.Value}}(i%100), itr.{{.Value}}(); !cmp.Equal(want, got) {
+			if want, got := arr.Value(i%100), itr.Value(); !cmp.Equal(want, got) {
 				t.Fatalf("unexpected value at index %d -want/+got:\n%s", i, cmp.Diff(want, got))
 			}
 		}

--- a/internal/arrowutil/types.tmpldata
+++ b/internal/arrowutil/types.tmpldata
@@ -50,7 +50,7 @@
     "MonoType": "semantic.BasicString",
     "IsNumeric": false,
     "IsComparable": true,
-    "Value": "Value",
+    "Value": "ValueCopy",
     "Append": "Append",
     "NewArray": "NewStringArray"
   }

--- a/internal/moving_average/array_container.go
+++ b/internal/moving_average/array_container.go
@@ -37,7 +37,7 @@ func (a *ArrayContainer) Value(i int) values.Value {
 	case *array.Float:
 		return values.New(float64(a.array.(*array.Float).Value(i)))
 	case *array.String:
-		return values.New(string(a.array.(*array.String).Value(i)))
+		return values.New(string(a.array.(*array.String).ValueCopy(i)))
 	default:
 		return nil
 	}
@@ -54,7 +54,7 @@ func (a *ArrayContainer) OrigValue(i int) interface{} {
 	case *array.Float:
 		return a.array.(*array.Float).Value(i)
 	case *array.String:
-		return string(a.array.(*array.String).Value(i))
+		return a.array.(*array.String).ValueCopy(i)
 	default:
 		return nil
 	}

--- a/result_iterator_test.go
+++ b/result_iterator_test.go
@@ -192,7 +192,7 @@ func TestQueryResultIterator_Results(t *testing.T) {
 				for i := 0; i < cr.Len(); i++ {
 					r := row{
 						Value: cr.Ints(0).Value(i),
-						Tag:   cr.Strings(1).Value(i),
+						Tag:   cr.Strings(1).ValueCopy(i),
 					}
 					got = append(got, r)
 				}

--- a/semantic/semantictest/cmp.go
+++ b/semantic/semantictest/cmp.go
@@ -219,7 +219,7 @@ func getValue(arr array.Array, i int) values.Value {
 	case *array.Float:
 		return values.New(arr.Value(i))
 	case *array.String:
-		return values.New(arr.Value(i))
+		return values.New(arr.ValueCopy(i))
 	case *array.Boolean:
 		return values.New(arr.Value(i))
 	default:

--- a/stdlib/experimental/diff.go
+++ b/stdlib/experimental/diff.go
@@ -381,7 +381,7 @@ func (d *diffSchema) appendRow(builders []array.Builder, which, i int) {
 		case *array.UintBuilder:
 			b.Append(arr.(*array.Uint).Value(i))
 		case *array.StringBuilder:
-			b.AppendBytes(arr.(*array.String).ValueBytes(i))
+			b.Append(arr.(*array.String).Value(i))
 		case *array.BooleanBuilder:
 			b.Append(arr.(*array.Boolean).Value(i))
 		default:

--- a/stdlib/experimental/mqtt/to.go
+++ b/stdlib/experimental/mqtt/to.go
@@ -316,12 +316,12 @@ func (t *ToMQTTTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 						if col.Type != flux.TString {
 							return errors.Newf(codes.FailedPrecondition, "invalid type for measurement column: %s", col.Type)
 						}
-						m.name = er.Strings(j).Value(i)
+						m.name = er.Strings(j).ValueCopy(i)
 					case isTag[j]:
 						if col.Type != flux.TString {
 							return errors.Newf(codes.FailedPrecondition, "invalid type for tag column: %s", col.Type)
 						}
-						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j).Value(i)})
+						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j).ValueCopy(i)})
 
 					case isValue[j]:
 						switch col.Type {
@@ -332,7 +332,7 @@ func (t *ToMQTTTransformation) Process(id execute.DatasetID, tbl flux.Table) err
 						case flux.TUInt:
 							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.UInts(j).Value(i)})
 						case flux.TString:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j).Value(i)})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j).ValueCopy(i)})
 						case flux.TTime:
 							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: values.Time(er.Times(j).Value(i))})
 						case flux.TBool:

--- a/stdlib/influxdata/influxdb/to.go
+++ b/stdlib/influxdata/influxdb/to.go
@@ -217,7 +217,7 @@ outer:
 		for j, col := range chunk.Cols() {
 			switch {
 			case col.Label == spec.MeasurementColumn:
-				metric.NameStr = er.Strings(j).Value(i)
+				metric.NameStr = er.Strings(j).ValueCopy(i)
 			case col.Label == timeColLabel:
 				valueTime := execute.ValueForRow(&er, i, j)
 				if valueTime.IsNull() {
@@ -230,7 +230,7 @@ outer:
 					return errors.New(codes.Invalid, "invalid type for tag column")
 				}
 
-				value := er.Strings(j).Value(i)
+				value := er.Strings(j).ValueCopy(i)
 				if value == "" {
 					// Skip tag value if it is empty.
 					continue

--- a/stdlib/kafka/to.go
+++ b/stdlib/kafka/to.go
@@ -353,12 +353,12 @@ func (t *ToKafkaTransformation) Process(id execute.DatasetID, tbl flux.Table) (e
 						if col.Type != flux.TString {
 							return errors.New(codes.FailedPrecondition, "invalid type for measurement column")
 						}
-						m.name = er.Strings(j).Value(i)
+						m.name = er.Strings(j).ValueCopy(i)
 					case isTag[j]:
 						if col.Type != flux.TString {
 							return errors.New(codes.FailedPrecondition, "invalid type for measurement column")
 						}
-						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j).Value(i)})
+						m.tags = append(m.tags, &protocol.Tag{Key: col.Label, Value: er.Strings(j).ValueCopy(i)})
 					case isValue[j]:
 						switch col.Type {
 						case flux.TFloat:
@@ -368,7 +368,7 @@ func (t *ToKafkaTransformation) Process(id execute.DatasetID, tbl flux.Table) (e
 						case flux.TUInt:
 							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.UInts(j).Value(i)})
 						case flux.TString:
-							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j).Value(i)})
+							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: er.Strings(j).ValueCopy(i)})
 						case flux.TTime:
 							m.fields = append(m.fields, &protocol.Field{Key: col.Label, Value: values.Time(er.Times(j).Value(i))})
 						case flux.TBool:

--- a/stdlib/sql/to.go
+++ b/stdlib/sql/to.go
@@ -471,7 +471,7 @@ func CreateInsertComponents(t *ToSQLTransformation, tbl flux.Table) (colNames []
 						valueArgs = append(valueArgs, nil)
 						break
 					}
-					valueArgs = append(valueArgs, er.Strings(j).Value(i))
+					valueArgs = append(valueArgs, er.Strings(j).ValueCopy(i))
 				case flux.TTime:
 					if er.Times(j).IsNull(i) {
 						valueArgs = append(valueArgs, nil)

--- a/stdlib/universe/distinct.go
+++ b/stdlib/universe/distinct.go
@@ -309,7 +309,7 @@ func (t *distinctTransformation) Process(id execute.DatasetID, tbl flux.Table) e
 					}
 					nullDistinct = true
 				} else {
-					v := cr.Strings(j).Value(i)
+					v := cr.Strings(j).ValueCopy(i)
 					if stringDistinct[v] {
 						continue
 					}

--- a/stdlib/universe/group.go
+++ b/stdlib/universe/group.go
@@ -427,7 +427,7 @@ func (t *groupTransformation) appendValueFromRow(b array.Builder, cr flux.ColRea
 		if vs.IsNull(i) {
 			b.AppendNull()
 		} else {
-			b.AppendBytes(vs.ValueBytes(i))
+			b.Append(vs.Value(i))
 		}
 	case flux.TBool:
 		b := b.(*array.BooleanBuilder)

--- a/stdlib/universe/key_values.go
+++ b/stdlib/universe/key_values.go
@@ -396,7 +396,7 @@ func (t *keyValuesTransformation) Process(id execute.DatasetID, tbl flux.Table) 
 							}
 							nullDistinct = true
 						} else {
-							v := vs.Value(i)
+							v := vs.ValueCopy(i)
 							if stringDistinct[[2]string{c.name, v}] {
 								continue
 							}

--- a/stdlib/universe/mode.go
+++ b/stdlib/universe/mode.go
@@ -220,7 +220,7 @@ func (t *modeTransformation) doString(cr flux.ColReader, tbl flux.Table, builder
 		if cr.Strings(j).IsNull(i) {
 			continue
 		}
-		v := cr.Strings(j).Value(i)
+		v := cr.Strings(j).ValueCopy(i)
 		stringMode[v]++
 	}
 

--- a/stdlib/universe/moving_average.go
+++ b/stdlib/universe/moving_average.go
@@ -373,7 +373,7 @@ func (m *movingAverageState) forceValue() error {
 				b.Append(arr.Value(arr.Len() - 1))
 			case *array.StringBuilder:
 				arr := arr.(*array.String)
-				b.AppendBytes(arr.ValueBytes(arr.Len() - 1))
+				b.Append(arr.Value(arr.Len() - 1))
 			case *array.BooleanBuilder:
 				arr := arr.(*array.Boolean)
 				b.Append(arr.Value(arr.Len() - 1))

--- a/stdlib/universe/pivot.go
+++ b/stdlib/universe/pivot.go
@@ -384,7 +384,7 @@ func valueToStr(cr flux.ColReader, c flux.ColMeta, row, col int) string {
 		}
 	case flux.TString:
 		if v := cr.Strings(col); v.IsValid(row) {
-			result = v.Value(row)
+			result = v.ValueCopy(row)
 		}
 	case flux.TTime:
 		if v := cr.Times(col); v.IsValid(row) {

--- a/stdlib/universe/table_fns.go
+++ b/stdlib/universe/table_fns.go
@@ -189,7 +189,7 @@ func arrayFromColumn(idx int, tbl flux.Table) (values.Array, error) {
 			switch typ {
 			case flux.TString:
 				if vs := cr.Strings(idx); vs.IsValid(i) {
-					vsSlice = append(vsSlice, values.New(vs.Value(i)))
+					vsSlice = append(vsSlice, values.New(vs.ValueCopy(i)))
 				} else {
 					vsSlice = append(vsSlice, values.NewNull(semantic.BasicString))
 				}
@@ -279,7 +279,7 @@ func objectFromRow(idx int, cr flux.ColReader) values.Object {
 		switch c.Type {
 		case flux.TString:
 			if vs := cr.Strings(j); vs.IsValid(idx) {
-				v = values.New(vs.Value(idx))
+				v = values.New(vs.ValueCopy(idx))
 			} else {
 				v = values.NewNull(semantic.BasicString)
 			}


### PR DESCRIPTION
Change the behviour of the string array back to the old behaviour where accessing the Value function returns a string that is backed by the arrow memory buffer. This avoids data allocations to memory outside of the memory allocator.

The implementation of array.String has been simplified somewhat as part of the new behaviour.

There are a number of places where correct behviour relies on copies of the data being made. To avoid having to fix all of these in the same PR a temporary ValueCopy function has been added to maintain the old semantics. This is being used everywhere the Value function was previously, except for cases where the value is obviously immediately processed, then discarded.

The cases where the `VisitCopy` function is being used will be address one at a time until we can avoid significant levels of unaccounted memory.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
