### PR TITLE
build: use gcc-12 for flatc build

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -4,9 +4,9 @@
 # and verification, we can list the rust container as a prior build stage, and
 # then pull in the artifacts we need. There is an added benefit that tagged versions
 # also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-FROM rust:1.85 as RUSTBUILD
+FROM rust:1.85 AS rustbuild
 
-FROM golang:1.24 as PKGCONFIG
+FROM golang:1.24 AS pkgconfig
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/
 RUN cd /go/src/github.com/influxdata/flux && \
     go build -o /usr/local/bin/cgo-pkgbuild github.com/influxdata/pkg-config
@@ -20,12 +20,13 @@ RUN apt-get update && \
     ca-certificates curl file gnupg \
     build-essential cmake nodejs npm \
     libxml2-dev libssl-dev libsqlite3-dev zlib1g-dev \
-    autoconf automake autotools-dev libtool xutils-dev valgrind && \
+    autoconf automake autotools-dev libtool xutils-dev valgrind \
+    gcc-12 g++-12 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install rust and rust tooling
-COPY --from=RUSTBUILD /usr/local/cargo /usr/local/cargo
-COPY --from=RUSTBUILD /usr/local/rustup /usr/local/rustup
+COPY --from=rustbuild /usr/local/cargo /usr/local/cargo
+COPY --from=rustbuild /usr/local/rustup /usr/local/rustup
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
@@ -67,7 +68,7 @@ COPY ./install_flatc.sh .
 RUN ./install_flatc.sh
 
 # Install pkg-config helper
-COPY --from=PKGCONFIG /usr/local/bin/cgo-pkgbuild /usr/local/bin/cgo-pkgbuild
+COPY --from=pkgconfig /usr/local/bin/cgo-pkgbuild /usr/local/bin/cgo-pkgbuild
 
 # Add builder user
 ENV UNAME=builder

--- a/install_flatc.sh
+++ b/install_flatc.sh
@@ -6,6 +6,6 @@ curl -LS https://github.com/google/flatbuffers/archive/v${FLATBUFFERS_VERSION}.t
     tar xvzf v${FLATBUFFERS_VERSION}.tar.gz && \
     mkdir flatbuffers-${FLATBUFFERS_VERSION}/build && \
     cd flatbuffers-${FLATBUFFERS_VERSION}/build && \
-    cmake -G "Unix Makefiles" .. && \
+    CC=/usr/bin/gcc-12 CXX=/usr/bin/g++-12 cmake -G "Unix Makefiles" .. && \
     make && make install && \
     cd ../.. && rm -rf flatbuffers-${FLATBUFFERS_VERSION} v${FLATBUFFERS_VERSION}.tar.gz


### PR DESCRIPTION
After the letest debian release the default gcc doesn't compiel flatc. Use the older gcc-12 version instead.
### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
