### PR TITLE
feat: update prep-release to use gh

### DIFF
--- a/prep-release.sh
+++ b/prep-release.sh
@@ -24,19 +24,19 @@ make generate
 
 message="build(flux): prepare Flux release for $version"
 
-git commit -am "$message"
+git commit --allow-empty -am "$message"
 git push
 
-if ! command -v hub &> /dev/null
+if ! command -v gh &> /dev/null
 then
-    echo "hub is not installed. Cannot open github PRs automatically."
+    echo "gh is not installed. Cannot open github PRs automatically."
     echo "Pull requests will have to be manually created."
-    HAS_HUB=0
+    HAS_GH=0
 else
-    HAS_HUB=1
+    HAS_GH=1
 fi
 
-if [ $HAS_HUB -eq 1 ]
+if [ $HAS_GH -eq 1 ]
 then
-    hub pull-request -m "$message" -r influxdata/flux-team
+    gh pr create --repo influxdata/flux --fill-first -r influxdata/flux-team
 fi


### PR DESCRIPTION
The gh command has replaced the hub command, update the prep-release script to use this instead. Also, as releses generally only contain security updates allow the release branch to have an empty commit.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
