### PR TITLE
feat: remove influxdb-iox-client-go dependency

### DIFF
--- a/dependencies/iox/client.go
+++ b/dependencies/iox/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/influxdata/flux/dependencies/influxdb"
 	"github.com/influxdata/flux/internal/errors"
 	"github.com/influxdata/flux/memory"
-	influxdbiox "github.com/influxdata/influxdb-iox-client-go"
 )
 
 type key int
@@ -42,6 +41,49 @@ func GetProvider(ctx context.Context) Provider {
 	return p.(Provider)
 }
 
+// ColumnType defines the column data types IOx can represent.
+type ColumnType int32
+
+const (
+	// ColumnTypeUnknown is an invalid column type.
+	ColumnTypeUnknown ColumnType = 0
+	// ColumnType_I64 is an int64.
+	ColumnType_I64 ColumnType = 1
+	// ColumnType_U64 is an uint64.
+	ColumnType_U64 ColumnType = 2
+	// ColumnType_F64 is an float64.
+	ColumnType_F64 ColumnType = 3
+	// ColumnType_BOOL is a bool.
+	ColumnType_BOOL ColumnType = 4
+	// ColumnType_STRING is a string.
+	ColumnType_STRING ColumnType = 5
+	// ColumnType_TIME is a timestamp.
+	ColumnType_TIME ColumnType = 6
+	// ColumnType_TAG is a tag value.
+	ColumnType_TAG ColumnType = 7
+)
+
+func (c ColumnType) String() string {
+	switch c {
+	case ColumnType_I64:
+		return "int64"
+	case ColumnType_U64:
+		return "uint64"
+	case ColumnType_F64:
+		return "float64"
+	case ColumnType_BOOL:
+		return "bool"
+	case ColumnType_STRING:
+		return "string"
+	case ColumnType_TIME:
+		return "timestamp"
+	case ColumnType_TAG:
+		return "tag"
+	default:
+		return "unknown"
+	}
+}
+
 // RecordReader is similar to the RecordReader interface provided by Arrow's array
 // package, but includes a method for detecting errors that are sent mid-stream.
 type RecordReader interface {
@@ -58,7 +100,7 @@ type Client interface {
 	// GetSchema will retrieve a schema for the given table if this client supports that capability.
 	// If this Client doesn't support this capability, it should return a flux error with the code
 	// codes.Unimplemented.
-	GetSchema(ctx context.Context, table string) (map[string]influxdbiox.ColumnType, error)
+	GetSchema(ctx context.Context, table string) (map[string]ColumnType, error)
 }
 
 // ErrorProvider is an implementation of the Provider that returns an error.

--- a/go.mod
+++ b/go.mod
@@ -63,8 +63,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-require github.com/influxdata/influxdb-iox-client-go v1.0.0-beta.1
-
 require (
 	cloud.google.com/go/auth v0.5.1 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,6 @@ github.com/influxdata/gosnowflake v1.9.0 h1:fw6peFfTfJK+jbI98RzEEbte8F1SNBX8a91c
 github.com/influxdata/gosnowflake v1.9.0/go.mod h1:VYPoQhZtz3I1zh+YIMG4axm/iUxoKCTbTEQl/SYvUNM=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040 h1:MBLCfcSsUyFPDJp6T7EoHp/Ph3Jkrm4EuUKLD2rUWHg=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
-github.com/influxdata/influxdb-iox-client-go v1.0.0-beta.1 h1:zDmAiE2o3Y/YZinI6CENzgQueJDuibUB9TWOZC5zCq0=
-github.com/influxdata/influxdb-iox-client-go v1.0.0-beta.1/go.mod h1:Chl4pz0SRqoPmEavex4vZaQlunqXqrtEPWAN54THFfo=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=


### PR DESCRIPTION
The github.com/influxdata/influxdb-iox-client-go module has been archived and is no longer receiving any updates. Flux depended on this simply for an enum-style type import. The ColumnType type in question has been copied into the flux code, removing the need for the dependency.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
