### PR TITLE
ci(semantic): cap GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited]
 
+permissions:
+  contents: read
+
 jobs:
   semantic:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at workflow level. No GitHub API writes from the workflow.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.