### PR TITLE
fix: use rust 1.85 in build image

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,7 +4,7 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-FROM rust:1.78 as RUSTBUILD
+FROM rust:1.85 as RUSTBUILD
 
 FROM golang:1.24 as PKGCONFIG
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/


### PR DESCRIPTION
Some of the rust components that are added to the build image need a newer rust version. Update the rust version used.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
