### PR TITLE
build(deps): update rust version

### DIFF
--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -704,9 +704,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "libflate"

--- a/libflux/Cargo.lock
+++ b/libflux/Cargo.lock
@@ -704,9 +704,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"

--- a/libflux/flux-core/Cargo.toml
+++ b/libflux/flux-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flux-core"
 version = "0.154.0"
-rust-version = "1.68"
+rust-version = "1.72"
 authors = ["Flux Team <flux-developers@influxdata.com>"]
 edition = "2021"
 

--- a/libflux/flux-core/src/formatter/tests.rs
+++ b/libflux/flux-core/src/formatter/tests.rs
@@ -236,8 +236,8 @@ fn vars() {
     assert_unchanged("2018-05-22T19:53:01+07:00"); // zone
     assert_unchanged("2018-05-22T19:53:23.09012Z"); // nano sec
     assert_unchanged("2018-05-22T19:53:01.09012-07:00"); // nano with zone
-    assert_unchanged(r#"/^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/"#); // regexp
-    assert_unchanged(r#"/^http:\/\/\w+\.com$/"#); // regexp_escape
+    assert_unchanged(r"/^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/"); // regexp
+    assert_unchanged(r"/^http:\/\/\w+\.com$/"); // regexp_escape
 }
 
 #[test]

--- a/libflux/flux-core/src/parser/strconv.rs
+++ b/libflux/flux-core/src/parser/strconv.rs
@@ -51,11 +51,11 @@ fn push_unescaped_string(s: &mut Vec<u8>, chars: &mut Chars) -> Result<(), Strin
 fn push_hex_byte(s: &mut Vec<u8>, chars: &mut Chars) -> Result<(), String> {
     let ch1 = match chars.next() {
         Some(c) => c,
-        None => return Err(r#"\x followed by 0 char, must be 2"#.to_string()),
+        None => return Err(r"\x followed by 0 char, must be 2".to_string()),
     };
     let ch2 = match chars.next() {
         Some(c) => c,
-        None => return Err(r#"\x followed by 1 char, must be 2"#.to_string()),
+        None => return Err(r"\x followed by 1 char, must be 2".to_string()),
     };
     let b1 = to_byte(ch1);
     let b2 = to_byte(ch2);

--- a/libflux/flux-core/src/parser/tests/literals.rs
+++ b/libflux/flux-core/src/parser/tests/literals.rs
@@ -50,7 +50,7 @@ fn regex_literal() {
 
 #[test]
 fn regex_literal_with_escape_sequence() {
-    let mut p = Parser::new(r#"/a\/b\\c\d/"#);
+    let mut p = Parser::new(r"/a\/b\\c\d/");
     let parsed = p.parse_file("".to_string());
     expect![[r#"
         File {
@@ -98,7 +98,7 @@ fn regex_literal_with_escape_sequence() {
 
 #[test]
 fn regex_literal_with_hex_escape() {
-    let mut p = Parser::new(r#"/^\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e(ZZ)?$/"#);
+    let mut p = Parser::new(r"/^\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e(ZZ)?$/");
     let parsed = p.parse_file("".to_string());
     expect![[r#"
         File {

--- a/libflux/flux-core/src/semantic/tests/vectorize.rs
+++ b/libflux/flux-core/src/semantic/tests/vectorize.rs
@@ -316,10 +316,10 @@ fn vectorize_with_construction_using_literal_string() -> anyhow::Result<()> {
 
     let function = get_vectorized_function(&pkg);
 
-    expect_test::expect![[r##"
+    expect_test::expect![[r#"
         (r) => {
             return {r:#A with a: ~~vecRepeat~~:string(v: "hello"):v[string]}:{#A with a: v[string]}
-        }:(r: #A) => {#A with a: v[string]}"##]]
+        }:(r: #A) => {#A with a: v[string]}"#]]
     .assert_eq(&crate::semantic::formatter::format_node(
         Node::FunctionExpr(function),
     )?);

--- a/libflux/flux/Cargo.toml
+++ b/libflux/flux/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "flux"
 version = "0.154.0"
-rust-version = "1.68"
+rust-version = "1.72"
 authors = ["Flux Team <flux-developers@influxdata.com>"]
 edition = "2021"
 

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -13,7 +13,7 @@ package libflux
 //
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "58302d93174bb2def223a5439ddbc596476216bf511a11f0ff2fc23865fc1d0a",
+	"libflux/Cargo.lock":                                                                          "f38444da6451aecd2bd7c4b977a713d5fa0fd7a80f775d13f8baa097bbfaebd4",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
 	"libflux/flux-core/Cargo.toml":                                                                "b0d9447d8532d4732f5fbbc605229ecfda4e24f7a01731f2949711b3f322add1",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "4a6511e9ccc9718eada01b29544bd4d5c324ae87a85906c25ad7193a890f86fc",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -13,9 +13,9 @@ package libflux
 //
 //lint:ignore U1000 generated code
 var sourceHashes = map[string]string{
-	"libflux/Cargo.lock":                                                                          "f38444da6451aecd2bd7c4b977a713d5fa0fd7a80f775d13f8baa097bbfaebd4",
+	"libflux/Cargo.lock":                                                                          "58302d93174bb2def223a5439ddbc596476216bf511a11f0ff2fc23865fc1d0a",
 	"libflux/Cargo.toml":                                                                          "91ac4e8b467440c6e8a9438011de0e7b78c2732403bb067d4dd31539ac8a90c1",
-	"libflux/flux-core/Cargo.toml":                                                                "b0d9447d8532d4732f5fbbc605229ecfda4e24f7a01731f2949711b3f322add1",
+	"libflux/flux-core/Cargo.toml":                                                                "971f23ba5dd621df72be85c61135abf1583b0bcc18e2cf51eb0d9107d61639db",
 	"libflux/flux-core/src/ast/check/mod.rs":                                                      "4a6511e9ccc9718eada01b29544bd4d5c324ae87a85906c25ad7193a890f86fc",
 	"libflux/flux-core/src/ast/mod.rs":                                                            "00fac7d9da0dfb0475a994b208b9e3d97ad2199a8dcc5bac941e2376c94b5f6b",
 	"libflux/flux-core/src/ast/walk/mod.rs":                                                       "b0069cedffd1a20c77c4fe12465a8350a50a8916d0f29798ab47212fdd0b0692",
@@ -59,7 +59,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/semantic/walk/mod.rs":                                                  "027f6d345ab58846bef1a8db26983e74143e880d5e82a500fd12642470b9d86a",
 	"libflux/flux-core/src/semantic/walk/test_utils.rs":                                           "043d5137ed626f1990c89f639e867e5b33a906f13c427313b497062f98215846",
 	"libflux/flux-core/src/semantic/walk/walk_mut.rs":                                             "3e9b8db77f35cfdee5ef7e24c1bc08845484f3cb7ecd50a82163b6ad46899662",
-	"libflux/flux/Cargo.toml":                                                                     "1dbb9643175c93b7e1c39dda6aa6a9684d7c31ed88bfc44e5bdee5ea4c2977eb",
+	"libflux/flux/Cargo.toml":                                                                     "913a8be19540592efc631bcb2f8b5fd25747a7297f6c1073fec40ad0f5ec255e",
 	"libflux/flux/FLUXDOC.md":                                                                     "92e6dd8043bd87b4924e09aa28fb5346630aee1214de28ea2c8fc0687cad0785",
 	"libflux/flux/build.rs":                                                                       "31dcb1e825555e56b4d959244c4ea630b1d32ccddc1f8615620e0c23552d914f",
 	"libflux/flux/src/cffi.rs":                                                                    "a5e3c5bb6eeb720f726cc7177afb5e7dd3a3e8b32ac269a2d48f199068995f78",

--- a/libflux/go/libflux/buildinfo.gen.go
+++ b/libflux/go/libflux/buildinfo.gen.go
@@ -30,7 +30,7 @@ var sourceHashes = map[string]string{
 	"libflux/flux-core/src/lib.rs":                                                                "487c5b2db051f7ed5276c566a9a6b2ee75d6a13459443cf94b51b6d90d20edd2",
 	"libflux/flux-core/src/map.rs":                                                                "342c1cc111d343f01b97f38be10a9f1097bdd57cdc56f55e92fd3ed5028e6973",
 	"libflux/flux-core/src/parser/mod.rs":                                                         "abc9f7fe02d4252c4046bf1f680916f328b5f04a73509413ef37b55a0daa1420",
-	"libflux/flux-core/src/parser/strconv.rs":                                                     "2e288c83dcc9cf6e1b6a503219108cd3ed74446f9a2906b551480fa298e14531",
+	"libflux/flux-core/src/parser/strconv.rs":                                                     "005ecd7a1a227d280dfd0bf065b7f9c49f68952daf7efe1c9bc3bfd91a30a909",
 	"libflux/flux-core/src/scanner/mod.rs":                                                        "eb7afb2eff162080046ddda7d1e9d01ffd4ec3a165bbcc95a001bf7edefa5e9c",
 	"libflux/flux-core/src/scanner/scanner.rl":                                                    "34e1f306994b8f69d0551110ce22efa75e0081b7c5f498ad293a739970bbcbc2",
 	"libflux/flux-core/src/scanner/scanner_generated.rs":                                          "d917184e05832393cb1ee3133723181a7eac31b259782ac3f1af56bf68a25ed4",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.68"
+channel = "1.72"
 components = ["rustfmt", "clippy"]
 targets = [
     "wasm32-unknown-unknown",


### PR DESCRIPTION
Update the rust version to 1.72, this is the earliest version that can be linked to musl 1.2.4.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
