### PR TITLE
fix(stdlib): error if using limit with negative offset

### DIFF
--- a/stdlib/universe/limit.go
+++ b/stdlib/universe/limit.go
@@ -49,6 +49,9 @@ func createLimitOpSpec(args flux.Arguments, a *flux.Administration) (flux.Operat
 	} else if ok {
 		spec.Offset = offset
 	}
+	if spec.Offset < 0 {
+		return nil, errors.Newf(codes.Invalid, "limit offset cannot be negative (%d)", spec.Offset)
+	}
 
 	return spec, nil
 }


### PR DESCRIPTION
A negative offset does not make sense with a limit function. Detect if a negative offset is being used and produce an error, rather than waiting for arrow to panic.

Fixes influxdata/influxdb#23265

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [x] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
