### PR TITLE
fix(libflux): only compile `flux-core` with `strict` if enabled in `flux`

### DIFF
--- a/libflux/flux/Cargo.toml
+++ b/libflux/flux/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 
 [features]
 default = ["strict", "cffi"]
-strict = []
+strict = ["flux-core/strict"]
 cffi = ["serde", "serde_json"]
 lsp = ["flux-core/lsp"]
 label-polymorphism = []
@@ -20,7 +20,7 @@ label-polymorphism = []
 anyhow = "1"
 env_logger = "0.9"
 flatbuffers = "22.9.29"
-flux-core = { path = "../flux-core" }
+flux-core = { path = "../flux-core", default-features = false }
 once_cell = "1"
 serde = { version = "^1.0.59", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
@@ -40,7 +40,7 @@ pretty_assertions = "1"
 anyhow = "1"
 env_logger = "0.9"
 flatbuffers = "22.9.29"
-flux-core = { path = "../flux-core" }
+flux-core = { path = "../flux-core", default-features = false }
 walkdir = "2"
 
 [[bench]]

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -59,7 +59,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/walk/mod.rs":                                                  "027f6d345ab58846bef1a8db26983e74143e880d5e82a500fd12642470b9d86a",
 	"libflux/flux-core/src/semantic/walk/test_utils.rs":                                           "043d5137ed626f1990c89f639e867e5b33a906f13c427313b497062f98215846",
 	"libflux/flux-core/src/semantic/walk/walk_mut.rs":                                             "3e9b8db77f35cfdee5ef7e24c1bc08845484f3cb7ecd50a82163b6ad46899662",
-	"libflux/flux/Cargo.toml":                                                                     "e99bdbe850082422eedbd74dc2890aed7e9ec3193bd366bd8c112c30acf4e3c4",
+	"libflux/flux/Cargo.toml":                                                                     "1dbb9643175c93b7e1c39dda6aa6a9684d7c31ed88bfc44e5bdee5ea4c2977eb",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "31dcb1e825555e56b4d959244c4ea630b1d32ccddc1f8615620e0c23552d914f",
 	"libflux/flux/src/cffi.rs":                                                                    "a5e3c5bb6eeb720f726cc7177afb5e7dd3a3e8b32ac269a2d48f199068995f78",


### PR DESCRIPTION
### Checklist

By inheriting the value of `strict` it is simpler to build `flux` in cases where warnings are acceptable without needing to patch the `flux-core` `Cargo.toml` or source.

The changes can be tested by adding a dead function to `flux-core` e.g. `fn dead_code() {}` and compiling `flux` with `--no-default-features`.

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [x] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
