### PR TITLE
build: use go version 1.27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   test:
     docker:
@@ -135,7 +135,7 @@ jobs:
             # Cargo's built-in support for fetching dependencies from GitHub requires
             # an ssh agent to be set up, which doesn't work on Circle's Windows executors.
             # See https://github.com/rust-lang/cargo/issues/1851#issuecomment-450130685
-            cat <<EOF >> ~/.cargo/config
+            cat \<<EOF >> ~/.cargo/config
             [net]
             git-fetch-with-cli = true
             EOF

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -6,12 +6,12 @@
 # is specified in rust-toolchain.toml, so always get the latest image.
 FROM rust:latest AS rustbuild
 
-FROM golang:1.25 AS pkgconfig
+FROM golang:1.27 AS pkgconfig
 COPY go.mod go.sum /go/src/github.com/influxdata/flux/
 RUN cd /go/src/github.com/influxdata/flux && \
     go build -o /usr/local/bin/cgo-pkgbuild github.com/influxdata/pkg-config
 
-FROM golang:1.25
+FROM golang:1.27
 
 # Install common packages
 RUN apt-get update && \


### PR DESCRIPTION
Update the go version used to build flux to 1.27. This replaces version 1.25, which is no longer supported.

### Checklist

Dear Author :wave:, the following checks should be completed (or explicitly dismissed) before merging.

- [x] ✏️ Write a PR description, regardless of triviality, to include the _value_ of this PR
- [ ] 🔗 Reference related issues
- [ ] 🏃 Test cases are included to exercise the new code
- [ ] 🧪 If **new packages** are being introduced to stdlib, link to Working Group discussion notes and ensure it lands under `experimental/`
- [ ] 📖 If **language features** are changing, ensure `docs/Spec.md` has been updated

Dear Reviewer(s) :wave:, you are responsible (among others) for ensuring the completeness and quality of the above before approval.
