### PR TITLE
fix(stdlib/influxdata/wideto): panic with null string key

### DIFF
--- a/stdlib/influxdata/influxdb/wide_to.go
+++ b/stdlib/influxdata/influxdb/wide_to.go
@@ -231,6 +231,11 @@ func getTablePointsMetadata(tbl flux.Table) (md tablePointsMetadata, err error) 
 			}
 			isTag[col.Label] = true
 
+			// If the tag is NULL then skip over adding its value to the tag set.
+			if tbl.Key().IsNull(j) {
+				continue
+			}
+
 			value := tbl.Key().ValueString(j)
 			if value == "" {
 				// Skip tag value if it is empty.

--- a/stdlib/influxdata/influxdb/wide_to_test.go
+++ b/stdlib/influxdata/influxdb/wide_to_test.go
@@ -134,7 +134,7 @@ func TestWideToTransformation(t *testing.T) {
 		static.Ints("f1", 1, nil, 3, nil),
 		static.StringKey("_measurement", "m0"),
 		static.TableList{
-			static.StringKeys("t0", "a", "b"),
+			static.StringKeys("t0", "a", nil, "b"),
 		},
 	}
 	if err := input.Do(func(tbl flux.Table) error {
@@ -147,6 +147,9 @@ func TestWideToTransformation(t *testing.T) {
 	want := `m0,t0=a f0=1,f1=1i 0
 m0,t0=a f0=2 10000000000
 m0,t0=a f0=3,f1=3i 20000000000
+m0 f0=1,f1=1i 0
+m0 f0=2 10000000000
+m0 f0=3,f1=3i 20000000000
 m0,t0=b f0=1,f1=1i 0
 m0,t0=b f0=2 10000000000
 m0,t0=b f0=3,f1=3i 20000000000


### PR DESCRIPTION
Update the wideTo function to cope with tables with a null tag value. In these cases the tag is skipped when writing to influxdb.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
