### PR TITLE
test: add libflux build with Rust beta toolchain

### DIFF
--- a/.github/workflows/libflux-rust-beta.yml
+++ b/.github/workflows/libflux-rust-beta.yml
@@ -1,0 +1,68 @@
+name: Build & Test libflux with upcoming Rust release
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # Run at 03:00 every Sunday
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    permissions:
+      issues: write
+    runs-on:
+      group: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rust-version: "beta"
+      - name: libflux build
+        working-directory: ./libflux
+        run: cargo +beta build --workspace --all-features --all-targets --verbose
+      - name: libflux test
+        working-directory: ./libflux
+        run: cargo +beta test --workspace --all-features --all-targets --verbose
+      - name: libflux lint
+        working-directory: ./libflux
+        run: cargo +beta clippy --workspace --all-features --all-targets --verbose -- -Dclippy::all -Dclippy::undocumented_unsafe_blocks
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'libflux build failed with Rust beta';
+            const body = `The scheduled build of libflux with Rust beta has failed.
+
+            **Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
+
+            Please investigate and fix any compatibility issues before the next stable Rust release.`;
+
+            // Check for existing open issue with same title
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'rust-beta-failure'
+            });
+
+            const existingIssue = issues.data.find(issue => issue.title === title);
+            if (existingIssue) {
+              // Add comment to existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: `Another failure occurred.\n\n**Workflow run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              });
+            } else {
+              // Create new issue
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['rust-beta-failure']
+              });
+            }

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -2,9 +2,9 @@
 
 # "Wait," you ask. "What's going on here?" Rather than handling rustup validation
 # and verification, we can list the rust container as a prior build stage, and
-# then pull in the artifacts we need. There is an added benefit that tagged versions
-# also include minor releases, so 1.2 includes 1.2.1 and so on, for bugfix releases.
-FROM rust:1.91 AS rustbuild
+# then pull in the artifacts we need. The exact rust version used to build libflux
+# is specified in rust-toolchain.toml, so always get the latest image.
+FROM rust:latest AS rustbuild
 
 FROM golang:1.24 AS pkgconfig
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/


### PR DESCRIPTION
Test building libflux with the rust beta toolchain. This will provide an early warning that the flux build will fail when the next Rust version is released.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
