### PR TITLE
docs: update comments to clarify behaviour

### DIFF
--- a/stdlib/influxdata/influxdb/influxdb.flux
+++ b/stdlib/influxdata/influxdb/influxdb.flux
@@ -6,7 +6,15 @@
 package influxdb
 
 
-// cardinality returns the series cardinality of data stored in InfluxDB.
+// cardinality returns the series cardinality of data retrieved InfluxDB.
+//
+// Although this function is similar to InfluxQL's `SHOW SERIES CARDINALITY` it works in a slightly
+// different manner.
+//
+// cardinality is time bounded and reports the  `influxdb.cardinality()` is time bounded and reports
+// the cardinality of data that matches the conditions passed into it rather than that of the bucket
+// as a whole.
+//
 //
 // ## Parameters
 // - bucket: Bucket to query cardinality from.
@@ -31,6 +39,9 @@ package influxdb
 //      Use a relative duration or absolute time. For example, `-1h` or `2019-08-28T22:00:00Z`.
 //      Durations are relative to `now()`. Default is `now()`.
 //
+//      Note: because the default is `now()`, any points that have been written into the future
+//      will not be counted unless a future `stop` date is provided
+//
 // - predicate: Predicate function that filters records.
 //      Default is `(r) => true`.
 //
@@ -42,9 +53,11 @@ package influxdb
 //
 // influxdb.cardinality(
 //     bucket: "example-bucket",
-//     start: -1y,
+//     start: time(v: 1),
 // )
 // ```
+// Note: if points have been written into the future, you will need to add an appropriate `stop` date
+//
 //
 // ### Query series cardinality in a measurement//
 // ```no_run
@@ -52,7 +65,7 @@ package influxdb
 //
 // influxdb.cardinality(
 //     bucket: "example-bucket",
-//     start: -1y,
+//     start: time(v: 1),
 //     predicate: (r) => r._measurement == "example-measurement",
 // )
 // ```
@@ -63,11 +76,17 @@ package influxdb
 //
 // influxdb.cardinality(
 //    bucket: "example-bucket",
-//    start: -1y,
+//    start: time(v: 1),
 //    predicate: (r) => r.exampleTag == "foo",
 // )
 // ```
 //
+// ### Query cardinality of data written in the last 4 hours
+// ```no_run
+// import "influxdata/influxdb"
+//
+// influxdb.cardinality(bucket: "example-bucket", start: -4h)
+// ```
 // ## Metadata
 // introduced: 0.92.0
 // tags: metadata


### PR DESCRIPTION
This updates the comments for `influxdb.cardinality()` to mirror the docs changes proposed in https://github.com/influxdata/docs-v2/pull/5629

The changes made:

* Clarify that `influxdb.cardinality()` does not default to providing a point-in-time reading for the bucket as a whole (differentiating it from `SHOW SERIES CARDINALITY`)
* Update the examples to make them behave more like their titles suggest
* Introduce an example showing application of a smaller time-range

Updates are being made to the comments because the docs are nominally generated from the comments, so we need to make sure the docs changes aren't lost if they're ever regenerated.


### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues


Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
