### PR TITLE
fix: panic in arrow table buffer

### DIFF
--- a/arrow/table_buffer.go
+++ b/arrow/table_buffer.go
@@ -26,7 +26,7 @@ type TableBuffer struct {
 var _ flux.ColReader = (*TableBuffer)(nil)
 
 func (t *TableBuffer) Len() int {
-	if len(t.Columns) == 0 {
+	if len(t.Values) == 0 {
 		return 0
 	}
 	return t.Values[0].Len()

--- a/execute/table/buffered_builder.go
+++ b/execute/table/buffered_builder.go
@@ -89,7 +89,7 @@ func (b *BufferedBuilder) appendBuffer(cr flux.ColReader, mem memory.Allocator) 
 func (b *BufferedBuilder) normalizeTableSchema(cols []flux.ColMeta, mem memory.Allocator) error {
 	// If there are no columns set for this builder, inherit the ones
 	// that were passed in.
-	if b.Columns == nil {
+	if len(b.Columns) == 0 {
 		b.Columns = cols
 		return nil
 	}


### PR DESCRIPTION
An empty arrow.TableBuffer can panic when calling Len() if it is in the process of being appended to by a table.BufferBuilder. Normally the TableBuffer maintains the invariant that the size of Columns is the same as the size if Values so to check one is equivalent to checkint the other. However when a BufferBuilder is merging buffers with different schema it will add new null-valued columns to the TableBuffer. This checks the TableBuffer.Len() between adding the column and adding the null-valued column.

In the case that the TableBuffer is empty, but the Columns array is a zero-length slice, rather than nil, a panic occurs.

There are two fixes here. Either of which fix the symptom, but both are worthwhile changes. TableBuffer.Len() now checks the length of the slice it is attempting to access before reading it.
BufferBuilder.normalizeSchema() now checks that the Columns slice length is 0 (rather than the value being nil) in order to use the shortcut normalize code path.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
