### PR TITLE
fix(stdlib): join path correctly in influxdb source

### DIFF
--- a/stdlib/influxdata/influxdb/source.go
+++ b/stdlib/influxdata/influxdb/source.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/ast"
@@ -111,7 +112,7 @@ func (s *source) newRequest(ctx context.Context) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	u.Path += "/api/v2/query"
+	u.Path = path.Join(u.Path, "/api/v2/query")
 	if org := s.spec.GetOrg(); org != nil {
 		u.RawQuery = func() string {
 			params := make(url.Values)


### PR DESCRIPTION
Update the influxdb from command to support URLs with a trailing slash.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
