### PR TITLE
fix: Make fewer copies when building a string array

### DIFF
--- a/array/array_test.go
+++ b/array/array_test.go
@@ -26,8 +26,8 @@ func TestString(t *testing.T) {
 					b.Append("abcdefghij")
 				}
 			},
-			bsz: 256, // 64 bytes nulls + 192 bytes data.
-			sz:  64,  // The minimum size of a buffer is 64 bytes
+			bsz: 64, // 64 bytes data.
+			sz:  64, // The minimum size of a buffer is 64 bytes
 			want: []interface{}{
 				"abcdefghij",
 				"abcdefghij",

--- a/array/builder.go
+++ b/array/builder.go
@@ -88,8 +88,9 @@ func (b *StringBuilder) AppendBytes(buf []byte) {
 
 }
 
-// Append appends a string to the array being built. The input string
-// will always be copied.
+// Append appends a string to the array being built. A reference
+// to the input string will not be retained by the builder. The
+// string will be copied, if necessary.
 func (b *StringBuilder) Append(v string) {
 	// Avoid copying the input string as AppendBytes
 	// will never keep a reference or modify the input.


### PR DESCRIPTION
Change the StringBuilder to only create an arrow builder when it becomes necessary. Whist the StringBuilder has only a single distinct value it will just record how long the array is. Creating an arrow.StringBuilder when a second distinct value is added.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
