### PR TITLE
fix: Revert "feat(execute): allocate memory for string content. (#5482)"

### DIFF
--- a/execute/allocator.go
+++ b/execute/allocator.go
@@ -1,8 +1,6 @@
 package execute
 
 import (
-	arrowmem "github.com/apache/arrow/go/v7/arrow/memory"
-
 	"github.com/influxdata/flux/memory"
 )
 
@@ -158,14 +156,17 @@ func (a *Allocator) GrowFloats(slice []float64, n int) []float64 {
 	return s
 }
 
-// Strings makes a slice of String values.
-func (a *Allocator) Strings(l, c int) []String {
+// Strings makes a slice of string values.
+// Only the string headers are accounted for.
+func (a *Allocator) Strings(l, c int) []string {
 	a.account(c, stringSize)
-	return make([]String, l, c)
+	return make([]string, l, c)
 }
 
-// AppendStrings appends Strings to a slice.
-func (a *Allocator) AppendStrings(slice []String, vs ...String) []String {
+// AppendStrings appends strings to a slice.
+// Only the string headers are accounted for.
+func (a *Allocator) AppendStrings(slice []string, vs ...string) []string {
+	// TODO(nathanielc): Account for actual size of strings
 	if cap(slice)-len(slice) >= len(vs) {
 		return append(slice, vs...)
 	}
@@ -175,14 +176,14 @@ func (a *Allocator) AppendStrings(slice []String, vs ...String) []String {
 	return s
 }
 
-func (a *Allocator) GrowStrings(slice []String, n int) []String {
+func (a *Allocator) GrowStrings(slice []string, n int) []string {
 	newCap := len(slice) + n
 	if newCap < cap(slice) {
 		return slice[:newCap]
 	}
 	// grow capacity same way as built-in append
 	newCap = newCap*3/2 + 1
-	s := make([]String, len(slice)+n, newCap)
+	s := make([]string, len(slice)+n, newCap)
 	copy(s, slice)
 	diff := cap(s) - cap(slice)
 	a.account(diff, stringSize)
@@ -218,14 +219,4 @@ func (a *Allocator) GrowTimes(slice []Time, n int) []Time {
 	diff := cap(s) - cap(slice)
 	a.account(diff, timeSize)
 	return s
-}
-
-// String represents a string stored in some backing byte slice.
-type String struct {
-	offset int
-	len    int
-}
-
-func (s String) Bytes(buf *arrowmem.Buffer) []byte {
-	return buf.Bytes()[s.offset : s.offset+s.len]
 }

--- a/execute/table_test.go
+++ b/execute/table_test.go
@@ -148,58 +148,6 @@ func TestTablesEqual(t *testing.T) {
 			},
 			want: false,
 		},
-		{
-			name: "string values",
-			data0: &executetest.Table{
-				ColMeta: []flux.ColMeta{
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_value", Type: flux.TString},
-				},
-				Data: [][]interface{}{
-					{execute.Time(1), "1"},
-					{execute.Time(2), "2"},
-					{execute.Time(3), "3"},
-				},
-			},
-			data1: &executetest.Table{
-				ColMeta: []flux.ColMeta{
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_value", Type: flux.TString},
-				},
-				Data: [][]interface{}{
-					{execute.Time(1), "1"},
-					{execute.Time(2), "2"},
-					{execute.Time(3), "3"},
-				},
-			},
-			want: true,
-		},
-		{
-			name: "string mismatch",
-			data0: &executetest.Table{
-				ColMeta: []flux.ColMeta{
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_value", Type: flux.TString},
-				},
-				Data: [][]interface{}{
-					{execute.Time(1), "1"},
-					{execute.Time(2), "2"},
-					{execute.Time(3), "3"},
-				},
-			},
-			data1: &executetest.Table{
-				ColMeta: []flux.ColMeta{
-					{Label: "_time", Type: flux.TTime},
-					{Label: "_value", Type: flux.TString},
-				},
-				Data: [][]interface{}{
-					{execute.Time(1), "1"},
-					{execute.Time(2), "2"},
-					{execute.Time(3), "4"},
-				},
-			},
-			want: false,
-		},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
This reverts commit bea958616a673ef6b07bb9d469634d0134e900c9.

This PR attempted to reduce the amount of un-accounted memory use. In doing so it introduced a significant amount of data copying. This has made the performance unacceptable. Reverting this change in order to come up with a better plan.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
