### PR TITLE
build: Update libtinfo package version

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -16,7 +16,7 @@ FROM golang:1.24
 # Install common packages
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-    openssl libtinfo5 ruby \
+    openssl libtinfo6 ruby \
     ca-certificates curl file gnupg \
     build-essential cmake nodejs npm \
     libxml2-dev libssl-dev libsqlite3-dev zlib1g-dev \


### PR DESCRIPTION
A new relese of Debian (trixie) has recently been released and this is the version backing the go:1.24 base image. This new debian version does not have a libtinfo5 package, but instead has a libtinfo6 package. Update to use the new package.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
