### PR TITLE
fix: null string to bytes conversions

### DIFF
--- a/stdlib/universe/typeconv.go
+++ b/stdlib/universe/typeconv.go
@@ -374,6 +374,9 @@ var byteConv = values.NewFunction(
 		} else if v.Type().Nature() == semantic.Dynamic {
 			v = v.Dynamic().Inner()
 		}
+		if v.IsNull() {
+			v = values.Null
+		}
 
 		switch v.Type().Nature() {
 		case semantic.String:

--- a/stdlib/universe/typeconv_test.go
+++ b/stdlib/universe/typeconv_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/influxdata/flux/dependencies/dependenciestest"
 	"github.com/influxdata/flux/dependency"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/semantic"
 	"github.com/influxdata/flux/values"
 )
 
@@ -784,5 +785,19 @@ func TestTypeconv_Duration(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTypeconv_Bytes_NullString(t *testing.T) {
+	myMap := map[string]values.Value{
+		"v": values.NewNull(semantic.BasicString),
+	}
+	args := values.NewObjectWithValues(myMap)
+	c := byteConv
+	ctx, deps := dependency.Inject(context.Background(), dependenciestest.Default())
+	defer deps.Finish()
+	_, err := c.Call(ctx, args)
+	if err == nil || err.Error() != "cannot convert null to bytes" {
+		t.Errorf(`Expected error "cannot convert null to bytes", got %q`, err)
 	}
 }


### PR DESCRIPTION
Avoid a panic if the bytes conversion function receives a string typed NULL value. The function now returns the same error as for other NULL values.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
