### PR TITLE
build: Update the go version used to build flux

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -6,12 +6,12 @@
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
 FROM rust:1.78 as RUSTBUILD
 
-FROM golang:1.21 as PKGCONFIG
+FROM golang:1.24 as PKGCONFIG
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/
 RUN cd /go/src/github.com/influxdata/flux && \
     go build -o /usr/local/bin/cgo-pkgbuild github.com/influxdata/pkg-config
 
-FROM golang:1.21
+FROM golang:1.24
 
 # Install common packages
 RUN apt-get update && \


### PR DESCRIPTION
Update the version of Go used to build flux to go1.24. This version is still receiving security updates and is required for some newer packages that dependbot wants to merge.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
